### PR TITLE
Upgrade fastlane-plugin-sentry to 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'danger-dangermattic', '~> 1.4'
 gem 'dotenv'
 gem 'fastlane', '~> 2.237'
 gem 'fastlane-plugin-firebase_app_distribution', '~> 1.0'
-gem 'fastlane-plugin-sentry', '~> 1.0'
+gem 'fastlane-plugin-sentry', '~> 2.5'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: ''
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.10'
 # To avoid errors like:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
       fastlane (>= 2.232.0)
       google-apis-firebaseappdistribution_v1 (>= 0.9.0)
       google-apis-firebaseappdistribution_v1alpha (>= 0.12.0)
-    fastlane-plugin-sentry (1.36.0)
+    fastlane-plugin-sentry (2.6.0)
       os (~> 1.1, >= 1.1.4)
     fastlane-plugin-wpmreleasetoolkit (14.10.0)
       buildkit (~> 1.5)
@@ -383,7 +383,7 @@ DEPENDENCIES
   dotenv
   fastlane (~> 2.237)
   fastlane-plugin-firebase_app_distribution (~> 1.0)
-  fastlane-plugin-sentry (~> 1.0)
+  fastlane-plugin-sentry (~> 2.5)
   fastlane-plugin-wpmreleasetoolkit (~> 14.10)
   openssl (~> 4.0)
   rake (~> 13.4)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -894,11 +894,11 @@ platform :ios do
 
     build_for_app_store_connect
 
-    sentry_upload_dsym(
+    sentry_debug_files_upload(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: 'a8c',
       project_slug: 'woocommerce-ios',
-      dsym_path: File.join(PROJECT_ROOT_FOLDER, 'WooCommerce.app.dSYM.zip')
+      path: [File.join(PROJECT_ROOT_FOLDER, 'WooCommerce.app.dSYM.zip')]
     )
     sh('cd .. && rm WooCommerce.app.dSYM.zip')
 
@@ -974,11 +974,11 @@ platform :ios do
       groups: FIREBASE_TESTERS_GROUP
     )
 
-    sentry_upload_dsym(
+    sentry_debug_files_upload(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: 'a8c',
       project_slug: 'woocommerce-ios',
-      dsym_path: './build/WooCommerce.app.dSYM.zip'
+      path: ['./build/WooCommerce.app.dSYM.zip']
     )
 
     next if pull_request_number.nil?


### PR DESCRIPTION
Closes: [AINFRA-2593](https://linear.app/a8c/issue/AINFRA-2593).

Run [a throwaway build](https://buildkite.com/automattic/woocommerce-ios/builds/39318/canvas?jid=019f4654-2e10-496a-a0df-2dd98823eaee&tab=output) to verify the upload, given it's skipped in this PR.

<img width="2164" height="1404" alt="image" src="https://github.com/user-attachments/assets/14fa6599-85b2-4874-8e01-bd7052c9e597" />

<details>
<summary>AI</summary>

## Description

`fastlane-plugin-sentry` v2 removed the `sentry_upload_dsym` action, which is why the Dependabot bump in #17388 could not merge on its own. This bumps the plugin to 2.6.0 and migrates both call sites to the replacement action, `sentry_debug_files_upload`, whose `path:` parameter takes an Array in place of the old single-String `dsym_path:`.

The plugin locates and version-checks its own bundled `sentry-cli`, so nothing changes on the CI images.

## Gotcha for the reviewer

**The green Prototype Build tick on this PR is a no-op.** `should-skip-job.sh` lists `fastlane/**`, `Gemfile`, and `Gemfile.lock` in `COMMON_PATTERNS`, so a PR touching only those files skips every build job. Prototype Build here prints `Skipping :firebase: Prototype Build - no relevant files changed` and passes without running `build_and_upload_prototype_build` — the one lane that calls the migrated action. Any fastlane-only PR has this blind spot; it is not specific to this one.

## Test Steps

To defeat the skip rule, #17507 stacks a throwaway commit touching one app source file, so Prototype Build runs for real on an agent holding `SENTRY_AUTH_TOKEN`. [Build 39318](https://buildkite.com/automattic/woocommerce-ios/builds/39318) confirms the authenticated upload:

```
--- Step: sentry_debug_files_upload ---
Using sentry-cli 3.6.0
> Found 22 debug information files
> Prepared debug information files for upload
> Uploaded 8 missing debug information files
Successfully ran debug-files upload
```

#17507 is never merged; delete it once this lands.

Additionally, on this PR: Ruby Automation Tests passed, confirming the new lockfile resolves and installs, and `ruby -c fastlane/Fastfile` is clean.


</details>