### PR TITLE
[Quality] Document fatalError justification and handled-error reporting conventions

### DIFF
--- a/.claude/agents/code-reviewer/code-reviewer.md
+++ b/.claude/agents/code-reviewer/code-reviewer.md
@@ -19,6 +19,8 @@ You are a code reviewer for the WooCommerce iOS project by Automattic. Review ch
 ### Swift Conventions
 - No force unwraps (`!`) or force casts (`as!`)
 - Error handling uses do-catch with DDLogError, not try?
+- Every `fatalError`/`preconditionFailure`/`assertionFailure` has a preceding comment justifying why crashing is correct and the state is unrecoverable
+- Production-relevant errors reported via `crashLogging.logError`/`logMessage` (not just `DDLogError`, which is local-only); reporting-and-continuing preferred over crashing
 - Classes marked final unless designed for subclassing
 - Line length under 163 characters
 - No parentheses around conditionals

--- a/.claude/agents/code-reviewer/code-reviewer.md
+++ b/.claude/agents/code-reviewer/code-reviewer.md
@@ -19,7 +19,7 @@ You are a code reviewer for the WooCommerce iOS project by Automattic. Review ch
 ### Swift Conventions
 - No force unwraps (`!`) or force casts (`as!`)
 - Error handling uses do-catch with DDLogError, not try?
-- Every `fatalError`/`preconditionFailure`/`assertionFailure` has a preceding comment justifying why crashing is correct and the state is unrecoverable
+- Every **added or modified** `fatalError`/`preconditionFailure`/`assertionFailure` has a preceding comment justifying why crashing is correct and the state is unrecoverable (a descriptive message alone does not count). Do not flag pre-existing crash sites the diff only moves or leaves untouched, nor the `init(coder:) has not been implemented` boilerplate
 - Production-relevant errors reported via `crashLogging.logError`/`logMessage` (not just `DDLogError`, which reaches the logs but raises no Sentry issue); reporting-and-continuing preferred over crashing
 - Classes marked final unless designed for subclassing
 - Line length under 163 characters

--- a/.claude/agents/code-reviewer/code-reviewer.md
+++ b/.claude/agents/code-reviewer/code-reviewer.md
@@ -20,7 +20,7 @@ You are a code reviewer for the WooCommerce iOS project by Automattic. Review ch
 - No force unwraps (`!`) or force casts (`as!`)
 - Error handling uses do-catch with DDLogError, not try?
 - Every `fatalError`/`preconditionFailure`/`assertionFailure` has a preceding comment justifying why crashing is correct and the state is unrecoverable
-- Production-relevant errors reported via `crashLogging.logError`/`logMessage` (not just `DDLogError`, which is local-only); reporting-and-continuing preferred over crashing
+- Production-relevant errors reported via `crashLogging.logError`/`logMessage` (not just `DDLogError`, which reaches the logs but raises no Sentry issue); reporting-and-continuing preferred over crashing
 - Classes marked final unless designed for subclassing
 - Line length under 163 characters
 - No parentheses around conditionals

--- a/.claude/rules/swift-style.md
+++ b/.claude/rules/swift-style.md
@@ -17,7 +17,9 @@ These rules are enforced by SwiftLint (see `.swiftlint.yml` for the full configu
 - `DDLog*` writes to the CocoaLumberjack logs — the Xcode console and the local log files shown in Settings → Help → Application Logs, which are also attached to support requests and uploaded alongside crash reports. It does NOT create a Sentry issue by itself, so a `DDLogError` alone is not searchable or alertable in production
 - Report production-relevant errors to the crash-logging system: `ServiceLocator.crashLogging.logError(_:userInfo:level:)` or `logMessage(_:properties:level:)` (`SeverityLevel` = `.fatal/.error/.warning/.info/.debug`)
 - Fail fast: crash (`fatalError`) when the app reaches a genuinely unrecoverable or corrupted state. For recoverable errors, report a handled event (`logError`/`logMessage`) rather than silently swallowing it — never swallow
-- Every `fatalError` / `preconditionFailure` / `assertionFailure` MUST have a preceding comment justifying why crashing is correct and the state is unrecoverable
+- From now on, every `fatalError` / `preconditionFailure` / `assertionFailure` you add or modify MUST have a preceding comment justifying why crashing is correct and the state is unrecoverable. A descriptive message is not a substitute: the message says what broke, the comment says why crashing beats recovering
+- The codebase still has many un-commented crash sites predating this rule. They are NOT a precedent to copy — do not treat existing bare `fatalError()` calls as the house style, and do not go fix them in unrelated PRs either
+- Exempt: the UIKit-mandated `required init?(coder:)` / `fatalError("init(coder:) has not been implemented")` boilerplate, which encodes no decision worth justifying
 - To report AND terminate on a truly unrecoverable state, use `crashLogging.logFatalErrorAndExit(_:userInfo:)` rather than a bare `fatalError` — it delivers the event to Sentry with metadata before exit
 - See `docs/coding-style-guide.md` (Error Handling) for examples
 

--- a/.claude/rules/swift-style.md
+++ b/.claude/rules/swift-style.md
@@ -13,6 +13,14 @@ These rules are enforced by SwiftLint (see `.swiftlint.yml` for the full configu
 - Never use `as!` or force unwrap with `!`. Use `as?` with guard/if-let
 - Avoid `try?` for silent failure. Use `do-catch` and log errors with `DDLogError`
 
+## Error Handling and Crash Logging
+- `DDLog*` writes to the local console only — it is NOT reported to Sentry
+- Report production-relevant errors to the crash-logging system: `ServiceLocator.crashLogging.logError(_:userInfo:level:)` or `logMessage(_:properties:level:)` (`SeverityLevel` = `.fatal/.error/.warning/.info/.debug`)
+- Fail fast: crash (`fatalError`) when the app reaches a genuinely unrecoverable or corrupted state. For recoverable errors, report a handled event (`logError`/`logMessage`) rather than silently swallowing it — never swallow
+- Every `fatalError` / `preconditionFailure` / `assertionFailure` MUST have a preceding comment justifying why crashing is correct and the state is unrecoverable
+- To report AND terminate on a truly unrecoverable state, use `crashLogging.logFatalErrorAndExit(_:userInfo:)` rather than a bare `fatalError` — it delivers the event to Sentry with metadata before exit
+- See `docs/coding-style-guide.md` (Error Handling) for examples
+
 ## Access Control
 - Use the most restrictive access level possible
 - Mark classes `final` unless designed for subclassing

--- a/.claude/rules/swift-style.md
+++ b/.claude/rules/swift-style.md
@@ -14,7 +14,7 @@ These rules are enforced by SwiftLint (see `.swiftlint.yml` for the full configu
 - Avoid `try?` for silent failure. Use `do-catch` and log errors with `DDLogError`
 
 ## Error Handling and Crash Logging
-- `DDLog*` writes to the local console only — it is NOT reported to Sentry
+- `DDLog*` writes to the CocoaLumberjack logs — the Xcode console and the local log files shown in Settings → Help → Application Logs, which are also attached to support requests and uploaded alongside crash reports. It does NOT create a Sentry issue by itself, so a `DDLogError` alone is not searchable or alertable in production
 - Report production-relevant errors to the crash-logging system: `ServiceLocator.crashLogging.logError(_:userInfo:level:)` or `logMessage(_:properties:level:)` (`SeverityLevel` = `.fatal/.error/.warning/.info/.debug`)
 - Fail fast: crash (`fatalError`) when the app reaches a genuinely unrecoverable or corrupted state. For recoverable errors, report a handled event (`logError`/`logMessage`) rather than silently swallowing it — never swallow
 - Every `fatalError` / `preconditionFailure` / `assertionFailure` MUST have a preceding comment justifying why crashing is correct and the state is unrecoverable

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -107,7 +107,9 @@ let fetchResults = try? resultsController.performFetch()
 
 ### Reporting handled errors (crash logging)
 
-`DDLogError` only writes to the local console — it is **not** reported anywhere. When an error matters in production (it signals a real problem rather than an expected/recoverable condition), also report it to the crash-logging system so it surfaces in Sentry as a handled, non-crash event while the app keeps running:
+`DDLogError` writes to the CocoaLumberjack logs: the Xcode console and the rotating local log files surfaced in Settings → Help → Application Logs. Those files travel with support requests, and `WCEventLoggingDataSource` attaches the most recent one to crash reports, so the text is not lost — but `DDLogError` does **not** create a Sentry issue by itself, which means nothing is searchable, alertable, or countable in production. It only helps once you already know which install to look at.
+
+When an error matters in production (it signals a real problem rather than an expected/recoverable condition), also report it to the crash-logging system so it surfaces in Sentry as a handled, non-crash event while the app keeps running:
 
 ```swift
 // An Error worth surfacing in production:
@@ -121,7 +123,7 @@ ServiceLocator.crashLogging.logMessage("Payment intent had no id", properties: n
 
 | Goal | Use |
 |------|-----|
-| Local-only console log (development) | `DDLogError` / `DDLogWarn` / … |
+| Console + local log file; no Sentry issue | `DDLogError` / `DDLogWarn` / … |
 | Report to Sentry, keep running | `crashLogging.logError(_:userInfo:level:)` / `logMessage(_:properties:level:)` |
 | Report to Sentry, then terminate | `crashLogging.logFatalErrorAndExit(_:userInfo:)` |
 

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -104,3 +104,35 @@ do {
 ```swift
 let fetchResults = try? resultsController.performFetch()
 ```
+
+### Reporting handled errors (crash logging)
+
+`DDLogError` only writes to the local console — it is **not** reported anywhere. When an error matters in production (it signals a real problem rather than an expected/recoverable condition), also report it to the crash-logging system so it surfaces in Sentry as a handled, non-crash event while the app keeps running:
+
+```swift
+// An Error worth surfacing in production:
+ServiceLocator.crashLogging.logError(error, userInfo: ["context": "receipt upload"], level: .error)
+
+// A non-Error condition worth flagging:
+ServiceLocator.crashLogging.logMessage("Payment intent had no id", properties: nil, level: .warning)
+```
+
+`SeverityLevel` is `.fatal / .error / .warning / .info / .debug`. Never silently swallow an error: report a handled event for recoverable problems, and fail fast (crash) when the state is genuinely unrecoverable or corrupted — see below.
+
+| Goal | Use |
+|------|-----|
+| Local-only console log (development) | `DDLogError` / `DDLogWarn` / … |
+| Report to Sentry, keep running | `crashLogging.logError(_:userInfo:level:)` / `logMessage(_:properties:level:)` |
+| Report to Sentry, then terminate | `crashLogging.logFatalErrorAndExit(_:userInfo:)` |
+
+### Crashing with `fatalError`
+
+Every `fatalError` (and `preconditionFailure` / `assertionFailure`) must be preceded by a comment justifying **why crashing is the correct response** and why the state is genuinely unrecoverable. If the app can keep running, report the error via `crashLogging.logError` / `logMessage` instead of crashing.
+
+```swift
+// fatalError: the app cannot function without a valid managed object model. This only
+// happens on a corrupt or incompatible install, which cannot be recovered at runtime.
+fatalError("Could not load the Core Data model")
+```
+
+When you must both report *and* terminate on a truly unrecoverable state, prefer `crashLogging.logFatalErrorAndExit(_:userInfo:)` (today used only by `CoreDataManager` for launch-time Core Data failures) over a bare `fatalError`, so the incident reaches Sentry with its metadata before the process exits.

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -129,12 +129,24 @@ ServiceLocator.crashLogging.logMessage("Payment intent had no id", properties: n
 
 ### Crashing with `fatalError`
 
-Every `fatalError` (and `preconditionFailure` / `assertionFailure`) must be preceded by a comment justifying **why crashing is the correct response** and why the state is genuinely unrecoverable. If the app can keep running, report the error via `crashLogging.logError` / `logMessage` instead of crashing.
+From now on, every `fatalError` (and `preconditionFailure` / `assertionFailure`) **you add or modify** must be preceded by a comment justifying **why crashing is the correct response** and why the state is genuinely unrecoverable. If the app can keep running, report the error via `crashLogging.logError` / `logMessage` instead of crashing.
 
 ```swift
 // fatalError: the app cannot function without a valid managed object model. This only
 // happens on a corrupt or incompatible install, which cannot be recovered at runtime.
 fatalError("Could not load the Core Data model")
+```
+
+A descriptive message does not satisfy this on its own. `fatalError("Could not load the Core Data model")` says *what* failed; the comment is where you argue that crashing beats recovering, which is the part a future reader cannot reconstruct from the code.
+
+This rule applies going forward, not retroactively. The codebase contains many crash sites that predate it, including bare `fatalError()` calls with no message at all — they are not the house style, and this is not a request to go comment them all. Fix them when you are already changing that code; otherwise leave them.
+
+The UIKit-mandated boilerplate is exempt, since it encodes no decision worth justifying:
+
+```swift
+required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+}
 ```
 
 When you must both report *and* terminate on a truly unrecoverable state, prefer `crashLogging.logFatalErrorAndExit(_:userInfo:)` (today used only by `CoreDataManager` for launch-time Core Data failures) over a bare `fatalError`, so the incident reaches Sentry with its metadata before the process exits.


### PR DESCRIPTION
## Description
WOOMOB-3550

With this PR we introduce documentation on how and when to use `fatalError`. The goal is twofold, we want to log errors more efficiently so we can detect all types early enough, as well as prevent crashes when we can detect these errors are recoverable and we can detect them in a less impactful way.

**What changed:**
- `docs/coding-style-guide.md` — extended the **Error Handling** section with:
  - *Reporting handled errors*: `DDLog*` is local-console only (not sent to Sentry); production-relevant errors should be reported via `crashLogging.logError(_:userInfo:level:)` / `logMessage(_:properties:level:)`, with a quick decision table.
  - *Crashing with `fatalError`*: every `fatalError` / `preconditionFailure` / `assertionFailure` must carry a preceding comment justifying why crashing is correct and the state is unrecoverable; use `logFatalErrorAndExit` when you must report **and** terminate.
- `.claude/rules/swift-style.md` — the same guidance in terse rule form for AI agents (also surfaced under `.agents/rules` via symlink).
- `.claude/agents/code-reviewer/code-reviewer.md` — two checklist lines so reviews flag un-justified crashes and errors that are only logged locally.

The guiding axis: **recoverable → report and continue; unrecoverable/corrupted → fail fast (crash)**; never silently swallow.

## Test Steps

N/A 

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not user-facing — no entry needed.)