### PR TITLE
DO NOT MERGE: force Prototype Build for #17506

### DIFF
--- a/WooCommerce/Classes/System/ProcessConfiguration.swift
+++ b/WooCommerce/Classes/System/ProcessConfiguration.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+// DO NOT MERGE. Touching an app source file defeats `should-skip-job.sh`, so that
+// Prototype Build actually runs and exercises the Sentry 2.x dSYM upload.
+
 /// Provides process-based configurations for screenshot generation and UI tests.
 struct ProcessConfiguration {
     /// Returns `true` when generating screenshots.


### PR DESCRIPTION
## Description

**Do not merge. Do not review.** This PR is a verification harness for #17506, stacked on top of it.

`should-skip-job.sh` lists `fastlane/**`, `Gemfile`, and `Gemfile.lock` under `COMMON_PATTERNS`, so #17506 — which touches only those files — skips every build job. Prototype Build there reports `Skipping :firebase: Prototype Build - no relevant files changed` and goes green without ever running `build_and_upload_prototype_build`, the one lane that calls the migrated `sentry_debug_files_upload` action.

The single commit here touches one app source file, which defeats the skip rule. That makes Prototype Build run for real, on an agent that has `SENTRY_AUTH_TOKEN`, exercising the authenticated dSYM upload that cannot otherwise be tested.

Once the log confirms the upload, this branch gets deleted and #17506 merges on its own.

## Test Steps

Watch Prototype Build on this PR and confirm the sentry step uploads debug files rather than skipping.
