### PR TITLE
[Maestro 1/8] Add smoke-test foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ default.profraw
 
 # Ignore Local Configuration files (like the ones used for Fastlane)
 .env
+**/.env.local
 
 # All secrets should be stored under .configure-files
 # Everything without a .enc extension is ignored

--- a/.maestro/CONTRACT.md
+++ b/.maestro/CONTRACT.md
@@ -1,0 +1,106 @@
+# Maestro iOS implementation contract
+
+This contract freezes the shared interfaces for the seven-branch Maestro stack.
+Flow owners may reference these interfaces but must not redefine them.
+
+## App and simulator
+
+- Every flow uses `appId: ${APP_ID}`.
+- `run-smoke-tests.sh` requires `--app PATH_TO_APP`, reads `CFBundleIdentifier`
+  from that bundle, installs that exact app, and exports the derived value as
+  `APP_ID`. Debug is the default build input; Alpha/prototype bundles work
+  without a hard-coded identifier.
+- `--device` accepts a simulator name or UDID. With no device argument, the
+  runner prefers an already booted compatible simulator. `pos-ipad` requires an
+  iPad and never degrades to a phone no-op.
+- No Maestro invocation passes XCUITest mock or eligibility-bypass launch
+  arguments.
+
+## Environment
+
+Normal profiles require only the credentials needed by their selected flows:
+
+```text
+MAESTRO_WOO_LAB_JETPACK_STORE_URL
+MAESTRO_WOO_LAB_WPCOM_EMAIL
+MAESTRO_WOO_LAB_WPCOM_PASSWORD
+MAESTRO_WOO_NO_JETPACK_SITE_URL
+MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME
+MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD
+MAESTRO_WOO_NOT_A_WOO_STORE_URL
+MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL
+```
+
+`MAESTRO_WOO_CONSUMER_KEY` and `MAESTRO_WOO_CONSUMER_SECRET` are optional and
+are validated only when explicit REST seeding or cleanup is requested. Local
+runs may load `.maestro/.env.local`; CI injects protected environment variables
+and never creates that file. iOS does not require Android's store or account.
+
+The runner generates `SUITE_RUN_ID=SUITE-<UTC timestamp>-<random suffix>` and
+passes it to every flow. Created entities use this value wherever the UI permits.
+
+## Runner CLI and profiles
+
+```text
+.maestro/scripts/run-smoke-tests.sh --app APP [--profile PROFILE]
+  [--device NAME_OR_UDID] [--include-tags CSV] [--exclude-tags CSV]
+  [--repeat N] [--rerun-failed JUNIT_XML] [--seed] [FLOW ...]
+.maestro/scripts/doctor.sh --app APP [the same profile/device selection]
+```
+
+Profiles:
+
+| Profile | Included tags | Excluded tags | Device |
+| --- | --- | --- | --- |
+| `core` | `smoke_core` | `flaky_quarantine,pos_ipad,ios_system` | iPhone |
+| `phone-full` | `smoke_core,smoke_extended,destructive` | `pos_ipad,ios_system` | iPhone |
+| `release` | promoted non-quarantined phone flows | `flaky_quarantine,pos_ipad,ios_system` | iPhone |
+| `burst` | release, repeated three times | same as release | iPhone |
+| `pos-ipad` | `pos_ipad` | none | iPad |
+| `ios-system` | `ios_system` | none | iPhone |
+
+Explicit `--include-tags` and `--exclude-tags` override profile tag defaults.
+Each failed flow is retried once; both attempts remain in the evidence. Reports
+contain JUnit XML, self-contained HTML, screenshots, diagnostics, and a redacted
+summary outside the repository.
+
+## Shared files and flow ownership
+
+Only the Core owner edits `.maestro/subflows/`. Shared names are:
+
+- `paste_into_focused_field.yaml`
+- `login.yaml`
+- `ensure_logged_in.yaml`
+- `navigate_to_dashboard.yaml`
+- `navigate_to_orders.yaml`
+- `navigate_to_products.yaml`
+- `navigate_to_more_menu.yaml`
+
+Flow filenames use the Android-equivalent names in the implementation plan.
+iOS-only system files are `ios_quick_actions.yaml`,
+`ios_notification_long_press.yaml`, `orders_qr_payment.yaml`,
+`orders_share_payment_link.yaml`, and `orders_barcode_scanner.yaml`.
+
+Tags are limited to `smoke_core`, `smoke_extended`, `flaky_quarantine`,
+`destructive`, `login`, `dashboard`, `orders`, `products`, `hub_menu`,
+`pos_ipad`, and `ios_system`.
+
+Coverage IDs come from the committed 88-item P2 snapshot. An ID maps to a flow
+only when that flow asserts the complete behavior. Unsupported hardware,
+watchOS, migration, real push delivery, external account completion, and camera
+decoding remain explicit `manual:` entries. Entry-point-only coverage is not
+promoted to a complete mapping.
+
+## Assertion and state rules
+
+- Prefer existing iOS accessibility identifiers; add production identifiers
+  only after hierarchy inspection proves a stable selector is absent.
+- Main assertions are mandatory, specific, and never wildcard-only.
+- Feature gates may skip only a genuinely absent store capability and must emit
+  an explicit exercised/skipped marker.
+- Login-reset flows clear application state and Keychain. Non-login flows call
+  `ensure_logged_in` and preserve authenticated state.
+- Credentials and long values use `paste_into_focused_field.yaml`; sensitive
+  clipboard contents are cleared immediately.
+- Destructive flows create or identify only run-owned entities, verify persisted
+  state, and permit documented leftovers. Cleanup is optional.

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,65 @@
+# WooCommerce iOS Maestro smoke tests
+
+This simulator-only suite complements XCUITest/WireMock with a production-like
+release signal against developer- or CI-supplied live WooCommerce test stores.
+It never requires Android's store, POS mocks, an eligibility bypass, REST
+consumer keys, a Linear issue, Test Analytics, or a notification channel.
+
+## Local setup
+
+1. Build or locate a Debug or Alpha/prototype `.app`.
+2. Copy `env.example` to `.env.local` and fill it locally.
+3. Run the linter and doctor without printing values:
+
+```bash
+.maestro/scripts/lint-env.py
+.maestro/scripts/doctor.sh --app /path/to/WooCommerce.app --profile core
+```
+
+The runner derives `APP_ID` from the supplied app, prefers an already booted
+compatible simulator, installs the app, generates a unique `SUITE_RUN_ID`, and
+stores artifacts under `~/woocommerce-maestro-output/` by default.
+
+## Profiles
+
+```bash
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile core
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile phone-full
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile release
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile burst
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile pos-ipad
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile ios-system
+```
+
+Run one flow or rerun failures:
+
+```bash
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app .maestro/flows/dashboard_stats.yaml
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --rerun-failed ~/woocommerce-maestro-output/SUITE-.../report.xml
+```
+
+Each failed flow is retried once. The final directory contains combined JUnit,
+self-contained HTML, per-attempt logs, screenshots, hierarchy/debug evidence,
+and a redacted JSON summary. Credential values are passed directly to Maestro
+and are never written to the summary or echoed in commands.
+
+## State and destructive data
+
+Login failures run before successful login. Non-login flows reuse the session
+through `ensure_logged_in`; flows requiring a genuinely fresh account state
+also clear Keychain. Created entities include `SUITE_RUN_ID` wherever the UI
+allows and later mutations target only that run-owned data. Leftovers on the
+configured destructive store are allowed. `--seed` is explicit and is the only
+mode that requires optional consumer credentials.
+
+POS runs require a real-eligible store/account and an iPad simulator. System
+surface flows are quarantined separately. Neither profile turns an ineligible
+device/store into a passing no-op.
+
+Validate traceability and static files with:
+
+```bash
+python3 .maestro/scripts/check-smoke-coverage.py
+python3 -m unittest discover .maestro/scripts/tests
+bash -n .maestro/scripts/*.sh
+```

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,0 +1,46 @@
+# WooCommerce iOS live-store Maestro workspace.
+# The repository runner derives APP_ID from the supplied .app bundle.
+appId: ${APP_ID}
+
+flows:
+  - "flows/*"
+
+executionOrder:
+  continueOnFailure: true
+  flowsOrder:
+    - flows/login_not_wp_site.yaml
+    - flows/login_wrong_credentials.yaml
+    - flows/login_help.yaml
+    - flows/login_not_woo_store.yaml
+    - flows/login_wrong_account.yaml
+    - flows/login_no_jetpack.yaml
+    - flows/login_google.yaml
+    - flows/login_successful.yaml
+    - flows/dashboard_stats.yaml
+    - flows/dashboard_view_all_analytics.yaml
+    - flows/dashboard_customize.yaml
+    - flows/orders_list_and_search.yaml
+    - flows/products_list_and_sort.yaml
+    - flows/products_detail.yaml
+    - flows/products_variations_and_tags.yaml
+    - flows/hub_menu_settings.yaml
+    - flows/hub_menu_payments.yaml
+    - flows/hub_menu_coupons.yaml
+    - flows/hub_menu_customers_inbox.yaml
+    - flows/hub_menu_admin_and_store.yaml
+    - flows/blaze_campaign.yaml
+    - flows/google_for_woo.yaml
+    - flows/orders_create.yaml
+    - flows/orders_details_and_actions.yaml
+    - flows/orders_mark_complete.yaml
+    - flows/orders_cash_payment.yaml
+    - flows/orders_refund.yaml
+    - flows/products_create.yaml
+    - flows/products_media_upload.yaml
+    - flows/pos_search_and_coupons.yaml
+    - flows/pos_cash_payment.yaml
+    - flows/ios_quick_actions.yaml
+    - flows/ios_notification_long_press.yaml
+    - flows/orders_qr_payment.yaml
+    - flows/orders_share_payment_link.yaml
+    - flows/orders_barcode_scanner.yaml

--- a/.maestro/diagnostic.yaml
+++ b/.maestro/diagnostic.yaml
@@ -1,0 +1,8 @@
+appId: ${APP_ID}
+name: iOS app launch diagnostic
+tags:
+  - diagnostic
+---
+- launchApp:
+    clearState: false
+- takeScreenshot: diagnostic-launch

--- a/.maestro/docs/index.html
+++ b/.maestro/docs/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>WooCommerce iOS Maestro operations</title>
+<style>body{font:16px system-ui;line-height:1.5;margin:2rem auto;max-width:900px;padding:0 1rem}code,pre{background:#f4f4f5}pre{padding:1rem;overflow:auto}th,td{border:1px solid #bbb;padding:.4rem;text-align:left}table{border-collapse:collapse}</style>
+<h1>WooCommerce iOS Maestro operations</h1>
+<p>This repository-owned suite is a live-store release signal. XCUITest and WireMock remain the deterministic acceptance layer.</p>
+<h2>Quick start</h2>
+<pre><code>cp .maestro/env.example .maestro/.env.local
+.maestro/scripts/lint-env.py
+.maestro/scripts/doctor.sh --app /path/to/WooCommerce.app --profile core
+.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile core</code></pre>
+<h2>Profiles</h2><table><tr><th>Name</th><th>Purpose</th></tr><tr><td>core</td><td>Stable phone release signal</td></tr><tr><td>phone-full</td><td>Core, extended, and destructive phone coverage</td></tr><tr><td>release</td><td>Promoted non-quarantined release set</td></tr><tr><td>burst</td><td>Three release repetitions</td></tr><tr><td>pos-ipad</td><td>Real-eligibility iPad POS</td></tr><tr><td>ios-system</td><td>Quarantined iOS system surfaces</td></tr></table>
+<h2>Evidence</h2><p>Runs produce JUnit XML, self-contained HTML, screenshots, diagnostics, redacted logs, and a summary. Inspect the failed attempt's log, hierarchy, screenshot, and app state before changing a selector or assertion.</p>
+<h2>Security</h2><p>Credentials live only in a local ignored file or protected CI environment variables. Consumer keys are optional and are validated only for an explicit seed request.</p>
+</html>

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -1,0 +1,24 @@
+# Copy to .maestro/.env.local and fill values locally. Never commit credentials.
+# Quote values containing whitespace or shell metacharacters, including `)`.
+
+# Jetpack-connected live test store using WordPress.com authentication.
+MAESTRO_WOO_LAB_JETPACK_STORE_URL=
+MAESTRO_WOO_LAB_WPCOM_EMAIL=
+MAESTRO_WOO_LAB_WPCOM_PASSWORD=
+
+# WooCommerce site without Jetpack, using site-admin credentials.
+MAESTRO_WOO_NO_JETPACK_SITE_URL=
+MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME=
+MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD=
+
+# Dedicated negative-login fixtures.
+MAESTRO_WOO_NOT_A_WOO_STORE_URL=
+MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL=
+
+# Optional. Required only with explicit --seed or cleanup tooling.
+MAESTRO_WOO_CONSUMER_KEY=
+MAESTRO_WOO_CONSUMER_SECRET=
+
+# Optional flow-specific data. Values must belong to the configured iOS store.
+MAESTRO_WOO_TEST_COUPON_CODE=
+MAESTRO_WOO_TEST_RECEIPT_EMAIL=

--- a/.maestro/scripts/check-smoke-coverage.py
+++ b/.maestro/scripts/check-smoke-coverage.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Offline coverage check for Maestro smoke flows."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ID_RE = re.compile(r"^\s*-\s+id:\s*([A-Za-z0-9_.-]+)\s*$")
+FLOW_RE = re.compile(r"^\s+flow:\s*(.+?)\s*$")
+MANUAL_RE = re.compile(r"^\s+manual:\s*(.+?)\s*$")
+P2_RE = re.compile(r"^#\s*p2:\s*(.+?)\s*$")
+
+
+def parse_snapshot(path: Path) -> dict[str, dict[str, str]]:
+    items: dict[str, dict[str, str]] = {}
+    current: str | None = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        id_match = ID_RE.match(line)
+        if id_match:
+            current = id_match.group(1)
+            items[current] = {}
+            continue
+        if current is None:
+            continue
+        flow_match = FLOW_RE.match(line)
+        if flow_match:
+            items[current]["flow"] = flow_match.group(1).strip().strip('"')
+            continue
+        manual_match = MANUAL_RE.match(line)
+        if manual_match:
+            items[current]["manual"] = manual_match.group(1).strip().strip('"')
+            continue
+    return items
+
+
+def parse_flow_headers(flows_dir: Path) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = {}
+    for flow in sorted(flows_dir.glob("*.yaml")):
+        ids: set[str] = set()
+        for line in flow.read_text(encoding="utf-8").splitlines()[:40]:
+            match = P2_RE.match(line)
+            if match:
+                ids.update(item.strip() for item in match.group(1).split(",") if item.strip())
+        result[str(flow)] = ids
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--coverage", default=".maestro/smoke-coverage.yaml", type=Path)
+    parser.add_argument("--flows-dir", default=".maestro/flows", type=Path)
+    args = parser.parse_args()
+
+    items = parse_snapshot(args.coverage)
+    flow_headers = parse_flow_headers(args.flows_dir)
+    errors: list[str] = []
+
+    for item_id, data in sorted(items.items()):
+        if not data.get("flow") and not data.get("manual"):
+            errors.append(f"{args.coverage}: item {item_id} has neither flow nor manual reason")
+
+    known_ids = set(items)
+    header_ids = set().union(*flow_headers.values()) if flow_headers else set()
+    for flow, ids in flow_headers.items():
+        if not ids:
+            errors.append(f"{flow}: missing '# p2:' header")
+        for item_id in sorted(ids - known_ids):
+            errors.append(f"{flow}: unknown p2 id {item_id}")
+
+    for item_id, data in sorted(items.items()):
+        flow = data.get("flow", "")
+        if flow and item_id not in header_ids:
+            errors.append(f"{args.coverage}: item {item_id} maps to {flow}, but no flow header declares it")
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print(f"Coverage snapshot OK: {len(items)} items, {len(flow_headers)} flows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/doctor.py
+++ b/.maestro/scripts/doctor.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Inspect iOS Maestro prerequisites without printing secret values."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUNNER_PATH = SCRIPT_DIR / "run-smoke-tests.py"
+SPEC = importlib.util.spec_from_file_location("woo_maestro_runner", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load {RUNNER_PATH}")
+RUNNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = RUNNER
+SPEC.loader.exec_module(RUNNER)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", required=True, type=Path)
+    parser.add_argument("--profile", choices=sorted(RUNNER.PROFILES), default="core")
+    parser.add_argument("--device")
+    parser.add_argument("--include-tags")
+    parser.add_argument("--exclude-tags")
+    parser.add_argument("--seed", action="store_true")
+    args = parser.parse_args()
+
+    checks: list[tuple[bool, str]] = []
+    for command in ("bash", "python3", "maestro", "xcrun", "plutil"):
+        path = shutil.which(command)
+        checks.append((path is not None, f"{command}: {path or 'not found'}"))
+
+    try:
+        values = RUNNER.load_environment()
+        checks.append((True, "local environment syntax is valid"))
+    except SystemExit:
+        values = dict(os.environ)
+        checks.append((False, "local environment syntax is invalid"))
+
+    try:
+        app_id = RUNNER.app_identifier(args.app)
+        checks.append((True, f"app bundle identifier: {app_id}"))
+    except (SystemExit, subprocess.SubprocessError) as error:
+        checks.append((False, f"app bundle: {error}"))
+
+    family = RUNNER.PROFILES[args.profile][3]
+    try:
+        simulator = RUNNER.resolve_simulator(args.device, family)
+        checks.append((True, f"simulator: {simulator['name']} ({simulator['udid']})"))
+    except (SystemExit, subprocess.SubprocessError) as error:
+        checks.append((False, f"simulator: {error}"))
+
+    include = RUNNER.csv(args.include_tags) or RUNNER.PROFILES[args.profile][0]
+    exclude = RUNNER.csv(args.exclude_tags)
+    if exclude is None:
+        exclude = RUNNER.PROFILES[args.profile][1]
+    namespace = argparse.Namespace(flows=[], rerun_failed=None)
+    try:
+        flows = RUNNER.select_flows(namespace, include, exclude)
+        checks.append((True, f"selected flows: {len(flows)}"))
+    except SystemExit as error:
+        checks.append((False, f"flow selection: {error}"))
+
+    required = {
+        "MAESTRO_WOO_LAB_JETPACK_STORE_URL",
+        "MAESTRO_WOO_LAB_WPCOM_EMAIL",
+        "MAESTRO_WOO_LAB_WPCOM_PASSWORD",
+    }
+    if args.seed:
+        required.update({"MAESTRO_WOO_CONSUMER_KEY", "MAESTRO_WOO_CONSUMER_SECRET"})
+    missing = sorted(name for name in required if not values.get(name))
+    checks.append((not missing, "required credentials are present" if not missing else "missing variables: " + ", ".join(missing)))
+
+    print("WooCommerce iOS Maestro doctor")
+    print(f"profile: {args.profile}")
+    failures = 0
+    for passed, message in checks:
+        print(f"[{'OK' if passed else 'FAIL'}] {message}")
+        failures += int(not passed)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/doctor.sh
+++ b/.maestro/scripts/doctor.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/doctor.py" "$@"

--- a/.maestro/scripts/lint-env.py
+++ b/.maestro/scripts/lint-env.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Lint local Maestro env files without printing secret values."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ASSIGNMENT_RE = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+INLINE_COMMENT_RE = re.compile(r"\s+#")
+SHELL_META_RE = re.compile(r"""[\s()&;<>|`$]""")
+DEPRECATED_ALIASES = {
+    "MAESTRO_WOO_LAB_STORE_URL": "MAESTRO_WOO_LAB_JETPACK_STORE_URL",
+    "MAESTRO_WOO_LAB_EMAIL": "MAESTRO_WOO_LAB_WPCOM_EMAIL",
+    "MAESTRO_WOO_LAB_PASSWORD": "MAESTRO_WOO_LAB_WPCOM_PASSWORD",
+    "MAESTRO_WOO_JN_SITE_URL": "MAESTRO_WOO_NO_JETPACK_SITE_URL",
+    "MAESTRO_WOO_JN_USERNAME": "MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME",
+    "MAESTRO_WOO_JN_PASSWORD": "MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD",
+}
+
+
+def expected_names(example_path: Path) -> set[str]:
+    names: set[str] = set()
+    if not example_path.exists():
+        return names
+    for line in example_path.read_text(errors="replace").splitlines():
+        match = ASSIGNMENT_RE.match(line.strip())
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+def strip_inline_comment(value: str) -> str:
+    split = INLINE_COMMENT_RE.split(value, maxsplit=1)
+    return split[0].rstrip()
+
+
+def is_quoted(value: str) -> bool:
+    value = value.strip()
+    return len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}
+
+
+def lint(path: Path, example_path: Path, seed: bool) -> tuple[list[str], list[str], int]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    count = 0
+    expected = expected_names(example_path)
+
+    if not path.exists():
+        return [f"{path} does not exist."], warnings, count
+
+    syntax = subprocess.run(["bash", "-n", str(path)], capture_output=True, text=True)
+    if syntax.returncode != 0:
+        errors.append(
+            f"{path}: shell syntax check failed. Check quoting around passwords or values with shell metacharacters."
+        )
+
+    seen: set[str] = set()
+    for line_number, raw_line in enumerate(path.read_text(errors="replace").splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        match = ASSIGNMENT_RE.match(stripped)
+        if not match:
+            errors.append(f"{path}:{line_number}: expected NAME=value or export NAME=value.")
+            continue
+
+        name, raw_value = match.groups()
+        count += 1
+        seen.add(name)
+
+        value = strip_inline_comment(raw_value)
+        if name.startswith("MAESTRO_WOO_") and expected and name not in expected and name not in DEPRECATED_ALIASES:
+            warnings.append(f"{path}:{line_number}: {name} is not declared in .maestro/env.example.")
+
+        if name in DEPRECATED_ALIASES:
+            warnings.append(f"{path}:{line_number}: {name} is supported as a legacy alias; prefer {DEPRECATED_ALIASES[name]}.")
+
+        if not seed and re.search(r"MAESTRO_WOO_.*CONSUMER_(KEY|SECRET)$", name):
+            warnings.append(f"{path}:{line_number}: {name} is only needed when running with --seed.")
+
+        if value and not is_quoted(value) and SHELL_META_RE.search(value):
+            errors.append(
+                f"{path}:{line_number}: {name} has an unquoted value containing shell metacharacters; wrap it in single quotes."
+            )
+
+    for name in sorted(seen):
+        if name.startswith("MAESTRO_WOO_") and "PASSWORD" in name:
+            # This intentionally does not inspect or print the value. The line-level checks above catch
+            # shell-unsafe password characters before the file is sourced.
+            continue
+
+    return errors, warnings, count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Lint .maestro/.env.local without printing secret values.")
+    parser.add_argument("--file", default=".maestro/.env.local", type=Path)
+    parser.add_argument("--example", default=".maestro/env.example", type=Path)
+    parser.add_argument("--seed", action="store_true", help="Allow Woo REST consumer key/secret variables.")
+    args = parser.parse_args()
+
+    errors, warnings, count = lint(args.file, args.example, args.seed)
+    for warning in warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {args.file} contains {count} assignment(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -226,6 +226,25 @@ def redact(text: str, values: dict[str, str]) -> str:
     return text
 
 
+def sanitize_artifacts(root: Path, values: dict[str, str], *, remove_images: bool = False) -> None:
+    """Redact Maestro's generated text evidence and suppress login screenshots."""
+    text_suffixes = {".html", ".json", ".log", ".txt", ".xml", ".yaml", ".yml"}
+    image_suffixes = {".heic", ".jpeg", ".jpg", ".png", ".webp"}
+    if not root.exists():
+        return
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if remove_images and path.suffix.lower() in image_suffixes:
+            path.unlink()
+            continue
+        if path.suffix.lower() in text_suffixes:
+            original = path.read_text(errors="replace")
+            sanitized = redact(original, values)
+            if sanitized != original:
+                path.write_text(sanitized, encoding="utf-8")
+
+
 def write_combined_junit(attempts: list[Attempt], destination: Path) -> tuple[int, int, int]:
     suites = ET.Element("testsuites")
     tests = failures = skipped = 0
@@ -317,9 +336,15 @@ def main() -> int:
                     log = output / "logs" / f"{prefix}.log"
                     debug = output / "diagnostics" / prefix
                     debug.mkdir()
-                    command = ["maestro", "test", "--udid", simulator["udid"], "--config", str(CONFIG_FILE), "--format", "JUNIT", "--output", str(junit), "--debug-output", str(debug), "--test-output-dir", str(output / "screenshots"), *env_args, str(flow)]
+                    screenshot_dir = output / "screenshots" / prefix
+                    screenshot_dir.mkdir()
+                    command = ["maestro", "test", "--udid", simulator["udid"], "--config", str(CONFIG_FILE), "--format", "JUNIT", "--output", str(junit), "--debug-output", str(debug), "--test-output-dir", str(screenshot_dir), *env_args, str(flow)]
                     completed = run(command, check=False)
                     log.write_text(redact(completed.stdout + completed.stderr, values), encoding="utf-8")
+                    is_login = "login" in flow_tags(flow)
+                    sanitize_artifacts(debug, values, remove_images=is_login)
+                    sanitize_artifacts(screenshot_dir, values, remove_images=is_login)
+                    sanitize_artifacts(junit.parent, values)
                     attempts.append(Attempt(flow, repetition, attempt_number, completed.returncode, junit, log, debug))
                     if completed.returncode == 0:
                         break
@@ -333,6 +358,7 @@ def main() -> int:
     report_attempts = list(final_by_flow_run.values())
     tests, failures, skipped = write_combined_junit(report_attempts, output / "report.xml")
     write_html(output / "report.html", run_id=run_id, app=app, app_id=app_id, simulator=simulator, profile=args.profile, attempts=attempts, tests=tests, failures=failures, skipped=skipped)
+    sanitize_artifacts(output, values)
     print(f"Maestro artifacts: {output}")
     print(f"Simulator: {simulator['name']} ({simulator['udid']})")
     print(f"Bundle identifier: {app_id}")

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Repository-owned Maestro runner for WooCommerce iOS simulator apps."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import os
+import random
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+MAESTRO_DIR = REPO_ROOT / ".maestro"
+FLOWS_DIR = MAESTRO_DIR / "flows"
+ENV_FILE = MAESTRO_DIR / ".env.local"
+CONFIG_FILE = MAESTRO_DIR / "config.yaml"
+LINT_ENV = SCRIPT_DIR / "lint-env.py"
+OUTPUT_DEFAULT = Path.home() / "woocommerce-maestro-output"
+
+PROFILES = {
+    "core": (["smoke_core"], ["flaky_quarantine", "pos_ipad", "ios_system"], 1, "iphone"),
+    "phone-full": (["smoke_core", "smoke_extended", "destructive"], ["pos_ipad", "ios_system"], 1, "iphone"),
+    "release": (["smoke_core", "smoke_extended", "destructive"], ["flaky_quarantine", "pos_ipad", "ios_system"], 1, "iphone"),
+    "burst": (["smoke_core", "smoke_extended", "destructive"], ["flaky_quarantine", "pos_ipad", "ios_system"], 3, "iphone"),
+    "pos-ipad": (["pos_ipad"], [], 1, "ipad"),
+    "ios-system": (["ios_system"], [], 1, "iphone"),
+}
+
+ORDERED_FLOWS = [
+    "diagnostic.yaml",
+    "login_not_wp_site.yaml", "login_wrong_credentials.yaml", "login_help.yaml",
+    "login_not_woo_store.yaml", "login_wrong_account.yaml", "login_no_jetpack.yaml",
+    "login_google.yaml", "login_successful.yaml", "dashboard_stats.yaml",
+    "dashboard_view_all_analytics.yaml", "dashboard_customize.yaml",
+    "orders_list_and_search.yaml", "products_list_and_sort.yaml", "products_detail.yaml",
+    "products_variations_and_tags.yaml", "hub_menu_settings.yaml", "hub_menu_payments.yaml",
+    "hub_menu_coupons.yaml", "hub_menu_customers_inbox.yaml", "hub_menu_admin_and_store.yaml",
+    "blaze_campaign.yaml", "google_for_woo.yaml", "orders_create.yaml",
+    "orders_details_and_actions.yaml", "orders_mark_complete.yaml", "orders_cash_payment.yaml",
+    "orders_refund.yaml", "products_create.yaml", "products_media_upload.yaml",
+    "pos_search_and_coupons.yaml", "pos_cash_payment.yaml", "ios_quick_actions.yaml",
+    "ios_notification_long_press.yaml", "orders_qr_payment.yaml",
+    "orders_share_payment_link.yaml", "orders_barcode_scanner.yaml",
+]
+
+SECRET_NAME_RE = re.compile(r"(?:PASSWORD|SECRET|CONSUMER_KEY|TOKEN)", re.I)
+ENV_ASSIGNMENT_RE = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+
+
+@dataclass
+class Attempt:
+    flow: Path
+    repeat: int
+    number: int
+    returncode: int
+    junit: Path
+    log: Path
+    debug: Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("flows", nargs="*", type=Path)
+    parser.add_argument("--app", required=True, type=Path, help="Debug or Alpha/prototype .app bundle")
+    parser.add_argument("--profile", choices=sorted(PROFILES), default="core")
+    parser.add_argument("--device", help="Simulator name or UDID")
+    parser.add_argument("--include-tags")
+    parser.add_argument("--exclude-tags")
+    parser.add_argument("--repeat", type=int)
+    parser.add_argument("--rerun-failed", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--seed", action="store_true")
+    parser.add_argument("--no-cleanup", action="store_true")
+    parser.add_argument("--no-open", action="store_true")
+    return parser.parse_args()
+
+
+def csv(value: str | None) -> list[str] | None:
+    if value is None:
+        return None
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def decode_env_value(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def load_environment() -> dict[str, str]:
+    values = dict(os.environ)
+    if not ENV_FILE.exists():
+        return values
+    lint = subprocess.run([sys.executable, str(LINT_ENV), "--file", str(ENV_FILE)], cwd=REPO_ROOT)
+    if lint.returncode:
+        raise SystemExit("Refusing to load an invalid .maestro/.env.local")
+    for raw_line in ENV_FILE.read_text(errors="replace").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = ENV_ASSIGNMENT_RE.match(stripped)
+        if match:
+            values[match.group(1)] = decode_env_value(match.group(2))
+    return values
+
+
+def run(command: list[str], *, capture: bool = True, check: bool = True, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=REPO_ROOT, text=True, capture_output=capture, check=check, env=env)
+
+
+def app_identifier(app: Path) -> str:
+    app = app.expanduser().resolve()
+    if not app.is_dir() or app.suffix != ".app":
+        raise SystemExit(f"--app must point to an existing .app bundle: {app}")
+    plist = app / "Info.plist"
+    result = run(["/usr/bin/plutil", "-extract", "CFBundleIdentifier", "raw", "-o", "-", str(plist)])
+    identifier = result.stdout.strip()
+    if not identifier:
+        raise SystemExit(f"CFBundleIdentifier is missing from {plist}")
+    return identifier
+
+
+def simulator_records() -> list[dict[str, str]]:
+    payload = json.loads(run(["xcrun", "simctl", "list", "devices", "available", "--json"]).stdout)
+    records: list[dict[str, str]] = []
+    for runtime, devices in payload.get("devices", {}).items():
+        if "iOS" not in runtime:
+            continue
+        for device in devices:
+            records.append({"name": device["name"], "udid": device["udid"], "state": device["state"], "runtime": runtime})
+    return records
+
+
+def resolve_simulator(selector: str | None, family: str) -> dict[str, str]:
+    records = simulator_records()
+    family_token = "ipad" if family == "ipad" else "iphone"
+    compatible = [item for item in records if family_token in item["name"].lower()]
+    if selector:
+        exact = [item for item in records if item["udid"] == selector or item["name"] == selector]
+        if len(exact) != 1:
+            raise SystemExit(f"--device must match exactly one available simulator name or UDID: {selector}")
+        selected = exact[0]
+        if family_token not in selected["name"].lower():
+            raise SystemExit(f"Profile requires an {family}; selected simulator is {selected['name']}")
+    else:
+        booted = [item for item in compatible if item["state"] == "Booted"]
+        if booted:
+            selected = booted[0]
+        elif compatible:
+            selected = compatible[0]
+        else:
+            raise SystemExit(f"No available {family} simulator is installed")
+    if selected["state"] != "Booted":
+        run(["xcrun", "simctl", "boot", selected["udid"]])
+    run(["xcrun", "simctl", "bootstatus", selected["udid"], "-b"], capture=False)
+    return selected
+
+
+def flow_tags(path: Path) -> set[str]:
+    tags: set[str] = set()
+    in_tags = False
+    for line in path.read_text(errors="replace").split("---", 1)[0].splitlines():
+        if line.strip() == "tags:":
+            in_tags = True
+        elif in_tags and line.lstrip().startswith("-"):
+            tags.add(line.split("-", 1)[1].strip())
+        elif in_tags and line and not line.startswith((" ", "\t")):
+            in_tags = False
+    return tags
+
+
+def failed_flow_stems(report: Path) -> set[str]:
+    root = ET.parse(report).getroot()
+    stems: set[str] = set()
+    for case in root.iter("testcase"):
+        if case.find("failure") is None and case.find("error") is None:
+            continue
+        haystack = " ".join([case.get("name", ""), case.get("classname", ""), case.get("file", "")])
+        stems.update(path.stem for path in FLOWS_DIR.glob("*.yaml") if path.stem in haystack)
+    return stems
+
+
+def select_flows(args: argparse.Namespace, include: list[str], exclude: list[str]) -> list[Path]:
+    if args.flows:
+        selected = [(path if path.is_absolute() else REPO_ROOT / path).resolve() for path in args.flows]
+    else:
+        selected = [FLOWS_DIR / name for name in ORDERED_FLOWS if (FLOWS_DIR / name).exists()]
+        selected.extend(sorted(path for path in FLOWS_DIR.glob("*.yaml") if path not in selected))
+        selected = [path for path in selected if (not include or flow_tags(path).intersection(include)) and not flow_tags(path).intersection(exclude)]
+    if args.rerun_failed:
+        stems = failed_flow_stems(args.rerun_failed)
+        selected = [path for path in selected if path.stem in stems]
+    missing = [str(path) for path in selected if not path.is_file()]
+    if missing:
+        raise SystemExit("Missing flow file(s): " + ", ".join(missing))
+    if not selected:
+        raise SystemExit("No Maestro flows matched the requested selection")
+    return selected
+
+
+def maestro_env_args(values: dict[str, str], app_id: str, run_id: str) -> list[str]:
+    exported = {name: value for name, value in values.items() if name.startswith("MAESTRO_") and value}
+    exported.update({"APP_ID": app_id, "SUITE_RUN_ID": run_id, "MAESTRO_SUITE_RUN_ID": run_id})
+    result: list[str] = []
+    for name in sorted(exported):
+        result.extend(["--env", f"{name}={exported[name]}"])
+    return result
+
+
+def redact(text: str, values: dict[str, str]) -> str:
+    secrets_to_hide = [value for name, value in values.items() if value and (name.startswith("MAESTRO_WOO_") or SECRET_NAME_RE.search(name))]
+    for value in sorted(set(secrets_to_hide), key=len, reverse=True):
+        text = text.replace(value, "<redacted>")
+    return text
+
+
+def write_combined_junit(attempts: list[Attempt], destination: Path) -> tuple[int, int, int]:
+    suites = ET.Element("testsuites")
+    tests = failures = skipped = 0
+    for attempt in attempts:
+        if not attempt.junit.exists():
+            suite = ET.SubElement(suites, "testsuite", name=f"{attempt.flow.stem}-attempt-{attempt.number}", tests="1", failures="1")
+            case = ET.SubElement(suite, "testcase", name=attempt.flow.stem, file=str(attempt.flow.relative_to(REPO_ROOT)))
+            ET.SubElement(case, "failure", message="Maestro did not produce JUnit output")
+            tests += 1
+            failures += 1
+            continue
+        root = ET.parse(attempt.junit).getroot()
+        children = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
+        for suite in children:
+            suite.set("name", f"{suite.get('name', attempt.flow.stem)} [run {attempt.repeat} attempt {attempt.number}]")
+            suites.append(suite)
+            tests += int(suite.get("tests", len(suite.findall("testcase"))))
+            failures += int(suite.get("failures", "0")) + int(suite.get("errors", "0"))
+            skipped += int(suite.get("skipped", "0"))
+    suites.set("tests", str(tests))
+    suites.set("failures", str(failures))
+    suites.set("skipped", str(skipped))
+    ET.ElementTree(suites).write(destination, encoding="utf-8", xml_declaration=True)
+    return tests, failures, skipped
+
+
+def write_html(destination: Path, *, run_id: str, app: Path, app_id: str, simulator: dict[str, str], profile: str, attempts: list[Attempt], tests: int, failures: int, skipped: int) -> None:
+    rows = []
+    for attempt in attempts:
+        state = "pass" if attempt.returncode == 0 else "fail"
+        rows.append(f"<tr><td>{html.escape(attempt.flow.name)}</td><td>{attempt.repeat}</td><td>{attempt.number}</td><td class='{state}'>{state.upper()}</td><td>{html.escape(str(attempt.debug.name))}</td></tr>")
+    destination.write_text(f"""<!doctype html><meta charset='utf-8'><title>WooCommerce iOS Maestro {html.escape(run_id)}</title>
+<style>body{{font:14px system-ui;margin:2rem;max-width:1100px}}table{{border-collapse:collapse;width:100%}}th,td{{border:1px solid #ccc;padding:.45rem;text-align:left}}.pass{{color:#067a35}}.fail{{color:#b42318}}code{{word-break:break-all}}</style>
+<h1>WooCommerce iOS Maestro run</h1><p><strong>{html.escape(run_id)}</strong></p>
+<ul><li>Profile: {html.escape(profile)}</li><li>App: <code>{html.escape(str(app))}</code></li><li>Bundle: <code>{html.escape(app_id)}</code></li><li>Simulator: {html.escape(simulator['name'])} (<code>{simulator['udid']}</code>)</li><li>Tests: {tests}; failures: {failures}; skipped: {skipped}</li></ul>
+<table><thead><tr><th>Flow</th><th>Repeat</th><th>Attempt</th><th>Result</th><th>Diagnostics</th></tr></thead><tbody>{''.join(rows)}</tbody></table>""", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repeat is not None and args.repeat < 1:
+        raise SystemExit("--repeat must be a positive integer")
+    for command in ("maestro", "xcrun"):
+        if not shutil.which(command):
+            raise SystemExit(f"Required command is missing: {command}")
+
+    include_default, exclude_default, repeat_default, family = PROFILES[args.profile]
+    include = csv(args.include_tags)
+    exclude = csv(args.exclude_tags)
+    include = include_default if include is None else include
+    exclude = exclude_default if exclude is None else exclude
+    repeat = args.repeat or repeat_default
+    values = load_environment()
+    app = args.app.expanduser().resolve()
+    app_id = app_identifier(app)
+    simulator = resolve_simulator(args.device, family)
+    run(["xcrun", "simctl", "install", simulator["udid"], str(app)])
+
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_id = f"SUITE-{stamp}-{secrets.token_hex(3)}"
+    output_root = (args.output_dir or Path(values.get("WOO_MAESTRO_OUTPUT_DIR", OUTPUT_DEFAULT))).expanduser()
+    output = output_root / run_id
+    output.mkdir(parents=True, exist_ok=False)
+    (output / "screenshots").mkdir()
+    (output / "diagnostics").mkdir()
+    (output / "logs").mkdir()
+
+    flows = select_flows(args, include, exclude)
+    summary = {
+        "run_id": run_id, "profile": args.profile, "app": str(app), "app_id": app_id,
+        "simulator_name": simulator["name"], "simulator_udid": simulator["udid"],
+        "include_tags": include, "exclude_tags": exclude, "repeat": repeat,
+        "flows": [str(path.relative_to(REPO_ROOT)) for path in flows],
+    }
+    (output / "run-summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+
+    if args.seed:
+        seed = SCRIPT_DIR / "seed-fixtures.py"
+        run([sys.executable, str(seed), "--mode", "seed", "--run-id", run_id, "--manifest", str(output / "run-manifest.json")], env=values)
+
+    attempts: list[Attempt] = []
+    env_args = maestro_env_args(values, app_id, run_id)
+    try:
+        for repetition in range(1, repeat + 1):
+            for flow in flows:
+                for attempt_number in (1, 2):
+                    prefix = f"r{repetition:02d}-{flow.stem}-a{attempt_number}"
+                    junit = output / f"{prefix}.xml"
+                    log = output / "logs" / f"{prefix}.log"
+                    debug = output / "diagnostics" / prefix
+                    debug.mkdir()
+                    command = ["maestro", "test", "--udid", simulator["udid"], "--config", str(CONFIG_FILE), "--format", "JUNIT", "--output", str(junit), "--debug-output", str(debug), "--test-output-dir", str(output / "screenshots"), *env_args, str(flow)]
+                    completed = run(command, check=False)
+                    log.write_text(redact(completed.stdout + completed.stderr, values), encoding="utf-8")
+                    attempts.append(Attempt(flow, repetition, attempt_number, completed.returncode, junit, log, debug))
+                    if completed.returncode == 0:
+                        break
+    finally:
+        if args.seed and not args.no_cleanup:
+            run([sys.executable, str(SCRIPT_DIR / "seed-fixtures.py"), "--mode", "cleanup", "--run-id", run_id, "--manifest", str(output / "run-manifest.json")], check=False, env=values)
+
+    final_by_flow_run: dict[tuple[Path, int], Attempt] = {}
+    for attempt in attempts:
+        final_by_flow_run[(attempt.flow, attempt.repeat)] = attempt
+    report_attempts = list(final_by_flow_run.values())
+    tests, failures, skipped = write_combined_junit(report_attempts, output / "report.xml")
+    write_html(output / "report.html", run_id=run_id, app=app, app_id=app_id, simulator=simulator, profile=args.profile, attempts=attempts, tests=tests, failures=failures, skipped=skipped)
+    print(f"Maestro artifacts: {output}")
+    print(f"Simulator: {simulator['name']} ({simulator['udid']})")
+    print(f"Bundle identifier: {app_id}")
+    print(f"Final results: {tests} tests, {failures} failures, {skipped} skipped")
+    return 1 if any(attempt.returncode for attempt in report_attempts) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/run-smoke-tests.sh
+++ b/.maestro/scripts/run-smoke-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/run-smoke-tests.py" "$@"

--- a/.maestro/scripts/seed-fixtures.py
+++ b/.maestro/scripts/seed-fixtures.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Optional run-owned REST seed/cleanup hook.
+
+Normal Maestro execution never calls this script. The initial iOS stack keeps
+UI-created entities as the source of truth; this hook records the explicit
+request and provides a stable extension point without making consumer keys a
+preflight dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("seed", "cleanup"), required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    args = parser.parse_args()
+    required = ("MAESTRO_WOO_CONSUMER_KEY", "MAESTRO_WOO_CONSUMER_SECRET")
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        parser.error("explicit REST seed/cleanup requires: " + ", ".join(missing))
+    if args.mode == "seed":
+        args.manifest.write_text(json.dumps({"run_id": args.run_id, "entities": []}, indent=2) + "\n")
+        print("Seed hook ready; this suite creates its run-owned fixtures through the UI.")
+    else:
+        if not args.manifest.exists():
+            parser.error(f"manifest does not exist: {args.manifest}")
+        print("Cleanup hook found no REST-seeded entities; UI-created leftovers are allowed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/tests/test_lint_env.py
+++ b/.maestro/scripts/tests/test_lint_env.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "lint-env.py"
+SPEC = importlib.util.spec_from_file_location("lint_env", SCRIPT)
+assert SPEC and SPEC.loader
+LINT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(LINT)
+
+
+class LintEnvTests(unittest.TestCase):
+    def test_rejects_unquoted_closing_parenthesis_without_echoing_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            env = root / ".env.local"
+            example = root / "env.example"
+            env.write_text("MAESTRO_WOO_LAB_WPCOM_PASSWORD=secret)\n")
+            example.write_text("MAESTRO_WOO_LAB_WPCOM_PASSWORD=\n")
+            errors, _, _ = LINT.lint(env, example, False)
+            self.assertTrue(errors)
+            self.assertNotIn("secret", " ".join(errors))
+
+    def test_accepts_single_quoted_shell_metacharacters(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            env = root / ".env.local"
+            example = root / "env.example"
+            env.write_text("MAESTRO_WOO_LAB_WPCOM_PASSWORD='safe ) value'\n")
+            example.write_text("MAESTRO_WOO_LAB_WPCOM_PASSWORD=\n")
+            errors, _, _ = LINT.lint(env, example, False)
+            self.assertEqual([], errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "run-smoke-tests.py"
+SPEC = importlib.util.spec_from_file_location("runner", SCRIPT)
+assert SPEC and SPEC.loader
+RUNNER = importlib.util.module_from_spec(SPEC)
+import sys
+sys.modules[SPEC.name] = RUNNER
+SPEC.loader.exec_module(RUNNER)
+
+
+class RunnerTests(unittest.TestCase):
+    def test_redacts_all_woo_values(self) -> None:
+        values = {"MAESTRO_WOO_LAB_WPCOM_PASSWORD": "do-not-print"}
+        self.assertEqual("failure: <redacted>", RUNNER.redact("failure: do-not-print", values))
+
+    def test_profile_contract(self) -> None:
+        self.assertEqual("iphone", RUNNER.PROFILES["core"][3])
+        self.assertEqual("ipad", RUNNER.PROFILES["pos-ipad"][3])
+        self.assertNotIn("flaky_quarantine", RUNNER.PROFILES["release"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -25,6 +25,32 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("ipad", RUNNER.PROFILES["pos-ipad"][3])
         self.assertNotIn("flaky_quarantine", RUNNER.PROFILES["release"][0])
 
+    def test_sanitize_artifacts_redacts_text_and_removes_login_images(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "commands.json").write_text('{"email":"merchant@example.com"}')
+            (root / "screen.png").write_bytes(b"image")
+            RUNNER.sanitize_artifacts(
+                root,
+                {"MAESTRO_WOO_LAB_WPCOM_EMAIL": "merchant@example.com"},
+                remove_images=True,
+            )
+            self.assertNotIn("merchant@example.com", (root / "commands.json").read_text())
+            self.assertFalse((root / "screen.png").exists())
+
+    def test_app_identifier_is_dynamic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            app = Path(directory) / "Prototype.app"
+            app.mkdir()
+            (app / "Info.plist").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+                '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+                '<plist version="1.0"><dict><key>CFBundleIdentifier</key>'
+                '<string>com.automattic.alpha.woocommerce</string></dict></plist>'
+            )
+            self.assertEqual("com.automattic.alpha.woocommerce", RUNNER.app_identifier(app))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.maestro/smoke-coverage.yaml
+++ b/.maestro/smoke-coverage.yaml
@@ -1,0 +1,283 @@
+# WooCommerce iOS Maestro smoke coverage snapshot (88 P2 checks).
+#
+# Source P2: https://woomobilep2.wordpress.com/flows-for-app-features-smoke-testing/
+# Fetched through context-a8c wpcom/posts-text on 2026-07-04.
+# P2 modified timestamp observed: 2026-05-18T02:37:47+00:00.
+#
+# Every item needs either `flow:` or `manual:`. Flow YAMLs declare covered
+# items with `# p2:` headers, and .maestro/scripts/check-smoke-coverage.py
+# validates this file offline.
+
+items:
+  - id: install.upgrade
+    title: Upgrade from existing store version
+    manual: "Requires App Store build replacement and logged-in migration state outside the initial simulator suite."
+  - id: install.fresh
+    title: Fresh install smoke
+    flow: .maestro/flows/login_successful.yaml
+
+  - id: login.help
+    title: Login help section
+    flow: .maestro/flows/login_help.yaml
+  - id: login.not-wp-site
+    title: Login with a non-WordPress site
+    flow: .maestro/flows/login_not_wp_site.yaml
+  - id: login.not-woo-store
+    title: Login to a WordPress site without WooCommerce
+    flow: .maestro/flows/login_not_woo_store.yaml
+  - id: login.no-jetpack
+    title: Login to WooCommerce site without Jetpack
+    flow: .maestro/flows/login_no_jetpack.yaml
+  - id: login.jetpack-not-connected
+    title: Login with Jetpack installed but not connected
+    manual: "Requires manually disconnecting Jetpack on a disposable Jurassic Ninja site."
+  - id: login.jetpack
+    title: Login to Jetpack-connected WooCommerce store
+    flow: .maestro/flows/login_successful.yaml
+  - id: login.wrong-account
+    title: Wrong account for the store
+    flow: .maestro/flows/login_wrong_account.yaml
+  - id: login.wrong-credentials
+    title: Wrong credentials
+    flow: .maestro/flows/login_wrong_credentials.yaml
+  - id: login.passwordless
+    title: Passwordless login
+    manual: "Later automation needs Mailosaur API and secret management."
+  - id: login.social-google
+    title: Social login with Google
+    flow: .maestro/flows/login_google.yaml
+  - id: login.social-apple
+    title: Social login with Apple
+    manual: "External Apple account completion is deferred until a simulator account fixture is supported."
+  - id: login.2fa
+    title: Login with 2FA
+    manual: "Needs dedicated test account plus TOTP secret handling."
+
+  - id: dashboard.stats
+    title: Dashboard charts and stats respond
+    flow: .maestro/flows/dashboard_stats.yaml
+  - id: dashboard.analytics
+    title: View all store analytics
+    flow: .maestro/flows/dashboard_view_all_analytics.yaml
+  - id: dashboard.customization
+    title: Dashboard card customization
+    flow: .maestro/flows/dashboard_customize.yaml
+
+  - id: orders.push.arrives
+    title: New order push notification arrives
+    manual: "Later automation should trigger an order via API and assert push delivery."
+  - id: orders.push.deep-link
+    title: Push opens the correct order
+    manual: "Blocked with push delivery automation."
+  - id: orders.list
+    title: Orders list loads
+    flow: .maestro/flows/orders_list_and_search.yaml
+  - id: orders.pagination
+    title: Orders pagination
+    flow: .maestro/flows/orders_list_and_search.yaml
+  - id: orders.search
+    title: Search for an order
+    flow: .maestro/flows/orders_list_and_search.yaml
+  - id: orders.create.products
+    title: Create order with products
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.variable-products
+    title: Create order with variable products
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.quantity
+    title: Increase and decrease quantity
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.product-discount
+    title: Apply product discount
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.custom-amount
+    title: Add custom amount
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.custom-amount-note
+    title: Add custom amount with note
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.shipping
+    title: Add shipping
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.customer-add
+    title: Add existing customer
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.customer-edit
+    title: Edit existing customer
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.create.note
+    title: Add customer note during order creation
+    flow: .maestro/flows/orders_create.yaml
+  - id: orders.barcode.open-scanner
+    title: Barcode button opens scanner
+    flow: .maestro/flows/orders_barcode_scanner.yaml
+  - id: orders.barcode.add-product
+    title: Add product using barcode scanner
+    manual: "Requires camera or guided manual mode."
+  - id: orders.collect-payment.qr
+    title: Scan to Pay displays QR code
+    flow: .maestro/flows/orders_qr_payment.yaml
+  - id: orders.collect-payment.share-link
+    title: Share payment link
+    flow: .maestro/flows/orders_share_payment_link.yaml
+  - id: orders.collect-payment.cash
+    title: Cash payment method
+    flow: .maestro/flows/orders_cash_payment.yaml
+  - id: orders.receipt
+    title: See receipt from order detail
+    flow: .maestro/flows/orders_details_and_actions.yaml
+  - id: orders.refund
+    title: Refund an order
+    flow: .maestro/flows/orders_refund.yaml
+  - id: orders.note
+    title: Add order note
+    flow: .maestro/flows/orders_details_and_actions.yaml
+  - id: orders.shipping-label
+    title: Create a shipping label
+    manual: "External shipping-label flow is outside current smoke scope."
+  - id: orders.mark-complete
+    title: Mark order complete
+    flow: .maestro/flows/orders_mark_complete.yaml
+  - id: orders.barcode.start-order
+    title: Start order creation by scanning barcode
+    manual: "Requires camera or guided manual mode."
+
+  - id: products.list
+    title: Product list loads
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.pagination
+    title: Product pagination
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.sort
+    title: Sort product list
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.search
+    title: Search product list
+    flow: .maestro/flows/products_list_and_sort.yaml
+  - id: products.detail.description
+    title: Product description details
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.media
+    title: Product media upload persists
+    flow: .maestro/flows/products_media_upload.yaml
+  - id: products.detail.price
+    title: Product price settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.inventory
+    title: Product inventory settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.categories
+    title: Product categories settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.type
+    title: Product type settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.tags
+    title: Product tags settings
+    flow: .maestro/flows/products_variations_and_tags.yaml
+  - id: products.detail.shipping
+    title: Product shipping settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.short-description
+    title: Product short description settings
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.linked
+    title: Linked products
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.downloads
+    title: Downloadable files
+    flow: .maestro/flows/products_detail.yaml
+  - id: products.detail.variations
+    title: Variations and variation detail
+    flow: .maestro/flows/products_variations_and_tags.yaml
+  - id: products.detail.variation-attributes
+    title: Variation attributes
+    flow: .maestro/flows/products_variations_and_tags.yaml
+  - id: products.create
+    title: Create product
+    flow: .maestro/flows/products_create.yaml
+
+  - id: hub.change-store
+    title: Change store
+    flow: .maestro/flows/hub_menu_admin_and_store.yaml
+  - id: hub.settings
+    title: Hub settings
+    flow: .maestro/flows/hub_menu_settings.yaml
+  - id: hub.payments
+    title: Payments hub
+    flow: .maestro/flows/hub_menu_payments.yaml
+  - id: hub.coupons.create
+    title: Create a coupon
+    flow: .maestro/flows/hub_menu_coupons.yaml
+  - id: hub.customers
+    title: Customers
+    flow: .maestro/flows/hub_menu_customers_inbox.yaml
+  - id: hub.inbox
+    title: Inbox
+    flow: .maestro/flows/hub_menu_customers_inbox.yaml
+  - id: hub.wc-admin
+    title: WC Admin
+    flow: .maestro/flows/hub_menu_admin_and_store.yaml
+  - id: hub.view-store
+    title: View Store
+    flow: .maestro/flows/hub_menu_admin_and_store.yaml
+  - id: hub.blaze.create
+    title: Blaze campaign creation entry point
+    flow: .maestro/flows/blaze_campaign.yaml
+  - id: hub.google-for-woo
+    title: Google for Woo campaign webview
+    flow: .maestro/flows/google_for_woo.yaml
+
+  - id: payments.card-reader
+    title: Collect payment using card reader
+    manual: "Hardware-dependent; later guided-manual mode."
+  - id: payments.ttp
+    title: Collect payment using Tap to Pay
+    manual: "Hardware/account-dependent; later guided-manual mode."
+  - id: payments.ipp-refund
+    title: Refund an IPP order
+    manual: "Hardware/payment-account dependent."
+
+  - id: pos.search-products
+    title: POS search products
+    flow: .maestro/flows/pos_search_and_coupons.yaml
+  - id: pos.add-products
+    title: POS add products to cart
+    flow: .maestro/flows/pos_cash_payment.yaml
+  - id: pos.coupons
+    title: POS use coupons
+    flow: .maestro/flows/pos_search_and_coupons.yaml
+  - id: pos.pay-card
+    title: POS pay with card
+    manual: "Card reader hardware-dependent; later guided-manual mode."
+  - id: pos.pay-cash
+    title: POS pay with cash
+    flow: .maestro/flows/pos_cash_payment.yaml
+  - id: pos.email-receipts
+    title: POS send and check email receipts
+    manual: "Sending and externally checking email requires a dedicated configured test address and mailbox access."
+
+  - id: other.localization
+    title: Switch device to non-English language
+    manual: "Requires locale matrix run; selectors are prepared to avoid text-driven navigation."
+  - id: other.home-widget
+    title: Home screen widgets
+    manual: "Outside Maestro app surface."
+  - id: other.quick-actions
+    title: Quick Actions
+    flow: .maestro/flows/ios_quick_actions.yaml
+  - id: other.ios-push-long-press
+    title: Long press iPhone push notification
+    flow: .maestro/flows/ios_notification_long_press.yaml
+  - id: other.watch.my-store
+    title: Watch app My Store
+    manual: "Watch app stays manual per plan."
+  - id: other.watch.orders-list
+    title: Watch app order list
+    manual: "Watch app stays manual per plan."
+  - id: other.watch.order-detail
+    title: Watch app order detail
+    manual: "Watch app stays manual per plan."
+  - id: other.watch.push
+    title: Watch push notification opens order details
+    manual: "Watch app stays manual per plan."


### PR DESCRIPTION
## Description

First PR in the eight-part iOS Maestro stack. It introduces the reusable smoke-test foundation:

- Maestro workspace configuration and an environment contract with ignored `.env.local` support.
- A simulator runner that derives the bundle identifier from a supplied `.app`, installs that app, selects profiles/devices, retries failures, supports failed-flow reruns, redacts artifacts, and writes JUnit/HTML/JSON evidence.
- Environment linting, side-effect-free diagnostics, offline coverage validation, optional fixture extension hooks, documentation, and Python contract tests.

This layer intentionally adds no executable app smoke flows. It is being merged only into `feature/maestro-smoke-testing-automation`, where the remaining stack layers complete the runnable suite before anything targets `trunk`.

## Validation

- 6 Python contract tests
- Python compilation and shell syntax
- example-environment lint
- `git diff --check`
- repository CI: green on the rebased head

No live Maestro flow was executed as part of this layer review because this PR contains only the runner foundation.

## Provisional limitations

- The committed coverage snapshot references flows owned by later stack layers, so the coverage checker is not expected to pass on this foundation commit in isolation. It becomes meaningful as those flow layers are merged.
- Initial retry reporting can turn fail-then-pass into a green result, and the initial REST fixture hook records an empty manifest without deleting UI-created data. Both trust/safety gaps are explicitly hardened in follow-up #17656 before the combined feature branch is considered release evidence.
- Debug/Alpha simulator apps are supported here; immutable release-candidate enforcement and real-device/hardware coverage are outside this layer.

## Test steps

1. Copy `.maestro/env.example` to `.maestro/.env.local` and provide the documented local values.
2. Run `python3 -m unittest discover -s .maestro/scripts/tests`.
3. Run `python3 .maestro/scripts/lint-env.py --file .maestro/env.example --example .maestro/env.example`.
4. With a compatible `.app`, run `.maestro/scripts/doctor.sh --app /path/to/WooCommerce.app --profile core`.
5. After the flow layers are merged, run a plan or diagnostic flow and confirm reports contain no credential values.

## Stack

1. #17525 — foundations
2. #17526 — core and login flows
3. #17527 — extended store flows
4. #17528 — destructive flows
5. #17529 — iPad POS flows
6. #17530 — iOS system-surface flows
7. #17531 — Buildkite integration
8. #17656 — trust, reliability, toolchain, and reporting hardening

Next: #17526

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. Internal test tooling only; no release note is required.
