### PR TITLE
[WOOMOB-3338] Add Badge component to the Store Design System

### DIFF
--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/Badge/StoreBadge.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/Badge/StoreBadge.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+public struct StoreBadge: View {
+    private let title: String
+    private let icon: StoreIconImage?
+    private let tone: StoreBadgeTone
+
+    public init(_ title: String,
+                icon: StoreIconImage? = nil,
+                tone: StoreBadgeTone = .neutral) {
+        self.title = title
+        self.icon = icon
+        self.tone = tone
+    }
+
+    public var body: some View {
+        HStack(spacing: StoreSpacing.s2) {
+            icon?.image(size: Constants.iconSize)
+                .accessibilityHidden(true)
+            Text(title).storeTextStyle(.bodySmall).lineLimit(1)
+        }
+        .foregroundStyle(tone.appearance.foreground)
+        .padding(.horizontal, StorePadding.p3)
+        .frame(minHeight: Constants.minHeight)
+        .background(tone.appearance.background ?? .clear)
+        .clipShape(RoundedRectangle(cornerRadius: StoreRadius.medium))
+        .overlay {
+            if let border = tone.appearance.border {
+                RoundedRectangle(cornerRadius: StoreRadius.medium)
+                    .strokeBorder(border, lineWidth: StoreStrokeWidth.medium)
+            }
+        }
+    }
+}
+
+private extension StoreBadge {
+    enum Constants {
+        // Figma's 8pt top/bottom padding sits around cap-height-trimmed text (8+8+8 = 24).
+        // SwiftUI's Text isn't cap-trimmed, so we hit that 24pt height via minHeight rather
+        // than literal vertical padding (which would overshoot). Matches Android's heightIn(min: 24).
+        static let minHeight: CGFloat = 24
+        static let iconSize: StoreIconSize = .extraSmall
+    }
+}

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/Badge/StoreBadgeTone.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/Badge/StoreBadgeTone.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// The color-coded tone of a ``StoreBadge``.
+///
+/// - Note: A closed type holding the color roles per tone; `background` and `border` are optional
+///   (`nil` means no fill / no border). Caution and Warning map to their like-named container
+///   tokens, matching the Android `WooBadge`.
+public struct StoreBadgeTone {
+    struct Appearance {
+        let background: Color?
+        let foreground: Color
+        let border: Color?
+
+        init(background: Color?, foreground: Color, border: Color? = nil) {
+            self.background = background
+            self.foreground = foreground
+            self.border = border
+        }
+    }
+
+    let appearance: Appearance
+
+    private init(appearance: Appearance) {
+        self.appearance = appearance
+    }
+
+    public static let error = StoreBadgeTone(
+        appearance: Appearance(background: .storeErrorContainer, foreground: .storeOnErrorContainer)
+    )
+
+    public static let caution = StoreBadgeTone(
+        appearance: Appearance(background: .storeCautionContainer, foreground: .storeOnCautionContainer)
+    )
+
+    public static let warning = StoreBadgeTone(
+        appearance: Appearance(background: .storeWarningContainer, foreground: .storeOnWarningContainer)
+    )
+
+    public static let success = StoreBadgeTone(
+        appearance: Appearance(background: .storeSuccessContainer, foreground: .storeOnSuccessContainer)
+    )
+
+    public static let info = StoreBadgeTone(
+        appearance: Appearance(background: .storeInfoContainer, foreground: .storeOnInfoContainer)
+    )
+
+    public static let neutral = StoreBadgeTone(
+        appearance: Appearance(background: .storeNeutralContainer, foreground: .storeOnNeutralContainer)
+    )
+
+    public static let neutralOutlined = StoreBadgeTone(
+        appearance: Appearance(background: nil, foreground: .storeOnSurface, border: .storeStateLayerOnSurfaceOpacity10)
+    )
+}

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/BadgeComponentView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/BadgeComponentView.swift
@@ -1,0 +1,56 @@
+#if DEBUG || ALPHA
+import SwiftUI
+import StoreDesignSystem
+
+struct BadgeComponentView: View {
+    private enum Tone: String, CaseIterable, Identifiable {
+        case error = "Error"
+        case caution = "Caution"
+        case warning = "Warning"
+        case success = "Success"
+        case info = "Info"
+        case neutral = "Neutral"
+        case neutralOutlined = "Outlined"
+
+        var id: Self { self }
+
+        var value: StoreBadgeTone {
+            switch self {
+            case .error: .error
+            case .caution: .caution
+            case .warning: .warning
+            case .success: .success
+            case .info: .info
+            case .neutral: .neutral
+            case .neutralOutlined: .neutralOutlined
+            }
+        }
+    }
+
+    @State private var tone: Tone = .neutral
+    @State private var showsIcon = true
+    @State private var label = "Label"
+
+    var body: some View {
+        ComponentDemoScaffold(title: "Badge") {
+            Picker("Tone", selection: $tone) {
+                ForEach(Tone.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            Toggle("Icon", isOn: $showsIcon)
+            TextField("Label", text: $label)
+        } preview: {
+            StoreBadge(label,
+                       icon: showsIcon ? StoreIcon.Star.regular : nil,
+                       tone: tone.value)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        BadgeComponentView()
+    }
+}
+#endif

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
@@ -30,6 +30,7 @@ private struct TokenCategoriesView: View {
 private struct ComponentsView: View {
     var body: some View {
         List {
+            NavigationLink("Badge") { BadgeComponentView() }
             NavigationLink("Button") { ButtonComponentView() }
         }
         .navigationTitle("Components")


### PR DESCRIPTION
Closes WOOMOB-3338

## Description

Adds **`StoreBadge`**, a compact, color-coded status label — the second component in the new Woo Mobile Design System (`StoreDesignSystem`).

**The API — a public SwiftUI badge:**
```swift
StoreBadge("Shipped", tone: .success)
StoreBadge("New", icon: StoreIcon.Star.regular, tone: .info)
StoreBadge("Draft")
```
- **Tones:** `.error` · `.caution` · `.warning` · `.success` · `.info` · `.neutral` · `.neutralOutlined`
- Optional leading icon; non-interactive; hugs content — light & dark.

Caution/Warning are name-matched to their like-named container tokens (matching Android's `WooBadge`); Neutral Outlined uses the on-surface state-layer border. Reuses the `ComponentDemoScaffold` introduced in the Button PR.

## Test Steps

1. Go to **Settings → Debug Panel → Design System → Components → Badge**.
2. In the configurator, change **Tone** (Error / Caution / Warning / Success / Info / Neutral / Outlined), toggle **Icon**, and edit the **Label** — confirm the live preview updates.
3. Toggle the device into **Dark Mode** and confirm all tones (especially Neutral Outlined) render correctly.

## Screenshots

<img width="256" height="554" alt="ScreenRecording_07-13-2026 15-57-16_1" src="https://github.com/user-attachments/assets/1976226e-e120-4a4f-bd9b-a846c95200b0" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
