### PR TITLE
Drop -sdk iphonesimulator from documented build commands

### DIFF
--- a/.claude/agents/debugger/debugger.md
+++ b/.claude/agents/debugger/debugger.md
@@ -55,7 +55,7 @@ bundle exec fastlane build_for_testing 2>&1 | grep "error:" | head -20
 
 # Run a single failing test (targeted tests require xcodebuild directly)
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   test -only-testing:"<Target>/<Class>/<method>" 2>&1 | tail -40
 
 # Check for stale generated code

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -32,7 +32,7 @@ bundle exec fastlane build_for_testing 2>&1 \
 ```bash
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
   -destination 'platform=iOS Simulator,name=iPhone 16' \
-  -sdk iphonesimulator test \
+  test \
   -only-testing:"<target>/<class>/<method>" 2>&1 | tail -50
 ```
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -50,7 +50,7 @@ Use the `/simulator` skill approach to discover a booted simulator UDID.
 
 ```bash
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination "platform=iOS Simulator,id=<UDID>" -sdk iphonesimulator \
+  -destination "platform=iOS Simulator,id=<UDID>" \
   build 2>&1 | tail -30
 ```
 

--- a/.claude/skills/woo-ai-smoke/SKILL.md
+++ b/.claude/skills/woo-ai-smoke/SKILL.md
@@ -308,7 +308,6 @@ struct SmokeRun {
 xcodebuild -workspace WooCommerce.xcworkspace \
   -scheme WooAIAssistant \
   -destination 'platform=iOS Simulator,name=iPhone 17' \
-  -sdk iphonesimulator \
   test -only-testing:"WooAIAssistantTests/SmokeRun" 2>&1 \
   | tee /tmp/woo-ai-smoke.log \
   | grep -E "\[smoke\||passed after|failed after|Test run with|error:"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,32 +66,32 @@ ContextA8C is an Automattic MCP server that gives AI tools access to Slack, P2s,
 ```bash
 # Build
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator build
+  -destination 'platform=iOS Simulator,name=iPhone 16' build
 
 # Run all unit tests
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator build test
+  -destination 'platform=iOS Simulator,name=iPhone 16' build test
 
 # Run single test class
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   test -only-testing:"WooCommerceTests/SomeTestClass"
 
 # Run single test method
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   test -only-testing:"WooCommerceTests/SomeTestClass/test_method_name"
 
 # Run module tests - use the module's own scheme for faster builds
 # When changes only affect a specific module (e.g. Yosemite, PointOfSale),
 # use that module's scheme instead of WooCommerce. Available schemes: Yosemite, PointOfSale, etc.
 xcodebuild -workspace WooCommerce.xcworkspace -scheme Yosemite \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   test -only-testing:"YosemiteTests/SomeTestClass"
 
 # Only use the WooCommerce scheme when changes span the main app target
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   test -only-testing:"WooCommerceTests"
 
 # Lint (SwiftLint via BuildTools plugin)
@@ -111,6 +111,8 @@ pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && \
 ```
 
 If the simulator `iPhone 16` is not available, discover what's installed: `xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5`
+
+Do not add `-sdk iphonesimulator` to these commands. It overrides the SDK for *every* target in the `WooCommerce` scheme — including the watchOS `WatchWidgetsExtension` — which then compiles the wrong `#if os(watchOS)` branch of `StoreWidgets/StoreWidgetTheme.swift` and fails with `reference to member 'accent' cannot be resolved`. `-destination` already selects the platform per target, so it is sufficient on its own.
 
 ## Architecture
 
@@ -181,17 +183,17 @@ When working on POS, you can build and test the module in isolation for faster f
 ```bash
 # Build PointOfSale module only
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   build-for-testing -only-testing:"PointOfSaleTests"
 
 # Run POS tests only
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   test -only-testing:"PointOfSaleTests"
 
 # Run a specific POS test class
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
-  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
   test -only-testing:"PointOfSaleTests/SomeTestClass"
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && \
 
 If the simulator `iPhone 16` is not available, discover what's installed: `xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5`
 
-Do not add `-sdk iphonesimulator` to these commands. It overrides the SDK for *every* target in the `WooCommerce` scheme — including the watchOS `WatchWidgetsExtension` — which then compiles the wrong `#if os(watchOS)` branch of `StoreWidgets/StoreWidgetTheme.swift` and fails with `reference to member 'accent' cannot be resolved`. `-destination` already selects the platform per target, so it is sufficient on its own.
+Do not add `-sdk iphonesimulator` to these commands. It overrides the SDK for *every* target in the `WooCommerce` scheme — including the watchOS `WatchWidgetsExtension` — which then compiles the wrong `#if os(watchOS)` branch of `WooCommerce/StoreWidgets/StoreWidgetTheme.swift` and fails with `reference to member 'accent' cannot be resolved`. `-destination` already selects the platform per target, so it is sufficient on its own.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,11 @@ pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && \
 
 If the simulator `iPhone 16` is not available, discover what's installed: `xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5`
 
-Do not add `-sdk iphonesimulator` to these commands. It overrides the SDK for *every* target in the `WooCommerce` scheme — including the watchOS `WatchWidgetsExtension` — which then compiles the wrong `#if os(watchOS)` branch of `WooCommerce/StoreWidgets/StoreWidgetTheme.swift` and fails with `reference to member 'accent' cannot be resolved`. `-destination` already selects the platform per target, so it is sufficient on its own.
+Do not add `-sdk iphonesimulator` to these commands.
+It overrides the SDK for *every* target in the `WooCommerce` scheme — including the watchOS `WatchWidgetsExtension` —
+which then compiles the wrong `#if os(watchOS)` branch of `WooCommerce/StoreWidgets/StoreWidgetTheme.swift`
+and fails with `reference to member 'accent' cannot be resolved`.
+`-destination` already selects the platform per target, so it is sufficient on its own.
 
 ## Architecture
 


### PR DESCRIPTION
## Why
AI coding agents (Codex, Claude Code) follow the `xcodebuild` commands documented in `AGENTS.md` and the agent skills verbatim. Those commands include `-sdk iphonesimulator`, which reliably breaks the build of the `WooCommerce` scheme — so agents hit a failure on the very first build step, before doing any real work. This is **not machine-specific**: it reproduces consistently in my Codex sessions, and a [Codex-posted comment by Josh on issue #3313](https://github.com/woocommerce/woocommerce-ios/issues/3313#issuecomment-4691084437) confirms the same failure beyond my machine. On my machine it had only been worked around via a local agent-memory note in Claude Code, which doesn't help the rest of the team. Fixing it at the source unblocks every agent (and anyone copying the docs).

## Description
The documented `xcodebuild` commands pass `-sdk iphonesimulator`. That flag overrides the SDK for **every** target in the `WooCommerce` scheme — including the watchOS `WatchWidgetsExtension` — forcing it onto the iOS SDK. The extension then compiles the wrong (`#else`, non-watchOS) branch of `WooCommerce/StoreWidgets/StoreWidgetTheme.swift`, which references `Color(.accent)`, and the build fails with:

```
reference to member 'accent' cannot be resolved
```

`-destination` already selects the platform per target, so `-sdk` is redundant and actively harmful here. This PR removes the flag from every documented command and adds a short note explaining why not to re-add it. Files updated:

- `AGENTS.md` — build/test commands + rationale note
- `.claude/skills/verify/SKILL.md`
- `.claude/skills/debug/SKILL.md`
- `.claude/skills/woo-ai-smoke/SKILL.md`
- `.claude/agents/debugger/debugger.md`

## Test Steps
1. From a clean checkout on this branch, run the documented build command:
   ```bash
   xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
     -destination 'platform=iOS Simulator,name=iPhone 16' build
   ```
2. Confirm the build succeeds and does **not** fail in `WatchWidgetsExtension` with `reference to member 'accent' cannot be resolved`.
3. (Optional) Re-add `-sdk iphonesimulator` and confirm the failure returns, demonstrating the flag is the cause.

## Screenshots
N/A — documentation/tooling change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not needed — internal docs/tooling only, no user-facing change.)