### PR TITLE
[Maestro 6/8] Add iOS system-surface smoke flows

### DIFF
--- a/.maestro/flows/ios_notification_long_press.yaml
+++ b/.maestro/flows/ios_notification_long_press.yaml
@@ -1,0 +1,25 @@
+# p2: other.ios-push-long-press
+# External prerequisite: a Woo notification must already be delivered to this
+# simulator. Generating a real push is intentionally deferred from this stack.
+appId: ${APP_ID}
+name: "iOS system - Notification long press"
+tags:
+  - flaky_quarantine
+  - ios_system
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- stopApp
+- pressKey: HOME
+- swipe:
+    start: "50%,0%"
+    end: "50%,75%"
+    duration: 1000
+- extendedWaitUntil:
+    visible: "Woo.*"
+    timeout: 10000
+- longPressOn:
+    text: "Woo.*"
+    index: 0
+- assertVisible: View
+- assertVisible: "Woo.*"
+- takeScreenshot: ios_notification_long_press

--- a/.maestro/flows/ios_quick_actions.yaml
+++ b/.maestro/flows/ios_quick_actions.yaml
@@ -10,6 +10,14 @@ tags:
 - runFlow: ../subflows/ensure_logged_in.yaml
 - stopApp
 - pressKey: HOME
+- tapOn:
+    text: Search
+    index: 0
+- inputText: Woo
+- hideKeyboard
+- extendedWaitUntil:
+    visible: "Woo.*"
+    timeout: 15000
 - longPressOn:
     text: "Woo.*"
     index: 0
@@ -18,7 +26,8 @@ tags:
 - assertVisible: Add a product
 - assertVisible: Collect Payment
 - takeScreenshot: ios_quick_actions
-- tapOn: New Order
+- tapOn:
+    point: "35%,24%"
 - extendedWaitUntil:
     visible:
       id: new-order-create-button

--- a/.maestro/flows/ios_quick_actions.yaml
+++ b/.maestro/flows/ios_quick_actions.yaml
@@ -1,0 +1,27 @@
+# p2: other.quick-actions
+# Exercises the installed app's real UIApplicationShortcutItems. The icon label
+# intentionally matches Debug (Woo (Dev)) and Alpha/prototype display names.
+appId: ${APP_ID}
+name: "iOS system - Home-screen Quick Actions"
+tags:
+  - flaky_quarantine
+  - ios_system
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- stopApp
+- pressKey: HOME
+- longPressOn:
+    text: "Woo.*"
+    index: 0
+- assertVisible: New Order
+- assertVisible: Orders
+- assertVisible: Add a product
+- assertVisible: Collect Payment
+- takeScreenshot: ios_quick_actions
+- tapOn: New Order
+- extendedWaitUntil:
+    visible:
+      id: new-order-create-button
+    timeout: 30000
+- assertVisible:
+    id: new-order-cancel-button

--- a/.maestro/flows/orders_barcode_scanner.yaml
+++ b/.maestro/flows/orders_barcode_scanner.yaml
@@ -12,17 +12,15 @@ tags:
 - runFlow: ../subflows/navigate_to_orders.yaml
 - tapOn:
     id: new-order-type-sheet-button
-- assertVisible:
-    id: new-order-add-product-via-sku-scanner-button
-- tapOn:
-    id: new-order-add-product-via-sku-scanner-button
+- assertVisible: Scan barcode
+- tapOn: Scan barcode
 - runFlow:
     when:
       visible: Allow
     commands:
       - tapOn: Allow
 - extendedWaitUntil:
-    visible: Scan barcode or QR Code
+    visible: Scan product barcode or QR Code
     timeout: 15000
 - assertVisible: Scan product barcode or QR Code
 - takeScreenshot: order_barcode_scanner_surface

--- a/.maestro/flows/orders_barcode_scanner.yaml
+++ b/.maestro/flows/orders_barcode_scanner.yaml
@@ -1,0 +1,28 @@
+# p2: orders.barcode.open-scanner
+# Camera barcode decoding is intentionally deferred. This flow proves the real
+# order-entry affordance opens the production scanner surface.
+appId: ${APP_ID}
+name: "iOS system - Order barcode scanner surface"
+tags:
+  - flaky_quarantine
+  - orders
+  - ios_system
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- assertVisible:
+    id: new-order-add-product-via-sku-scanner-button
+- tapOn:
+    id: new-order-add-product-via-sku-scanner-button
+- runFlow:
+    when:
+      visible: Allow
+    commands:
+      - tapOn: Allow
+- extendedWaitUntil:
+    visible: Scan barcode or QR Code
+    timeout: 15000
+- assertVisible: Scan product barcode or QR Code
+- takeScreenshot: order_barcode_scanner_surface

--- a/.maestro/flows/orders_qr_payment.yaml
+++ b/.maestro/flows/orders_qr_payment.yaml
@@ -23,15 +23,18 @@ tags:
 - swipe:
     direction: UP
 - tapOn:
-    id: add-customer-note-button
+    id: new-order-add-custom-amount-button
 - tapOn:
-    id: edit-note-text-editor
+    id: custom-amount-fixed-button
+- inputText: "1"
+- tapOn: "Custom amount"
 - runFlow:
     file: ../subflows/paste_into_focused_field.yaml
     env:
       TEXT_TO_PASTE: QR ${SUITE_RUN_ID}
 - tapOn:
-    id: edit-note-done-button
+    id: order-add-custom-amount-view-add-custom-amount-button
+- assertVisible: QR ${SUITE_RUN_ID}
 - tapOn:
     id: new-order-create-button
 - extendedWaitUntil:

--- a/.maestro/flows/orders_qr_payment.yaml
+++ b/.maestro/flows/orders_qr_payment.yaml
@@ -1,0 +1,58 @@
+# p2: orders.collect-payment.qr
+# Prerequisite: the configured store generates payment URLs for new orders.
+# External QR scanning and payment completion are intentionally out of scope.
+appId: ${APP_ID}
+name: "iOS system - Order QR payment surface"
+tags:
+  - flaky_quarantine
+  - destructive
+  - orders
+  - ios_system
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- tapOn:
+    id: new-order-add-product-button
+- tapOn:
+    id: product-item
+    index: 0
+- tapOn:
+    id: product-multiple-selection-done-button
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-customer-note-button
+- tapOn:
+    id: edit-note-text-editor
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: QR ${SUITE_RUN_ID}
+- tapOn:
+    id: edit-note-done-button
+- tapOn:
+    id: new-order-create-button
+- extendedWaitUntil:
+    visible:
+      id: order-details-table-view
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      id: order-details-collect-payment-button
+    direction: DOWN
+- tapOn:
+    id: order-details-collect-payment-button
+- assertVisible:
+    id: payment-methods-header-label
+- tapOn:
+    id: payment-methods-view-scan-to-pay-row
+- extendedWaitUntil:
+    visible:
+      id: scan-to-pay-qr-code
+    timeout: 15000
+- assertVisible: Scan QR and follow instructions
+- assertVisible:
+    id: scan-to-pay-done-button
+- takeScreenshot: order_qr_payment_surface

--- a/.maestro/flows/orders_share_payment_link.yaml
+++ b/.maestro/flows/orders_share_payment_link.yaml
@@ -1,0 +1,56 @@
+# p2: orders.collect-payment.share-link
+# Prerequisite: the configured store generates payment URLs for new orders.
+# The flow verifies the real iOS share surface without contacting a recipient.
+appId: ${APP_ID}
+name: "iOS system - Share an order payment link"
+tags:
+  - flaky_quarantine
+  - destructive
+  - orders
+  - ios_system
+---
+- runFlow: ../subflows/ensure_logged_in.yaml
+- runFlow: ../subflows/navigate_to_orders.yaml
+- tapOn:
+    id: new-order-type-sheet-button
+- tapOn:
+    id: new-order-add-product-button
+- tapOn:
+    id: product-item
+    index: 0
+- tapOn:
+    id: product-multiple-selection-done-button
+- swipe:
+    direction: UP
+- tapOn:
+    id: add-customer-note-button
+- tapOn:
+    id: edit-note-text-editor
+- runFlow:
+    file: ../subflows/paste_into_focused_field.yaml
+    env:
+      TEXT_TO_PASTE: Share ${SUITE_RUN_ID}
+- tapOn:
+    id: edit-note-done-button
+- tapOn:
+    id: new-order-create-button
+- extendedWaitUntil:
+    visible:
+      id: order-details-table-view
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      id: order-details-collect-payment-button
+    direction: DOWN
+- tapOn:
+    id: order-details-collect-payment-button
+- assertVisible:
+    id: payment-methods-header-label
+- tapOn:
+    id: payment-methods-view-payment-link-row
+- extendedWaitUntil:
+    visible: Copy
+    timeout: 15000
+- assertVisible: Messages
+- assertVisible: Mail
+- takeScreenshot: order_payment_link_share_sheet

--- a/.maestro/flows/orders_share_payment_link.yaml
+++ b/.maestro/flows/orders_share_payment_link.yaml
@@ -23,15 +23,18 @@ tags:
 - swipe:
     direction: UP
 - tapOn:
-    id: add-customer-note-button
+    id: new-order-add-custom-amount-button
 - tapOn:
-    id: edit-note-text-editor
+    id: custom-amount-fixed-button
+- inputText: "1"
+- tapOn: "Custom amount"
 - runFlow:
     file: ../subflows/paste_into_focused_field.yaml
     env:
       TEXT_TO_PASTE: Share ${SUITE_RUN_ID}
 - tapOn:
-    id: edit-note-done-button
+    id: order-add-custom-amount-view-add-custom-amount-button
+- assertVisible: Share ${SUITE_RUN_ID}
 - tapOn:
     id: new-order-create-button
 - extendedWaitUntil:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -769,6 +769,7 @@ private extension ProductsSection {
             }
         })
         .frame(maxWidth: .infinity)
+        .accessibilityIdentifier(OrderForm.Accessibility.addProductViaSKUScannerButtonIdentifier)
         .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
             scroll.scrollTo(addProductViaSKUScannerButton)
         }, content: {
@@ -790,6 +791,7 @@ private extension ProductsSection {
             }
         })
         .accessibilityLabel(OrderForm.Localization.scanProductButtonAccessibilityLabel)
+        .accessibilityIdentifier(OrderForm.Accessibility.addProductViaSKUScannerButtonIdentifier)
         .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
             scroll.scrollTo(addProductViaSKUScannerButton)
         }, content: {

--- a/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
@@ -20,6 +20,7 @@ struct ScanToPayView: View {
                             .interpolation(.none)
                             .resizable()
                             .frame(width: Layout.qrCodeWidth, height: Layout.qrCodeHeight)
+                            .accessibilityIdentifier("scan-to-pay-qr-code")
                         DoneButton() {
                             dismiss()
                             DispatchQueue.main.asyncAfter(deadline: .now() + Constants.onSuccessCallDelayAfterDismiss) {
@@ -59,6 +60,7 @@ struct ScanToPayView: View {
                 onButtonTapped()
             }
             .buttonStyle(PrimaryButtonStyle())
+            .accessibilityIdentifier("scan-to-pay-done-button")
         }
     }
 }


### PR DESCRIPTION
## Description

Sixth PR in the eight-part iOS Maestro stack. It adds a separately quarantined `ios-system` profile covering:

- Home-screen Quick Actions, asserting all declared shortcuts and opening New Order.
- Long-pressing a pre-existing Woo notification and asserting its context menu.
- Creating a run-owned order, opening Scan to Pay, and asserting the production QR surface.
- Creating a run-owned order and asserting the real iOS payment-link share sheet.
- Opening the production order barcode-scanner surface without claiming camera decoding.

It also adds focused accessibility identifiers for the order scanner affordance and Scan to Pay QR/done controls.

## Validation

- all five system-surface YAML files parsed successfully
- exact layer diff passes `git diff --check`
- focused accessibility-identifier changes reviewed against existing SwiftUI code
- repository CI: green on the rebased head

No simulator system UI or live store was exercised during this review. Runtime behavior remains quarantined pending dedicated system-state fixtures.

## Safety and limitations

- Every flow is `flaky_quarantine` and selected only by the `ios-system` profile.
- Notification long-press requires a real Woo notification to have already arrived; this layer does not generate or validate push delivery or an order deep link.
- QR and payment-share flows create run-owned orders and are tagged `destructive`; after #17656 they require the explicit cleanup journal/`--seed` contract.
- QR scanning/payment completion, barcode decoding, physical card readers, Tap to Pay, widgets, watchOS, localization matrices, and other real-device-only behavior remain manual.
- Quick Actions target the installed app's real `UIApplicationShortcutItems`; no test-only shortcut or eligibility bypass is introduced.

## Test steps

1. Configure a dedicated smoke store and install a compatible app on an iPhone simulator.
2. Prepare the exact external prerequisite for the one flow under test, such as a delivered Woo notification.
3. After #17656, run `.maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --profile ios-system --seed` for the complete profile.
4. Confirm unsupported external behavior is reported as a prerequisite/limitation and that destructive run-owned orders are cleaned.

## Stack

1. #17525 — foundations
2. #17526 — core and login flows
3. #17527 — extended store flows
4. #17528 — destructive flows
5. #17529 — iPad POS flows
6. #17530 — iOS system-surface flows
7. #17531 — Buildkite integration
8. #17656 — trust, reliability, toolchain, and reporting hardening

Previous: #17529 · Next: #17531

## Screenshots

N/A — no visual change; this layer only adds accessibility identifiers to existing controls.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. Test automation and accessibility identifiers only; no release note is required.
