### PR TITLE
[Maestro 7/8] Add Buildkite smoke-test integration

### DIFF
--- a/.buildkite/commands/run-maestro-tests.sh
+++ b/.buildkite/commands/run-maestro-tests.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -euo pipefail
+
+PROFILE="${MAESTRO_PROFILE:-release}"
+APP_VARIANT="${MAESTRO_APP_VARIANT:-debug}"
+APP_ARTIFACT="${MAESTRO_APP_ARTIFACT:-build-products.tar}"
+APP_SOURCE_BUILD_ID="${MAESTRO_APP_SOURCE_BUILD_ID:-}"
+APP_PATH="${MAESTRO_APP_PATH:-}"
+DEVICE="${MAESTRO_DEVICE:-}"
+OUTPUT_KEY="${BUILDKITE_JOB_ID:-local-$$}"
+OUTPUT_ROOT="${MAESTRO_OUTPUT_DIR:-build/maestro/$OUTPUT_KEY}"
+
+if [[ "${BUILDKITE:-false}" == "true" && -e .maestro/.env.local ]]; then
+  echo "CI Maestro runs must use protected environment variables, not .maestro/.env.local." >&2
+  exit 2
+fi
+
+case "$PROFILE" in
+  release|burst|pos-ipad|ios-system) ;;
+  *)
+    echo "Unsupported CI Maestro profile: $PROFILE" >&2
+    exit 2
+    ;;
+esac
+
+case "$APP_VARIANT" in
+  debug) ;;
+  alpha|prototype)
+    if [[ -z "$APP_PATH" ]]; then
+      echo "MAESTRO_APP_PATH is required for an Alpha/prototype simulator app." >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "MAESTRO_APP_VARIANT must be debug, alpha, or prototype." >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "${MAESTRO_CI_RESOURCE_KEY:-}" || "${MAESTRO_CI_RESOURCE_KEY}" == "unconfigured" ]]; then
+  echo "MAESTRO_CI_RESOURCE_KEY must be a protected, opaque identifier for the configured test store/account." >&2
+  exit 2
+fi
+
+required_environment=(
+  MAESTRO_WOO_LAB_JETPACK_STORE_URL
+  MAESTRO_WOO_LAB_WPCOM_EMAIL
+  MAESTRO_WOO_LAB_WPCOM_PASSWORD
+)
+for variable in "${required_environment[@]}"; do
+  if [[ -z "${!variable:-}" ]]; then
+    echo "Missing protected environment variable: $variable" >&2
+    exit 2
+  fi
+done
+
+echo "--- :package: Downloading simulator app artifact"
+if [[ ! -e "$APP_ARTIFACT" ]]; then
+  if [[ -n "$APP_SOURCE_BUILD_ID" ]]; then
+    buildkite-agent artifact download "$APP_ARTIFACT" . --build "$APP_SOURCE_BUILD_ID"
+  else
+    download_artifact "$APP_ARTIFACT"
+  fi
+fi
+
+case "$APP_ARTIFACT" in
+  *.tar) tar -xf "$APP_ARTIFACT" ;;
+  *.tar.gz|*.tgz) tar -xzf "$APP_ARTIFACT" ;;
+  *.zip) ditto -x -k "$APP_ARTIFACT" . ;;
+esac
+
+if [[ -z "$APP_PATH" ]]; then
+  default_app="DerivedData/Build/Products/Debug-iphonesimulator/WooCommerce.app"
+  if [[ -d "$default_app" ]]; then
+    APP_PATH="$default_app"
+  else
+    app_count=0
+    while IFS= read -r candidate; do
+      APP_PATH="$candidate"
+      app_count=$((app_count + 1))
+    done < <(find DerivedData/Build/Products -type d -path '*-iphonesimulator/*.app' -prune 2>/dev/null)
+    if [[ "$app_count" -ne 1 ]]; then
+      echo "Expected one simulator .app in the Debug artifact; found $app_count. Set MAESTRO_APP_PATH explicitly." >&2
+      exit 2
+    fi
+  fi
+fi
+
+if [[ ! -d "$APP_PATH" || "$APP_PATH" != *.app ]]; then
+  echo "Simulator app was not found at MAESTRO_APP_PATH: $APP_PATH" >&2
+  exit 2
+fi
+
+mkdir -p "$OUTPUT_ROOT"
+
+runner=(
+  .maestro/scripts/run-smoke-tests.sh
+  --app "$APP_PATH"
+  --profile "$PROFILE"
+  --output-dir "$OUTPUT_ROOT"
+  --no-open
+)
+if [[ -n "$DEVICE" ]]; then
+  runner+=(--device "$DEVICE")
+fi
+
+echo "--- :iphone: Running Maestro $PROFILE profile with the $APP_VARIANT simulator app"
+set +e
+"${runner[@]}"
+status=$?
+set -e
+
+report_count=$(find "$OUTPUT_ROOT" -type f -name report.xml | wc -l | tr -d ' ')
+html_count=$(find "$OUTPUT_ROOT" -type f -name report.html | wc -l | tr -d ' ')
+if [[ "$report_count" -eq 0 || "$html_count" -eq 0 ]]; then
+  echo "Maestro did not produce both report.xml and report.html under $OUTPUT_ROOT." >&2
+  if [[ "$status" -eq 0 ]]; then
+    status=1
+  fi
+else
+  echo "Maestro produced $report_count JUnit report(s) and $html_count HTML report(s)."
+fi
+
+exit "$status"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -174,6 +174,74 @@ steps:
           context: UI Tests (iPad)
 
   #################
+  # Maestro live-store smoke tests (on demand, non-blocking)
+  #################
+  - input: Run Maestro live-store smoke tests?
+    prompt: Run the production-like simulator suite against the protected iOS test store?
+    key: maestro_smoke_triggered
+    if: build.branch == "trunk"
+    fields:
+      - select: Profile
+        key: maestro-profile
+        default: release
+        options:
+          - label: Release
+            value: release
+          - label: Burst (three release runs)
+            value: burst
+          - label: POS (eligible iPad)
+            value: pos-ipad
+          - label: iOS system surfaces
+            value: ios-system
+      - select: Simulator app
+        key: maestro-app-variant
+        default: debug
+        options:
+          - label: Debug artifact from this build
+            value: debug
+          - label: Alpha/prototype artifact
+            value: prototype
+      - text: App artifact name
+        key: maestro-app-artifact
+        default: build-products.tar
+      - text: App path after extraction
+        key: maestro-app-path
+        required: false
+        hint: Required for Alpha/prototype; for example build/Prototype/WooCommerce.app
+      - text: Source Buildkite build ID
+        key: maestro-app-source-build-id
+        required: false
+        hint: Optional; use when the app artifact belongs to another Buildkite build
+
+  - label: ":iphone: Maestro live-store smoke"
+    depends_on:
+      - build
+      - maestro_smoke_triggered
+    if: build.branch == "trunk"
+    command: |
+      export MAESTRO_PROFILE="$(buildkite-agent meta-data get maestro-profile)"
+      export MAESTRO_APP_VARIANT="$(buildkite-agent meta-data get maestro-app-variant)"
+      export MAESTRO_APP_ARTIFACT="$(buildkite-agent meta-data get maestro-app-artifact)"
+      export MAESTRO_APP_PATH="$(buildkite-agent meta-data get maestro-app-path --default '')"
+      export MAESTRO_APP_SOURCE_BUILD_ID="$(buildkite-agent meta-data get maestro-app-source-build-id --default '')"
+      .buildkite/commands/run-maestro-tests.sh
+    secrets:
+      MAESTRO_WOO_LAB_JETPACK_STORE_URL: MAESTRO_WOO_LAB_JETPACK_STORE_URL
+      MAESTRO_WOO_LAB_WPCOM_EMAIL: MAESTRO_WOO_LAB_WPCOM_EMAIL
+      MAESTRO_WOO_LAB_WPCOM_PASSWORD: MAESTRO_WOO_LAB_WPCOM_PASSWORD
+    plugins: [$CI_TOOLKIT]
+    soft_fail: true
+    concurrency: 1
+    concurrency_group: "woocommerce-ios/maestro/${MAESTRO_CI_RESOURCE_KEY:-unconfigured}"
+    artifact_paths:
+      - build/maestro/**/report.xml
+      - build/maestro/**/report.html
+      - build/maestro/**/screenshots/**/*
+      - build/maestro/**/diagnostics/**/*
+      - build/maestro/**/logs/**/*
+      - build/maestro/**/run-summary.json
+
+  #################
   # Claude Build Analysis - dynamically uploaded so Build result conditions evaluate at runtime after the wait
   #################
   - wait: ~

--- a/.buildkite/release-pipelines/maestro-smoke.yml
+++ b/.buildkite/release-pipelines/maestro-smoke.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: mac
+
+env:
+  IMAGE_ID: $IMAGE_ID
+  MAESTRO_PROFILE: "${MAESTRO_PROFILE:-release}"
+  MAESTRO_APP_VARIANT: "${MAESTRO_APP_VARIANT:-debug}"
+  MAESTRO_APP_ARTIFACT: "${MAESTRO_APP_ARTIFACT:-build-products.tar}"
+  MAESTRO_APP_SOURCE_BUILD_ID: "${MAESTRO_APP_SOURCE_BUILD_ID:-}"
+  MAESTRO_APP_PATH: "${MAESTRO_APP_PATH:-}"
+  MAESTRO_DEVICE: "${MAESTRO_DEVICE:-}"
+  MAESTRO_CI_RESOURCE_KEY: "${MAESTRO_CI_RESOURCE_KEY:-unconfigured}"
+
+steps:
+  - label: ":pipeline: Build Debug simulator app"
+    key: maestro_debug_build
+    command: .buildkite/commands/build-for-testing.sh
+    plugins: [$CI_TOOLKIT]
+
+  - label: ":iphone: Maestro ${MAESTRO_PROFILE:-release} smoke"
+    command: .buildkite/commands/run-maestro-tests.sh
+    depends_on: maestro_debug_build
+    secrets:
+      MAESTRO_WOO_LAB_JETPACK_STORE_URL: MAESTRO_WOO_LAB_JETPACK_STORE_URL
+      MAESTRO_WOO_LAB_WPCOM_EMAIL: MAESTRO_WOO_LAB_WPCOM_EMAIL
+      MAESTRO_WOO_LAB_WPCOM_PASSWORD: MAESTRO_WOO_LAB_WPCOM_PASSWORD
+    plugins: [$CI_TOOLKIT]
+    soft_fail: true
+    concurrency: 1
+    concurrency_group: "woocommerce-ios/maestro/${MAESTRO_CI_RESOURCE_KEY:-unconfigured}"
+    artifact_paths:
+      - build/maestro/**/report.xml
+      - build/maestro/**/report.html
+      - build/maestro/**/screenshots/**/*
+      - build/maestro/**/diagnostics/**/*
+      - build/maestro/**/logs/**/*
+      - build/maestro/**/run-summary.json

--- a/.buildkite/schedules/maestro-smoke-burst.yml
+++ b/.buildkite/schedules/maestro-smoke-burst.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: mac
+
+env:
+  IMAGE_ID: $IMAGE_ID
+  MAESTRO_PROFILE: burst
+  MAESTRO_APP_VARIANT: debug
+  MAESTRO_APP_ARTIFACT: build-products.tar
+  MAESTRO_CI_RESOURCE_KEY: "${MAESTRO_CI_RESOURCE_KEY:-unconfigured}"
+
+steps:
+  - label: ":pipeline: Build Debug simulator app"
+    key: maestro_burst_build
+    command: .buildkite/commands/build-for-testing.sh
+    plugins: [$CI_TOOLKIT]
+
+  - label: ":repeat: Maestro release burst"
+    command: .buildkite/commands/run-maestro-tests.sh
+    depends_on: maestro_burst_build
+    secrets:
+      MAESTRO_WOO_LAB_JETPACK_STORE_URL: MAESTRO_WOO_LAB_JETPACK_STORE_URL
+      MAESTRO_WOO_LAB_WPCOM_EMAIL: MAESTRO_WOO_LAB_WPCOM_EMAIL
+      MAESTRO_WOO_LAB_WPCOM_PASSWORD: MAESTRO_WOO_LAB_WPCOM_PASSWORD
+    plugins: [$CI_TOOLKIT]
+    soft_fail: true
+    concurrency: 1
+    concurrency_group: "woocommerce-ios/maestro/${MAESTRO_CI_RESOURCE_KEY:-unconfigured}"
+    artifact_paths:
+      - build/maestro/**/report.xml
+      - build/maestro/**/report.html
+      - build/maestro/**/screenshots/**/*
+      - build/maestro/**/diagnostics/**/*
+      - build/maestro/**/logs/**/*
+      - build/maestro/**/run-summary.json

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -28,6 +28,11 @@ ENV_FILE = MAESTRO_DIR / ".env.local"
 CONFIG_FILE = MAESTRO_DIR / "config.yaml"
 LINT_ENV = SCRIPT_DIR / "lint-env.py"
 OUTPUT_DEFAULT = Path.home() / "woocommerce-maestro-output"
+NOT_WOO_STORE_FLOW = "login_not_woo_store.yaml"
+NOT_WOO_STORE_WPCOM_FALLBACK = {
+    "MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL",
+    "MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD",
+}
 
 PROFILES = {
     "core": (["smoke_core"], ["flaky_quarantine", "pos_ipad", "ios_system"], 1, "iphone"),
@@ -230,7 +235,10 @@ def required_environment(flows: list[Path], *, seed: bool) -> set[str]:
             continue
         visited.add(path)
         text = path.read_text(errors="replace")
-        required.update(ENV_REFERENCE_RE.findall(text))
+        references = set(ENV_REFERENCE_RE.findall(text))
+        if path.name == NOT_WOO_STORE_FLOW:
+            references.difference_update(NOT_WOO_STORE_WPCOM_FALLBACK)
+        required.update(references)
         for reference in SUBFLOW_REFERENCE_RE.findall(text):
             paths.append((path.parent / reference).resolve())
     if seed:
@@ -242,6 +250,10 @@ def validate_environment(flows: list[Path], values: dict[str, str], *, seed: boo
     missing = sorted(name for name in required_environment(flows, seed=seed) if not values.get(name))
     if missing:
         raise SystemExit("Missing environment required by selected flows: " + ", ".join(missing))
+    if any(flow.name == NOT_WOO_STORE_FLOW for flow in flows):
+        configured_fallback = [bool(values.get(name)) for name in NOT_WOO_STORE_WPCOM_FALLBACK]
+        if any(configured_fallback) and not all(configured_fallback):
+            raise SystemExit("Not-Woo-store WP.com fallback requires both email and password, or neither")
 
 
 def maestro_env_args(values: dict[str, str], app_id: str, run_id: str) -> list[str]:

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -14,6 +14,7 @@ import secrets
 import shutil
 import subprocess
 import sys
+import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
@@ -275,6 +276,14 @@ def redact(text: str, values: dict[str, str]) -> str:
     return text
 
 
+def flow_status(returncodes: list[int]) -> str:
+    if not returncodes or returncodes[-1] != 0:
+        return "FAIL"
+    if len(returncodes) > 1:
+        return "FLAKY"
+    return "PASS"
+
+
 def sanitize_artifacts(root: Path, values: dict[str, str], *, remove_images: bool = False) -> None:
     """Redact Maestro's generated text evidence and suppress login screenshots."""
     text_suffixes = {".html", ".json", ".log", ".txt", ".xml", ".yaml", ".yml"}
@@ -372,13 +381,30 @@ def main() -> int:
 
     if args.seed:
         seed = SCRIPT_DIR / "seed-fixtures.py"
+        print("--- Seeding deterministic fixtures", flush=True)
         run([sys.executable, str(seed), "--mode", "seed", "--run-id", run_id, "--manifest", str(output / "run-manifest.json")], env=values)
 
     attempts: list[Attempt] = []
     env_args = maestro_env_args(values, app_id, run_id)
+    total_runs = len(flows) * repeat
+    suite_started = time.monotonic()
+    run_index = 0
+    statuses: list[str] = []
+    print("--- Running Maestro flows", flush=True)
+    print(f"Run ID:       {run_id}", flush=True)
+    print(f"Profile:      {args.profile}", flush=True)
+    print(f"Simulator:    {simulator['name']} ({simulator['udid']})", flush=True)
+    print(f"Output:       {output}", flush=True)
+    print(f"Repeat:       {repeat}", flush=True)
+    print(f"Include tags: {','.join(include) or '<none>'}", flush=True)
+    print(f"Exclude tags: {','.join(exclude) or '<none>'}", flush=True)
     try:
         for repetition in range(1, repeat + 1):
             for flow in flows:
+                run_index += 1
+                flow_started = time.monotonic()
+                flow_returncodes: list[int] = []
+                print(f"[{run_index}/{total_runs}] {flow.stem} (repeat {repetition}/{repeat})", flush=True)
                 for attempt_number in (1, 2):
                     prefix = f"r{repetition:02d}-{flow.stem}-a{attempt_number}"
                     junit = output / f"{prefix}.xml"
@@ -395,8 +421,15 @@ def main() -> int:
                     sanitize_artifacts(screenshot_dir, values, remove_images=is_login)
                     sanitize_artifacts(junit.parent, values)
                     attempts.append(Attempt(flow, repetition, attempt_number, completed.returncode, junit, log, debug))
+                    flow_returncodes.append(completed.returncode)
                     if completed.returncode == 0:
                         break
+                    if attempt_number == 1:
+                        print("  first attempt failed; retrying once", flush=True)
+                status = flow_status(flow_returncodes)
+                statuses.append(status)
+                duration = round(time.monotonic() - flow_started)
+                print(f"  {status} in {duration}s", flush=True)
     finally:
         if args.seed and not args.no_cleanup:
             run([sys.executable, str(SCRIPT_DIR / "seed-fixtures.py"), "--mode", "cleanup", "--run-id", run_id, "--manifest", str(output / "run-manifest.json")], check=False, env=values)
@@ -405,12 +438,20 @@ def main() -> int:
     for attempt in attempts:
         final_by_flow_run[(attempt.flow, attempt.repeat)] = attempt
     report_attempts = list(final_by_flow_run.values())
+    print("--- Generating reports", flush=True)
     tests, failures, skipped = write_combined_junit(report_attempts, output / "report.xml")
     write_html(output / "report.html", run_id=run_id, app=app, app_id=app_id, simulator=simulator, profile=args.profile, attempts=attempts, tests=tests, failures=failures, skipped=skipped)
     sanitize_artifacts(output, values)
+    passed = statuses.count("PASS")
+    flaky = statuses.count("FLAKY")
+    failed = statuses.count("FAIL")
+    suite_duration = round(time.monotonic() - suite_started)
     print(f"Maestro artifacts: {output}")
+    print(f"Report: {output / 'report.html'}")
+    print(f"JUnit:  {output / 'report.xml'}")
     print(f"Simulator: {simulator['name']} ({simulator['udid']})")
     print(f"Bundle identifier: {app_id}")
+    print(f"Result: {passed} passed, {flaky} flaky, {failed} failed out of {total_runs} executions ({suite_duration}s)")
     print(f"Final results: {tests} tests, {failures} failures, {skipped} skipped")
     return 1 if any(attempt.returncode for attempt in report_attempts) else 0
 

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -68,6 +68,17 @@ class RunnerTests(unittest.TestCase):
             self.assertIn("MAESTRO_WOO_VARIABLE_PRODUCT_NAME", required)
             self.assertNotIn("MAESTRO_WOO_CONSUMER_KEY", required)
 
+    def test_not_woo_store_requires_its_dedicated_credentials(self) -> None:
+        flow = RUNNER.FLOWS_DIR / "login_not_woo_store.yaml"
+
+        required = RUNNER.required_environment([flow], seed=False)
+
+        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_URL", required)
+        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", required)
+        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD", required)
+        self.assertNotIn("MAESTRO_WOO_LAB_WPCOM_EMAIL", required)
+        self.assertNotIn("MAESTRO_WOO_LAB_WPCOM_PASSWORD", required)
+
     def test_seed_explicitly_requires_consumer_keys(self) -> None:
         required = RUNNER.required_environment([], seed=True)
         self.assertIn("MAESTRO_WOO_CONSUMER_KEY", required)

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -68,12 +68,14 @@ class RunnerTests(unittest.TestCase):
             self.assertIn("MAESTRO_WOO_VARIABLE_PRODUCT_NAME", required)
             self.assertNotIn("MAESTRO_WOO_CONSUMER_KEY", required)
 
-    def test_not_woo_store_requires_its_dedicated_credentials(self) -> None:
+    def test_not_woo_store_requires_both_dedicated_credential_routes(self) -> None:
         flow = RUNNER.FLOWS_DIR / "login_not_woo_store.yaml"
 
         required = RUNNER.required_environment([flow], seed=False)
 
         self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_URL", required)
+        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME", required)
+        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD", required)
         self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", required)
         self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD", required)
         self.assertNotIn("MAESTRO_WOO_LAB_WPCOM_EMAIL", required)

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -68,7 +68,7 @@ class RunnerTests(unittest.TestCase):
             self.assertIn("MAESTRO_WOO_VARIABLE_PRODUCT_NAME", required)
             self.assertNotIn("MAESTRO_WOO_CONSUMER_KEY", required)
 
-    def test_not_woo_store_requires_both_dedicated_credential_routes(self) -> None:
+    def test_not_woo_store_requires_site_admin_credentials_only(self) -> None:
         flow = RUNNER.FLOWS_DIR / "login_not_woo_store.yaml"
 
         required = RUNNER.required_environment([flow], seed=False)
@@ -76,10 +76,25 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_URL", required)
         self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME", required)
         self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD", required)
-        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", required)
-        self.assertIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD", required)
+        self.assertNotIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL", required)
+        self.assertNotIn("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_PASSWORD", required)
         self.assertNotIn("MAESTRO_WOO_LAB_WPCOM_EMAIL", required)
         self.assertNotIn("MAESTRO_WOO_LAB_WPCOM_PASSWORD", required)
+
+    def test_not_woo_store_wpcom_fallback_must_be_complete(self) -> None:
+        flow = RUNNER.FLOWS_DIR / "login_not_woo_store.yaml"
+        values = {
+            "MAESTRO_WOO_NOT_A_WOO_STORE_URL": "https://example.com",
+            "MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_USERNAME": "admin",
+            "MAESTRO_WOO_NOT_A_WOO_STORE_SITE_ADMIN_PASSWORD": "password",
+            "MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL": "merchant@example.com",
+        }
+
+        with self.assertRaisesRegex(SystemExit, "requires both email and password"):
+            RUNNER.validate_environment([flow], values, seed=False)
+
+        values.pop("MAESTRO_WOO_NOT_A_WOO_STORE_WPCOM_EMAIL")
+        RUNNER.validate_environment([flow], values, seed=False)
 
     def test_seed_explicitly_requires_consumer_keys(self) -> None:
         required = RUNNER.required_environment([], seed=True)

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -20,6 +20,11 @@ class RunnerTests(unittest.TestCase):
         values = {"MAESTRO_WOO_LAB_WPCOM_PASSWORD": "do-not-print"}
         self.assertEqual("failure: <redacted>", RUNNER.redact("failure: do-not-print", values))
 
+    def test_flow_status_reports_pass_flaky_and_fail(self) -> None:
+        self.assertEqual("PASS", RUNNER.flow_status([0]))
+        self.assertEqual("FLAKY", RUNNER.flow_status([1, 0]))
+        self.assertEqual("FAIL", RUNNER.flow_status([1, 1]))
+
     def test_profile_contract(self) -> None:
         self.assertEqual("iphone", RUNNER.PROFILES["core"][3])
         self.assertEqual("ipad", RUNNER.PROFILES["pos-ipad"][3])


### PR DESCRIPTION
## Description

Seventh PR in the eight-part iOS Maestro stack. It connects the repository runner to Buildkite through:

- An on-demand, initially non-blocking smoke step on `trunk`.
- A standalone release pipeline and a repeated release-burst pipeline definition.
- Debug simulator builds by default, with explicit Alpha/prototype artifact/path/build-ID inputs.
- Release, burst, POS iPad, and iOS system-surface profile selection.
- Protected environment injection without creating `.maestro/.env.local` in CI.
- Per-store/account concurrency controls and uploads for JUnit, HTML, screenshots, diagnostics, logs, and the run summary.

This layer provides CI wiring; it does not yet make Maestro a release gate.

## Validation

- 12 Python runner contract tests
- shell syntax for the Buildkite wrapper and Maestro scripts
- Buildkite YAML files parsed successfully
- exact layer diff passes `git diff --check`
- repository CI: green on the rebased head

The manual Buildkite smoke step was not triggered during this review, so artifact download, protected secrets, the target simulator queue, and report rendering still need a real CI canary.

## Provisional limitations

- Jobs are deliberately `soft_fail`; results require human review and do not block a release.
- The `release` profile currently selects the four promoted core flows. `phone-full`, POS, and system coverage remains quarantined or explicitly selected.
- The default path tests a convenient Debug simulator build, not an immutable signed release candidate.
- This layer does not pin Maestro/Java, distinguish recovered flakes in standard CI status, provide real destructive cleanup, or publish concise status annotations.
- #17656 pins Maestro 2.8.0/Java 21, hardens outcomes and cleanup, adds candidate/run metadata, faithful reruns, Test Analytics upload, annotations, and a non-gating scheduled `phone-full` lane. Release-candidate enforcement remains follow-up work.
- CI cadence remains the P2 decision: beta/release-triggered plus a final release run, initially one current-OS phone and tablet per platform, with the release manager owning result review.

## Test steps

1. Run `bash -n .buildkite/commands/run-maestro-tests.sh` and parse the three Buildkite YAML entry points.
2. In Buildkite, provide the protected store/account resource key and required credentials.
3. Canary the four-flow `release` profile against a known simulator artifact and confirm every declared artifact uploads.
4. Repeat with an explicit Alpha/prototype artifact and verify the derived bundle identifier/app identity.
5. Do not treat a soft-failed or recovered run as clean release evidence.

## Stack

1. #17525 — foundations
2. #17526 — core and login flows
3. #17527 — extended store flows
4. #17528 — destructive flows
5. #17529 — iPad POS flows
6. #17530 — iOS system-surface flows
7. #17531 — Buildkite integration
8. #17656 — trust, reliability, toolchain, and reporting hardening

Previous: #17530 · Next: #17656

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. CI test tooling only; no release note is required.
