### PR TITLE
[Maestro 4/8] Add destructive smoke flows

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -60,6 +60,12 @@ The lab store used by `phone-full` must be eligible for Inbox. The P2 lists
 Inbox as required hub coverage, so an absent `menu-inbox` fails the extended
 flow instead of being reported as a feature-gated skip.
 
+The destructive order-creation flow additionally requires exact names for one
+priced simple product, one priced variable product with an available variation,
+and an existing-customer search value. Configure them with the three
+`MAESTRO_WOO_*` fixture variables documented in `env.example`; the runner fails
+preflight rather than silently omitting those assertions.
+
 Validate traceability and static files with:
 
 ```bash

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -30,3 +30,8 @@ MAESTRO_WOO_CONSUMER_SECRET=
 # Optional flow-specific data. Values must belong to the configured iOS store.
 MAESTRO_WOO_TEST_COUPON_CODE=
 MAESTRO_WOO_TEST_RECEIPT_EMAIL=
+
+# Required by the complete destructive order-creation assertion.
+MAESTRO_WOO_SIMPLE_PRODUCT_NAME=
+MAESTRO_WOO_VARIABLE_PRODUCT_NAME=
+MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH=

--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -1,0 +1,63 @@
+# p2: orders.collect-payment.cash
+appId: ${APP_ID}
+name: Collect cash for a run-owned order
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - destructive
+  - orders
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- tapOn:
+    id: new-order-add-product-button
+- tapOn:
+    id: product-item
+    index: 0
+- tapOn:
+    id: product-multiple-selection-done-button
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-customer-note-button
+- tapOn:
+    id: edit-note-text-editor
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Cash ${SUITE_RUN_ID}
+- tapOn:
+    id: edit-note-done-button
+- tapOn:
+    id: new-order-create-button
+- extendedWaitUntil:
+    visible:
+      id: order-details-table-view
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      id: order-details-collect-payment-button
+    direction: DOWN
+- tapOn:
+    id: order-details-collect-payment-button
+- assertVisible:
+    id: payment-methods-header-label
+- tapOn:
+    id: payment-methods-view-cash-row
+- assertVisible: Cash received
+- tapOn: Cash received
+- inputText: "9999"
+- assertVisible: Change due
+- tapOn: Mark Order as Complete
+- extendedWaitUntil:
+    visible:
+      text: Completed
+    timeout: 30000
+- assertVisible: Completed
+- scrollUntilVisible:
+    element:
+      text: Cash ${SUITE_RUN_ID}
+    direction: DOWN
+- assertVisible: Cash ${SUITE_RUN_ID}

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -1,0 +1,155 @@
+# p2: orders.create.products, orders.create.variable-products, orders.create.quantity, orders.create.product-discount, orders.create.custom-amount, orders.create.custom-amount-note, orders.create.shipping, orders.create.customer-add, orders.create.customer-edit, orders.create.note
+appId: ${APP_ID}
+name: Create a run-owned order with customer, shipping, discount, amount, and note
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - destructive
+  - orders
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- assertVisible:
+    id: new-order-create-button
+
+# Add an exact real simple product and persist a quantity of two.
+- tapOn:
+    id: new-order-add-product-button
+- assertVisible:
+    id: product-selector-search-bar
+- tapOn:
+    id: product-selector-search-bar
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${MAESTRO_WOO_SIMPLE_PRODUCT_NAME}
+- hideKeyboard
+- tapOn: ${MAESTRO_WOO_SIMPLE_PRODUCT_NAME}
+- tapOn:
+    id: product-multiple-selection-done-button
+- assertVisible: Quantity
+- tapOn:
+    text: "1"
+    below: Quantity
+- eraseText
+- inputText: "2"
+- tapOn: Done
+- assertVisible:
+    text: "2"
+    below: Quantity
+- assertVisible: Add Discount
+- tapOn: Add Discount
+- assertVisible: Enter amount
+- tapOn: Enter amount
+- inputText: "1"
+- tapOn: Add
+- assertVisible: Discount
+
+# Select an exact variable product, then an actual variation.
+- tapOn:
+    id: new-order-add-product-button
+- tapOn:
+    id: product-selector-search-bar
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
+- hideKeyboard
+- tapOn: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
+- extendedWaitUntil:
+    visible:
+      id: product-variation-item
+    timeout: 30000
+- tapOn:
+    id: product-variation-item
+    index: 0
+- tapOn: Back
+- tapOn:
+    id: product-multiple-selection-done-button
+- assertVisible: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
+
+# Select an existing customer, then edit the order-specific email field.
+- swipe:
+    direction: UP
+- tapOn: Add Customer Details
+- tapOn:
+    id: customer-search-screen-search-field
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
+- hideKeyboard
+- tapOn: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
+- assertVisible: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
+- tapOn: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
+- tapOn: Enter email address
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: maestro-${SUITE_RUN_ID}@example.com
+- hideKeyboard
+- assertVisible: maestro-${SUITE_RUN_ID}@example.com
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-shipping-button
+- inputText: "1"
+- tapOn:
+    id: add-shipping-name-field
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro ${SUITE_RUN_ID}
+- hideKeyboard
+- tapOn:
+    id: add-shipping-done-button
+- swipe:
+    direction: UP
+- tapOn:
+    id: new-order-add-custom-amount-button
+- tapOn:
+    id: custom-amount-fixed-button
+- inputText: "1"
+- tapOn:
+    id: order-add-custom-amount-name-field
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Custom amount ${SUITE_RUN_ID}
+- hideKeyboard
+- tapOn:
+    id: order-add-custom-amount-view-add-custom-amount-button
+- assertVisible: Custom amount ${SUITE_RUN_ID}
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-customer-note-button
+- tapOn:
+    id: edit-note-text-editor
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro order ${SUITE_RUN_ID}
+- tapOn:
+    id: edit-note-done-button
+- tapOn:
+    id: new-order-create-button
+
+# Persisted order details, not the creation form, are the completion signal.
+- extendedWaitUntil:
+    visible:
+      id: order-details-table-view
+    timeout: 30000
+- assertVisible:
+    id: summary-table-view-cell-title-label
+- scrollUntilVisible:
+    element:
+      text: Maestro order ${SUITE_RUN_ID}
+    direction: DOWN
+- assertVisible: Maestro order ${SUITE_RUN_ID}
+- assertVisible: Maestro ${SUITE_RUN_ID}
+- assertVisible: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
+- assertVisible: Custom amount ${SUITE_RUN_ID}

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -16,55 +16,95 @@ tags:
 - assertVisible:
     id: new-order-create-button
 
-# Discover a live variable product directly in the order selector, then use an
-# actual variation as the order's primary line item. This proves the product is
-# orderable and avoids both a named fixture and remote-search differences.
+# Discover a live variable product directly in the order selector, then select
+# two distinct purchasable variations. This proves both line items are real,
+# avoids a named fixture, and guarantees one or more variable-product lines.
 - tapOn:
     id: new-order-add-product-button
 - scrollUntilVisible:
     element:
-      text: ".*[1-9][0-9]* variations?.*"
+      text: ".*(?:[2-9]|[1-9][0-9]+) variations.*"
       childOf:
         id: product-item
     direction: DOWN
     timeout: 30000
 - tapOn:
-    text: ".*[1-9][0-9]* variations?.*"
+    text: ".*(?:[2-9]|[1-9][0-9]+) variations.*"
     childOf:
       id: product-item
 - extendedWaitUntil:
     visible:
       id: product-variation-item
     timeout: 30000
+- copyTextFrom:
+    text: ".+"
+    childOf:
+      id: product-variation-item
+    index: 0
+- evalScript: |
+    output.orderVariationOne = String(maestro.copiedText || '').trim();
+- copyTextFrom:
+    text: ".+"
+    childOf:
+      id: product-variation-item
+    index: 1
+- evalScript: |
+    output.orderVariationTwo = String(maestro.copiedText || '').trim();
+    function escaped(value) {
+      return String(value)
+        .replace(/[.*+?^$()|[\]\\]/g, '\\$&')
+        .replace(/[{}]/g, '\\$&');
+    }
+    output.orderVariationOnePattern = '^' + escaped(output.orderVariationOne.replace(/ - /g, ', ')) + '(?: • .+)?$';
+    output.orderVariationTwoPattern = '^' + escaped(output.orderVariationTwo.replace(/ - /g, ', ')) + '(?: • .+)?$';
+- assertTrue:
+    condition: ${output.orderVariationOne.length > 0 && output.orderVariationTwo.length > 0 && output.orderVariationOne !== output.orderVariationTwo}
+    label: Two distinct purchasable variation rows are exposed
 - tapOn:
     id: product-variation-item
     index: 0
+- tapOn:
+    id: product-variation-item
+    index: 1
 - tapOn: Back
 - tapOn:
     id: product-multiple-selection-done-button
+- extendedWaitUntil:
+    visible:
+      text: "${output.orderVariationOnePattern}"
+    timeout: 30000
 - assertVisible:
-    id: product-item
+    text: "${output.orderVariationTwoPattern}"
+- takeScreenshot: order_two_distinct_variation_line_items
 
-# Persist quantity and discount on the selected real variation.
-- assertVisible: Quantity
+# Persist quantity and discount on the selected real variation. The quantity
+# field is exposed only after expanding its initially collapsed line-item card.
+- tapOn:
+    text: ".*, 1 × .*"
+    index: 0
+    point: "96%,20%"
+- extendedWaitUntil:
+    visible: Order Count
+    timeout: 15000
 - tapOn:
     text: "1"
-    below: Quantity
+    below: Order Count
+    above: Price
 - eraseText
 - inputText: "2"
 - tapOn: Done
 - assertVisible:
     text: "2"
-    below: Quantity
+    below: Order Count
 - tapOn:
     text: "2"
-    below: Quantity
+    below: Order Count
 - eraseText
 - inputText: "1"
 - tapOn: Done
 - assertVisible:
     text: "1"
-    below: Quantity
+    below: Order Count
 - assertVisible: Add Discount
 - tapOn: Add Discount
 - assertVisible: Enter amount

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -7,28 +7,45 @@ tags:
   - destructive
   - orders
 ---
+- stopApp
 - runFlow: ../subflows/ensure_logged_in.yaml
+
 - runFlow: ../subflows/navigate_to_orders.yaml
 - tapOn:
     id: new-order-type-sheet-button
 - assertVisible:
     id: new-order-create-button
 
-# Add an exact real simple product and persist a quantity of two.
+# Discover a live variable product directly in the order selector, then use an
+# actual variation as the order's primary line item. This proves the product is
+# orderable and avoids both a named fixture and remote-search differences.
 - tapOn:
     id: new-order-add-product-button
-- assertVisible:
-    id: product-selector-search-bar
+- scrollUntilVisible:
+    element:
+      text: ".*[1-9][0-9]* variations?.*"
+      childOf:
+        id: product-item
+    direction: DOWN
+    timeout: 30000
 - tapOn:
-    id: product-selector-search-bar
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${MAESTRO_WOO_SIMPLE_PRODUCT_NAME}
-- hideKeyboard
-- tapOn: ${MAESTRO_WOO_SIMPLE_PRODUCT_NAME}
+    text: ".*[1-9][0-9]* variations?.*"
+    childOf:
+      id: product-item
+- extendedWaitUntil:
+    visible:
+      id: product-variation-item
+    timeout: 30000
+- tapOn:
+    id: product-variation-item
+    index: 0
+- tapOn: Back
 - tapOn:
     id: product-multiple-selection-done-button
+- assertVisible:
+    id: product-item
+
+# Persist quantity and discount on the selected real variation.
 - assertVisible: Quantity
 - tapOn:
     text: "1"
@@ -47,53 +64,76 @@ tags:
 - tapOn: Add
 - assertVisible: Discount
 
-# Select an exact variable product, then an actual variation.
-- tapOn:
-    id: new-order-add-product-button
-- tapOn:
-    id: product-selector-search-bar
-- runFlow:
-    file: ../subflows/paste_into_focused_field.yaml
-    env:
-      TEXT_TO_PASTE: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
-- hideKeyboard
-- tapOn: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
-- extendedWaitUntil:
-    visible:
-      id: product-variation-item
-    timeout: 30000
-- tapOn:
-    id: product-variation-item
-    index: 0
-- tapOn: Back
-- tapOn:
-    id: product-multiple-selection-done-button
-- assertVisible: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
-
-# Select an existing customer, then edit the order-specific email field.
+# Select the first real customer exposed by the live store. Source inspection
+# confirms Edit Customer Details writes only the draft order's copied billing
+# and shipping snapshot; it never dispatches a customer-update action.
 - swipe:
     direction: UP
 - tapOn: Add Customer Details
+- runFlow:
+    when:
+      visible: Add Customer Details
+    commands:
+      - tapOn: Add Customer Details
+- extendedWaitUntil:
+    visible:
+      id: default-search-results-table-view
+    timeout: 30000
+- copyTextFrom:
+    text: ".+@.+"
+    childOf:
+      id: default-search-results-table-view
+    index: 0
+- evalScript: ${output.selectedCustomerEmail = (String(maestro.copiedText || '').match(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+/) || [''])[0]}
+- assertTrue:
+    condition: ${output.selectedCustomerEmail.length > 0}
+    label: "External prerequisite: the live store must expose at least one existing customer with an email address"
 - tapOn:
     id: customer-search-screen-search-field
 - runFlow:
     file: ../subflows/paste_into_focused_field.yaml
     env:
-      TEXT_TO_PASTE: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
-- hideKeyboard
-- tapOn: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
-- assertVisible: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
-- tapOn: ${MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH}
-- tapOn: Enter email address
+      TEXT_TO_PASTE: ${output.selectedCustomerEmail}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible:
+      id: updated-search-results-table-view
+    timeout: 30000
+- tapOn:
+    text: "${output.selectedCustomerEmail}"
+    childOf:
+      id: updated-search-results-table-view
+- extendedWaitUntil:
+    visible: Edit Customer Details
+    timeout: 30000
+- tapOn: Edit Customer Details
+- assertVisible:
+    id: order-address-form-first-name-field
+- assertVisible:
+    text: ".+@.+"
+# The existing identifier belongs to the whole row, so focus the editable
+# value area explicitly without changing the app's accessibility contract.
+- tapOn:
+    point: "72%,24%"
 - eraseText
 - runFlow:
     file: ../subflows/paste_into_focused_field.yaml
     env:
-      TEXT_TO_PASTE: maestro-${SUITE_RUN_ID}@example.com
-- hideKeyboard
-- assertVisible: maestro-${SUITE_RUN_ID}@example.com
-- swipe:
-    direction: UP
+      TEXT_TO_PASTE: Maestro-${SUITE_RUN_ID}
+- tapOn:
+    id: order-customer-details-done-button
+- assertVisible:
+    text: '[\s\S]*Maestro-${SUITE_RUN_ID}[\s\S]*'
+- runFlow:
+    when:
+      visible: Hide details
+    commands:
+      - tapOn: Hide details
+- scrollUntilVisible:
+    element:
+      id: add-shipping-button
+    direction: DOWN
+    timeout: 30000
 - tapOn:
     id: add-shipping-button
 - inputText: "1"
@@ -106,8 +146,11 @@ tags:
 - hideKeyboard
 - tapOn:
     id: add-shipping-done-button
-- swipe:
-    direction: UP
+- scrollUntilVisible:
+    element:
+      id: new-order-add-custom-amount-button
+    direction: DOWN
+    timeout: 30000
 - tapOn:
     id: new-order-add-custom-amount-button
 - tapOn:
@@ -123,8 +166,11 @@ tags:
 - tapOn:
     id: order-add-custom-amount-view-add-custom-amount-button
 - assertVisible: Custom amount ${SUITE_RUN_ID}
-- swipe:
-    direction: UP
+- scrollUntilVisible:
+    element:
+      id: add-customer-note-button
+    direction: DOWN
+    timeout: 30000
 - tapOn:
     id: add-customer-note-button
 - tapOn:
@@ -150,6 +196,21 @@ tags:
       text: Maestro order ${SUITE_RUN_ID}
     direction: DOWN
 - assertVisible: Maestro order ${SUITE_RUN_ID}
-- assertVisible: Maestro ${SUITE_RUN_ID}
-- assertVisible: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}
 - assertVisible: Custom amount ${SUITE_RUN_ID}
+- scrollUntilVisible:
+    element:
+      text: "View Billing Information"
+      below:
+        text: "CUSTOMER"
+    direction: DOWN
+- tapOn:
+    text: "View Billing Information"
+    below:
+      text: "CUSTOMER"
+- extendedWaitUntil:
+    visible: "Billing Information"
+    timeout: 15000
+- assertVisible:
+    text: '[\s\S]*Maestro-${SUITE_RUN_ID}[\s\S]*'
+- assertVisible:
+    text: "Email: ${output.selectedCustomerEmail}"

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -56,6 +56,15 @@ tags:
 - assertVisible:
     text: "2"
     below: Quantity
+- tapOn:
+    text: "2"
+    below: Quantity
+- eraseText
+- inputText: "1"
+- tapOn: Done
+- assertVisible:
+    text: "1"
+    below: Quantity
 - assertVisible: Add Discount
 - tapOn: Add Discount
 - assertVisible: Enter amount

--- a/.maestro/flows/orders_create.yaml
+++ b/.maestro/flows/orders_create.yaml
@@ -17,10 +17,28 @@ tags:
     id: new-order-create-button
 
 # Discover a live variable product directly in the order selector, then select
-# two distinct purchasable variations. This proves both line items are real,
-# avoids a named fixture, and guarantees one or more variable-product lines.
+# two distinct purchasable variations. The store must expose a published,
+# in-stock Variable product with at least two priced variations; unpriced or
+# out-of-stock shared products are intentionally not mutated by this flow.
 - tapOn:
     id: new-order-add-product-button
+- extendedWaitUntil:
+    visible: Filter
+    timeout: 15000
+- tapOn: Filter
+- extendedWaitUntil:
+    visible: Product Type
+    timeout: 15000
+- tapOn: Product Type
+- extendedWaitUntil:
+    visible: Variable
+    timeout: 15000
+- tapOn: Variable
+- tapOn: Show Products
+- extendedWaitUntil:
+    visible:
+      id: product-item
+    timeout: 30000
 - scrollUntilVisible:
     element:
       text: ".*(?:[2-9]|[1-9][0-9]+) variations.*"

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -1,0 +1,69 @@
+# p2: orders.receipt, orders.note
+appId: ${APP_ID}
+name: Persist a run-owned order note and open its receipt
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - destructive
+  - orders
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- tapOn:
+    id: new-order-add-product-button
+- tapOn:
+    id: product-item
+    index: 0
+- tapOn:
+    id: product-multiple-selection-done-button
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-customer-note-button
+- tapOn:
+    id: edit-note-text-editor
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Details ${SUITE_RUN_ID}
+- tapOn:
+    id: edit-note-done-button
+- tapOn:
+    id: new-order-create-button
+- extendedWaitUntil:
+    visible:
+      id: order-details-table-view
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      text: Details ${SUITE_RUN_ID}
+    direction: DOWN
+- assertVisible: Details ${SUITE_RUN_ID}
+
+# Take a cash payment so this same run-owned order becomes receipt-eligible.
+- scrollUntilVisible:
+    element:
+      id: order-details-collect-payment-button
+    direction: DOWN
+- tapOn:
+    id: order-details-collect-payment-button
+- assertVisible:
+    id: payment-methods-header-label
+- tapOn:
+    id: payment-methods-view-cash-row
+- assertVisible: Cash received
+- tapOn: Cash received
+- inputText: "9999"
+- tapOn: Mark Order as Complete
+- extendedWaitUntil:
+    visible:
+      text: See Receipt
+    timeout: 30000
+- tapOn: See Receipt
+- extendedWaitUntil:
+    visible:
+      text: Receipt
+    timeout: 30000
+- assertVisible: Receipt

--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -1,0 +1,60 @@
+# p2: orders.mark-complete
+appId: ${APP_ID}
+name: Mark a run-owned processing order complete
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - destructive
+  - orders
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- tapOn:
+    id: new-order-add-product-button
+- tapOn:
+    id: product-item
+    index: 0
+- tapOn:
+    id: product-multiple-selection-done-button
+- tapOn:
+    id: order-status-section-edit-button
+- assertVisible:
+    id: order-status-list
+- tapOn: Processing
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-customer-note-button
+- tapOn:
+    id: edit-note-text-editor
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Complete ${SUITE_RUN_ID}
+- tapOn:
+    id: edit-note-done-button
+- tapOn:
+    id: new-order-create-button
+- extendedWaitUntil:
+    visible:
+      id: order-details-table-view
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      text: Mark Order Complete
+    direction: DOWN
+- tapOn: Mark Order Complete
+- assertVisible: Review Order
+- tapOn: Mark Order Complete
+- extendedWaitUntil:
+    visible:
+      text: Completed
+    timeout: 30000
+- assertVisible: Completed
+- scrollUntilVisible:
+    element:
+      text: Complete ${SUITE_RUN_ID}
+    direction: DOWN
+- assertVisible: Complete ${SUITE_RUN_ID}

--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -1,0 +1,72 @@
+# p2: orders.refund
+appId: ${APP_ID}
+name: Refund a run-owned paid order
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - destructive
+  - orders
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- tapOn:
+    id: new-order-add-product-button
+- tapOn:
+    id: product-item
+    index: 0
+- tapOn:
+    id: product-multiple-selection-done-button
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-customer-note-button
+- tapOn:
+    id: edit-note-text-editor
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Refund ${SUITE_RUN_ID}
+- tapOn:
+    id: edit-note-done-button
+- tapOn:
+    id: new-order-create-button
+- extendedWaitUntil:
+    visible:
+      id: order-details-table-view
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      id: order-details-collect-payment-button
+    direction: DOWN
+- tapOn:
+    id: order-details-collect-payment-button
+- tapOn:
+    id: payment-methods-view-cash-row
+- tapOn: Cash received
+- inputText: "9999"
+- tapOn: Mark Order as Complete
+- extendedWaitUntil:
+    visible:
+      text: Issue Refund
+    timeout: 30000
+- tapOn: Issue Refund
+- assertVisible: Select all
+- tapOn: Select all
+- tapOn: Next
+- extendedWaitUntil:
+    visible:
+      text: Refund
+    timeout: 15000
+- tapOn: Refund
+- extendedWaitUntil:
+    visible:
+      text: Refunded Products
+    timeout: 30000
+- assertVisible: Refunded Products
+- scrollUntilVisible:
+    element:
+      text: Refund ${SUITE_RUN_ID}
+    direction: DOWN
+- assertVisible: Refund ${SUITE_RUN_ID}

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -1,0 +1,44 @@
+# p2: products.create
+appId: ${APP_ID}
+name: Create and reopen a run-owned physical product
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - destructive
+  - products
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_products.yaml
+- tapOn:
+    id: product-add-button
+- assertVisible:
+    id: product-creation-sheet
+- tapOn: Physical product
+- assertVisible:
+    id: product-form
+- tapOn:
+    id: product-title
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro ${SUITE_RUN_ID}
+- hideKeyboard
+- tapOn:
+    id: publish-product-button
+- extendedWaitUntil:
+    visible:
+      id: save-product-button
+    timeout: 30000
+- assertVisible: Maestro ${SUITE_RUN_ID}
+- tapOn:
+    text: Products
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: Maestro ${SUITE_RUN_ID}
+    timeout: 30000
+- tapOn: Maestro ${SUITE_RUN_ID}
+- assertVisible:
+    id: save-product-button
+- assertVisible: Maestro ${SUITE_RUN_ID}

--- a/.maestro/flows/products_create.yaml
+++ b/.maestro/flows/products_create.yaml
@@ -1,44 +1,487 @@
-# p2: products.create
+# p2: products.create, products.detail.description, products.detail.price, products.detail.type, products.detail.tags, products.detail.short-description, products.detail.linked, products.detail.downloads
 appId: ${APP_ID}
-name: Create and reopen a run-owned physical product
+name: Create, publish, and verify a run-owned product lifecycle
 tags:
   - smoke_extended
   - flaky_quarantine
   - destructive
   - products
 ---
+- stopApp
 - runFlow: ../subflows/ensure_logged_in.yaml
 - runFlow: ../subflows/navigate_to_products.yaml
+- extendedWaitUntil:
+    notVisible: Offline - using cached data
+    timeout: 60000
+
+# Create a run-owned product that can be selected as the main product's upsell.
 - tapOn:
     id: product-add-button
-- assertVisible:
-    id: product-creation-sheet
+- extendedWaitUntil:
+    visible: Create Product|Select a product type
+    timeout: 15000
+- runFlow:
+    when:
+      visible: Create Product
+    commands:
+      - tapOn: Add manually
 - tapOn: Physical product
-- assertVisible:
-    id: product-form
+- extendedWaitUntil:
+    visible:
+      id: product-form
+    timeout: 20000
+- runFlow:
+    when:
+      visible: Boost your sales with linked products
+    commands:
+      - tapOn: Close
+- runFlow:
+    when:
+      visible: Got it
+    commands:
+      - tapOn: Got it
 - tapOn:
     id: product-title
 - eraseText
 - runFlow:
     file: ../subflows/paste_into_focused_field.yaml
     env:
-      TEXT_TO_PASTE: Maestro ${SUITE_RUN_ID}
+      TEXT_TO_PASTE: Maestro Upsell ${SUITE_RUN_ID}
 - hideKeyboard
-- tapOn:
-    id: publish-product-button
+- scrollUntilVisible:
+    element: Close
+    direction: UP
+    timeout: 1000
+    optional: true
+- runFlow:
+    when:
+      visible: Close
+    commands:
+      - tapOn: Close
+- extendedWaitUntil:
+    visible: Publish
+    timeout: 30000
+- tapOn: Publish
 - extendedWaitUntil:
     visible:
-      id: save-product-button
+      id: edit-product-more-options-button
+    timeout: 60000
+- tapOn:
+    id: edit-product-more-options-button
+- extendedWaitUntil:
+    visible: View Product in Store
+    timeout: 60000
+- assertVisible: Trash product
+- tapOn:
+    point: "10%,15%"
+- assertVisible: Maestro Upsell ${SUITE_RUN_ID}
+- tapOn:
+    point: "10%,10%"
+- extendedWaitUntil:
+    visible:
+      id: products-table-view
     timeout: 30000
-- assertVisible: Maestro ${SUITE_RUN_ID}
+
+# Build the main product entirely inside this run.
+- tapOn:
+    id: product-add-button
+- extendedWaitUntil:
+    visible: Create Product|Select a product type
+    timeout: 15000
+- runFlow:
+    when:
+      visible: Create Product
+    commands:
+      - tapOn: Add manually
+- tapOn: Physical product
+- extendedWaitUntil:
+    visible:
+      id: product-form
+    timeout: 20000
+- runFlow:
+    when:
+      visible: Boost your sales with linked products
+    commands:
+      - tapOn: Close
+- runFlow:
+    when:
+      visible: Got it
+    commands:
+      - tapOn: Got it
+- tapOn:
+    id: product-title
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro Product ${SUITE_RUN_ID}
+- hideKeyboard
+
+# Main description.
+- tapOn:
+    id: product-description
+- extendedWaitUntil:
+    visible: Rich Content
+    timeout: 15000
+- tapOn: Rich Content
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro description ${SUITE_RUN_ID}
+- tapOn: Done
+- extendedWaitUntil:
+    visible:
+      id: product-form
+    timeout: 15000
+
+# Regular price.
+- scrollUntilVisible:
+    element: Add Price
+    direction: DOWN
+    timeout: 15000
+- tapOn: Add Price
+- extendedWaitUntil:
+    visible: Price
+    timeout: 15000
+- tapOn:
+    text: Empty
+    index: 0
+- inputText: "19.99"
+- tapOn: Done
+- extendedWaitUntil:
+    visible:
+      text: "Regular price: .*19[.,]99.*"
+    timeout: 15000
+
+# The creation choice is persisted as a simple, non-virtual physical product.
+- scrollUntilVisible:
+    element: Physical
+    direction: DOWN
+    timeout: 15000
+- assertVisible: Physical
+- tapOn: Product type
+- extendedWaitUntil:
+    visible: Change product type
+    timeout: 15000
+- assertNotVisible: Physical product
+- assertVisible: Virtual product
+- assertVisible: Variable product
+- tapOn: Dismiss
+
+# Unique tag.
+- scrollUntilVisible:
+    element: Add more details
+    direction: DOWN
+    timeout: 15000
+- tapOn: Add more details
+- extendedWaitUntil:
+    visible: Tags
+    timeout: 15000
+- tapOn: Tags
+- extendedWaitUntil:
+    visible:
+      id: add-tags
+    timeout: 15000
+- tapOn:
+    id: add-tags
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: maestro-${SUITE_RUN_ID}
+- tapOn: Save
+- extendedWaitUntil:
+    visible: maestro-${SUITE_RUN_ID}
+    timeout: 30000
+
+# Unique short description.
+- scrollUntilVisible:
+    element: Add more details
+    direction: DOWN
+    timeout: 15000
+- tapOn: Add more details
+- tapOn: Short description
+- extendedWaitUntil:
+    visible: Rich Content
+    timeout: 15000
+- tapOn: Rich Content
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro short ${SUITE_RUN_ID}
+- tapOn: Done
+- extendedWaitUntil:
+    visible: Maestro short ${SUITE_RUN_ID}
+    timeout: 15000
+
+# Link the exact run-owned upsell product.
+- scrollUntilVisible:
+    element: Add more details
+    direction: DOWN
+    timeout: 15000
+- tapOn: Add more details
+- tapOn: Linked products
+- extendedWaitUntil:
+    visible: Linked Products
+    timeout: 15000
+- tapOn:
+    text: Add Products
+    index: 0
+- extendedWaitUntil:
+    visible: Upsells
+    timeout: 15000
+- tapOn: Add Products
+- extendedWaitUntil:
+    visible: Add Products
+    timeout: 15000
+- tapOn: Search
+- extendedWaitUntil:
+    visible:
+      id: product-search-screen-search-field
+    timeout: 15000
+- tapOn:
+    id: product-search-screen-search-field
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro Upsell ${SUITE_RUN_ID}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible:
+      id: updated-search-results-table-view
+    timeout: 30000
+- assertVisible:
+    text: Maestro Upsell ${SUITE_RUN_ID}
+    childOf:
+      id: updated-search-results-table-view
+- tapOn:
+    text: Maestro Upsell ${SUITE_RUN_ID}
+    childOf:
+      id: updated-search-results-table-view
+    index: 0
+- tapOn: Done
+- extendedWaitUntil:
+    visible: 1 Product Selected
+    timeout: 15000
+- tapOn: Done
+- extendedWaitUntil:
+    visible: Maestro Upsell ${SUITE_RUN_ID}
+    timeout: 15000
+- tapOn: Done
+- extendedWaitUntil:
+    visible: Linked Products
+    timeout: 15000
+- assertVisible: 1 product
+- tapOn: Done
+- scrollUntilVisible:
+    element: 1 upsell product 0 cross-sell product
+    direction: DOWN
+    timeout: 15000
+- assertVisible: 1 upsell product 0 cross-sell product
+
+# Add a downloadable file by URL. Saving the child editor returns to the
+# downloadable-files list, where the exact run-owned name and URL are asserted.
+- scrollUntilVisible:
+    element: Add more details
+    direction: DOWN
+    timeout: 15000
+- tapOn: Add more details
+- tapOn: Downloadable files
+- extendedWaitUntil:
+    visible: Downloadable Files
+    timeout: 15000
+- tapOn: Add File
+- extendedWaitUntil:
+    visible: Select upload method
+    timeout: 15000
+- tapOn: Enter file URL
+- extendedWaitUntil:
+    visible: Add Downloadable File
+    timeout: 15000
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: https://example.com/download-${SUITE_RUN_ID}.txt
+- tapOn:
+    text: File Name
+    index: 1
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: download-${SUITE_RUN_ID}.txt
+- tapOn: Add products' downloadable files' info remotely
+- extendedWaitUntil:
+    visible: download-${SUITE_RUN_ID}.txt
+    timeout: 15000
+- assertVisible: https://example.com/download-${SUITE_RUN_ID}.txt
+- tapOn: Done
+- extendedWaitUntil:
+    visible: 1 file
+    timeout: 15000
+
+# Publish, leave the editor, search remotely, and reopen this exact product.
+- extendedWaitUntil:
+    notVisible: Offline - using cached data
+    timeout: 60000
+- extendedWaitUntil:
+    visible: Publish
+    timeout: 30000
+- tapOn: Publish
+- extendedWaitUntil:
+    visible:
+      id: edit-product-more-options-button
+    timeout: 60000
+- tapOn:
+    id: edit-product-more-options-button
+- extendedWaitUntil:
+    visible: View Product in Store
+    timeout: 60000
+- assertVisible: Trash product
+- tapOn:
+    point: "10%,15%"
+- assertVisible: Maestro Product ${SUITE_RUN_ID}
 - tapOn:
     text: Products
     index: 0
 - extendedWaitUntil:
     visible:
-      text: Maestro ${SUITE_RUN_ID}
+      id: products-table-view
     timeout: 30000
-- tapOn: Maestro ${SUITE_RUN_ID}
+- tapOn:
+    id: product-search-button
+- extendedWaitUntil:
+    visible:
+      id: product-search-screen-search-field
+    timeout: 15000
+- tapOn:
+    id: product-search-screen-search-field
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro Product ${SUITE_RUN_ID}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible:
+      id: updated-search-results-table-view
+    timeout: 30000
 - assertVisible:
-    id: save-product-button
-- assertVisible: Maestro ${SUITE_RUN_ID}
+    text: Maestro Product ${SUITE_RUN_ID}
+    childOf:
+      id: updated-search-results-table-view
+- tapOn:
+    text: Maestro Product ${SUITE_RUN_ID}
+    childOf:
+      id: updated-search-results-table-view
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: edit-product-more-options-button
+    timeout: 30000
+- assertVisible: Maestro Product ${SUITE_RUN_ID}
+
+# Persisted main description, asserted inside its editor.
+- tapOn: Description
+- extendedWaitUntil:
+    visible: Rich Content
+    timeout: 15000
+- assertVisible: Maestro description ${SUITE_RUN_ID}
+- tapOn: Done
+
+# Persisted price.
+- scrollUntilVisible:
+    element:
+      text: "Regular price: .*19[.,]99.*"
+    direction: DOWN
+    timeout: 15000
+- tapOn:
+    text: "Regular price: .*19[.,]99.*"
+- extendedWaitUntil:
+    visible: Price
+    timeout: 15000
+- assertVisible:
+    text: "19[.,]99.*"
+- tapOn: Done
+
+# Adding a file preserves the underlying simple product and changes the iOS
+# editor's visible classification from Physical to Downloadable.
+- scrollUntilVisible:
+    element: Downloadable
+    direction: DOWN
+    timeout: 15000
+- assertVisible: Product type
+- assertVisible: Downloadable
+
+# Persisted unique tag.
+- scrollUntilVisible:
+    element: Tags
+    direction: DOWN
+    timeout: 15000
+    centerElement: true
+- tapOn: Tags
+- extendedWaitUntil:
+    visible:
+      id: add-tags
+    timeout: 15000
+- assertVisible:
+    id: add-tags
+    text: ".*maestro-${SUITE_RUN_ID}.*"
+- tapOn:
+    point: "10%,10%"
+
+# Persisted unique short description.
+- scrollUntilVisible:
+    element: Short description
+    direction: DOWN
+    timeout: 15000
+    centerElement: true
+- tapOn: Short description
+- extendedWaitUntil:
+    visible: Rich Content
+    timeout: 15000
+- assertVisible: Maestro short ${SUITE_RUN_ID}
+- tapOn: Done
+
+# Persisted exact linked upsell.
+- scrollUntilVisible:
+    element: Linked products
+    direction: DOWN
+    timeout: 15000
+    centerElement: true
+- tapOn: Linked products
+- extendedWaitUntil:
+    visible: Linked Products
+    timeout: 15000
+- assertVisible: 1 product
+- tapOn:
+    text: Edit Products
+    index: 0
+- extendedWaitUntil:
+    visible: Upsells
+    timeout: 15000
+- assertVisible: Maestro Upsell ${SUITE_RUN_ID}
+- tapOn:
+    text: Linked Products
+    index: 0
+- tapOn: Done
+
+# Persisted exact downloadable file.
+- scrollUntilVisible:
+    element: Downloadable files
+    direction: DOWN
+    timeout: 15000
+    centerElement: true
+- tapOn: Downloadable files
+- extendedWaitUntil:
+    visible: Downloadable Files
+    timeout: 15000
+- assertVisible: download-${SUITE_RUN_ID}.txt
+- assertVisible: https://example.com/download-${SUITE_RUN_ID}.txt
+- tapOn: Done
+- extendedWaitUntil:
+    visible:
+      id: edit-product-more-options-button
+    timeout: 15000
+- takeScreenshot: product_run_owned_persisted_lifecycle

--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -1,4 +1,4 @@
-# p2: products.detail.description, products.detail.price, products.detail.inventory, products.detail.categories, products.detail.type, products.detail.shipping, products.detail.short-description, products.detail.linked, products.detail.downloads
+# p2: products.detail.inventory, products.detail.categories, products.detail.shipping
 # Uses an unsaved Physical-product detail form so every empty-field entry point
 # is deterministic; the flow exits without publishing or leaving store data.
 appId: ${APP_ID}

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -1,0 +1,60 @@
+# p2: products.detail.media
+appId: ${APP_ID}
+name: Create a run-owned product with persisted device media
+tags:
+  - smoke_extended
+  - flaky_quarantine
+  - destructive
+  - products
+---
+# Put a deterministic image in the simulator library before opening the app picker.
+- addMedia:
+    - ../../WooCommerce/WooCommerceScreenshots/ScreenshotImages.xcassets/black-coral-shades.imageset/black-coral-shades.png
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_products.yaml
+- tapOn:
+    id: product-add-button
+- assertVisible:
+    id: product-creation-sheet
+- tapOn: Physical product
+- tapOn:
+    id: product-title
+- eraseText
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Media ${SUITE_RUN_ID}
+- hideKeyboard
+- tapOn: Add a product image
+- assertVisible: Choose from device
+- tapOn: Choose from device
+- extendedWaitUntil:
+    visible:
+      text: Photos
+    timeout: 15000
+- tapOn:
+    point: 20%,25%
+- tapOn: Add
+- extendedWaitUntil:
+    notVisible:
+      text: Add a product image
+    timeout: 30000
+- tapOn:
+    id: publish-product-button
+- extendedWaitUntil:
+    visible:
+      id: save-product-button
+    timeout: 30000
+- assertNotVisible: Add a product image
+- assertVisible: Media ${SUITE_RUN_ID}
+- tapOn:
+    text: Products
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: Media ${SUITE_RUN_ID}
+    timeout: 30000
+- tapOn: Media ${SUITE_RUN_ID}
+- assertVisible:
+    id: save-product-button
+- assertNotVisible: Add a product image

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -1,4 +1,4 @@
-# p2: products.detail.tags, products.detail.variations, products.detail.variation-attributes
+# p2: products.detail.variations, products.detail.variation-attributes
 # Prerequisite: store has an editable Variable product with at least one generated variation and attribute.
 appId: ${APP_ID}
 name: "Products - Variations and tags"

--- a/.maestro/scripts/doctor.py
+++ b/.maestro/scripts/doctor.py
@@ -68,13 +68,7 @@ def main() -> int:
     except SystemExit as error:
         checks.append((False, f"flow selection: {error}"))
 
-    required = {
-        "MAESTRO_WOO_LAB_JETPACK_STORE_URL",
-        "MAESTRO_WOO_LAB_WPCOM_EMAIL",
-        "MAESTRO_WOO_LAB_WPCOM_PASSWORD",
-    }
-    if args.seed:
-        required.update({"MAESTRO_WOO_CONSUMER_KEY", "MAESTRO_WOO_CONSUMER_SECRET"})
+    required = RUNNER.required_environment(flows if 'flows' in locals() else [], seed=args.seed)
     missing = sorted(name for name in required if not values.get(name))
     checks.append((not missing, "required credentials are present" if not missing else "missing variables: " + ", ".join(missing)))
 

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -57,6 +57,8 @@ ORDERED_FLOWS = [
 
 SECRET_NAME_RE = re.compile(r"(?:PASSWORD|SECRET|CONSUMER_KEY|TOKEN)", re.I)
 ENV_ASSIGNMENT_RE = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+ENV_REFERENCE_RE = re.compile(r"\$\{(MAESTRO_[A-Z0-9_]+)\}")
+SUBFLOW_REFERENCE_RE = re.compile(r"(?:file:|runFlow:)\s*([^\s#]+\.ya?ml)")
 
 
 @dataclass
@@ -217,6 +219,31 @@ def normalized_store_host(value: str) -> str:
     return (parsed.hostname or "").lower().rstrip(".")
 
 
+def required_environment(flows: list[Path], *, seed: bool) -> set[str]:
+    """Return selected-flow requirements without making optional REST keys global."""
+    paths = list(flows)
+    visited: set[Path] = set()
+    required = set()
+    while paths:
+        path = paths.pop().resolve()
+        if path in visited or not path.exists():
+            continue
+        visited.add(path)
+        text = path.read_text(errors="replace")
+        required.update(ENV_REFERENCE_RE.findall(text))
+        for reference in SUBFLOW_REFERENCE_RE.findall(text):
+            paths.append((path.parent / reference).resolve())
+    if seed:
+        required.update({"MAESTRO_WOO_CONSUMER_KEY", "MAESTRO_WOO_CONSUMER_SECRET"})
+    return required
+
+
+def validate_environment(flows: list[Path], values: dict[str, str], *, seed: bool) -> None:
+    missing = sorted(name for name in required_environment(flows, seed=seed) if not values.get(name))
+    if missing:
+        raise SystemExit("Missing environment required by selected flows: " + ", ".join(missing))
+
+
 def maestro_env_args(values: dict[str, str], app_id: str, run_id: str) -> list[str]:
     exported = {name: value for name, value in values.items() if name.startswith("MAESTRO_") and value}
     lab_store_url = values.get("MAESTRO_WOO_LAB_JETPACK_STORE_URL", "")
@@ -310,9 +337,6 @@ def main() -> int:
     values = load_environment()
     app = args.app.expanduser().resolve()
     app_id = app_identifier(app)
-    simulator = resolve_simulator(args.device, family)
-    run(["xcrun", "simctl", "install", simulator["udid"], str(app)])
-
     stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     run_id = f"SUITE-{stamp}-{secrets.token_hex(3)}"
     output_root = (args.output_dir or Path(values.get("WOO_MAESTRO_OUTPUT_DIR", OUTPUT_DEFAULT))).expanduser()
@@ -323,6 +347,9 @@ def main() -> int:
     (output / "logs").mkdir()
 
     flows = select_flows(args, include, exclude)
+    validate_environment(flows, values, seed=args.seed)
+    simulator = resolve_simulator(args.device, family)
+    run(["xcrun", "simctl", "install", simulator["udid"], str(app)])
     summary = {
         "run_id": run_id, "profile": args.profile, "app": str(app), "app_id": app_id,
         "simulator_name": simulator["name"], "simulator_udid": simulator["udid"],

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -60,6 +60,19 @@ class RunnerTests(unittest.TestCase):
 
         self.assertIn("MAESTRO_WOO_LAB_JETPACK_STORE_HOST=shop.example.com", args)
 
+    def test_selected_flow_environment_is_required_but_consumer_keys_are_not(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            flow = Path(directory) / "flow.yaml"
+            flow.write_text("appId: ${APP_ID}\n---\n- inputText: ${MAESTRO_WOO_VARIABLE_PRODUCT_NAME}\n")
+            required = RUNNER.required_environment([flow], seed=False)
+            self.assertIn("MAESTRO_WOO_VARIABLE_PRODUCT_NAME", required)
+            self.assertNotIn("MAESTRO_WOO_CONSUMER_KEY", required)
+
+    def test_seed_explicitly_requires_consumer_keys(self) -> None:
+        required = RUNNER.required_environment([], seed=True)
+        self.assertIn("MAESTRO_WOO_CONSUMER_KEY", required)
+        self.assertIn("MAESTRO_WOO_CONSUMER_SECRET", required)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.maestro/smoke-coverage.yaml
+++ b/.maestro/smoke-coverage.yaml
@@ -156,13 +156,13 @@ items:
     flow: .maestro/flows/products_list_and_sort.yaml
   - id: products.detail.description
     title: Product description details
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.media
     title: Product media upload persists
     flow: .maestro/flows/products_media_upload.yaml
   - id: products.detail.price
     title: Product price settings
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.inventory
     title: Product inventory settings
     flow: .maestro/flows/products_detail.yaml
@@ -171,22 +171,22 @@ items:
     flow: .maestro/flows/products_detail.yaml
   - id: products.detail.type
     title: Product type settings
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.tags
     title: Product tags settings
-    flow: .maestro/flows/products_variations_and_tags.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.shipping
     title: Product shipping settings
     flow: .maestro/flows/products_detail.yaml
   - id: products.detail.short-description
     title: Product short description settings
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.linked
     title: Linked products
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.downloads
     title: Downloadable files
-    flow: .maestro/flows/products_detail.yaml
+    flow: .maestro/flows/products_create.yaml
   - id: products.detail.variations
     title: Variations and variation detail
     flow: .maestro/flows/products_variations_and_tags.yaml

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -43,6 +43,7 @@ struct AddCustomAmountView: View {
                     TextField(viewModel.customAmountPlaceholder, text: $viewModel.name)
                         .secondaryTitleStyle()
                         .foregroundColor(Color(.textSubtle))
+                        .accessibilityIdentifier(AccessibilityIdentifiers.customAmountNameField)
                         .focused($focusedField, equals: .name)
                         .onChange(of: focusedField) { _, focusedField in
                             guard focusedField == .name else { return }
@@ -141,5 +142,6 @@ private extension AddCustomAmountView {
     enum AccessibilityIdentifiers {
         static let addCustomAmountButton = "order-add-custom-amount-view-add-custom-amount-button"
         static let deleteCustomAmountButton = "order-add-custom-amount-view-delete-custom-amount-button"
+        static let customAmountNameField = "order-add-custom-amount-name-field"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
@@ -52,6 +52,7 @@ struct ProductVariationSelectorView: View {
                         ForEach(viewModel.productVariationRows) { rowViewModel in
                             ProductRow(multipleSelectionsEnabled: true,
                                        viewModel: rowViewModel)
+                                .accessibilityIdentifier("product-variation-item")
                                 .accessibilityHint(Localization.productRowAccessibilityHint)
                                 .padding(Constants.defaultPadding)
                                 .redacted(reason: viewModel.selectionDisabled ? .placeholder : [])


### PR DESCRIPTION
## Description

Fourth PR in the eight-part iOS Maestro stack. It adds quarantined, run-owned flows that intentionally mutate a disposable test store:

- Order creation with distinct live variation rows, an existing customer, quantity increase/decrease, product discount, custom amount/name, shipping, and customer-facing note.
- Order receipt/note checks, completion, cash payment, and refund, each operating on an order created by that flow and marked with `SUITE_RUN_ID`.
- A persisted run-owned product lifecycle covering title, description, price, downloadable type, tags, short description, linked product, and downloadable file.
- Device-media upload on a run-owned product.
- Focused accessibility identifiers for the custom-amount name field and variation rows.

All flows added here are tagged `smoke_extended`, `flaky_quarantine`, and `destructive`. They are not release-gating.

## Validation

- 9 Python runner contract tests
- all YAML files parsed successfully
- Python compilation, shell syntax, and example-environment lint
- exact layer diff passes `git diff --check`
- repository CI: green on the rebased head

No destructive flow was executed against a live store during this review. Assertions, ownership markers, and app identifiers were reviewed statically; fixture-backed runtime verification remains required before promotion.

## Safety and limitations

- This initial layer selects the first visible real customer and copies its email into run artifacts/order assertions. It does not update the underlying customer, but #17656 replaces this with an explicitly configured synthetic-customer email to avoid capturing arbitrary store data.
- The initial optional REST fixture hook writes an empty manifest and allows leftovers. #17656 makes `--seed` mandatory for destructive runtime selection, initializes cleanup before UI mutation, discovers only exact-run entities, and journals successful deletions for retryable cleanup.
- Blind fail-then-pass retries are unsafe for stateful mutation. #17656 disables them for destructive flows and makes flaky outcomes visible for eligible non-destructive flows.
- Media coverage uses one deterministic simulator-library image; it does not exercise every media source from the P2.
- Variable-product and existing-customer fixtures must be orderable, in stock, and dedicated to smoke testing.

## Test steps

1. Use a disposable smoke store with an orderable variable product and a synthetic existing customer.
2. Configure `.maestro/.env.local`, including consumer credentials only for the hardened `--seed` cleanup path from #17656.
3. After #17656 is merged, run `.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile phone-full --seed`.
4. Verify the report records run-owned entities and a successful cleanup; treat leftover data or cleanup failure as a failed run.

## Stack

1. #17525 — foundations
2. #17526 — core and login flows
3. #17527 — extended store flows
4. #17528 — destructive flows
5. #17529 — iPad POS flows
6. #17530 — iOS system-surface flows
7. #17531 — Buildkite integration
8. #17656 — trust, reliability, toolchain, and reporting hardening

Previous: #17527 · Next: #17529

## Screenshots

N/A — no visual change; this layer only adds accessibility identifiers to existing controls.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. Test automation and accessibility identifiers only; no release note is required.
