### PR TITLE
[WOOMOB-3345] Add NoticeBanner component to the Store Design System

### DIFF
--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/NoticeBanner/StoreNoticeBanner.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/NoticeBanner/StoreNoticeBanner.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+public struct StoreNoticeBanner: View {
+    private let title: String
+    private let description: String?
+    private let tone: StoreNoticeBannerTone
+    private let icon: StoreIconImage?
+
+    public init(_ title: String,
+                description: String? = nil,
+                tone: StoreNoticeBannerTone = .neutral,
+                icon: StoreIconImage? = nil) {
+        self.title = title
+        self.description = description
+        self.tone = tone
+        self.icon = icon
+    }
+
+    public var body: some View {
+        HStack(alignment: .center, spacing: StoreSpacing.s4) {
+            icon?.image(size: .large)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: StoreSpacing.s4) {
+                Text(title).storeTextStyle(.bodyMedium.emphasized)
+                if let description {
+                    Text(description).storeTextStyle(.bodyMedium)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(StorePadding.p6)
+        .foregroundStyle(tone.appearance.foreground)
+        .background(tone.appearance.background ?? .clear)
+        .clipShape(RoundedRectangle(cornerRadius: StoreRadius.large))
+        .overlay {
+            if let border = tone.appearance.border {
+                RoundedRectangle(cornerRadius: StoreRadius.large)
+                    .strokeBorder(border, lineWidth: StoreStrokeWidth.regular)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/NoticeBanner/StoreNoticeBannerTone.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/NoticeBanner/StoreNoticeBannerTone.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// The tone of a ``StoreNoticeBanner``.
+///
+/// - Note: A closed type holding the color roles for one tone. `background` and `border` are
+///   optional (`nil` means no fill / no border); only the neutral-outlined tone is bordered.
+public struct StoreNoticeBannerTone {
+    /// The tone's color roles. `background` and `border` are optional: `nil` means no fill / no border.
+    struct Appearance {
+        let background: Color?
+        let foreground: Color
+        let border: Color?
+
+        init(background: Color?, foreground: Color, border: Color? = nil) {
+            self.background = background
+            self.foreground = foreground
+            self.border = border
+        }
+    }
+
+    let appearance: Appearance
+
+    private init(appearance: Appearance) {
+        self.appearance = appearance
+    }
+
+    public static let error = StoreNoticeBannerTone(
+        appearance: Appearance(background: .storeErrorContainer, foreground: .storeOnErrorContainer)
+    )
+
+    public static let caution = StoreNoticeBannerTone(
+        appearance: Appearance(background: .storeCautionContainer, foreground: .storeOnCautionContainer)
+    )
+
+    public static let warning = StoreNoticeBannerTone(
+        appearance: Appearance(background: .storeWarningContainer, foreground: .storeOnWarningContainer)
+    )
+
+    public static let success = StoreNoticeBannerTone(
+        appearance: Appearance(background: .storeSuccessContainer, foreground: .storeOnSuccessContainer)
+    )
+
+    public static let info = StoreNoticeBannerTone(
+        appearance: Appearance(background: .storeInfoContainer, foreground: .storeOnInfoContainer)
+    )
+
+    public static let neutral = StoreNoticeBannerTone(
+        appearance: Appearance(background: .storeNeutralContainer, foreground: .storeOnNeutralContainer)
+    )
+
+    public static let neutralOutlined = StoreNoticeBannerTone(
+        appearance: Appearance(background: nil, foreground: .storeOnNeutralContainer, border: .storeNeutralContainer)
+    )
+}

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
@@ -31,6 +31,7 @@ private struct ComponentsView: View {
     var body: some View {
         List {
             NavigationLink("Button") { ButtonComponentView() }
+            NavigationLink("NoticeBanner") { NoticeBannerComponentView() }
         }
         .navigationTitle("Components")
     }

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/NoticeBannerComponentView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/NoticeBannerComponentView.swift
@@ -1,0 +1,62 @@
+#if DEBUG || ALPHA
+import SwiftUI
+import StoreDesignSystem
+
+struct NoticeBannerComponentView: View {
+    private enum Tone: String, CaseIterable, Identifiable {
+        case error = "Error"
+        case caution = "Caution"
+        case warning = "Warning"
+        case success = "Success"
+        case info = "Info"
+        case neutral = "Neutral"
+        case neutralOutlined = "Neutral Outlined"
+
+        var id: Self { self }
+
+        var value: StoreNoticeBannerTone {
+            switch self {
+            case .error: .error
+            case .caution: .caution
+            case .warning: .warning
+            case .success: .success
+            case .info: .info
+            case .neutral: .neutral
+            case .neutralOutlined: .neutralOutlined
+            }
+        }
+    }
+
+    @State private var tone: Tone = .error
+    @State private var title = "Orders synced"
+    @State private var description = "New order data is available."
+    @State private var showsIcon = true
+    @State private var showsDescription = true
+
+    var body: some View {
+        ComponentDemoScaffold(title: "NoticeBanner") {
+            Picker("Tone", selection: $tone) {
+                ForEach(Tone.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            Toggle("Icon", isOn: $showsIcon)
+            Toggle("Description", isOn: $showsDescription)
+            TextField("Title", text: $title)
+            TextField("Description", text: $description)
+        } preview: {
+            StoreNoticeBanner(title,
+                              description: showsDescription ? description : nil,
+                              tone: tone.value,
+                              icon: showsIcon ? StoreIcon.CircleInfo.regular : nil)
+                .padding()
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        NoticeBannerComponentView()
+    }
+}
+#endif


### PR DESCRIPTION
Closes WOOMOB-3345

## Description

Adds **`StoreNoticeBanner`**, a color-toned inline notice for the new Woo Mobile Design System (`StoreDesignSystem`).

**The API — a public SwiftUI view:**
```swift
StoreNoticeBanner("Orders synced",
                  description: "New order data is available.",
                  tone: .success,
                  icon: StoreIcon.CirclePlus.solid)
StoreNoticeBanner("Connection issue", tone: .warning, icon: StoreIcon.Bolt.regular)
```
- **Tones:** `.error` · `.caution` · `.warning` · `.success` · `.info` · `.neutral` · `.neutralOutlined`
- Required title; optional `description` and leading `icon`; tone defaults to `.neutral`.
- Fills the available width; the icon is tinted to the tone's foreground.
- Tokens only — reuses the existing alert container colorsets, so no new tokens.

## Test Steps

1. Go to **Settings → Debug Panel → Design System → Components → NoticeBanner**.
2. In the configurator, change **Tone**, toggle **Icon** / **Description**, and edit the **Title** / **Description** text — confirm the live preview updates.
3. Toggle the device into **Dark Mode** and confirm the banner renders correctly (alert container colors currently mirror their light values, pending the DS tokens PR).

## Screenshots

<img width="256" height="554" alt="ScreenRecording_07-13-2026 16-03-15_1" src="https://github.com/user-attachments/assets/05f86fa6-f675-4fc7-9d72-2f6c4882bce6" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

