### PR TITLE
[Maestro 3/8] Add extended store smoke flows

### DIFF
--- a/.maestro/CONTRACT.md
+++ b/.maestro/CONTRACT.md
@@ -102,8 +102,9 @@ promoted to a complete mapping.
 - Prefer existing iOS accessibility identifiers; add production identifiers
   only after hierarchy inspection proves a stable selector is absent.
 - Main assertions are mandatory, specific, and never wildcard-only.
-- Feature gates may skip only a genuinely absent store capability and must emit
-  an explicit exercised/skipped marker.
+- A feature-gated item maps to P2 coverage only when the selected profile's
+  fixture guarantees eligibility. `hub.inbox` is mandatory for `phone-full`;
+  an ineligible store fails the flow instead of emitting a passing skip.
 - Login-reset flows clear application state and Keychain. Non-login flows call
   `ensure_logged_in` and preserve authenticated state.
 - Credentials and long values use `paste_into_focused_field.yaml`; sensitive

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -56,6 +56,10 @@ POS runs require a real-eligible store/account and an iPad simulator. System
 surface flows are quarantined separately. Neither profile turns an ineligible
 device/store into a passing no-op.
 
+The lab store used by `phone-full` must be eligible for Inbox. The P2 lists
+Inbox as required hub coverage, so an absent `menu-inbox` fails the extended
+flow instead of being reported as a feature-gated skip.
+
 Validate traceability and static files with:
 
 ```bash

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -2,6 +2,7 @@
 # Quote values containing whitespace or shell metacharacters, including `)`.
 
 # Jetpack-connected live test store using WordPress.com authentication.
+# Extended smoke coverage requires this store to be eligible for Inbox.
 MAESTRO_WOO_LAB_JETPACK_STORE_URL=
 MAESTRO_WOO_LAB_WPCOM_EMAIL=
 MAESTRO_WOO_LAB_WPCOM_PASSWORD=

--- a/.maestro/flows/blaze_campaign.yaml
+++ b/.maestro/flows/blaze_campaign.yaml
@@ -1,0 +1,52 @@
+# p2: hub.blaze.create
+# Blaze is a genuine store eligibility gate. When exposed, the flow reaches a creation-capable destination.
+appId: ${APP_ID}
+name: "Blaze - Campaign creation"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- scroll
+- scroll
+- runFlow:
+    when:
+      notVisible:
+        id: "menu-blaze"
+    commands:
+      - evalScript: ${console.log('FEATURE_SKIPPED hub.blaze.create reason=store_not_eligible')}
+      - takeScreenshot: blaze_skipped
+- runFlow:
+    when:
+      visible:
+        id: "menu-blaze"
+    commands:
+      - evalScript: ${console.log('FEATURE_EXERCISED hub.blaze.create')}
+      - tapOn:
+          id: "menu-blaze"
+      - extendedWaitUntil:
+          visible: "Blaze Campaigns|Get your products seen by millions"
+          timeout: 25000
+      - assertNotVisible:
+          id: "menu-blaze"
+      - runFlow:
+          when:
+            visible: "Blaze Campaigns"
+          commands:
+            - assertVisible: "Create"
+      - runFlow:
+          when:
+            visible: "Get your products seen by millions"
+          commands:
+            - assertVisible: "Create Your Campaign"
+      - takeScreenshot: blaze_campaign_destination
+      - back
+      - extendedWaitUntil:
+          visible:
+            id: "menu-blaze"
+          timeout: 15000
+

--- a/.maestro/flows/blaze_campaign.yaml
+++ b/.maestro/flows/blaze_campaign.yaml
@@ -49,4 +49,3 @@ tags:
           visible:
             id: "menu-blaze"
           timeout: 15000
-

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -1,34 +1,206 @@
 # p2: dashboard.customization
-# Prerequisite: authenticated Jetpack store. This flow does not persist changes.
+# Reviews and Coupons are always available in DashboardViewModel. The flow
+# derives their persisted selection from rendered dashboard cards, normalizes
+# Reviews off and Coupons on, and restores that state at the end.
 appId: ${APP_ID}
-name: "Dashboard - Customize cards"
+name: "Dashboard - Customize, persist, reorder, and restore cards"
 tags:
   - smoke_extended
   - flaky_quarantine
   - dashboard
 ---
-- runFlow:
-    file: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/ensure_logged_in.yaml
 - runFlow:
     file: ../subflows/navigate_to_dashboard.yaml
 - assertVisible: "My store"
+
+# Normalize Reviews off. Card presence is the existing app-owned signal that
+# the persisted dashboard selection contains Reviews.
+- scrollUntilVisible:
+    element:
+      text: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+    optional: true
+- runFlow:
+    when:
+      visible: "Most recent reviews"
+    commands:
+      - tapOn:
+          text: "Edit"
+      - extendedWaitUntil:
+          visible: "Customize"
+          timeout: 15000
+      - scrollUntilVisible:
+          element: "Most recent reviews"
+          direction: DOWN
+          timeout: 15000
+      - tapOn: "Most recent reviews"
+      - tapOn: "Save"
+      - extendedWaitUntil:
+          visible: "My store"
+          timeout: 15000
+
+# Normalize Coupons on. If its dashboard card is absent, select it once.
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
+- scrollUntilVisible:
+    element:
+      text: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+    optional: true
+- runFlow:
+    when:
+      notVisible: "Most active coupons"
+    commands:
+      - tapOn:
+          text: "Edit"
+      - extendedWaitUntil:
+          visible: "Customize"
+          timeout: 15000
+      - scrollUntilVisible:
+          element: "Most active coupons"
+          direction: DOWN
+          timeout: 15000
+      - tapOn: "Most active coupons"
+      - tapOn: "Save"
+      - extendedWaitUntil:
+          visible: "My store"
+          timeout: 15000
+
+# Toggle Reviews on and prove persistence after an app restart.
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
 - tapOn:
     text: "Edit"
-    retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Customize"
     timeout: 15000
-- assertVisible: "Customize"
-- assertVisible: "Performance"
 - scrollUntilVisible:
-    element: "Top performers"
+    element: "Most recent reviews"
     direction: DOWN
-    timeout: 10000
-- assertVisible: "Top performers"
-- assertVisible: "Save"
-- takeScreenshot: dashboard_customize
+    timeout: 15000
+- tapOn: "Most recent reviews"
+- tapOn: "Save"
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Most recent reviews"
+- stopApp
+- launchApp
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Most recent reviews"
+
+# Reviews and Coupons are adjacent in the normalized selected-card ordering.
+# Drag the native trailing reorder control one row upward.
 - tapOn:
-    point: "8%,12%"
+    text: "Edit"
 - extendedWaitUntil:
-    visible: "My store"
-    timeout: 10000
+    visible: "Customize"
+    timeout: 15000
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+- assertVisible:
+    text: "Most recent reviews"
+    below:
+      text: "Most active coupons"
+- swipe:
+    start: "92%,42%"
+    end: "92%,36%"
+    duration: 2000
+- assertVisible:
+    text: "Most recent reviews"
+    above:
+      text: "Most active coupons"
+- tapOn: "Save"
+
+# Downward-only traversal proves the rendered card order.
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Most recent reviews"
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Most active coupons"
+- stopApp
+- launchApp
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
+- tapOn:
+    text: "Edit"
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+- assertVisible:
+    text: "Most recent reviews"
+    above:
+      text: "Most active coupons"
+
+# Restore Coupons before Reviews, save, and prove persistence.
+- swipe:
+    start: "92%,36%"
+    end: "92%,42%"
+    duration: 2000
+- assertVisible:
+    text: "Most recent reviews"
+    below:
+      text: "Most active coupons"
+- tapOn: "Save"
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Most active coupons"
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Most recent reviews"
+- stopApp
+- launchApp
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
+- tapOn:
+    text: "Edit"
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+- assertVisible:
+    text: "Most recent reviews"
+    below:
+      text: "Most active coupons"
+
+# Restore Reviews to hidden, restart, and assert the restored dashboard state.
+- tapOn: "Most recent reviews"
+- tapOn: "Save"
+- stopApp
+- launchApp
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Most active coupons"
+- scrollUntilVisible:
+    element:
+      text: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+    optional: true
+- assertNotVisible: "Most recent reviews"
+- takeScreenshot: dashboard_customize_restored

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -27,7 +27,8 @@ tags:
 - assertVisible: "Top performers"
 - assertVisible: "Save"
 - takeScreenshot: dashboard_customize
-- back
+- tapOn:
+    point: "8%,12%"
 - extendedWaitUntil:
     visible: "My store"
     timeout: 10000

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -1,0 +1,33 @@
+# p2: dashboard.customization
+# Prerequisite: authenticated Jetpack store. This flow does not persist changes.
+appId: ${APP_ID}
+name: "Dashboard - Customize cards"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - dashboard
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
+- assertVisible: "My store"
+- tapOn:
+    text: "Edit"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible: "Customize"
+    timeout: 15000
+- assertVisible: "Customize"
+- assertVisible: "Performance"
+- scrollUntilVisible:
+    element: "Top performers"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Top performers"
+- assertVisible: "Save"
+- takeScreenshot: dashboard_customize
+- back
+- extendedWaitUntil:
+    visible: "My store"
+    timeout: 10000

--- a/.maestro/flows/dashboard_customize.yaml
+++ b/.maestro/flows/dashboard_customize.yaml
@@ -1,145 +1,407 @@
 # p2: dashboard.customization
-# Reviews and Coupons are always available in DashboardViewModel. The flow
-# derives their persisted selection from rendered dashboard cards, normalizes
-# Reviews off and Coupons on, and restores that state at the end.
+# Every known card is toggled or explicitly classified as unavailable/hidden.
+# All selectable mutations persist across one relaunch, then the captured
+# original states are restored and asserted after another relaunch. A card
+# reorder is also persisted, reversed, and verified before anchor restoration.
 appId: ${APP_ID}
-name: "Dashboard - Customize, persist, reorder, and restore cards"
+name: "Dashboard - Exercise every card, persist selection and reorder, then restore"
 tags:
   - smoke_extended
   - flaky_quarantine
   - dashboard
 ---
 - runFlow: ../subflows/ensure_logged_in.yaml
-- runFlow:
-    file: ../subflows/navigate_to_dashboard.yaml
-- assertVisible: "My store"
+- runFlow: ../subflows/navigate_to_dashboard.yaml
+- runFlow: ../helpers/open_dashboard_customizer.yaml
 
-# Normalize Reviews off. Card presence is the existing app-owned signal that
-# the persisted dashboard selection contains Reviews.
+# Capture the two always-available anchor cards and keep both selected so the
+# list's last-selected guard cannot block any non-anchor toggle.
+- evalScript: |
+    output.dashboardReviewsOriginal = '';
+    output.dashboardCouponsOriginal = '';
+- repeat:
+    times: 6
+    commands:
+      - swipe: { start: "50%,25%", end: "50%,80%", duration: 300 }
 - scrollUntilVisible:
-    element:
-      text: "Most recent reviews"
+    element: "Most recent reviews"
     direction: DOWN
     timeout: 15000
-    optional: true
 - runFlow:
     when:
-      visible: "Most recent reviews"
+      visible:
+        id: "selectable-item-selected-Most recent reviews"
     commands:
-      - tapOn:
-          text: "Edit"
-      - extendedWaitUntil:
-          visible: "Customize"
-          timeout: 15000
+      - evalScript: |
+          output.dashboardReviewsOriginal = 'selected';
+- runFlow:
+    when:
+      visible:
+        id: "selectable-item-unselected-Most recent reviews"
+    commands:
+      - evalScript: |
+          output.dashboardReviewsOriginal = 'unselected';
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: selected }
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    when:
+      visible:
+        id: "selectable-item-selected-Most active coupons"
+    commands:
+      - evalScript: |
+          output.dashboardCouponsOriginal = 'selected';
+- runFlow:
+    when:
+      visible:
+        id: "selectable-item-unselected-Most active coupons"
+    commands:
+      - evalScript: |
+          output.dashboardCouponsOriginal = 'unselected';
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most active coupons, DESIRED_STATE: selected }
+- assertTrue:
+    condition: ${output.dashboardReviewsOriginal !== '' && output.dashboardCouponsOriginal !== ''}
+    label: Capture original dashboard anchor selection
+
+# Toggle every non-anchor card exactly once while retaining both anchors.
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: AI Assistant, CARD_KEY: ai }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Store setup, CARD_KEY: store_setup }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Performance, CARD_KEY: performance }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Top performers, CARD_KEY: top_performers }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Blaze campaigns, CARD_KEY: blaze }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Inbox, CARD_KEY: inbox }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Stock, CARD_KEY: stock }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Most recent orders, CARD_KEY: recent_orders }
+- runFlow:
+    file: ../helpers/dashboard_toggle_card.yaml
+    env: { CARD_TITLE: Google Ads campaigns, CARD_KEY: google_ads }
+
+# Exercise both anchor controls while preserving one selected guard. Reviews is
+# toggled off/on in-session; Coupons is toggled off and persisted below.
+- repeat:
+    times: 6
+    commands:
+      - swipe: { start: "50%,25%", end: "50%,80%", duration: 300 }
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: unselected }
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: selected }
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most active coupons, DESIRED_STATE: unselected }
+- runFlow: ../helpers/save_dashboard_customizer.yaml
+
+# Relaunch and assert the externally persisted inverse state for every
+# selectable non-anchor card plus the deliberately persisted Coupons change.
+- stopApp
+- launchApp
+- runFlow: ../helpers/open_dashboard_customizer.yaml
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: AI Assistant, CARD_KEY: ai, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Store setup, CARD_KEY: store_setup, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Performance, CARD_KEY: performance, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Top performers, CARD_KEY: top_performers, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Blaze campaigns, CARD_KEY: blaze, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Inbox, CARD_KEY: inbox, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Stock, CARD_KEY: stock, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Most recent orders, CARD_KEY: recent_orders, EXPECTED_MODE: inverse }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Google Ads campaigns, CARD_KEY: google_ads, EXPECTED_MODE: inverse }
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+- assertVisible:
+    id: "selectable-item-selected-Most recent reviews"
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+- assertVisible:
+    id: "selectable-item-unselected-Most active coupons"
+
+# Restore every non-anchor and the dynamically captured anchor selections.
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: AI Assistant, CARD_KEY: ai }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Store setup, CARD_KEY: store_setup }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Performance, CARD_KEY: performance }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Top performers, CARD_KEY: top_performers }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Blaze campaigns, CARD_KEY: blaze }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Inbox, CARD_KEY: inbox }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Stock, CARD_KEY: stock }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Most recent orders, CARD_KEY: recent_orders }
+- runFlow:
+    file: ../helpers/dashboard_restore_card.yaml
+    env: { CARD_TITLE: Google Ads campaigns, CARD_KEY: google_ads }
+- repeat:
+    times: 6
+    commands:
+      - swipe: { start: "50%,25%", end: "50%,80%", duration: 300 }
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most active coupons, DESIRED_STATE: selected }
+- runFlow:
+    when:
+      true: ${output.dashboardReviewsOriginal === 'unselected'}
+    commands:
       - scrollUntilVisible:
           element: "Most recent reviews"
           direction: DOWN
           timeout: 15000
-      - tapOn: "Most recent reviews"
-      - tapOn: "Save"
-      - extendedWaitUntil:
-          visible: "My store"
-          timeout: 15000
-
-# Normalize Coupons on. If its dashboard card is absent, select it once.
-- runFlow:
-    file: ../subflows/navigate_to_dashboard.yaml
-- scrollUntilVisible:
-    element:
-      text: "Most active coupons"
-    direction: DOWN
-    timeout: 15000
-    optional: true
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: unselected }
 - runFlow:
     when:
-      notVisible: "Most active coupons"
+      true: ${output.dashboardCouponsOriginal === 'unselected'}
     commands:
-      - tapOn:
-          text: "Edit"
-      - extendedWaitUntil:
-          visible: "Customize"
-          timeout: 15000
       - scrollUntilVisible:
           element: "Most active coupons"
           direction: DOWN
           timeout: 15000
-      - tapOn: "Most active coupons"
-      - tapOn: "Save"
-      - extendedWaitUntil:
-          visible: "My store"
-          timeout: 15000
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most active coupons, DESIRED_STATE: unselected }
+- runFlow: ../helpers/save_dashboard_customizer.yaml
 
-# Toggle Reviews on and prove persistence after an app restart.
-- runFlow:
-    file: ../subflows/navigate_to_dashboard.yaml
-- tapOn:
-    text: "Edit"
-- extendedWaitUntil:
-    visible: "Customize"
-    timeout: 15000
-- scrollUntilVisible:
-    element: "Most recent reviews"
-    direction: DOWN
-    timeout: 15000
-- tapOn: "Most recent reviews"
-- tapOn: "Save"
-- scrollUntilVisible:
-    element: "Most recent reviews"
-    direction: DOWN
-    timeout: 30000
-- assertVisible: "Most recent reviews"
+# Prove all captured selections were restored across another relaunch.
 - stopApp
 - launchApp
+- runFlow: ../helpers/open_dashboard_customizer.yaml
 - runFlow:
-    file: ../subflows/navigate_to_dashboard.yaml
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: AI Assistant, CARD_KEY: ai, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Store setup, CARD_KEY: store_setup, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Performance, CARD_KEY: performance, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Top performers, CARD_KEY: top_performers, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Blaze campaigns, CARD_KEY: blaze, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Inbox, CARD_KEY: inbox, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Stock, CARD_KEY: stock, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Most recent orders, CARD_KEY: recent_orders, EXPECTED_MODE: original }
+- runFlow:
+    file: ../helpers/dashboard_assert_card.yaml
+    env: { CARD_TITLE: Google Ads campaigns, CARD_KEY: google_ads, EXPECTED_MODE: original }
+- repeat:
+    times: 6
+    commands:
+      - swipe: { start: "50%,25%", end: "50%,80%", duration: 300 }
 - scrollUntilVisible:
     element: "Most recent reviews"
     direction: DOWN
-    timeout: 30000
-- assertVisible: "Most recent reviews"
+    timeout: 15000
+- runFlow:
+    when:
+      true: ${output.dashboardReviewsOriginal === 'selected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-selected-Most recent reviews"
+- runFlow:
+    when:
+      true: ${output.dashboardReviewsOriginal === 'unselected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-unselected-Most recent reviews"
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    when:
+      true: ${output.dashboardCouponsOriginal === 'selected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-selected-Most active coupons"
+- runFlow:
+    when:
+      true: ${output.dashboardCouponsOriginal === 'unselected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-unselected-Most active coupons"
+- stopApp
+- launchApp
 
-# Reviews and Coupons are adjacent in the normalized selected-card ordering.
-# Drag the native trailing reorder control one row upward.
-- tapOn:
-    text: "Edit"
-- extendedWaitUntil:
-    visible: "Customize"
-    timeout: 15000
+# Prepare two selected adjacent anchors, persist an inverse order, prove it
+# after relaunch, reverse it, and prove the restored order after relaunch.
+- runFlow: ../helpers/open_dashboard_customizer.yaml
 - scrollUntilVisible:
     element: "Most recent reviews"
     direction: DOWN
     timeout: 15000
-- assertVisible:
-    text: "Most recent reviews"
-    below:
-      text: "Most active coupons"
-- swipe:
-    start: "92%,42%"
-    end: "92%,36%"
-    duration: 2000
+- runFlow:
+    when:
+      visible:
+        id: "selectable-item-unselected-Most recent reviews"
+    commands:
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: selected }
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    when:
+      visible:
+        id: "selectable-item-unselected-Most active coupons"
+    commands:
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most active coupons, DESIRED_STATE: selected }
+- runFlow:
+    when:
+      true: ${output.dashboardReviewsOriginal === 'unselected' || output.dashboardCouponsOriginal === 'unselected'}
+    commands:
+      - runFlow: ../helpers/save_dashboard_customizer.yaml
+- stopApp
+- launchApp
+- runFlow: ../helpers/open_dashboard_customizer.yaml
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: unselected }
+- scrollUntilVisible:
+    element: "Most active coupons"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most active coupons, DESIRED_STATE: unselected }
+- runFlow: ../helpers/save_dashboard_customizer.yaml
+- runFlow: ../helpers/open_dashboard_customizer.yaml
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: selected }
+- runFlow:
+    file: ../helpers/set_dashboard_card_selection.yaml
+    env: { CARD_TITLE: Most active coupons, DESIRED_STATE: selected }
+- runFlow: ../helpers/save_dashboard_customizer.yaml
+- runFlow: ../helpers/open_dashboard_customizer.yaml
+- scrollUntilVisible:
+    element: "Most recent reviews"
+    direction: DOWN
+    timeout: 15000
 - assertVisible:
     text: "Most recent reviews"
     above:
       text: "Most active coupons"
-- tapOn: "Save"
-
-# Downward-only traversal proves the rendered card order.
+- swipe: { start: "92%,54%", end: "92%,60%", duration: 2000 }
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible:
+    text: "Most recent reviews"
+    below:
+      text: "Most active coupons"
+- runFlow: ../helpers/save_dashboard_customizer.yaml
+- stopApp
+- launchApp
+- runFlow: ../helpers/open_dashboard_customizer.yaml
 - scrollUntilVisible:
     element: "Most recent reviews"
     direction: DOWN
-    timeout: 30000
-- assertVisible: "Most recent reviews"
-- scrollUntilVisible:
-    element: "Most active coupons"
-    direction: DOWN
-    timeout: 30000
-- assertVisible: "Most active coupons"
+    timeout: 15000
+- assertVisible:
+    text: "Most recent reviews"
+    below:
+      text: "Most active coupons"
+- swipe: { start: "92%,60%", end: "92%,54%", duration: 2000 }
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible:
+    text: "Most recent reviews"
+    above:
+      text: "Most active coupons"
+- runFlow: ../helpers/save_dashboard_customizer.yaml
 - stopApp
 - launchApp
-- runFlow:
-    file: ../subflows/navigate_to_dashboard.yaml
-- tapOn:
-    text: "Edit"
+- runFlow: ../helpers/open_dashboard_customizer.yaml
 - scrollUntilVisible:
     element: "Most recent reviews"
     direction: DOWN
@@ -149,58 +411,63 @@ tags:
     above:
       text: "Most active coupons"
 
-# Restore Coupons before Reviews, save, and prove persistence.
-- swipe:
-    start: "92%,36%"
-    end: "92%,42%"
-    duration: 2000
-- assertVisible:
-    text: "Most recent reviews"
-    below:
-      text: "Most active coupons"
-- tapOn: "Save"
-- scrollUntilVisible:
-    element: "Most active coupons"
-    direction: DOWN
-    timeout: 30000
-- assertVisible: "Most active coupons"
-- scrollUntilVisible:
-    element: "Most recent reviews"
-    direction: DOWN
-    timeout: 30000
-- assertVisible: "Most recent reviews"
+# Restore the captured anchor selections and verify the shared state one final
+# time after relaunch. Non-anchor order and selection were already restored.
+- runFlow:
+    when:
+      true: ${output.dashboardReviewsOriginal === 'unselected'}
+    commands:
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most recent reviews, DESIRED_STATE: unselected }
+- runFlow:
+    when:
+      true: ${output.dashboardCouponsOriginal === 'unselected'}
+    commands:
+      - runFlow:
+          file: ../helpers/set_dashboard_card_selection.yaml
+          env: { CARD_TITLE: Most active coupons, DESIRED_STATE: unselected }
+- runFlow:
+    when:
+      true: ${output.dashboardReviewsOriginal === 'unselected' || output.dashboardCouponsOriginal === 'unselected'}
+    commands:
+      - runFlow: ../helpers/save_dashboard_customizer.yaml
 - stopApp
 - launchApp
-- runFlow:
-    file: ../subflows/navigate_to_dashboard.yaml
-- tapOn:
-    text: "Edit"
+- runFlow: ../helpers/open_dashboard_customizer.yaml
 - scrollUntilVisible:
     element: "Most recent reviews"
     direction: DOWN
     timeout: 15000
-- assertVisible:
-    text: "Most recent reviews"
-    below:
-      text: "Most active coupons"
-
-# Restore Reviews to hidden, restart, and assert the restored dashboard state.
-- tapOn: "Most recent reviews"
-- tapOn: "Save"
-- stopApp
-- launchApp
 - runFlow:
-    file: ../subflows/navigate_to_dashboard.yaml
+    when:
+      true: ${output.dashboardReviewsOriginal === 'selected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-selected-Most recent reviews"
+- runFlow:
+    when:
+      true: ${output.dashboardReviewsOriginal === 'unselected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-unselected-Most recent reviews"
 - scrollUntilVisible:
     element: "Most active coupons"
     direction: DOWN
-    timeout: 30000
-- assertVisible: "Most active coupons"
-- scrollUntilVisible:
-    element:
-      text: "Most recent reviews"
-    direction: DOWN
     timeout: 15000
-    optional: true
-- assertNotVisible: "Most recent reviews"
+- runFlow:
+    when:
+      true: ${output.dashboardCouponsOriginal === 'selected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-selected-Most active coupons"
+- runFlow:
+    when:
+      true: ${output.dashboardCouponsOriginal === 'unselected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-unselected-Most active coupons"
+- stopApp
+- launchApp
+- runFlow: ../subflows/navigate_to_dashboard.yaml
 - takeScreenshot: dashboard_customize_restored

--- a/.maestro/flows/dashboard_view_all_analytics.yaml
+++ b/.maestro/flows/dashboard_view_all_analytics.yaml
@@ -1,0 +1,33 @@
+# p2: dashboard.analytics
+# Prerequisite: store has at least one order, so the Performance analytics card is available.
+appId: ${APP_ID}
+name: "Dashboard - View all store analytics"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - dashboard
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_dashboard.yaml
+- scrollUntilVisible:
+    element: "View all store analytics"
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    text: "View all store analytics"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible: "Analytics"
+    timeout: 20000
+- assertVisible: "Analytics"
+- assertVisible: "Date range"
+- assertVisible: "Revenue"
+- assertVisible: "Edit"
+- takeScreenshot: dashboard_view_all_analytics
+- back
+- extendedWaitUntil:
+    visible: "My store"
+    timeout: 10000
+

--- a/.maestro/flows/dashboard_view_all_analytics.yaml
+++ b/.maestro/flows/dashboard_view_all_analytics.yaml
@@ -22,12 +22,13 @@ tags:
     visible: "Analytics"
     timeout: 20000
 - assertVisible: "Analytics"
-- assertVisible: "Date range"
-- assertVisible: "Revenue"
+- assertVisible: "Today"
+- assertVisible: "REVENUE"
+- assertVisible: "ORDERS"
+- assertVisible: "See report"
 - assertVisible: "Edit"
 - takeScreenshot: dashboard_view_all_analytics
 - back
 - extendedWaitUntil:
     visible: "My store"
     timeout: 10000
-

--- a/.maestro/flows/google_for_woo.yaml
+++ b/.maestro/flows/google_for_woo.yaml
@@ -1,0 +1,43 @@
+# p2: hub.google-for-woo
+# Google for WooCommerce is a genuine plugin/account eligibility gate.
+appId: ${APP_ID}
+name: "Google for WooCommerce - Campaign webview"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- scroll
+- scroll
+- runFlow:
+    when:
+      notVisible:
+        id: "menu-google-ads"
+    commands:
+      - evalScript: ${console.log('FEATURE_SKIPPED hub.google-for-woo reason=plugin_or_ads_account_not_eligible')}
+      - takeScreenshot: google_for_woo_skipped
+- runFlow:
+    when:
+      visible:
+        id: "menu-google-ads"
+    commands:
+      - evalScript: ${console.log('FEATURE_EXERCISED hub.google-for-woo')}
+      - tapOn:
+          id: "menu-google-ads"
+      - extendedWaitUntil:
+          visible: "Google for WooCommerce"
+          timeout: 30000
+      - assertVisible: "Google for WooCommerce"
+      - assertVisible: "Cancel"
+      - assertNotVisible:
+          id: "menu-google-ads"
+      - takeScreenshot: google_for_woo_webview
+      - tapOn: "Cancel"
+      - extendedWaitUntil:
+          visible:
+            id: "menu-google-ads"
+          timeout: 15000

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -43,6 +43,27 @@ tags:
     visible:
       id: "store-title"
     timeout: 15000
+- copyTextFrom:
+    id: "store-title"
+- evalScript: |
+    output.storeOriginalName = String(maestro.copiedText || '').trim();
+- copyTextFrom:
+    id: "store-url"
+- evalScript: |
+    function host(value) {
+      return String(value || '').trim().toLowerCase()
+        .replace(/^https?:\/\//, '')
+        .split('/')[0]
+        .split('?')[0]
+        .split('#')[0]
+        .replace(/:\d+$/, '')
+        .replace(/\.$/, '');
+    }
+    output.storeOriginalURL = String(maestro.copiedText || '').trim();
+    output.storeOriginalHost = host(output.storeOriginalURL);
+    if (!output.storeOriginalHost) {
+      throw new Error('Current Hub store URL is empty');
+    }
 - tapOn:
     id: "store-title"
 - extendedWaitUntil:
@@ -50,10 +71,111 @@ tags:
     timeout: 20000
 - assertVisible: "Select Store"
 - assertVisible: "PICK STORE TO CONNECT"
-- assertVisible: "Dismiss"
-- takeScreenshot: hub_change_store
-- tapOn: "Dismiss"
+- copyTextFrom:
+    id: "url-label"
+    index: 0
+- evalScript: |
+    output.storeFirstURL = String(maestro.copiedText || '').trim();
+- copyTextFrom:
+    id: "name-label"
+    index: 0
+- evalScript: |
+    output.storeFirstName = String(maestro.copiedText || '').trim();
+- evalScript: |
+    function host(value) {
+      return String(value || '').trim().toLowerCase()
+        .replace(/^https?:\/\//, '')
+        .split('/')[0]
+        .split('?')[0]
+        .split('#')[0]
+        .replace(/:\d+$/, '')
+        .replace(/\.$/, '');
+    }
+    output.storeTargetHost = host(output.storeFirstURL);
+    output.storeTargetName = output.storeFirstName;
+    if (!output.storeTargetHost || output.storeTargetHost === output.storeOriginalHost) {
+      throw new Error('Store picker must expose a different Woo store in its first row');
+    }
+- takeScreenshot: hub_store_picker_discovery
+- tapOn:
+    point: "50%,43%"
+- takeScreenshot: hub_store_picker_target_selected
+- extendedWaitUntil:
+    visible:
+      id: "login-epilogue-continue-button"
+      enabled: true
+    timeout: 10000
+- tapOn:
+    id: "login-epilogue-continue-button"
+- extendedWaitUntil:
+    visible: "Menu"
+    timeout: 90000
+- tapOn: "Menu"
 - extendedWaitUntil:
     visible:
       id: "store-title"
+    timeout: 30000
+- copyTextFrom:
+    id: "store-url"
+- assertTrue:
+    condition: ${String(maestro.copiedText || '').trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/$/, '') !== String(MAESTRO_WOO_LAB_JETPACK_STORE_URL || '').trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/$/, '')}
+    label: Hub identity changed to the dynamically selected store
+- tapOn: "Products"
+- extendedWaitUntil:
+    visible:
+      id: "products-table-view"
+    timeout: 30000
+- assertVisible:
+    id: "products-table-view"
+- takeScreenshot: hub_change_store_target_loaded
+
+# Restore the shared account's original store immediately after the target
+# store-backed surface has loaded, then prove the original identity returned.
+- tapOn: "Menu"
+- extendedWaitUntil:
+    visible:
+      id: "store-title"
+    timeout: 20000
+- tapOn:
+    id: "store-title"
+- extendedWaitUntil:
+    visible: "Select Store"
+    timeout: 20000
+- scrollUntilVisible:
+    element:
+      id: "url-label"
+      text: ".*${MAESTRO_WOO_LAB_JETPACK_STORE_HOST}.*"
+    direction: DOWN
+    timeout: 15000
+    centerElement: true
+- tapOn:
+    point: "50%,75%"
+- takeScreenshot: hub_store_picker_original_selected
+- extendedWaitUntil:
+    visible:
+      id: "login-epilogue-continue-button"
+      enabled: true
     timeout: 10000
+- tapOn:
+    id: "login-epilogue-continue-button"
+- extendedWaitUntil:
+    visible: "Menu"
+    timeout: 90000
+- tapOn: "Menu"
+- extendedWaitUntil:
+    visible:
+      id: "store-url"
+    timeout: 30000
+- copyTextFrom:
+    id: "store-url"
+- assertTrue:
+    condition: ${String(maestro.copiedText || '').trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/$/, '') === String(MAESTRO_WOO_LAB_JETPACK_STORE_URL || '').trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/$/, '')}
+    label: Original Hub store identity is restored
+- tapOn: "Products"
+- extendedWaitUntil:
+    visible:
+      id: "products-table-view"
+    timeout: 30000
+- assertVisible:
+    id: "products-table-view"
+- takeScreenshot: hub_change_store_restored

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -1,0 +1,59 @@
+# p2: hub.change-store, hub.wc-admin, hub.view-store
+appId: ${APP_ID}
+name: "Hub Menu - WooCommerce Admin, View Store, and change store"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- scrollUntilVisible:
+    element:
+      id: "menu-view-store"
+    direction: DOWN
+    timeout: 15000
+- tapOn:
+    id: "menu-view-store"
+- extendedWaitUntil:
+    visible: "View Store"
+    timeout: 20000
+- assertVisible: "View Store"
+- assertNotVisible:
+    id: "menu-view-store"
+- takeScreenshot: hub_view_store
+- back
+- extendedWaitUntil:
+    visible:
+      id: "menu-view-store"
+    timeout: 15000
+- tapOn:
+    id: "menu-woocommerce-admin"
+- extendedWaitUntil:
+    visible: "WooCommerce Admin"
+    timeout: 20000
+- assertVisible: "WooCommerce Admin"
+- assertNotVisible:
+    id: "menu-woocommerce-admin"
+- takeScreenshot: hub_woocommerce_admin
+- back
+- extendedWaitUntil:
+    visible:
+      id: "store-title"
+    timeout: 15000
+- tapOn:
+    id: "store-title"
+- extendedWaitUntil:
+    visible: "Connected Stores"
+    timeout: 20000
+- assertVisible: "Connected Stores"
+- assertVisible: "Dismiss"
+- takeScreenshot: hub_change_store
+- tapOn: "Dismiss"
+- extendedWaitUntil:
+    visible:
+      id: "store-title"
+    timeout: 10000
+

--- a/.maestro/flows/hub_menu_admin_and_store.yaml
+++ b/.maestro/flows/hub_menu_admin_and_store.yaml
@@ -24,7 +24,7 @@ tags:
 - assertNotVisible:
     id: "menu-view-store"
 - takeScreenshot: hub_view_store
-- back
+- tapOn: "Back"
 - extendedWaitUntil:
     visible:
       id: "menu-view-store"
@@ -38,7 +38,7 @@ tags:
 - assertNotVisible:
     id: "menu-woocommerce-admin"
 - takeScreenshot: hub_woocommerce_admin
-- back
+- tapOn: "Back"
 - extendedWaitUntil:
     visible:
       id: "store-title"
@@ -46,9 +46,10 @@ tags:
 - tapOn:
     id: "store-title"
 - extendedWaitUntil:
-    visible: "Connected Stores"
+    visible: "Select Store"
     timeout: 20000
-- assertVisible: "Connected Stores"
+- assertVisible: "Select Store"
+- assertVisible: "PICK STORE TO CONNECT"
 - assertVisible: "Dismiss"
 - takeScreenshot: hub_change_store
 - tapOn: "Dismiss"
@@ -56,4 +57,3 @@ tags:
     visible:
       id: "store-title"
     timeout: 10000
-

--- a/.maestro/flows/hub_menu_coupons.yaml
+++ b/.maestro/flows/hub_menu_coupons.yaml
@@ -43,9 +43,8 @@ tags:
     visible:
       id: "coupon-create-button"
     timeout: 10000
-- back
+- tapOn: "Back"
 - extendedWaitUntil:
     visible:
       id: "menu-coupons"
     timeout: 10000
-

--- a/.maestro/flows/hub_menu_coupons.yaml
+++ b/.maestro/flows/hub_menu_coupons.yaml
@@ -1,0 +1,51 @@
+# p2: hub.coupons.create
+appId: ${APP_ID}
+name: "Hub Menu - Coupons"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- scrollUntilVisible:
+    element:
+      id: "menu-coupons"
+    direction: DOWN
+    timeout: 15000
+- tapOn:
+    id: "menu-coupons"
+- extendedWaitUntil:
+    visible:
+      id: "coupon-create-button"
+    timeout: 20000
+- assertVisible: "Coupons"
+- tapOn:
+    id: "coupon-create-button"
+- extendedWaitUntil:
+    visible: "Create Coupon"
+    timeout: 10000
+- assertVisible: "Percentage Discount"
+- assertVisible: "Fixed Cart Discount"
+- assertVisible: "Fixed Product Discount"
+- tapOn: "Percentage Discount"
+- extendedWaitUntil:
+    visible: "Create coupon"
+    timeout: 15000
+- assertVisible: "Coupon Code"
+- assertVisible: "Regenerate Coupon Code"
+- assertVisible: "Discount Type"
+- takeScreenshot: hub_coupon_creation_form
+- tapOn: "Cancel"
+- extendedWaitUntil:
+    visible:
+      id: "coupon-create-button"
+    timeout: 10000
+- back
+- extendedWaitUntil:
+    visible:
+      id: "menu-coupons"
+    timeout: 10000
+

--- a/.maestro/flows/hub_menu_customers_inbox.yaml
+++ b/.maestro/flows/hub_menu_customers_inbox.yaml
@@ -1,5 +1,5 @@
 # p2: hub.customers, hub.inbox
-# Inbox is a genuine feature gate based on store eligibility.
+# Inbox eligibility is a required fixture capability for extended smoke runs.
 appId: ${APP_ID}
 name: "Hub Menu - Customers and Inbox"
 tags:
@@ -29,31 +29,23 @@ tags:
     visible:
       id: "menu-customers"
     timeout: 10000
-- scroll
-- runFlow:
-    when:
-      notVisible:
-        id: "menu-inbox"
-    commands:
-      - evalScript: ${console.log('FEATURE_SKIPPED hub.inbox reason=store_not_eligible')}
-      - takeScreenshot: hub_inbox_skipped
-- runFlow:
-    when:
-      visible:
-        id: "menu-inbox"
-    commands:
-      - evalScript: ${console.log('FEATURE_EXERCISED hub.inbox')}
-      - tapOn:
-          id: "menu-inbox"
-      - extendedWaitUntil:
-          visible: "Inbox"
-          timeout: 20000
-      - assertVisible: "Inbox"
-      - assertNotVisible:
-          id: "menu-customers"
-      - takeScreenshot: hub_inbox
-      - tapOn: "Back"
-      - extendedWaitUntil:
-          visible:
-            id: "menu-customers"
-          timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "menu-inbox"
+    direction: DOWN
+    timeout: 15000
+    label: "Require an Inbox-eligible extended-smoke store"
+- tapOn:
+    id: "menu-inbox"
+- extendedWaitUntil:
+    visible: "Inbox"
+    timeout: 20000
+- assertVisible: "Inbox"
+- assertNotVisible:
+    id: "menu-customers"
+- takeScreenshot: hub_inbox
+- tapOn: "Back"
+- extendedWaitUntil:
+    visible:
+      id: "menu-customers"
+    timeout: 10000

--- a/.maestro/flows/hub_menu_customers_inbox.yaml
+++ b/.maestro/flows/hub_menu_customers_inbox.yaml
@@ -1,0 +1,60 @@
+# p2: hub.customers, hub.inbox
+# Inbox is a genuine feature gate based on store eligibility.
+appId: ${APP_ID}
+name: "Hub Menu - Customers and Inbox"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- scrollUntilVisible:
+    element:
+      id: "menu-customers"
+    direction: DOWN
+    timeout: 15000
+- tapOn:
+    id: "menu-customers"
+- extendedWaitUntil:
+    visible: "Search for customers"
+    timeout: 20000
+- assertVisible: "Customers"
+- assertVisible: "Search for customers"
+- takeScreenshot: hub_customers
+- back
+- extendedWaitUntil:
+    visible:
+      id: "menu-customers"
+    timeout: 10000
+- scroll
+- runFlow:
+    when:
+      notVisible:
+        id: "menu-inbox"
+    commands:
+      - evalScript: ${console.log('FEATURE_SKIPPED hub.inbox reason=store_not_eligible')}
+      - takeScreenshot: hub_inbox_skipped
+- runFlow:
+    when:
+      visible:
+        id: "menu-inbox"
+    commands:
+      - evalScript: ${console.log('FEATURE_EXERCISED hub.inbox')}
+      - tapOn:
+          id: "menu-inbox"
+      - extendedWaitUntil:
+          visible: "Inbox"
+          timeout: 20000
+      - assertVisible: "Inbox"
+      - assertNotVisible:
+          id: "menu-customers"
+      - takeScreenshot: hub_inbox
+      - back
+      - extendedWaitUntil:
+          visible:
+            id: "menu-customers"
+          timeout: 10000
+

--- a/.maestro/flows/hub_menu_customers_inbox.yaml
+++ b/.maestro/flows/hub_menu_customers_inbox.yaml
@@ -24,7 +24,7 @@ tags:
 - assertVisible: "Customers"
 - assertVisible: "Search for customers"
 - takeScreenshot: hub_customers
-- back
+- tapOn: "Back"
 - extendedWaitUntil:
     visible:
       id: "menu-customers"
@@ -52,9 +52,8 @@ tags:
       - assertNotVisible:
           id: "menu-customers"
       - takeScreenshot: hub_inbox
-      - back
+      - tapOn: "Back"
       - extendedWaitUntil:
           visible:
             id: "menu-customers"
           timeout: 10000
-

--- a/.maestro/flows/hub_menu_payments.yaml
+++ b/.maestro/flows/hub_menu_payments.yaml
@@ -46,7 +46,7 @@ tags:
       - extendedWaitUntil:
           visible: "Payments"
           timeout: 10000
-- back
+- tapOn: "Back"
 - extendedWaitUntil:
     visible:
       id: "menu-payments"

--- a/.maestro/flows/hub_menu_payments.yaml
+++ b/.maestro/flows/hub_menu_payments.yaml
@@ -1,0 +1,53 @@
+# p2: hub.payments
+# Card-reader rows are a genuine territory/store capability gate.
+appId: ${APP_ID}
+name: "Hub Menu - Payments"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- tapOn:
+    id: "menu-payments"
+- extendedWaitUntil:
+    visible: "Payments"
+    timeout: 20000
+- assertVisible: "Payments"
+- scroll
+- scroll
+- runFlow:
+    when:
+      notVisible:
+        id: "card-reader-manuals"
+    commands:
+      - evalScript: ${console.log('FEATURE_SKIPPED hub.payments.card-readers reason=unsupported_store_territory')}
+      - takeScreenshot: hub_payments_card_readers_skipped
+- runFlow:
+    when:
+      visible:
+        id: "card-reader-manuals"
+    commands:
+      - evalScript: ${console.log('FEATURE_EXERCISED hub.payments.card-readers')}
+      - assertVisible: "Order Card Reader"
+      - assertVisible: "Manage Card Reader"
+      - tapOn:
+          id: "card-reader-manuals"
+      - extendedWaitUntil:
+          visible: "Card Reader Manuals"
+          timeout: 15000
+      - assertVisible: "BBPOS Chipper 2X BT"
+      - assertVisible: "Stripe Reader M2"
+      - takeScreenshot: hub_payments_manuals
+      - back
+      - extendedWaitUntil:
+          visible: "Payments"
+          timeout: 10000
+- back
+- extendedWaitUntil:
+    visible:
+      id: "menu-payments"
+    timeout: 10000

--- a/.maestro/flows/hub_menu_settings.yaml
+++ b/.maestro/flows/hub_menu_settings.yaml
@@ -1,0 +1,49 @@
+# p2: hub.settings
+appId: ${APP_ID}
+name: "Hub Menu - Settings"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - hub_menu
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_more_menu.yaml
+- assertVisible:
+    id: "dashboard-settings-button"
+- assertVisible:
+    id: "menu-payments"
+- tapOn:
+    id: "dashboard-settings-button"
+- extendedWaitUntil:
+    visible: "Help & Support"
+    timeout: 15000
+- assertVisible: "Settings"
+- assertVisible: "Help & Support"
+- assertVisible: "Troubleshoot Connection"
+- scrollUntilVisible:
+    element: "Privacy Settings"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Privacy Settings"
+- assertVisible:
+    id: "settings-beta-features-button"
+- scrollUntilVisible:
+    element: "WooCommerce"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "WooCommerce"
+- scrollUntilVisible:
+    element:
+      id: "settings-log-out-button"
+    direction: DOWN
+    timeout: 10000
+- assertVisible:
+    id: "settings-log-out-button"
+- takeScreenshot: hub_settings
+- back
+- extendedWaitUntil:
+    visible:
+      id: "dashboard-settings-button"
+    timeout: 10000

--- a/.maestro/flows/hub_menu_settings.yaml
+++ b/.maestro/flows/hub_menu_settings.yaml
@@ -42,7 +42,7 @@ tags:
 - assertVisible:
     id: "settings-log-out-button"
 - takeScreenshot: hub_settings
-- back
+- tapOn: "Back"
 - extendedWaitUntil:
     visible:
       id: "dashboard-settings-button"

--- a/.maestro/flows/login_google.yaml
+++ b/.maestro/flows/login_google.yaml
@@ -27,7 +27,25 @@ tags:
       id: "prologue-title-label"
     timeout: 15000
 - tapOn:
-    id: "Prologue Continue Button"
+    id: "Prologue Self Hosted Button"
+- runFlow:
+    when:
+      visible: "No computer? Log in with site address"
+    commands:
+      - tapOn: "No computer? Log in with site address"
+- extendedWaitUntil:
+    visible:
+      id: "Site address"
+    timeout: 15000
+- tapOn:
+    id: "Site address"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${MAESTRO_WOO_LAB_JETPACK_STORE_URL}
+- hideKeyboard
+- tapOn:
+    id: "Site Address Next Button"
 - extendedWaitUntil:
     visible:
       id: "Continue with Google Button"

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -57,24 +57,20 @@ tags:
           id: "Sign in with site credentials Button"
 
 - extendedWaitUntil:
-    visible:
-      id: "usernameField"
+    visible: "Username"
     timeout: 30000
-- tapOn:
-    id: "usernameField"
+- tapOn: "Username"
 - runFlow:
     file: ../subflows/paste_into_focused_field.yaml
     env:
       TEXT_TO_PASTE: ${MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_USERNAME}
-- tapOn:
-    id: "passwordField"
+- tapOn: "Password"
 - runFlow:
     file: ../subflows/paste_into_focused_field.yaml
     env:
       TEXT_TO_PASTE: ${MAESTRO_WOO_NO_JETPACK_SITE_ADMIN_PASSWORD}
 - hideKeyboard
-- tapOn:
-    id: "submitButton"
+- tapOn: "Continue"
 
 - runFlow:
     when:
@@ -95,9 +91,35 @@ tags:
       - tapOn: "Not now"
 
 - extendedWaitUntil:
-    visible:
-      id: "tab-bar-my-store-item"
+    visible: "Manage Privacy|Save Password\\?"
     timeout: 60000
+- runFlow:
+    when:
+      visible: "Manage Privacy"
+    commands:
+      - tapOn: "Save"
+- runFlow:
+    when:
+      visible: "Save Password?"
+    commands:
+      - tapOn: "Not Now"
+- extendedWaitUntil:
+    visible: "Manage Privacy|Save Password\\?|Orders"
+    timeout: 30000
+- runFlow:
+    when:
+      visible: "Manage Privacy"
+    commands:
+      - tapOn: "Save"
+- runFlow:
+    when:
+      visible: "Save Password?"
+    commands:
+      - tapOn: "Not Now"
+- extendedWaitUntil:
+    visible:
+      id: "tab-bar-orders-item"
+    timeout: 15000
 - assertVisible:
     id: "tab-bar-orders-item"
 - assertVisible:

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -52,7 +52,6 @@ tags:
 - extendedWaitUntil:
     visible: "Username|Email address"
     timeout: 30000
-
 - runFlow:
     when:
       visible:
@@ -108,8 +107,13 @@ tags:
           env:
             TEXT_TO_PASTE: ${MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD}
       - hideKeyboard
-      - tapOn:
-          id: "Continue Button"
+      - runFlow:
+          when:
+            visible:
+              id: "Continue Button"
+          commands:
+            - tapOn:
+                id: "Continue Button"
       - runFlow:
           when:
             visible: "Save Password?"

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -69,8 +69,13 @@ tags:
     env:
       TEXT_TO_PASTE: ${MAESTRO_WOO_LAB_WPCOM_PASSWORD}
 - hideKeyboard
-- tapOn:
-    id: "Continue Button"
+- runFlow:
+    when:
+      visible:
+        id: "Continue Button"
+    commands:
+      - tapOn:
+          id: "Continue Button"
 - runFlow:
     when:
       visible: "Save Password?"

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -26,7 +26,25 @@ tags:
       id: "prologue-title-label"
     timeout: 15000
 - tapOn:
-    id: "Prologue Continue Button"
+    id: "Prologue Self Hosted Button"
+- runFlow:
+    when:
+      visible: "No computer? Log in with site address"
+    commands:
+      - tapOn: "No computer? Log in with site address"
+- extendedWaitUntil:
+    visible:
+      id: "Site address"
+    timeout: 15000
+- tapOn:
+    id: "Site address"
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${MAESTRO_WOO_LAB_JETPACK_STORE_URL}
+- hideKeyboard
+- tapOn:
+    id: "Site Address Next Button"
 - extendedWaitUntil:
     visible:
       id: "Email address"
@@ -51,8 +69,17 @@ tags:
     env:
       TEXT_TO_PASTE: "maestro-intentionally-wrong-password"
 - hideKeyboard
-- tapOn:
-    id: "Continue Button"
+- extendedWaitUntil:
+    visible:
+      id: "Continue Button|Password Error"
+    timeout: 15000
+- runFlow:
+    when:
+      visible:
+        id: "Continue Button"
+    commands:
+      - tapOn:
+          id: "Continue Button"
 - runFlow:
     when:
       visible: "Save Password?"

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -1,0 +1,78 @@
+# p2: products.detail.description, products.detail.price, products.detail.inventory, products.detail.categories, products.detail.type, products.detail.shipping, products.detail.short-description, products.detail.linked, products.detail.downloads
+# Uses an unsaved Physical-product detail form so every empty-field entry point
+# is deterministic; the flow exits without publishing or leaving store data.
+appId: ${APP_ID}
+name: "Products - Product detail view"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - products
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+- tapOn:
+    id: "product-add-button"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible:
+      id: "product-creation-sheet"
+    timeout: 10000
+- tapOn: "Physical product"
+- extendedWaitUntil:
+    visible:
+      id: "edit-product-more-options-button"
+    timeout: 20000
+- assertVisible:
+    id: "product-title"
+- assertVisible:
+    id: "product-description"
+- scrollUntilVisible:
+    element: "Add Price"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Add Price"
+- assertVisible: "Inventory"
+- scrollUntilVisible:
+    element: "Product type"
+    direction: DOWN
+    timeout: 15000
+- assertVisible: "Product type"
+- tapOn:
+    id: "edit-product-more-options-button"
+- extendedWaitUntil:
+    visible: "Shipping"
+    timeout: 10000
+- assertVisible: "Shipping"
+- scrollUntilVisible:
+    element: "Categories"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Categories"
+- scrollUntilVisible:
+    element: "Short description"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Short description"
+- scrollUntilVisible:
+    element: "Linked products"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Linked products"
+- scrollUntilVisible:
+    element: "Downloadable files"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Downloadable files"
+- takeScreenshot: products_detail_settings
+- back
+- runFlow:
+    when:
+      visible: "Discard"
+    commands:
+      - tapOn: "Discard"
+- extendedWaitUntil:
+    visible:
+      id: "products-table-view"
+    timeout: 10000

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -16,8 +16,19 @@ tags:
     id: "product-add-button"
     retryTapIfNoChange: true
 - extendedWaitUntil:
-    visible:
-      id: "product-creation-sheet"
+    visible: "Create Product|Select a product type"
+    timeout: 10000
+- runFlow:
+    when:
+      visible: "Create Product"
+    commands:
+      - tapOn: "Add manually"
+- extendedWaitUntil:
+    visible: "Select a product type"
+    timeout: 10000
+- assertVisible: "Select a product type"
+- extendedWaitUntil:
+    visible: "Physical product"
     timeout: 10000
 - tapOn: "Physical product"
 - extendedWaitUntil:
@@ -41,6 +52,37 @@ tags:
 - assertVisible: "Product type"
 - tapOn:
     id: "edit-product-more-options-button"
+- extendedWaitUntil:
+    visible: "Product Settings"
+    timeout: 10000
+- tapOn: "Product Settings"
+- extendedWaitUntil:
+    visible: "PUBLISH SETTINGS"
+    timeout: 10000
+- assertVisible: "Status"
+- assertVisible: "Visibility"
+- assertVisible: "Catalog Visibility"
+- assertVisible: "Virtual Product"
+- assertVisible: "Downloadable Product"
+- assertVisible: "Enable Reviews"
+- scrollUntilVisible:
+    element: "Slug"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Slug"
+- assertVisible: "Purchase Note"
+- assertVisible: "Menu Order"
+- takeScreenshot: products_publish_settings
+- tapOn: "Done"
+- extendedWaitUntil:
+    visible:
+      id: "edit-product-more-options-button"
+    timeout: 10000
+- scrollUntilVisible:
+    element: "Add more details"
+    direction: DOWN
+    timeout: 10000
+- tapOn: "Add more details"
 - extendedWaitUntil:
     visible: "Shipping"
     timeout: 10000
@@ -66,12 +108,17 @@ tags:
     timeout: 10000
 - assertVisible: "Downloadable files"
 - takeScreenshot: products_detail_settings
-- back
+- tapOn: "Dismiss"
+- extendedWaitUntil:
+    visible:
+      id: "edit-product-more-options-button"
+    timeout: 10000
+- tapOn: "Products"
 - runFlow:
     when:
-      visible: "Discard"
+      visible: "Discard changes"
     commands:
-      - tapOn: "Discard"
+      - tapOn: "Discard changes"
 - extendedWaitUntil:
     visible:
       id: "products-table-view"

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -1,0 +1,83 @@
+# p2: products.detail.tags, products.detail.variations, products.detail.variation-attributes
+# Prerequisite: store has an editable Variable product with at least one generated variation and attribute.
+appId: ${APP_ID}
+name: "Products - Variations and tags"
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - products
+---
+- runFlow:
+    file: ../subflows/ensure_logged_in.yaml
+- runFlow:
+    file: ../subflows/navigate_to_products.yaml
+- tapOn:
+    id: "product-filter-button"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible: "Product Type"
+    timeout: 10000
+- tapOn: "Product Type"
+- extendedWaitUntil:
+    visible: "Variable"
+    timeout: 10000
+- tapOn: "Variable"
+- tapOn: "Show Products"
+- extendedWaitUntil:
+    visible:
+      id: "products-table-view"
+    timeout: 20000
+- tapOn:
+    id: "products-table-view"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible:
+      id: "edit-product-more-options-button"
+    timeout: 20000
+- tapOn:
+    id: "edit-product-more-options-button"
+- extendedWaitUntil:
+    visible: "Tags"
+    timeout: 10000
+- tapOn: "Tags"
+- extendedWaitUntil:
+    visible:
+      id: "add-tags"
+    timeout: 15000
+- assertVisible: "Tags"
+- assertVisible:
+    id: "add-tags"
+- takeScreenshot: products_tags
+- back
+- extendedWaitUntil:
+    visible:
+      id: "edit-product-more-options-button"
+    timeout: 10000
+- scrollUntilVisible:
+    element: "Variations"
+    direction: DOWN
+    timeout: 15000
+- assertVisible: "Variations"
+- scrollUntilVisible:
+    element: "Variations Attributes"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "Variations Attributes"
+- tapOn: "Variations"
+- extendedWaitUntil:
+    visible: "Variations"
+    timeout: 20000
+- assertVisible: "Variations"
+- tapOn:
+    point: "50%,30%"
+- extendedWaitUntil:
+    visible: "Attributes"
+    timeout: 20000
+- assertVisible: "Attributes"
+- assertVisible: "Enabled"
+- takeScreenshot: products_variation_detail
+- back
+- extendedWaitUntil:
+    visible: "Variations"
+    timeout: 10000
+

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -28,14 +28,32 @@ tags:
       id: "products-table-view"
     timeout: 20000
 - tapOn:
-    id: "products-table-view"
-    retryTapIfNoChange: true
+    point: "50%,37%"
 - extendedWaitUntil:
     visible:
       id: "edit-product-more-options-button"
     timeout: 20000
 - tapOn:
     id: "edit-product-more-options-button"
+- extendedWaitUntil:
+    visible: "Product Settings"
+    timeout: 10000
+- tapOn: "Product Settings"
+- extendedWaitUntil:
+    visible: "PUBLISH SETTINGS"
+    timeout: 10000
+- assertVisible: "Status"
+- assertVisible: "Visibility"
+- tapOn: "Done"
+- extendedWaitUntil:
+    visible:
+      id: "edit-product-more-options-button"
+    timeout: 10000
+- scrollUntilVisible:
+    element: "Add more details"
+    direction: DOWN
+    timeout: 15000
+- tapOn: "Add more details"
 - extendedWaitUntil:
     visible: "Tags"
     timeout: 10000
@@ -48,7 +66,13 @@ tags:
 - assertVisible:
     id: "add-tags"
 - takeScreenshot: products_tags
-- back
+- tapOn:
+    point: "10%,12%"
+- runFlow:
+    when:
+      visible: "Dismiss"
+    commands:
+      - tapOn: "Dismiss"
 - extendedWaitUntil:
     visible:
       id: "edit-product-more-options-button"
@@ -57,19 +81,16 @@ tags:
     element: "Variations"
     direction: DOWN
     timeout: 15000
+- assertVisible: "2 variations"
 - assertVisible: "Variations"
-- scrollUntilVisible:
-    element: "Variations Attributes"
-    direction: DOWN
-    timeout: 10000
-- assertVisible: "Variations Attributes"
 - tapOn: "Variations"
 - extendedWaitUntil:
     visible: "Variations"
     timeout: 20000
 - assertVisible: "Variations"
 - tapOn:
-    point: "50%,30%"
+    point: "93%,27%"
+    retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Attributes"
     timeout: 20000
@@ -80,4 +101,3 @@ tags:
 - extendedWaitUntil:
     visible: "Variations"
     timeout: 10000
-

--- a/.maestro/helpers/dashboard_assert_card.yaml
+++ b/.maestro/helpers/dashboard_assert_card.yaml
@@ -1,0 +1,49 @@
+appId: ${APP_ID}
+---
+- evalScript: |
+    const original = output['dashboardCardState_' + String(CARD_KEY)];
+    if (!original) {
+      throw new Error('Missing captured dashboard state for ' + String(CARD_TITLE));
+    }
+    if (String(EXPECTED_MODE) === 'inverse') {
+      output.dashboardExpectedState = original === 'selected' ? 'unselected' :
+        original === 'unselected' ? 'selected' : original;
+    } else {
+      output.dashboardExpectedState = original;
+    }
+- repeat:
+    times: 6
+    commands:
+      - swipe: { start: "50%,25%", end: "50%,80%", duration: 300 }
+- scrollUntilVisible:
+    element: "${CARD_TITLE}"
+    direction: DOWN
+    timeout: 15000
+    optional: true
+- runFlow:
+    when:
+      true: ${output.dashboardExpectedState === 'selected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-selected-${CARD_TITLE}"
+- runFlow:
+    when:
+      true: ${output.dashboardExpectedState === 'unselected'}
+    commands:
+      - assertVisible:
+          id: "selectable-item-unselected-${CARD_TITLE}"
+- runFlow:
+    when:
+      true: ${output.dashboardExpectedState === 'unavailable'}
+    commands:
+      - assertVisible:
+          text: "${CARD_TITLE}"
+      - assertVisible:
+          text: "Unavailable"
+          rightOf:
+            text: "${CARD_TITLE}"
+- runFlow:
+    when:
+      true: ${output.dashboardExpectedState === 'hidden'}
+    commands:
+      - assertNotVisible: "${CARD_TITLE}"

--- a/.maestro/helpers/dashboard_restore_card.yaml
+++ b/.maestro/helpers/dashboard_restore_card.yaml
@@ -1,0 +1,26 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: dashboard_assert_card.yaml
+    env:
+      CARD_TITLE: ${CARD_TITLE}
+      CARD_KEY: ${CARD_KEY}
+      EXPECTED_MODE: inverse
+- runFlow:
+    when:
+      true: ${output.dashboardExpectedState === 'selected'}
+    commands:
+      - runFlow:
+          file: set_dashboard_card_selection.yaml
+          env:
+            CARD_TITLE: ${CARD_TITLE}
+            DESIRED_STATE: unselected
+- runFlow:
+    when:
+      true: ${output.dashboardExpectedState === 'unselected'}
+    commands:
+      - runFlow:
+          file: set_dashboard_card_selection.yaml
+          env:
+            CARD_TITLE: ${CARD_TITLE}
+            DESIRED_STATE: selected

--- a/.maestro/helpers/dashboard_toggle_card.yaml
+++ b/.maestro/helpers/dashboard_toggle_card.yaml
@@ -1,0 +1,52 @@
+appId: ${APP_ID}
+---
+- repeat:
+    times: 6
+    commands:
+      - swipe: { start: "50%,25%", end: "50%,80%", duration: 300 }
+- scrollUntilVisible:
+    element: "${CARD_TITLE}"
+    direction: DOWN
+    timeout: 15000
+    optional: true
+- runFlow:
+    when:
+      visible:
+        id: "selectable-item-selected-${CARD_TITLE}"
+    commands:
+      - evalScript: |
+          output['dashboardCardState_' + String(CARD_KEY)] = 'selected';
+      - runFlow:
+          file: set_dashboard_card_selection.yaml
+          env:
+            CARD_TITLE: ${CARD_TITLE}
+            DESIRED_STATE: unselected
+- runFlow:
+    when:
+      visible:
+        id: "selectable-item-unselected-${CARD_TITLE}"
+    commands:
+      - evalScript: |
+          output['dashboardCardState_' + String(CARD_KEY)] = 'unselected';
+      - runFlow:
+          file: set_dashboard_card_selection.yaml
+          env:
+            CARD_TITLE: ${CARD_TITLE}
+            DESIRED_STATE: selected
+- runFlow:
+    when:
+      visible:
+        text: "Unavailable"
+        rightOf:
+          text: "${CARD_TITLE}"
+    commands:
+      - evalScript: |
+          output['dashboardCardState_' + String(CARD_KEY)] = 'unavailable';
+          console.log('DASHBOARD_CARD_UNAVAILABLE ' + String(CARD_TITLE));
+- runFlow:
+    when:
+      notVisible: "${CARD_TITLE}"
+    commands:
+      - evalScript: |
+          output['dashboardCardState_' + String(CARD_KEY)] = 'hidden';
+          console.log('DASHBOARD_CARD_HIDDEN ' + String(CARD_TITLE));

--- a/.maestro/helpers/open_dashboard_customizer.yaml
+++ b/.maestro/helpers/open_dashboard_customizer.yaml
@@ -1,0 +1,40 @@
+appId: ${APP_ID}
+---
+- extendedWaitUntil:
+    visible:
+      id: "dashboard-edit-button"
+      enabled: true
+    timeout: 30000
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn:
+    id: "dashboard-edit-button"
+    enabled: true
+    retryTapIfNoChange: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible:
+        id: "dashboard-edit-button"
+        enabled: true
+    commands:
+      - tapOn:
+          id: "dashboard-edit-button"
+          enabled: true
+          retryTapIfNoChange: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible:
+        id: "dashboard-edit-button"
+        enabled: true
+    commands:
+      - tapOn:
+          id: "dashboard-edit-button"
+          enabled: true
+          retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible: "Customize"
+    timeout: 15000

--- a/.maestro/helpers/save_dashboard_customizer.yaml
+++ b/.maestro/helpers/save_dashboard_customizer.yaml
@@ -1,0 +1,35 @@
+appId: ${APP_ID}
+---
+- extendedWaitUntil:
+    visible:
+      text: "Save"
+      enabled: true
+    timeout: 15000
+- tapOn:
+    text: "Save"
+    enabled: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible:
+        text: "Save"
+        enabled: true
+    commands:
+      - tapOn:
+          text: "Save"
+          enabled: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible:
+        text: "Save"
+        enabled: true
+    commands:
+      - tapOn:
+          text: "Save"
+          enabled: true
+- extendedWaitUntil:
+    notVisible: "Customize"
+    timeout: 30000

--- a/.maestro/helpers/set_dashboard_card_selection.yaml
+++ b/.maestro/helpers/set_dashboard_card_selection.yaml
@@ -1,0 +1,34 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    when:
+      true: ${String(DESIRED_STATE) === 'selected'}
+      visible:
+        id: "selectable-item-unselected-${CARD_TITLE}"
+    commands:
+      - tapOn:
+          id: "selectable-item-row-${CARD_TITLE}"
+- runFlow:
+    when:
+      true: ${String(DESIRED_STATE) === 'selected'}
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "selectable-item-selected-${CARD_TITLE}"
+          timeout: 15000
+- runFlow:
+    when:
+      true: ${String(DESIRED_STATE) === 'unselected'}
+      visible:
+        id: "selectable-item-selected-${CARD_TITLE}"
+    commands:
+      - tapOn:
+          id: "selectable-item-row-${CARD_TITLE}"
+- runFlow:
+    when:
+      true: ${String(DESIRED_STATE) === 'unselected'}
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "selectable-item-unselected-${CARD_TITLE}"
+          timeout: 15000

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -17,6 +17,7 @@ import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -210,8 +211,17 @@ def select_flows(args: argparse.Namespace, include: list[str], exclude: list[str
     return selected
 
 
+def normalized_store_host(value: str) -> str:
+    candidate = value.strip()
+    parsed = urlsplit(candidate if "://" in candidate else f"//{candidate}")
+    return (parsed.hostname or "").lower().rstrip(".")
+
+
 def maestro_env_args(values: dict[str, str], app_id: str, run_id: str) -> list[str]:
     exported = {name: value for name, value in values.items() if name.startswith("MAESTRO_") and value}
+    lab_store_url = values.get("MAESTRO_WOO_LAB_JETPACK_STORE_URL", "")
+    if lab_store_host := normalized_store_host(lab_store_url):
+        exported["MAESTRO_WOO_LAB_JETPACK_STORE_HOST"] = lab_store_host
     exported.update({"APP_ID": app_id, "SUITE_RUN_ID": run_id, "MAESTRO_SUITE_RUN_ID": run_id})
     result: list[str] = []
     for name in sorted(exported):

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -51,6 +51,15 @@ class RunnerTests(unittest.TestCase):
             )
             self.assertEqual("com.automattic.alpha.woocommerce", RUNNER.app_identifier(app))
 
+    def test_maestro_env_args_derives_lab_store_host(self) -> None:
+        args = RUNNER.maestro_env_args(
+            {"MAESTRO_WOO_LAB_JETPACK_STORE_URL": "http://shop.example.com/path"},
+            "com.example.app",
+            "run-1",
+        )
+
+        self.assertIn("MAESTRO_WOO_LAB_JETPACK_STORE_HOST=shop.example.com", args)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.maestro/subflows/navigate_to_dashboard.yaml
+++ b/.maestro/subflows/navigate_to_dashboard.yaml
@@ -4,5 +4,5 @@ appId: ${APP_ID}
     id: "tab-bar-my-store-item"
 - extendedWaitUntil:
     visible:
-      id: "performance-time-range-menu"
+      text: "Edit"
     timeout: 30000

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -136,6 +136,7 @@ struct DashboardView: View {
                             }
                         }
                 })
+                .accessibilityIdentifier("dashboard-edit-button")
                 .disabled(viewModel.isReloadingAllData)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
@@ -36,6 +36,7 @@ struct SelectableItemRow: View {
                 Text(title)
                     .bodyStyle(isEnabled)
                     .multilineTextAlignment(.leading)
+                    .accessibilityIdentifier(selected ? "selectable-item-selected" : "selectable-item-unselected")
                 subtitle.map {
                     Text($0)
                         .footnoteStyle(isEnabled: isEnabled)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
@@ -36,7 +36,7 @@ struct SelectableItemRow: View {
                 Text(title)
                     .bodyStyle(isEnabled)
                     .multilineTextAlignment(.leading)
-                    .accessibilityIdentifier(selected ? "selectable-item-selected" : "selectable-item-unselected")
+                    .accessibilityIdentifier("selectable-item-\(selected ? "selected" : "unselected")-\(title)")
                 subtitle.map {
                     Text($0)
                         .footnoteStyle(isEnabled: isEnabled)
@@ -54,6 +54,8 @@ struct SelectableItemRow: View {
         .padding([.top, .bottom], Constants.hStackPadding)
         .frame(minHeight: displayMode.minHeight)
         .contentShape(Rectangle())
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("selectable-item-row-\(title)")
     }
 
     private var selectionIcon: some View {


### PR DESCRIPTION
## Description

Third PR in the eight-part iOS Maestro stack. It adds quarantined, state-restoring live-store coverage for:

- Dashboard card selection, persistence across relaunches, reordering, restoration of the captured original state, and Analytics Hub.
- Product-detail, variation, attribute, and tag entry points.
- Settings, Payments, Coupons, Customers, Inbox, WC Admin, and View Store surfaces.
- Blaze and Google for Woo destinations when the configured store is eligible.
- Store switching that dynamically selects a different visible host and then restores the original store.

It also adds narrowly scoped accessibility identifiers for the dashboard edit action and selectable rows. Every flow introduced here is tagged `smoke_extended` and `flaky_quarantine`; none is part of the four-flow release signal.

## Validation

- 7 Python runner contract tests
- all YAML files parsed successfully
- Python compilation, shell syntax, and example-environment lint
- exact layer diff passes `git diff --check`
- removed the trailing blank line in `blaze_campaign.yaml` found during this review
- repository CI rerun on the corrected head

No live store or simulator execution was performed during this review. The YAML assertions and state-restoration logic were reviewed statically; runtime reliability still needs the planned fixture-backed polishing passes.

## Coverage and limitations

- Dashboard customization is the strongest flow in this layer: it captures visible card state, proves selection/order persistence across relaunches, reverses the mutations, and reasserts restoration.
- Product inventory, categories, and shipping only verify their entry points here; they do not persist those settings.
- Settings covers representative rows rather than opening every item. Payments checks card-reader/manual surfaces only when eligible.
- Coupons reaches and verifies the creation form, then cancels; it does not create a coupon.
- Blaze and Google for Woo can emit an explicit eligibility skip and only verify a creation-capable destination/webview when available; neither submits a campaign.
- Inbox is a required `phone-full` fixture capability and fails when absent. Other conditional feature surfaces remain non-gating because the entire layer is quarantined.
- #17656 tightens the final coverage contract so these partial entry-point checks are not presented as complete release evidence.

## Test steps

1. Configure `.maestro/.env.local` for a disposable store exposing the documented extended features, including Inbox.
2. Install a compatible simulator app.
3. Run `.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --include-tags smoke_extended`.
4. Confirm dashboard state is restored after the final relaunch and store switching returns to the original host.
5. Treat feature eligibility skips and every quarantined failure as review evidence, not a release-gating result.

## Stack

1. #17525 — foundations
2. #17526 — core and login flows
3. #17527 — extended store flows
4. #17528 — destructive flows
5. #17529 — iPad POS flows
6. #17530 — iOS system-surface flows
7. #17531 — Buildkite integration
8. #17656 — trust, reliability, toolchain, and reporting hardening

Previous: #17526 · Next: #17528

## Screenshots

N/A — no visual change; this layer only adds accessibility metadata to existing controls.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. Test automation and accessibility identifiers only; no release note is required.
