### PR TITLE
[Maestro 5/8] Add real-store iPad POS smoke flows

### DIFF
--- a/.maestro/flows/pos_cash_payment.yaml
+++ b/.maestro/flows/pos_cash_payment.yaml
@@ -1,0 +1,74 @@
+# p2: pos.add-products, pos.pay-cash
+# Prerequisites: an authenticated, genuinely POS-eligible store on an iPad
+# with at least one purchasable product and cash payments available.
+appId: ${APP_ID}
+name: "POS - Cash payment and new order"
+tags:
+  - flaky_quarantine
+  - destructive
+  - pos_ipad
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- tapOn:
+    id: tab-bar-pos-item
+- extendedWaitUntil:
+    visible:
+      id: "pos-product-card-.*|pos-ineligible-view"
+    timeout: 90000
+- assertNotVisible:
+    id: pos-ineligible-view
+# Give the created POS order an unmistakable run-owned line item.
+- tapOn:
+    id: pos-custom-amount-entry-row
+- tapOn:
+    id: pos-custom-amount-amount-field
+- inputText: "1"
+- tapOn:
+    id: pos-custom-amount-name-field
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Maestro ${SUITE_RUN_ID}
+- hideKeyboard
+- tapOn:
+    id: pos-add-custom-amount-submit-button
+- assertVisible:
+    id: pos-custom-amount-row
+- tapOn:
+    id: "pos-product-card-.*"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: "pos-cart-item-product-.*|pos-cart-item-variation-.*"
+    timeout: 30000
+- tapOn:
+    id: pos-checkout-button
+- extendedWaitUntil:
+    visible:
+      id: pos-total-field
+    timeout: 30000
+- assertVisible:
+    id: pos-cash-payment-button
+- tapOn:
+    id: pos-cash-payment-button
+- assertVisible:
+    id: pos-mark-payment-complete-button
+- tapOn:
+    id: pos-mark-payment-complete-button
+- extendedWaitUntil:
+    visible:
+      id: pos-payment-success-view
+    timeout: 45000
+- assertVisible:
+    id: pos-email-receipt-button
+- assertVisible:
+    id: pos-new-order-button
+- takeScreenshot: pos_cash_payment_success
+- tapOn:
+    id: pos-new-order-button
+- extendedWaitUntil:
+    visible:
+      id: "pos-product-card-.*"
+    timeout: 30000
+- assertNotVisible:
+    id: "pos-cart-item-product-.*|pos-cart-item-variation-.*"

--- a/.maestro/flows/pos_search_and_coupons.yaml
+++ b/.maestro/flows/pos_search_and_coupons.yaml
@@ -1,0 +1,70 @@
+# p2: pos.search-products, pos.coupons
+# Prerequisites: an authenticated, genuinely POS-eligible store on an iPad,
+# at least one purchasable product, and at least one active coupon.
+appId: ${APP_ID}
+name: "POS - Search, products, cart, and coupons"
+tags:
+  - flaky_quarantine
+  - pos_ipad
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- tapOn:
+    id: tab-bar-pos-item
+- extendedWaitUntil:
+    visible:
+      id: "pos-product-card-.*|pos-ineligible-view"
+    timeout: 90000
+- assertNotVisible:
+    id: pos-ineligible-view
+- assertVisible:
+    id: "pos-product-card-.*"
+
+# Derive the search from the live catalog instead of requiring fixture names.
+- copyTextFrom:
+    text: ".+"
+    childOf:
+      id: "pos-product-card-.*"
+    index: 0
+- evalScript: ${output.posProductName = String(maestro.copiedText || '').trim()}
+- assertTrue:
+    condition: ${output.posProductName.length > 0}
+    label: First live POS product exposes a searchable name
+- tapOn:
+    id: pos-search-button
+- assertVisible:
+    id: pos-search-field
+- tapOn:
+    id: pos-search-field
+- evalScript: ${output.clipboardText = output.posProductName}
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+- extendedWaitUntil:
+    visible:
+      text: ${output.posProductName}
+      childOf:
+        id: "pos-product-card-.*"
+    timeout: 30000
+- tapOn:
+    id: "pos-product-card-.*"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: "pos-cart-item-product-.*|pos-cart-item-variation-.*"
+    timeout: 30000
+
+# Apply an actual live-store coupon and prove it reaches the cart.
+- tapOn: Coupons
+- extendedWaitUntil:
+    visible:
+      id: "pos-coupon-card-.*"
+    timeout: 30000
+- tapOn:
+    id: "pos-coupon-card-.*"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: "pos-cart-coupon-.*"
+    timeout: 30000
+- assertVisible:
+    id: pos-checkout-button
+- takeScreenshot: pos_product_and_coupon_cart

--- a/Modules/Sources/PointOfSale/Presentation/CouponRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CouponRowView.swift
@@ -82,6 +82,7 @@ struct CouponRowView: View {
         .posItemCardBorderStyles()
         .padding(.horizontal, Constants.horizontalPadding)
         .geometryGroup()
+        .accessibilityIdentifier("pos-cart-coupon-\(couponItem.posItemIdentifier.itemID)")
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/ItemList.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/ItemList.swift
@@ -150,6 +150,7 @@ struct ItemListRow: View {
             }, label: {
                 CouponCardView(coupon: coupon)
             })
+            .accessibilityIdentifier("pos-coupon-card-\(coupon.id.itemID)")
         }
     }
 }


### PR DESCRIPTION
## Description

Fifth PR in the eight-part iOS Maestro stack. It adds two real-store iPad POS flows:

- Product loading and live-data search, adding a product, selecting a real active coupon, and asserting both cart/coupon state.
- A run-owned custom amount plus live product, checkout totals, cash payment completion, receipt availability, and starting a clean new order.

The layer adds focused coupon accessibility identifiers to the POS module. Both flows require a genuinely POS-eligible store/account and an iPad simulator; they fail instead of treating ineligibility as a pass.

## Validation

- both POS YAML files parsed successfully
- exact layer diff passes `git diff --check`
- focused accessibility-identifier changes reviewed against the POS module conventions
- repository CI: green on the rebased head

No POS store or iPad simulator was used during this review. The selectors and assertions were reviewed statically; runtime fixture compatibility and reliability remain to be measured.

## Safety and limitations

- Both flows are `flaky_quarantine` and isolated behind the `pos-ipad` profile.
- The cash flow is also `destructive`; after #17656 it requires the explicit `--seed` cleanup contract and must leave no run-owned order behind.
- Product/coupon search derives values from the live catalog, so the fixture needs at least one purchasable product and one active coupon.
- Cash payment is covered. Card-reader payment, Tap to Pay, and external email-receipt verification remain manual because they require physical hardware or external mailbox ownership.
- POS eligibility is not bypassed with test launch arguments or app mocks.

## Test steps

1. Use a dedicated POS-eligible test store with a purchasable product and active coupon.
2. Boot an iPad simulator and install a compatible app.
3. Run the non-paying cart flow explicitly, or run the full `pos-ipad` profile only after #17656 with the required cleanup setup.
4. Confirm the cash order contains the exact `SUITE_RUN_ID`, receipt/new-order controls appear, and the new cart is empty.

## Stack

1. #17525 — foundations
2. #17526 — core and login flows
3. #17527 — extended store flows
4. #17528 — destructive flows
5. #17529 — iPad POS flows
6. #17530 — iOS system-surface flows
7. #17531 — Buildkite integration
8. #17656 — trust, reliability, toolchain, and reporting hardening

Previous: #17528 · Next: #17530

## Screenshots

N/A — no visual change; this layer only adds accessibility identifiers to existing POS controls.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. Test automation and accessibility identifiers only; no release note is required.
