### PR TITLE
Log Jetpack Tunnel raw body errors

### DIFF
--- a/Modules/Sources/NetworkingCore/Remote/JetpackTunnelRawBodyErrorLogger.swift
+++ b/Modules/Sources/NetworkingCore/Remote/JetpackTunnelRawBodyErrorLogger.swift
@@ -5,8 +5,6 @@ protocol JetpackTunnelRawBodyErrorLogging {
 }
 
 struct JetpackTunnelRawBodyErrorLogger: JetpackTunnelRawBodyErrorLogging {
-    private typealias JSONDictionary = [String: Any]
-
     private let maxSnippetLength: Int
     private let warningSink: (String) -> Void
 
@@ -25,27 +23,121 @@ struct JetpackTunnelRawBodyErrorLogger: JetpackTunnelRawBodyErrorLogging {
         warningSink(message)
     }
 
-    func buildMessage(responseData: Data, request: JetpackRequest, transportStatus: Int?) -> String? {
+    private func buildMessage(responseData: Data, request: JetpackRequest, transportStatus: Int?) -> String? {
         guard let rawBodyError = rawBodyErrorContext(from: responseData) else {
             return nil
         }
 
         let snippet = sanitizedSnippet(rawBodyError.rawBody)
-        return [
-            "Jetpack Tunnel raw_body error:",
-            "method=\(sanitize(request.method.rawValue.uppercased())),",
-            "path=\(sanitize(normalizedPath(for: request))),",
-            "transport_status=\(transportStatus.map { String($0) } ?? "nil"),",
-            "proxy_status=\(rawBodyError.proxyStatus.map { String($0) } ?? "nil"),",
-            "error_code=\(sanitize(rawBodyError.errorCode ?? "nil")),",
-            "error_message=\(sanitize(rawBodyError.errorMessage ?? "nil")),",
-            "raw_body_truncated=\(snippet.truncated),",
+        let fields = [
+            "method=\(request.method.rawValue.uppercased())",
+            "path=\(sanitize(normalizedPath(for: request)))",
+            transportStatus.map { "transport_status=\($0)" },
+            rawBodyError.proxyStatus.map { "proxy_status=\($0)" },
+            "error_code=\(sanitize(rawBodyError.errorCode))",
+            "error_message=\(sanitize(rawBodyError.errorMessage))",
+            "raw_body_truncated=\(snippet.truncated)",
             "raw_body_snippet=\(snippet.value)"
-        ].joined(separator: " ")
+        ].compactMap { $0 }
+
+        return "Jetpack Tunnel raw_body error: \(fields.joined(separator: ", "))"
     }
 }
 
 private extension JetpackTunnelRawBodyErrorLogger {
+    struct RawBodyErrorResponse: Decodable {
+        let payload: RawBodyErrorPayload
+        let body: RawBodyErrorBody?
+
+        init(from decoder: Decoder) throws {
+            payload = try RawBodyErrorPayload(from: decoder)
+
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            body = try? container.decodeIfPresent(RawBodyErrorBody.self, forKey: .body)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case body
+        }
+    }
+
+    struct RawBodyErrorPayload: Decodable {
+        let error: String?
+        let code: String?
+        let message: String?
+        let status: Int?
+        let data: RawBodyErrorData?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            error = try? container.decodeIfPresent(String.self, forKey: .error)
+            code = try? container.decodeIfPresent(String.self, forKey: .code)
+            message = try? container.decodeIfPresent(String.self, forKey: .message)
+            status = container.failsafeDecodeIfPresent(integerForKey: .status)
+            data = try? container.decodeIfPresent(RawBodyErrorData.self, forKey: .data)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case error
+            case code
+            case message
+            case status
+            case data
+        }
+    }
+
+    struct RawBodyErrorData: Decodable {
+        let status: Int?
+        let rawBody: String?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            status = container.failsafeDecodeIfPresent(integerForKey: .status)
+            rawBody = try? container.decodeIfPresent(String.self, forKey: .rawBody)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case status
+            case rawBody = "raw_body"
+        }
+    }
+
+    enum RawBodyErrorBody: Decodable {
+        case payload(RawBodyErrorPayload)
+        case jsonString(String)
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+
+            if let payload = try? container.decode(RawBodyErrorPayload.self) {
+                self = .payload(payload)
+                return
+            }
+
+            if let jsonString = try? container.decode(String.self) {
+                self = .jsonString(jsonString)
+                return
+            }
+
+            throw DecodingError.typeMismatch(
+                RawBodyErrorBody.self,
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected object or stringified JSON body")
+            )
+        }
+
+        var payload: RawBodyErrorPayload? {
+            switch self {
+            case .payload(let payload):
+                return payload
+            case .jsonString(let jsonString):
+                guard let data = jsonString.data(using: .utf8) else {
+                    return nil
+                }
+                return try? JSONDecoder().decode(RawBodyErrorPayload.self, from: data)
+            }
+        }
+    }
+
     struct RawBodyErrorContext {
         let errorCode: String?
         let errorMessage: String?
@@ -60,95 +152,53 @@ private extension JetpackTunnelRawBodyErrorLogger {
 
     private static let redactionPatterns: [RedactionPattern] = [
         RedactionPattern(
-            expression: #"(?i)(authorization\s*[:=]\s*(?:[a-z]+\s+)?)[^\s<>,;"\\]+(?=\\[nrtvf]|\s|[<>,;"]|$)"#,
-            replacement: "$1[redacted]"
+            expression: #"(?i)\bBearer\s+[^\s,;]+"#,
+            replacement: "Bearer [redacted]"
         ),
         RedactionPattern(
-            expression: #"(?i)\b((?:set-cookie|cookie)\s*[:=]\s*).*?(?=\\[nrtvf]|\s*(?:authorization|set-cookie|cookie)\s*[:=]|[<>]|$)"#,
-            replacement: "$1[redacted]"
+            expression: #"(?i)\b(Cookie|Set-Cookie):\s*[^\n\r,]+"#,
+            replacement: "$1: [redacted]"
         ),
         RedactionPattern(
             expression: #"(?i)("(?:consumer_key|consumer_secret|access_token|token|application_password|password)"\s*:\s*")[^"]*(")"#,
             replacement: "$1[redacted]$2"
         ),
         RedactionPattern(
-            expression: #"(?i)\b((?:consumer_key|consumer_secret|access_token|token|application_password|password)\s*[=:]\s*)[^&\s;'",<>\\]+"#,
-            replacement: "$1[redacted]"
-        ),
-        RedactionPattern(
-            expression: #"(?i)\b((?:session|wordpress_logged_in[\w-]*)\s*=\s*)[^&\s;'",<>\\]+"#,
-            replacement: "$1[redacted]"
+            expression: #"(?i)(^|[?&;\s])((?:consumer_key|consumer_secret|access_token|token|application_password|password)=)[^&;\s,"'}]+"#,
+            replacement: "$1$2[redacted]"
         )
     ]
 
-    private static let readableBoundaryPatterns: [RedactionPattern] = [
-        RedactionPattern(
-            expression: #"(?i)([^\s<>,;:"'=])((?:authorization|set-cookie|cookie)\s*[:=])"#,
-            replacement: "$1 $2"
-        ),
-        RedactionPattern(
-            expression: #"(?i)([^A-Za-z_\s<>,;:"'=])((?:session|wordpress_logged_in[\w-]*)\s*=)"#,
-            replacement: "$1 $2"
-        )
-    ]
+    private static let whitespacePattern = #"\s+"#
 
     private func rawBodyErrorContext(from responseData: Data) -> RawBodyErrorContext? {
-        guard let rootDictionary = jsonDictionary(from: responseData) else {
+        guard let response = try? JSONDecoder().decode(RawBodyErrorResponse.self, from: responseData) else {
             return nil
         }
 
-        if let rootError = rawBodyErrorContext(from: rootDictionary, fallbackProxyStatus: intValue(rootDictionary["status"])) {
+        if let rootError = rawBodyErrorContext(from: response.payload, fallbackProxyStatus: response.payload.status) {
             return rootError
         }
 
-        let envelopeStatus = intValue(rootDictionary["status"])
-        if let bodyDictionary = rootDictionary["body"] as? JSONDictionary {
-            return rawBodyErrorContext(from: bodyDictionary, fallbackProxyStatus: envelopeStatus)
-        }
-
-        if let bodyString = rootDictionary["body"] as? String,
-           let bodyData = bodyString.data(using: .utf8),
-           let bodyDictionary = jsonDictionary(from: bodyData) {
-            return rawBodyErrorContext(from: bodyDictionary, fallbackProxyStatus: envelopeStatus)
+        if let bodyPayload = response.body?.payload {
+            return rawBodyErrorContext(from: bodyPayload, fallbackProxyStatus: response.payload.status)
         }
 
         return nil
     }
 
-    private func rawBodyErrorContext(from dictionary: JSONDictionary, fallbackProxyStatus: Int?) -> RawBodyErrorContext? {
-        guard let data = dictionary["data"] as? JSONDictionary,
-              let rawBody = data["raw_body"] as? String,
-              rawBody.isEmpty == false else {
+    private func rawBodyErrorContext(from payload: RawBodyErrorPayload, fallbackProxyStatus: Int?) -> RawBodyErrorContext? {
+        guard let rawBody = payload.data?.rawBody,
+              rawBody.contains(where: { $0.isWhitespace == false }) else {
             return nil
         }
 
         return RawBodyErrorContext(
-            errorCode: dictionary["error"] as? String ?? dictionary["code"] as? String,
-            errorMessage: dictionary["message"] as? String,
-            proxyStatus: intValue(data["status"]) ?? fallbackProxyStatus,
+            errorCode: payload.error ?? payload.code,
+            errorMessage: payload.message,
+            proxyStatus: payload.data?.status ?? fallbackProxyStatus,
             rawBody: rawBody
         )
-    }
-
-    private func jsonDictionary(from data: Data) -> JSONDictionary? {
-        guard let object = try? JSONSerialization.jsonObject(with: data),
-              let dictionary = object as? JSONDictionary else {
-            return nil
-        }
-        return dictionary
-    }
-
-    private func intValue(_ value: Any?) -> Int? {
-        switch value {
-        case let value as Int:
-            return value
-        case let value as NSNumber:
-            return value.intValue
-        case let value as String:
-            return Int(value)
-        default:
-            return nil
-        }
     }
 
     private func normalizedPath(for request: JetpackRequest) -> String {
@@ -176,32 +226,15 @@ private extension JetpackTunnelRawBodyErrorLogger {
         return (String(sanitized.prefix(maxSnippetLength)), truncated)
     }
 
-    private func sanitize(_ value: String) -> String {
-        let readableValue = Self.readableBoundaryPatterns.reduce(singleLineReadableValue(value)) { partialResult, pattern in
+    private func sanitize(_ value: String?) -> String {
+        Self.redactionPatterns.reduce(value ?? "") { partialResult, pattern in
             partialResult.replacingOccurrences(
                 of: pattern.expression,
                 with: pattern.replacement,
                 options: .regularExpression
             )
         }
-
-        return Self.redactionPatterns.reduce(readableValue) { partialResult, pattern in
-            partialResult.replacingOccurrences(
-                of: pattern.expression,
-                with: pattern.replacement,
-                options: .regularExpression
-            )
-        }.trimmingCharacters(in: .whitespaces)
-    }
-
-    private func singleLineReadableValue(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\r\n", with: "\\n")
-            .replacingOccurrences(of: "\n", with: "\\n")
-            .replacingOccurrences(of: "\r", with: "\\r")
-            .replacingOccurrences(of: "\t", with: "\\t")
-            .replacingOccurrences(of: "\u{0B}", with: "\\v")
-            .replacingOccurrences(of: "\u{0C}", with: "\\f")
-            .replacingOccurrences(of: #" {2,}"#, with: " ", options: .regularExpression)
+        .replacingOccurrences(of: Self.whitespacePattern, with: " ", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Modules/Sources/NetworkingCore/Remote/JetpackTunnelRawBodyErrorLogger.swift
+++ b/Modules/Sources/NetworkingCore/Remote/JetpackTunnelRawBodyErrorLogger.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+protocol JetpackTunnelRawBodyErrorLogging {
+    func logIfNeeded(responseData: Data?, request: Request, transportStatus: Int?)
+}
+
+struct JetpackTunnelRawBodyErrorLogger: JetpackTunnelRawBodyErrorLogging {
+    private typealias JSONDictionary = [String: Any]
+
+    private let maxSnippetLength: Int
+    private let warningSink: (String) -> Void
+
+    init(maxSnippetLength: Int = 2048, warningSink: @escaping (String) -> Void = { DDLogWarn($0) }) {
+        self.maxSnippetLength = maxSnippetLength
+        self.warningSink = warningSink
+    }
+
+    func logIfNeeded(responseData: Data?, request: Request, transportStatus: Int?) {
+        guard let responseData,
+              let jetpackRequest = request as? JetpackRequest,
+              let message = buildMessage(responseData: responseData, request: jetpackRequest, transportStatus: transportStatus) else {
+            return
+        }
+
+        warningSink(message)
+    }
+
+    func buildMessage(responseData: Data, request: JetpackRequest, transportStatus: Int?) -> String? {
+        guard let rawBodyError = rawBodyErrorContext(from: responseData) else {
+            return nil
+        }
+
+        let snippet = sanitizedSnippet(rawBodyError.rawBody)
+        return [
+            "Jetpack Tunnel raw_body error:",
+            "method=\(sanitize(request.method.rawValue.uppercased())),",
+            "path=\(sanitize(normalizedPath(for: request))),",
+            "transport_status=\(transportStatus.map { String($0) } ?? "nil"),",
+            "proxy_status=\(rawBodyError.proxyStatus.map { String($0) } ?? "nil"),",
+            "error_code=\(sanitize(rawBodyError.errorCode ?? "nil")),",
+            "error_message=\(sanitize(rawBodyError.errorMessage ?? "nil")),",
+            "raw_body_truncated=\(snippet.truncated),",
+            "raw_body_snippet=\(snippet.value)"
+        ].joined(separator: " ")
+    }
+}
+
+private extension JetpackTunnelRawBodyErrorLogger {
+    struct RawBodyErrorContext {
+        let errorCode: String?
+        let errorMessage: String?
+        let proxyStatus: Int?
+        let rawBody: String
+    }
+
+    struct RedactionPattern {
+        let expression: String
+        let replacement: String
+    }
+
+    private static let redactionPatterns: [RedactionPattern] = [
+        RedactionPattern(
+            expression: #"(?i)(authorization\s*[:=]\s*(?:[a-z]+\s+)?)[^\s<>,;"\\]+(?=\\[nrtvf]|\s|[<>,;"]|$)"#,
+            replacement: "$1[redacted]"
+        ),
+        RedactionPattern(
+            expression: #"(?i)\b((?:set-cookie|cookie)\s*[:=]\s*).*?(?=\\[nrtvf]|\s*(?:authorization|set-cookie|cookie)\s*[:=]|[<>]|$)"#,
+            replacement: "$1[redacted]"
+        ),
+        RedactionPattern(
+            expression: #"(?i)("(?:consumer_key|consumer_secret|access_token|token|application_password|password)"\s*:\s*")[^"]*(")"#,
+            replacement: "$1[redacted]$2"
+        ),
+        RedactionPattern(
+            expression: #"(?i)\b((?:consumer_key|consumer_secret|access_token|token|application_password|password)\s*[=:]\s*)[^&\s;'",<>\\]+"#,
+            replacement: "$1[redacted]"
+        ),
+        RedactionPattern(
+            expression: #"(?i)\b((?:session|wordpress_logged_in[\w-]*)\s*=\s*)[^&\s;'",<>\\]+"#,
+            replacement: "$1[redacted]"
+        )
+    ]
+
+    private static let readableBoundaryPatterns: [RedactionPattern] = [
+        RedactionPattern(
+            expression: #"(?i)([^\s<>,;:"'=])((?:authorization|set-cookie|cookie)\s*[:=])"#,
+            replacement: "$1 $2"
+        ),
+        RedactionPattern(
+            expression: #"(?i)([^A-Za-z_\s<>,;:"'=])((?:session|wordpress_logged_in[\w-]*)\s*=)"#,
+            replacement: "$1 $2"
+        )
+    ]
+
+    private func rawBodyErrorContext(from responseData: Data) -> RawBodyErrorContext? {
+        guard let rootDictionary = jsonDictionary(from: responseData) else {
+            return nil
+        }
+
+        if let rootError = rawBodyErrorContext(from: rootDictionary, fallbackProxyStatus: intValue(rootDictionary["status"])) {
+            return rootError
+        }
+
+        let envelopeStatus = intValue(rootDictionary["status"])
+        if let bodyDictionary = rootDictionary["body"] as? JSONDictionary {
+            return rawBodyErrorContext(from: bodyDictionary, fallbackProxyStatus: envelopeStatus)
+        }
+
+        if let bodyString = rootDictionary["body"] as? String,
+           let bodyData = bodyString.data(using: .utf8),
+           let bodyDictionary = jsonDictionary(from: bodyData) {
+            return rawBodyErrorContext(from: bodyDictionary, fallbackProxyStatus: envelopeStatus)
+        }
+
+        return nil
+    }
+
+    private func rawBodyErrorContext(from dictionary: JSONDictionary, fallbackProxyStatus: Int?) -> RawBodyErrorContext? {
+        guard let data = dictionary["data"] as? JSONDictionary,
+              let rawBody = data["raw_body"] as? String,
+              rawBody.isEmpty == false else {
+            return nil
+        }
+
+        return RawBodyErrorContext(
+            errorCode: dictionary["error"] as? String ?? dictionary["code"] as? String,
+            errorMessage: dictionary["message"] as? String,
+            proxyStatus: intValue(data["status"]) ?? fallbackProxyStatus,
+            rawBody: rawBody
+        )
+    }
+
+    private func jsonDictionary(from data: Data) -> JSONDictionary? {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = object as? JSONDictionary else {
+            return nil
+        }
+        return dictionary
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let value as Int:
+            return value
+        case let value as NSNumber:
+            return value.intValue
+        case let value as String:
+            return Int(value)
+        default:
+            return nil
+        }
+    }
+
+    private func normalizedPath(for request: JetpackRequest) -> String {
+        if let requestPath = pathWithoutHost(from: request.path) {
+            return requestPath
+        }
+
+        let requestPath = String(request.path.drop(while: { $0 == "/" }))
+        return request.wooApiVersion.path + requestPath
+    }
+
+    private func pathWithoutHost(from path: String) -> String? {
+        guard let components = URLComponents(string: path),
+              components.scheme != nil || components.host != nil else {
+            return nil
+        }
+
+        let query = components.query.map { "?\($0)" } ?? ""
+        return components.path + query
+    }
+
+    private func sanitizedSnippet(_ value: String) -> (value: String, truncated: Bool) {
+        let sanitized = sanitize(value)
+        let truncated = sanitized.count > maxSnippetLength
+        return (String(sanitized.prefix(maxSnippetLength)), truncated)
+    }
+
+    private func sanitize(_ value: String) -> String {
+        let readableValue = Self.readableBoundaryPatterns.reduce(singleLineReadableValue(value)) { partialResult, pattern in
+            partialResult.replacingOccurrences(
+                of: pattern.expression,
+                with: pattern.replacement,
+                options: .regularExpression
+            )
+        }
+
+        return Self.redactionPatterns.reduce(readableValue) { partialResult, pattern in
+            partialResult.replacingOccurrences(
+                of: pattern.expression,
+                with: pattern.replacement,
+                options: .regularExpression
+            )
+        }.trimmingCharacters(in: .whitespaces)
+    }
+
+    private func singleLineReadableValue(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\r\n", with: "\\n")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+            .replacingOccurrences(of: "\u{0B}", with: "\\v")
+            .replacingOccurrences(of: "\u{0C}", with: "\\f")
+            .replacingOccurrences(of: #" {2,}"#, with: " ", options: .regularExpression)
+    }
+}

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -10,6 +10,10 @@ open class Remote: NSObject {
     ///
     let network: Network
 
+    /// Jetpack Tunnel raw-body diagnostics logger.
+    ///
+    var jetpackTunnelRawBodyErrorLogger: JetpackTunnelRawBodyErrorLogging = JetpackTunnelRawBodyErrorLogger()
+
     /// Designated Initializer.
     ///
     /// - Parameters:
@@ -35,6 +39,7 @@ open class Remote: NSObject {
         do {
             try request.responseDataValidator().validate(data: data)
         } catch {
+            logJetpackTunnelRawBodyErrorIfPresent(responseData: data, request: request, transportStatus: nil)
             handleResponseError(error: error, for: request)
             throw error
         }
@@ -56,6 +61,7 @@ open class Remote: NSObject {
             try request.responseDataValidator().validate(data: data)
             return try JSONDecoder().decode(T.self, from: data)
         } catch {
+            logJetpackTunnelRawBodyErrorIfPresent(responseData: data, request: request, transportStatus: nil)
             handleResponseError(error: error, for: request)
             handleDecodingError(error: error, for: request, entityName: "\(T.self)")
             throw error
@@ -251,6 +257,7 @@ private extension Remote {
 
             DispatchQueue.main.async {
                 if case let .failure(error) = result {
+                    self?.logJetpackTunnelRawBodyErrorIfPresent(responseData: data, request: request, transportStatus: nil)
                     self?.handleResponseError(error: error, for: request)
                     self?.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
                     DDLogError("<> Mapping Error: \(error)")
@@ -265,6 +272,7 @@ private extension Remote {
         do {
             return try Self.validateAndMap(data, request: request, mapper: mapper)
         } catch {
+            logJetpackTunnelRawBodyErrorIfPresent(responseData: data, request: request, transportStatus: nil)
             DDLogError("<> Mapping Error: \(error)")
             handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
             throw error
@@ -275,6 +283,18 @@ private extension Remote {
 // MARK: - Private Methods
 //
 private extension Remote {
+
+    func logJetpackTunnelRawBodyErrorIfPresent(responseData: Data?, request: Request, transportStatus: Int?) {
+        guard request is JetpackRequest else {
+            return
+        }
+
+        jetpackTunnelRawBodyErrorLogger.logIfNeeded(
+            responseData: responseData,
+            request: request,
+            transportStatus: transportStatus
+        )
+    }
 
     /// Handles *all* of the DotcomError(s) that are successfully parsed.
     ///
@@ -317,6 +337,12 @@ private extension Remote {
         guard let response = networkError.response else {
             return networkError
         }
+
+        logJetpackTunnelRawBodyErrorIfPresent(
+            responseData: response,
+            request: request,
+            transportStatus: networkError.responseCode
+        )
 
         /// Pass the response to request's validator
         /// which will attempt to parse the response into corresponding error.

--- a/Modules/Tests/NetworkingTests/Remote/JetpackTunnelRawBodyErrorLoggerTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/JetpackTunnelRawBodyErrorLoggerTests.swift
@@ -24,9 +24,10 @@ struct JetpackTunnelRawBodyErrorLoggerTests {
         #expect(message.contains("error_message=Server could not read response."))
         #expect(message.contains("raw_body_truncated=false"))
         #expect(message.contains(
-            "raw_body_snippet=<html>\\n Fatal error consumer_key=[redacted] Authorization: Bearer [redacted] Cookie: [redacted]\\n</html>"
+            "raw_body_snippet=<html> Fatal error consumer_key=[redacted] Authorization: Bearer [redacted] Cookie: [redacted] </html>"
         ))
         #expect(!message.contains("\n"))
+        #expect(!message.contains("\\n"))
         #expect(!message.contains("ck_secret"))
         #expect(!message.contains("bearer-secret"))
         #expect(!message.contains("session=abc"))
@@ -50,19 +51,91 @@ struct JetpackTunnelRawBodyErrorLoggerTests {
         #expect(!message.contains("app-pass"))
     }
 
-    @Test func logIfNeeded_when_raw_body_contains_basic_authorization_then_redacts_header_value() throws {
+    @Test func logIfNeeded_when_body_envelope_is_stringified_json_then_uses_nested_error_context() throws {
         // Given
-        let rawBody = "<html>Authorization: Basic basic-secret failed</html>"
+        let body = """
+        {"code":"no_response_body_code","message":"Stringified body","data":{"raw_body":"<html>Fatal error</html>"}}
+        """
+        let responseData = try JSONSerialization.data(withJSONObject: [
+            "status": "504",
+            "body": body
+        ])
+
+        // When
+        let message = try message(forResponseData: responseData, method: .post, path: "orders")
+
+        // Then
+        #expect(message.contains("method=POST"))
+        #expect(message.contains("path=/wc/v3/orders"))
+        #expect(message.contains("proxy_status=504"))
+        #expect(message.contains("error_code=no_response_body_code"))
+        #expect(message.contains("error_message=Stringified body"))
+        #expect(message.contains("raw_body_snippet=<html>Fatal error</html>"))
+    }
+
+    @Test func logIfNeeded_when_data_status_is_string_then_prefers_it_over_root_status() throws {
+        // Given
+        let responseData = Data("""
+        {
+          "status": 500,
+          "code": "no_response_body_code",
+          "message": "Server could not read response.",
+          "data": {
+            "status": "503",
+            "raw_body": "<html>Fatal error</html>"
+          }
+        }
+        """.utf8)
+
+        // When
+        let message = try message(forResponseData: responseData)
+
+        // Then
+        #expect(message.contains("proxy_status=503"))
+        #expect(message.contains("error_code=no_response_body_code"))
+    }
+
+    @Test func logIfNeeded_when_raw_body_contains_sensitive_labels_then_redacts_secret_values() throws {
+        // Given
+        let rawBody = """
+        Authorization: Bearer abc123
+        Cookie: wordpress_logged_in=wpLoginValue
+        Set-Cookie: session=sessionValue
+        consumer_key=ckValue
+        consumer_secret=csValue
+        {
+          "consumer_key": "jsonConsumerKey",
+          "consumer_secret": "jsonConsumerSecret",
+          "access_token": "jsonAccessToken",
+          "token": "jsonToken",
+          "application_password": "jsonApplicationPassword",
+          "password": "jsonPassword"
+        }
+        """
 
         // When
         let message = try message(forRawBody: rawBody)
 
         // Then
-        #expect(message.contains("Authorization: Basic [redacted]"))
-        #expect(!message.contains("basic-secret"))
+        #expect(message.contains("[redacted]"))
+        [
+            "abc123",
+            "wpLoginValue",
+            "sessionValue",
+            "ckValue",
+            "csValue",
+            "jsonConsumerKey",
+            "jsonConsumerSecret",
+            "jsonAccessToken",
+            "jsonToken",
+            "jsonApplicationPassword",
+            "jsonPassword"
+        ].forEach { secretValue in
+            #expect(!message.contains(secretValue))
+        }
     }
 
-    @Test func logIfNeeded_when_raw_body_contains_newlines_and_tabs_then_keeps_visible_boundaries_on_one_log_line() throws {
+    @Test func logIfNeeded_when_raw_body_contains_newlines_and_tabs_then_collapses_whitespace() throws {
         // Given
         let rawBody = "<html>\n\tFatal error\nAuthorization: Bearer newline-secret\nCookie: session=cookie-secret\n</html>"
 
@@ -70,97 +143,50 @@ struct JetpackTunnelRawBodyErrorLoggerTests {
         let message = try message(forRawBody: rawBody)
 
         // Then
-        let expectedSnippet = "raw_body_snippet=<html>\\n\\tFatal error\\n Authorization: Bearer [redacted]" +
-            "\\n Cookie: [redacted]\\n</html>"
+        let expectedSnippet = "raw_body_snippet=<html> Fatal error Authorization: Bearer [redacted] Cookie: [redacted] </html>"
         #expect(message.contains(expectedSnippet))
         #expect(!message.contains("\n"))
+        #expect(!message.contains("\\n"))
         #expect(!message.contains("\t"))
         #expect(!message.contains("newline-secret"))
         #expect(!message.contains("cookie-secret"))
     }
 
-    @Test func logIfNeeded_when_flattened_html_glues_authorization_to_previous_text_then_redacts_and_inserts_readable_boundaries() throws {
+    @Test func logIfNeeded_when_sensitive_labels_are_glued_then_does_not_insert_boundaries() throws {
         // Given
         let rawBody = "WOOMOB-3429 forced HTMLForced HTML response for WOOMOB-3429" +
             "Authorization: Bearer fake-review-token" +
-            "Cookie: wordpress_logged_in_test=wpLoginSecret; session=abc"
+            "Cookie: wordpress_logged_in_test=wpLoginValue; session=abc"
 
         // When
         let message = try message(forRawBody: rawBody)
 
         // Then
         let expectedSnippet = "raw_body_snippet=WOOMOB-3429 forced HTMLForced HTML response for WOOMOB-3429" +
-            " Authorization: Bearer [redacted] Cookie: [redacted]"
+            "Authorization: Bearer [redacted] wordpress_logged_in_test=wpLoginValue; session=abc"
         #expect(message.contains(expectedSnippet))
-        #expect(!message.contains("WOOMOB-3429Authorization"))
-        #expect(!message.contains("[redacted]Cookie"))
+        #expect(message.contains("WOOMOB-3429Authorization"))
         #expect(!message.contains("fake-review-token"))
-        #expect(!message.contains("wpLoginSecret"))
-        #expect(!message.contains("session=abc"))
     }
 
-    @Test func logIfNeeded_when_sensitive_labels_are_glued_then_redacts_without_erasing_following_boundaries() throws {
+    @Test func logIfNeeded_when_raw_body_is_missing_or_blank_then_emits_no_message() throws {
         // Given
-        let rawBody = "prefixCookie: wordpress_logged_in_test=wpLoginSecret" +
-            "Authorization: Bearer authSecret" +
-            "Set-Cookie: session=setSecret\n" +
-            "footer9session=standaloneSecret tail9wordpress_logged_in_xyz=loginSecret"
-
-        // When
-        let message = try message(forRawBody: rawBody)
-
-        // Then
-        let expectedSnippet = "raw_body_snippet=prefix Cookie: [redacted] Authorization: Bearer [redacted] " +
-            "Set-Cookie: [redacted]\\nfooter9 session=[redacted] tail9 wordpress_logged_in_xyz=[redacted]"
-        #expect(message.contains(expectedSnippet))
-        #expect(!message.contains("prefixCookie"))
-        #expect(!message.contains("authSecretSet-Cookie"))
-        #expect(!message.contains("wpLoginSecret"))
-        #expect(!message.contains("authSecret"))
-        #expect(!message.contains("setSecret"))
-        #expect(!message.contains("standaloneSecret"))
-        #expect(!message.contains("loginSecret"))
-    }
-
-    @Test func logIfNeeded_when_raw_body_contains_standalone_session_cookie_then_redacts_value() throws {
-        // Given
-        let rawBody = "<html>Fatal error session=abc failed</html>"
-
-        // When
-        let message = try message(forRawBody: rawBody)
-
-        // Then
-        #expect(message.contains("session=[redacted]"))
-        #expect(!message.contains("session=abc"))
-    }
-
-    @Test func logIfNeeded_when_raw_body_contains_standalone_wordpress_logged_in_cookie_then_redacts_value() throws {
-        // Given
-        let rawBody = "<html>Fatal error wordpress_logged_in_123=secret failed</html>"
-
-        // When
-        let message = try message(forRawBody: rawBody)
-
-        // Then
-        #expect(message.contains("wordpress_logged_in_123=[redacted]"))
-        #expect(!message.contains("secret"))
-    }
-
-    @Test func logIfNeeded_when_raw_body_is_missing_then_emits_no_message() throws {
-        // Given
-        let responseData = Data("""
+        let missingRawBodyData = Data("""
         {
           "error": "no_response_body",
           "message": "Server could not read response.",
           "data": { "status": 500 }
         }
         """.utf8)
+        let blankRawBodyData = try responseData(rawBody: " \n\t ")
 
         // When
-        let messages = messages(forResponseData: responseData)
+        let missingRawBodyMessages = messages(forResponseData: missingRawBodyData)
+        let blankRawBodyMessages = messages(forResponseData: blankRawBodyData)
 
         // Then
-        #expect(messages.isEmpty)
+        #expect(missingRawBodyMessages.isEmpty)
+        #expect(blankRawBodyMessages.isEmpty)
     }
 
     @Test func logIfNeeded_when_request_is_not_jetpack_then_emits_no_message() throws {
@@ -223,20 +249,6 @@ struct JetpackTunnelRawBodyErrorLoggerTests {
         let snippet = try #require(message.components(separatedBy: "raw_body_snippet=").last)
         #expect(message.contains("raw_body_truncated=true"))
         #expect(snippet.count == 2048)
-    }
-
-    @Test func logIfNeeded_includes_original_request_methods() throws {
-        // Given
-        let responseData = try #require(Loader.contentsOf("jetpack-tunnel-raw-body-error"))
-        let methods: [HTTPMethod] = [.get, .post, .put, .delete]
-
-        for method in methods {
-            // When
-            let message = try message(forResponseData: responseData, method: method)
-
-            // Then
-            #expect(message.contains("method=\(method.rawValue.uppercased())"))
-        }
     }
 
     private func message(

--- a/Modules/Tests/NetworkingTests/Remote/JetpackTunnelRawBodyErrorLoggerTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/JetpackTunnelRawBodyErrorLoggerTests.swift
@@ -1,0 +1,307 @@
+import Alamofire
+import Foundation
+import Testing
+
+@testable import Networking
+@testable import NetworkingCore
+
+@Suite("JetpackTunnelRawBodyErrorLoggerTests")
+struct JetpackTunnelRawBodyErrorLoggerTests {
+    @Test func logIfNeeded_when_root_raw_body_exists_then_emits_expected_context_and_sanitized_snippet() throws {
+        // Given
+        let fixture = "jetpack-tunnel-raw-body-error"
+
+        // When
+        let message = try message(fromFixture: fixture)
+
+        // Then
+        #expect(message.contains("Jetpack Tunnel raw_body error:"))
+        #expect(message.contains("method=GET"))
+        #expect(message.contains("path=/wc/v3/products"))
+        #expect(message.contains("transport_status=500"))
+        #expect(message.contains("proxy_status=502"))
+        #expect(message.contains("error_code=no_response_body"))
+        #expect(message.contains("error_message=Server could not read response."))
+        #expect(message.contains("raw_body_truncated=false"))
+        #expect(message.contains(
+            "raw_body_snippet=<html>\\n Fatal error consumer_key=[redacted] Authorization: Bearer [redacted] Cookie: [redacted]\\n</html>"
+        ))
+        #expect(!message.contains("\n"))
+        #expect(!message.contains("ck_secret"))
+        #expect(!message.contains("bearer-secret"))
+        #expect(!message.contains("session=abc"))
+    }
+
+    @Test func logIfNeeded_when_body_envelope_has_raw_body_then_uses_nested_error_context() throws {
+        // Given
+        let fixture = "jetpack-tunnel-raw-body-envelope-error"
+
+        // When
+        let message = try message(fromFixture: fixture, method: .post, path: "orders")
+
+        // Then
+        #expect(message.contains("method=POST"))
+        #expect(message.contains("path=/wc/v3/orders"))
+        #expect(message.contains("transport_status=500"))
+        #expect(message.contains("proxy_status=503"))
+        #expect(message.contains("error_code=no_response_body"))
+        #expect(message.contains("error_message=Remote site returned non-JSON response"))
+        #expect(message.contains("application_password=[redacted]"))
+        #expect(!message.contains("app-pass"))
+    }
+
+    @Test func logIfNeeded_when_raw_body_contains_basic_authorization_then_redacts_header_value() throws {
+        // Given
+        let rawBody = "<html>Authorization: Basic basic-secret failed</html>"
+
+        // When
+        let message = try message(forRawBody: rawBody)
+
+        // Then
+        #expect(message.contains("Authorization: Basic [redacted]"))
+        #expect(!message.contains("basic-secret"))
+    }
+
+    @Test func logIfNeeded_when_raw_body_contains_newlines_and_tabs_then_keeps_visible_boundaries_on_one_log_line() throws {
+        // Given
+        let rawBody = "<html>\n\tFatal error\nAuthorization: Bearer newline-secret\nCookie: session=cookie-secret\n</html>"
+
+        // When
+        let message = try message(forRawBody: rawBody)
+
+        // Then
+        let expectedSnippet = "raw_body_snippet=<html>\\n\\tFatal error\\n Authorization: Bearer [redacted]" +
+            "\\n Cookie: [redacted]\\n</html>"
+        #expect(message.contains(expectedSnippet))
+        #expect(!message.contains("\n"))
+        #expect(!message.contains("\t"))
+        #expect(!message.contains("newline-secret"))
+        #expect(!message.contains("cookie-secret"))
+    }
+
+    @Test func logIfNeeded_when_flattened_html_glues_authorization_to_previous_text_then_redacts_and_inserts_readable_boundaries() throws {
+        // Given
+        let rawBody = "WOOMOB-3429 forced HTMLForced HTML response for WOOMOB-3429" +
+            "Authorization: Bearer fake-review-token" +
+            "Cookie: wordpress_logged_in_test=wpLoginSecret; session=abc"
+
+        // When
+        let message = try message(forRawBody: rawBody)
+
+        // Then
+        let expectedSnippet = "raw_body_snippet=WOOMOB-3429 forced HTMLForced HTML response for WOOMOB-3429" +
+            " Authorization: Bearer [redacted] Cookie: [redacted]"
+        #expect(message.contains(expectedSnippet))
+        #expect(!message.contains("WOOMOB-3429Authorization"))
+        #expect(!message.contains("[redacted]Cookie"))
+        #expect(!message.contains("fake-review-token"))
+        #expect(!message.contains("wpLoginSecret"))
+        #expect(!message.contains("session=abc"))
+    }
+
+    @Test func logIfNeeded_when_sensitive_labels_are_glued_then_redacts_without_erasing_following_boundaries() throws {
+        // Given
+        let rawBody = "prefixCookie: wordpress_logged_in_test=wpLoginSecret" +
+            "Authorization: Bearer authSecret" +
+            "Set-Cookie: session=setSecret\n" +
+            "footer9session=standaloneSecret tail9wordpress_logged_in_xyz=loginSecret"
+
+        // When
+        let message = try message(forRawBody: rawBody)
+
+        // Then
+        let expectedSnippet = "raw_body_snippet=prefix Cookie: [redacted] Authorization: Bearer [redacted] " +
+            "Set-Cookie: [redacted]\\nfooter9 session=[redacted] tail9 wordpress_logged_in_xyz=[redacted]"
+        #expect(message.contains(expectedSnippet))
+        #expect(!message.contains("prefixCookie"))
+        #expect(!message.contains("authSecretSet-Cookie"))
+        #expect(!message.contains("wpLoginSecret"))
+        #expect(!message.contains("authSecret"))
+        #expect(!message.contains("setSecret"))
+        #expect(!message.contains("standaloneSecret"))
+        #expect(!message.contains("loginSecret"))
+    }
+
+    @Test func logIfNeeded_when_raw_body_contains_standalone_session_cookie_then_redacts_value() throws {
+        // Given
+        let rawBody = "<html>Fatal error session=abc failed</html>"
+
+        // When
+        let message = try message(forRawBody: rawBody)
+
+        // Then
+        #expect(message.contains("session=[redacted]"))
+        #expect(!message.contains("session=abc"))
+    }
+
+    @Test func logIfNeeded_when_raw_body_contains_standalone_wordpress_logged_in_cookie_then_redacts_value() throws {
+        // Given
+        let rawBody = "<html>Fatal error wordpress_logged_in_123=secret failed</html>"
+
+        // When
+        let message = try message(forRawBody: rawBody)
+
+        // Then
+        #expect(message.contains("wordpress_logged_in_123=[redacted]"))
+        #expect(!message.contains("secret"))
+    }
+
+    @Test func logIfNeeded_when_raw_body_is_missing_then_emits_no_message() throws {
+        // Given
+        let responseData = Data("""
+        {
+          "error": "no_response_body",
+          "message": "Server could not read response.",
+          "data": { "status": 500 }
+        }
+        """.utf8)
+
+        // When
+        let messages = messages(forResponseData: responseData)
+
+        // Then
+        #expect(messages.isEmpty)
+    }
+
+    @Test func logIfNeeded_when_request_is_not_jetpack_then_emits_no_message() throws {
+        // Given
+        let responseData = try #require(Loader.contentsOf("jetpack-tunnel-raw-body-error"))
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: "products")
+
+        // When
+        let messages = messages(forResponseData: responseData, request: request)
+
+        // Then
+        #expect(messages.isEmpty)
+    }
+
+    @Test func logIfNeeded_when_context_contains_secret_query_values_then_redacts_context() throws {
+        // Given
+        let path = "orders?consumer_secret=cs_secret&access_token=access-secret"
+
+        // When
+        let message = try message(fromFixture: "jetpack-tunnel-raw-body-error", path: path)
+
+        // Then
+        #expect(message.contains("path=/wc/v3/orders?consumer_secret=[redacted]&access_token=[redacted]"))
+        #expect(!message.contains("cs_secret"))
+        #expect(!message.contains("access-secret"))
+    }
+
+    @Test func logIfNeeded_when_relative_path_starts_with_slash_then_removes_duplicate_separator() throws {
+        // Given
+        let path = "/products"
+
+        // When
+        let message = try message(fromFixture: "jetpack-tunnel-raw-body-error", path: path)
+
+        // Then
+        #expect(message.contains("path=/wc/v3/products"))
+    }
+
+    @Test func logIfNeeded_when_context_contains_full_url_then_logs_path_without_host() throws {
+        // Given
+        let path = "https://example.com/wp-json/wc/v3/orders?consumer_key=ck_secret"
+
+        // When
+        let message = try message(fromFixture: "jetpack-tunnel-raw-body-error", path: path)
+
+        // Then
+        #expect(message.contains("path=/wp-json/wc/v3/orders?consumer_key=[redacted]"))
+        #expect(!message.contains("example.com"))
+        #expect(!message.contains("ck_secret"))
+    }
+
+    @Test func logIfNeeded_when_sanitized_raw_body_exceeds_limit_then_truncates_and_marks_true() throws {
+        // Given
+        let longRawBody = String(repeating: "a", count: 2055)
+
+        // When
+        let message = try message(forRawBody: longRawBody, method: .delete, path: "products/1")
+
+        // Then
+        let snippet = try #require(message.components(separatedBy: "raw_body_snippet=").last)
+        #expect(message.contains("raw_body_truncated=true"))
+        #expect(snippet.count == 2048)
+    }
+
+    @Test func logIfNeeded_includes_original_request_methods() throws {
+        // Given
+        let responseData = try #require(Loader.contentsOf("jetpack-tunnel-raw-body-error"))
+        let methods: [HTTPMethod] = [.get, .post, .put, .delete]
+
+        for method in methods {
+            // When
+            let message = try message(forResponseData: responseData, method: method)
+
+            // Then
+            #expect(message.contains("method=\(method.rawValue.uppercased())"))
+        }
+    }
+
+    private func message(
+        forRawBody rawBody: String,
+        method: HTTPMethod = .get,
+        path: String = "products",
+        transportStatus: Int = 500
+    ) throws -> String {
+        let responseData = try responseData(rawBody: rawBody)
+        return try message(forResponseData: responseData, method: method, path: path, transportStatus: transportStatus)
+    }
+
+    private func message(
+        fromFixture fixture: String,
+        method: HTTPMethod = .get,
+        path: String = "products",
+        transportStatus: Int = 500
+    ) throws -> String {
+        let responseData = try #require(Loader.contentsOf(fixture))
+        return try message(forResponseData: responseData, method: method, path: path, transportStatus: transportStatus)
+    }
+
+    private func message(
+        forResponseData responseData: Data,
+        method: HTTPMethod = .get,
+        path: String = "products",
+        transportStatus: Int = 500
+    ) throws -> String {
+        let messages = messages(forResponseData: responseData, method: method, path: path, transportStatus: transportStatus)
+        #expect(messages.count == 1)
+        return try #require(messages.first)
+    }
+
+    private func messages(
+        forResponseData responseData: Data,
+        method: HTTPMethod = .get,
+        path: String = "products",
+        transportStatus: Int = 500
+    ) -> [String] {
+        let request = JetpackRequest(wooApiVersion: .mark3, method: method, siteID: 123, path: path, parameters: [:])
+        return messages(forResponseData: responseData, request: request, transportStatus: transportStatus)
+    }
+
+    private func messages(
+        forResponseData responseData: Data,
+        request: NetworkingCore.Request,
+        transportStatus: Int = 500
+    ) -> [String] {
+        var messages: [String] = []
+        let logger = JetpackTunnelRawBodyErrorLogger(warningSink: { messages.append($0) })
+
+        logger.logIfNeeded(responseData: responseData, request: request, transportStatus: transportStatus)
+
+        return messages
+    }
+
+    private func responseData(rawBody: String) throws -> Data {
+        let payload: [String: Any] = [
+            "error": "no_response_body",
+            "message": "Server could not read response.",
+            "data": [
+                "status": 500,
+                "raw_body": rawBody
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: payload)
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
@@ -1310,19 +1310,11 @@ final class RemoteTests: XCTestCase {
 private extension RemoteTests {
     func assertRawBodyDotcomError(_ error: Error?, file: StaticString = #file, line: UInt = #line) {
         guard let error,
-              case let DotcomError.unknown(code, message, data) = error else {
+              case let DotcomError.unknown(code, _, _) = error else {
             return XCTFail("Expected DotcomError.unknown", file: file, line: line)
         }
 
         XCTAssertEqual(code, "no_response_body", file: file, line: line)
-        XCTAssertEqual(message, "Server could not read response.", file: file, line: line)
-        XCTAssertEqual(data?["status"]?.value as? Int, 502, file: file, line: line)
-        XCTAssertEqual(
-            data?["raw_body"]?.value as? String,
-            "<html>\n  Fatal error consumer_key=ck_secret Authorization: Bearer bearer-secret Cookie: session=abc\n</html>",
-            file: file,
-            line: line
-        )
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
@@ -757,6 +757,116 @@ final class RemoteTests: XCTestCase {
 
     // MARK: Mapping `NetworkError`
 
+    func test_enqueue_async_when_jetpack_network_error_response_contains_raw_body_then_logs_and_preserves_mapped_error() async throws {
+        // Given
+        let network = MockNetwork()
+        let remote = Remote(network: network)
+        let logger = SpyJetpackTunnelRawBodyErrorLogger()
+        remote.jetpackTunnelRawBodyErrorLogger = logger
+        let responseData = try XCTUnwrap(Loader.contentsOf("jetpack-tunnel-raw-body-error"))
+        network.simulateError(
+            requestUrlSuffix: "something",
+            error: NetworkError.unacceptableStatusCode(statusCode: 500, response: responseData)
+        )
+
+        // When
+        do {
+            try await remote.enqueue(request)
+            XCTFail("Expected the request to throw")
+        } catch {
+            // Then
+            assertRawBodyDotcomError(error)
+        }
+
+        let call = try XCTUnwrap(logger.calls.first)
+        XCTAssertEqual(logger.calls.count, 1)
+        XCTAssertEqual(call.responseData, responseData)
+        XCTAssertEqual(call.requestMethod, "POST")
+        XCTAssertEqual(call.requestPath, "something")
+        XCTAssertEqual(call.transportStatus, 500)
+    }
+
+    func test_enqueue_with_mapper_when_jetpack_validation_error_contains_raw_body_then_logs_and_preserves_completion_error() throws {
+        // Given
+        let network = MockNetwork()
+        let mapper = DummyMapper()
+        let remote = Remote(network: network)
+        let logger = SpyJetpackTunnelRawBodyErrorLogger()
+        remote.jetpackTunnelRawBodyErrorLogger = logger
+        let responseData = try XCTUnwrap(Loader.contentsOf("jetpack-tunnel-raw-body-error"))
+        network.simulateResponse(requestUrlSuffix: "something", filename: "jetpack-tunnel-raw-body-error")
+
+        // When
+        let result: (Any?, Error?) = waitFor { promise in
+            remote.enqueue(self.request, mapper: mapper) { output, error in
+                promise((output, error))
+            }
+        }
+
+        // Then
+        XCTAssertNil(result.0)
+        assertRawBodyDotcomError(result.1)
+
+        let call = try XCTUnwrap(logger.calls.first)
+        XCTAssertEqual(logger.calls.count, 1)
+        XCTAssertEqual(call.responseData, responseData)
+        XCTAssertEqual(call.requestMethod, "POST")
+        XCTAssertEqual(call.requestPath, "something")
+        XCTAssertNil(call.transportStatus)
+    }
+
+    func test_enqueue_async_when_jetpack_network_error_response_contains_envelope_raw_body_then_logs_and_preserves_network_error() async throws {
+        // Given
+        let network = MockNetwork()
+        let remote = Remote(network: network)
+        let logger = SpyJetpackTunnelRawBodyErrorLogger()
+        remote.jetpackTunnelRawBodyErrorLogger = logger
+        let responseData = try XCTUnwrap(Loader.contentsOf("jetpack-tunnel-raw-body-envelope-error"))
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500, response: responseData)
+        network.simulateError(requestUrlSuffix: "something", error: expectedError)
+
+        // When
+        do {
+            try await remote.enqueue(request)
+            XCTFail("Expected the request to throw")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+
+        let call = try XCTUnwrap(logger.calls.first)
+        XCTAssertEqual(logger.calls.count, 1)
+        XCTAssertEqual(call.responseData, responseData)
+        XCTAssertEqual(call.requestMethod, "POST")
+        XCTAssertEqual(call.requestPath, "something")
+        XCTAssertEqual(call.transportStatus, 500)
+    }
+
+    func test_enqueue_async_when_non_jetpack_network_error_response_contains_raw_body_then_does_not_log() async throws {
+        // Given
+        let network = MockNetwork()
+        let remote = Remote(network: network)
+        let logger = SpyJetpackTunnelRawBodyErrorLogger()
+        remote.jetpackTunnelRawBodyErrorLogger = logger
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: "something")
+        let responseData = try XCTUnwrap(Loader.contentsOf("jetpack-tunnel-raw-body-error"))
+        network.simulateError(
+            requestUrlSuffix: "something",
+            error: NetworkError.unacceptableStatusCode(statusCode: 500, response: responseData)
+        )
+
+        // When
+        do {
+            try await remote.enqueue(request)
+            XCTFail("Expected the request to throw")
+        } catch {
+            // Then
+            assertRawBodyDotcomError(error)
+        }
+
+        XCTAssertTrue(logger.calls.isEmpty)
+    }
+
     /// Verifies that `enqueue:mapper:` (with `Result`) maps an error from `responseData` when error has proper response data
     ///
     func test_enqueue_request_with_result_throws_DotcomError_from_NetworkError_with_response_data() throws {
@@ -1194,6 +1304,46 @@ final class RemoteTests: XCTestCase {
         for (key, value) in expectedHeaders {
             XCTAssertEqual(headers[key], value, "Header \(key) should match expected value")
         }
+    }
+}
+
+private extension RemoteTests {
+    func assertRawBodyDotcomError(_ error: Error?, file: StaticString = #file, line: UInt = #line) {
+        guard let error,
+              case let DotcomError.unknown(code, message, data) = error else {
+            return XCTFail("Expected DotcomError.unknown", file: file, line: line)
+        }
+
+        XCTAssertEqual(code, "no_response_body", file: file, line: line)
+        XCTAssertEqual(message, "Server could not read response.", file: file, line: line)
+        XCTAssertEqual(data?["status"]?.value as? Int, 502, file: file, line: line)
+        XCTAssertEqual(
+            data?["raw_body"]?.value as? String,
+            "<html>\n  Fatal error consumer_key=ck_secret Authorization: Bearer bearer-secret Cookie: session=abc\n</html>",
+            file: file,
+            line: line
+        )
+    }
+}
+
+private final class SpyJetpackTunnelRawBodyErrorLogger: JetpackTunnelRawBodyErrorLogging {
+    struct Call {
+        let responseData: Data?
+        let requestMethod: String?
+        let requestPath: String?
+        let transportStatus: Int?
+    }
+
+    private(set) var calls: [Call] = []
+
+    func logIfNeeded(responseData: Data?, request: Request, transportStatus: Int?) {
+        let jetpackRequest = request as? JetpackRequest
+        calls.append(Call(
+            responseData: responseData,
+            requestMethod: jetpackRequest?.method.rawValue.uppercased(),
+            requestPath: jetpackRequest?.path,
+            transportStatus: transportStatus
+        ))
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Validators/DotcomValidatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Validators/DotcomValidatorTests.swift
@@ -86,4 +86,24 @@ class DotcomValidatorTests: XCTestCase {
             XCTAssertEqual(dotcomError, .statsModuleDisabled())
         }
     }
+
+    func test_raw_body_error_preserves_data_raw_body() throws {
+        // Given
+        let payloadAsData = try XCTUnwrap(Loader.contentsOf("jetpack-tunnel-raw-body-error", extension: "json"))
+
+        // Then
+        XCTAssertThrowsError(try DotcomValidator().validate(data: payloadAsData)) { error in
+            guard case let DotcomError.unknown(code, message, data) = error else {
+                return XCTFail("Expected DotcomError.unknown")
+            }
+
+            XCTAssertEqual(code, "no_response_body")
+            XCTAssertEqual(message, "Server could not read response.")
+            XCTAssertEqual(data?["status"]?.value as? Int, 502)
+            XCTAssertEqual(
+                data?["raw_body"]?.value as? String,
+                "<html>\n  Fatal error consumer_key=ck_secret Authorization: Bearer bearer-secret Cookie: session=abc\n</html>"
+            )
+        }
+    }
 }

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-tunnel-raw-body-envelope-error.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-tunnel-raw-body-envelope-error.json
@@ -1,0 +1,11 @@
+{
+  "status": 500,
+  "body": {
+    "error": "no_response_body",
+    "message": "Remote site returned non-JSON response",
+    "data": {
+      "status": 503,
+      "raw_body": "<html>upstream application_password=app-pass failed</html>"
+    }
+  }
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-tunnel-raw-body-error.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-tunnel-raw-body-error.json
@@ -1,0 +1,8 @@
+{
+  "error": "no_response_body",
+  "message": "Server could not read response.",
+  "data": {
+    "status": 502,
+    "raw_body": "<html>\n  Fatal error consumer_key=ck_secret Authorization: Bearer bearer-secret Cookie: session=abc\n</html>"
+  }
+}


### PR DESCRIPTION
## Description
Fixes WOOMOB-3429

Jetpack Tunnel can return a WordPress.com proxy error whose payload includes `data.raw_body`: the raw upstream response from the merchant's site. That raw body is often the most useful clue when support is diagnosing a broken Jetpack-tunneled WooCommerce API request, but iOS was not surfacing it in app logs. Android added the same diagnostic in woocommerce/woocommerce-android#16182.

This PR adds an internal NetworkingCore logger for Jetpack-tunneled responses that include `raw_body`. When present, it writes one warning-level support log with:

- original tunneled method and Woo path
- WordPress.com transport status and proxied site status
- proxy error code/message
- whether the snippet was truncated
- a sanitized `raw_body` snippet capped at 2048 characters

Safety/behavior notes:

- Logs only for `JetpackRequest`; REST/non-Jetpack requests are ignored.
- Supports both known payload shapes: root `data.raw_body` and envelope `body.data.raw_body`.
- Redacts auth, cookie, token, password, application password, consumer key/secret, `session`, and `wordpress_logged_in*` values before truncation.
- Does not log request headers, request body, request parameters, or change the mapped/thrown error.

## Test Steps

The most truthful manual reproduction is to make a real Jetpack-connected WooCommerce test site return HTML from `/wp-json/wc/v3/products`, then open Products in the iOS app through the Jetpack tunnel. WordPress.com should wrap the upstream HTML in `data.raw_body`; this PR should then emit the sanitized support-log entry.

Important: use a disposable/staging site and remove the plugin after testing. It intentionally breaks the product-list REST endpoint while active.

### Recommended: real Jetpack-connected site

1. On a Jetpack-connected WooCommerce test site, install this tiny test-only plugin.

[woomob-3429-products-html.zip](https://github.com/user-attachments/files/29816318/woomob-3429-products-html.zip)

2. Sanity-check the site-side failure in a browser or terminal:

   ```bash
   curl -i 'https://YOUR_TEST_SITE/wp-json/wc/v3/products'
   ```

   Expected: HTTP 500, `Content-Type: text/html`, `X-WOOMOB-3429-Repro: products-html`, and the forced HTML body.

3. Build and run the app on this branch.

   ```bash
   xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
     -destination 'platform=iOS Simulator,name=iPhone 16' \
     -sdk iphonesimulator build
   ```

4. Log into the same Jetpack-connected test site in the app using a WP.com/Jetpack login path, then open the Products tab to trigger `GET /wc/v3/products` through the Jetpack tunnel.

   Caveat: this PR intentionally logs only Jetpack-tunneled errors. If the app has switched that site to direct REST/application-password mode, this manual path will not exercise the new logger. Use a Jetpack-connected site where application-password switching is not enabled/available, or use the WireMock fallback below.

5. Check the Xcode console, Console.app, or the app's Activity Log under Settings -> Help & Support for one warning that starts with:

   ```text
   Jetpack Tunnel raw_body error:
   ```

   Expected log details:

   - `method=GET`
   - `path=/wc/v3/products`
   - `raw_body_truncated=false`
   - `raw_body_snippet` contains the forced HTML response
   - fake values such as `fake-review-token`, `fake-login-cookie`, `fake-session`, `fake-consumer-secret`, and `fake-app-password` do not appear; their values should be `[redacted]`

   To search simulator file logs directly after opening Products:

   ```bash
   CONTAINER=$(xcrun simctl get_app_container booted com.automattic.woocommerce data)
   find "$CONTAINER" -type f -name "*.log" -print0 | xargs -0 grep -h "Jetpack Tunnel raw_body error"
   ```

6. Remove the plugin from the test site.

### Fallback: local WireMock reproduction

Use this when you do not have a disposable Jetpack-connected test site. It is less end-to-end than the plugin flow, but it still exercises the iOS app against a mocked WordPress.com Jetpack Tunnel response with `data.raw_body`.

1. Start the mock server:

   ```bash
   ./API-Mocks/scripts/start.sh 8282 &
   ```

2. Install a temporary high-priority mapping:

   ```bash
   curl -s -X POST 'http://localhost:8282/__admin/mappings' \
     -H 'Content-Type: application/json' \
     --data-binary @- <<'JSON'
   {
     "priority": 1,
     "request": {
       "method": "GET",
       "urlPathPattern": "/rest/v1.1/jetpack-blogs/[0-9]+/rest-api/",
       "queryParameters": {
         "path": { "contains": "/wc/v3/products" }
       }
     },
     "response": {
       "status": 200,
       "jsonBody": {
         "error": "woocommerce_rest_cannot_view",
         "message": "Sorry, you cannot list resources.",
         "data": {
           "status": 500,
           "raw_body": "<html><body>Upstream site failed. Authorization: Bearer fake-review-token; Cookie: wordpress_logged_in_test=fake-login-cookie; session=fake-session; consumer_secret=fake-consumer-secret; application_password=fake-app-password</body></html>"
         }
       },
       "headers": { "Content-Type": "application/json" }
     }
   }
   JSON
   ```

3. Launch the app with the mock API and log in with the standard UI-test credentials:

   ```bash
   xcrun simctl launch booted com.automattic.woocommerce mocked-wpcom-api logout-at-launch disable-animations
   ```

   In the app: store `yourwoosite.com`, email `t@wp.com`, password `pw`, 2FA `123456`, then open Products and check for the same `Jetpack Tunnel raw_body error:` log.

4. Stop the mock server when done:

   ```bash
   ./API-Mocks/scripts/stop.sh 8282
   ```

### Automated checks run

```bash
xcodebuild -workspace WooCommerce.xcworkspace -scheme Networking \
  -destination 'platform=iOS Simulator,id=D7699BF8-2C81-4882-8F13-E090DA2CF87C' \
  -sdk iphonesimulator test \
  -only-testing:"NetworkingTests/JetpackTunnelRawBodyErrorLoggerTests" \
  -only-testing:"NetworkingTests/DotcomValidatorTests/test_raw_body_error_preserves_data_raw_body" \
  -only-testing:"NetworkingTests/RemoteTests/test_enqueue_async_when_jetpack_network_error_response_contains_raw_body_then_logs_and_preserves_mapped_error" \
  -only-testing:"NetworkingTests/RemoteTests/test_enqueue_with_mapper_when_jetpack_validation_error_contains_raw_body_then_logs_and_preserves_completion_error" \
  -only-testing:"NetworkingTests/RemoteTests/test_enqueue_async_when_jetpack_network_error_response_contains_envelope_raw_body_then_logs_and_preserves_network_error" \
  -only-testing:"NetworkingTests/RemoteTests/test_enqueue_async_when_non_jetpack_network_error_response_contains_raw_body_then_does_not_log"
```

Result: 5 selected XCTest tests passed, plus 12 `JetpackTunnelRawBodyErrorLoggerTests` Swift Testing tests passed.

```bash
pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && \
  swift package plugin --allow-writing-to-directory .. \
  --allow-writing-to-package-directory swiftlint --working-directory .. --quiet && popd
```

Result: passed with no reported violations.

```bash
git diff --check origin/trunk...HEAD
```

Result: passed.

## Screenshots
N/A — support-log-only change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.