### PR TITLE
Fix failing iPad UI test: PaymentsTests test_load_learn_more_link

### DIFF
--- a/Modules/Sources/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -19,7 +19,7 @@ public final class PaymentsScreen: ScreenObject {
     }
 
     private let learnMoreButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.textViews["Learn more about In‑Person Payments"].firstMatch
+        $0.staticTexts["Learn more about In‑Person Payments"].firstMatch
     }
 
     private let IPPDocumentationHeaderTextGetter: (XCUIApplication) -> XCUIElement = {


### PR DESCRIPTION
## Description
Fixes the failing iPad UI test `PaymentsTests.test_load_learn_more_link()` (WOOMOB-3553).

#17481 (my own PR 😓) replaced the UITextView-backed `AttributedText` in `InPersonPaymentsLearnMore` with a SwiftUI `Text` (`LearnMoreAttributedText`). SwiftUI `Text` is exposed in the accessibility hierarchy as a `StaticText` rather than a `TextView`, so the screen object's `textViews["Learn more about In‑Person Payments"]` query no longer matched anything and the test failed with:

```
No matches found for first query match sequence: `Descendants matching type TextView` -> `Elements matching predicate '"Learn more about In‑Person Payments" IN identifiers'`
```

<img width="1504" height="757" alt="Screenshot 2026-07-10 at 10 33 25 AM" src="https://github.com/user-attachments/assets/07f963cb-cea8-47d9-8ec0-043f854d7e16" />


This updates the query to `staticTexts`. The existing coordinate-based `click()` on the leading edge of the text still opens the documentation web view, so no other changes are needed.

Note: the iPhone UI test suite is unaffected because this test is skipped on iPhone via `XCTSkipIf` — `click()` is only supported on iPad (workaround for `tap()` on attributed-text links no longer working since Xcode 16), so on iPhone the element query is never reached.

## Test Steps

**Optional**, I ran the UI test locally and ensured it passed.

Run the iPad UI test on an iPad simulator (verified locally on iPad Pro 13-inch (M5), reproducing the failure before the fix and passing after):

```
xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerceUITests \
  -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M5)' \
  test -only-testing:"WooCommerceUITests/PaymentsTests/test_load_learn_more_link"
```

(Requires the WireMock mock server: `rake mocks`.)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
