### PR TITLE
Only remove branch protection at publish_release, not finalize_release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -716,7 +716,7 @@ platform :ios do
     UI.success("Successfully downloaded and committed latest translations for #{release_version_current}")
   end
 
-  # Finalizes a release by bumping version number, removing branch protection, closing milestone,
+  # Finalizes a release by bumping version number, closing milestone,
   # and triggering the final release build on CI
   #
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
@@ -750,11 +750,6 @@ platform :ios do
     trigger_release_build(branch_to_build: "release/#{version}")
 
     create_backmerge_pr
-
-    remove_branch_protection(
-      repository: GITHUB_REPO,
-      branch: "release/#{version}"
-    )
 
     # Close milestone
     begin


### PR DESCRIPTION
Fixes [AINFRA-18](https://linear.app/a8c/issue/AINFRA-18).

## What

Stop `finalize_release` from calling `remove_branch_protection`. Branch protection is now only removed during `publish_release` (rollout time).

## Why

Currently `finalize_release` removes the release branch's protection. Once the `release/x.y -> trunk` backmerge PR is merged, GitHub deletes the now-unprotected branch. But `finalize_release` happens *before* the build is approved — while release managers are still smoke-testing the TestFlight / Play build and waiting for App Store / Play review. If a last-minute fix is needed (an Apple/Google rejection, a crash found during smoke testing, etc.), we need to push more commits to the release branch and re-run `finalize_release`, but the branch may already have been deleted.

Protection should only be removed once the build is approved and we're rolling out, i.e. in `publish_release`. At that point commits to the release branch are neither allowed nor needed, and the branch can safely be deleted.

## How

`publish_release` already unprotects-and-deletes the release branch via the `delete_remote_git_branch!` helper (which removes protection immediately before deleting the branch). So the `remove_branch_protection` call in `finalize_release` was pure redundancy — this PR simply removes it. No change is needed in `publish_release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
