### PR TITLE
Add DEBUG-only auto-login shortcut for local repro/debug workflows

### DIFF
--- a/.claude/skills/auto-login/SKILL.md
+++ b/.claude/skills/auto-login/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: auto-login
-description: Launch the WooCommerce app on a simulator already authenticated into a given store (application password or WPCom), skipping the manual login UI. Meant to be referenced by other skills/workflows that need a logged-in session fast, but also directly runnable.
+description: Launch the WooCommerce app on a simulator already authenticated into a given store (site credentials, application password, or WPCom), skipping the manual login UI. Meant to be referenced by other skills/workflows that need a logged-in session fast, but also directly runnable.
 user-invocable: true
 allowed-tools: "Bash"
-argument-hint: "<UDID> <site-address> <username> <secret> [auth-type: applicationPassword|wpcom] [store-id]"
+argument-hint: "<UDID> <site-address> <username> <secret> [auth-type: wporg|applicationPassword|wpcom] [store-id]"
 ---
 
 # Auto-Login
@@ -21,8 +21,12 @@ the caller's responsibility (see `/build`, `/simulator`, and JN site provisionin
 - The app already built **and installed** for that simulator, from a `DEBUG` configuration (the default for
   simulator builds). If not installed yet, build first and `xcrun simctl install <UDID> <path-to-.app>`.
 - Credentials for the target store:
-  - `applicationPassword` (default) — a wp-admin username + an application password created on that site.
-    This is the right choice for a self-hosted/Jurassic Ninja site with no Jetpack connection.
+  - `wporg` (default) — the wp-admin username + real password (e.g. a fresh Jurassic Ninja site's admin
+    credentials). Works with no extra setup: the app's networking layer automatically does the
+    cookie/nonce handshake and generates+stores a proper application password on the first REST call.
+  - `applicationPassword` — a wp-admin username + an application password created on that site (e.g. via
+    `wp user application-password create <user> <name> --porcelain` over SSH). Use this if `wporg` doesn't
+    work for some reason (e.g. a security plugin blocking the wp-login.php handshake).
   - `wpcom` — a WordPress.com username + auth token, plus the store's real numeric site ID (`store-id`).
 
 ## Usage
@@ -33,8 +37,11 @@ bash .claude/skills/auto-login/Scripts/launch.sh <UDID> <site-address> <username
 
 Examples:
 ```bash
-# Self-hosted / JN site via application password (auth-type defaults to applicationPassword)
-bash .claude/skills/auto-login/Scripts/launch.sh "$UDID" https://example-jn-site.com admin "abcd 1234 efgh 5678"
+# Self-hosted / JN site via its real admin username+password (auth-type defaults to wporg)
+bash .claude/skills/auto-login/Scripts/launch.sh "$UDID" https://example-jn-site.com admin "real-admin-password"
+
+# Self-hosted site via an application password instead
+bash .claude/skills/auto-login/Scripts/launch.sh "$UDID" https://example-jn-site.com admin "abcd 1234 efgh 5678" applicationPassword
 
 # WPCom-connected site (needs the real site ID)
 bash .claude/skills/auto-login/Scripts/launch.sh "$UDID" https://example.com someuser somewpcomtoken wpcom 123456789
@@ -69,5 +76,8 @@ These stem from the app-side `DEBUG` shortcut itself and are accepted tradeoffs,
 - **No error is surfaced on bad credentials.** Unlike the real login UI, this shortcut doesn't validate role
   eligibility, WooCommerce installation, or application-password validity. Bad credentials just produce a
   blank/broken dashboard — check the simulator's console log (`DDLogError`) if the store doesn't load.
+- **`wporg` needs the wp-login.php cookie/nonce handshake to succeed on first REST call.** If a security
+  plugin (e.g. Jetpack's account-protection module) blocks that handshake, `wporg` will silently fail the
+  same way as any other bad credentials — fall back to `applicationPassword` in that case.
 - If you also pass `logout-at-launch` in the same launch, auto-login will silently re-authenticate right
   after it deauthenticates — the two aren't designed to be combined.

--- a/.claude/skills/auto-login/SKILL.md
+++ b/.claude/skills/auto-login/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: auto-login
+description: Launch the WooCommerce app on a simulator already authenticated into a given store (application password or WPCom), skipping the manual login UI. Meant to be referenced by other skills/workflows that need a logged-in session fast, but also directly runnable.
+user-invocable: true
+allowed-tools: "Bash"
+argument-hint: "<UDID> <site-address> <username> <secret> [auth-type: applicationPassword|wpcom] [store-id]"
+---
+
+# Auto-Login
+
+Launch the app already authenticated into a store, skipping the manual login UI. Backed by a `DEBUG`-only
+shortcut in `ProcessConfiguration.swift` that seeds `SessionManager` credentials + store ID at launch, before
+`AppCoordinator` decides whether to show the login screen or the tab bar.
+
+**Scope**: this skill only launches. It does not build the app, install it, or provision a site — those are
+the caller's responsibility (see `/build`, `/simulator`, and JN site provisioning tools/skills).
+
+## Prerequisites
+
+- A booted simulator (use the `/simulator` skill approach if none is booted)
+- The app already built **and installed** for that simulator, from a `DEBUG` configuration (the default for
+  simulator builds). If not installed yet, build first and `xcrun simctl install <UDID> <path-to-.app>`.
+- Credentials for the target store:
+  - `applicationPassword` (default) — a wp-admin username + an application password created on that site.
+    This is the right choice for a self-hosted/Jurassic Ninja site with no Jetpack connection.
+  - `wpcom` — a WordPress.com username + auth token, plus the store's real numeric site ID (`store-id`).
+
+## Usage
+
+```bash
+bash .claude/skills/auto-login/Scripts/launch.sh <UDID> <site-address> <username> <secret> [auth-type] [store-id]
+```
+
+Examples:
+```bash
+# Self-hosted / JN site via application password (auth-type defaults to applicationPassword)
+bash .claude/skills/auto-login/Scripts/launch.sh "$UDID" https://example-jn-site.com admin "abcd 1234 efgh 5678"
+
+# WPCom-connected site (needs the real site ID)
+bash .claude/skills/auto-login/Scripts/launch.sh "$UDID" https://example.com someuser somewpcomtoken wpcom 123456789
+```
+
+The script launches twice: a seeding launch that reads the credentials and persists them to
+Keychain/UserDefaults, then a second plain relaunch (no debug env vars) that boots already-authenticated
+from the start — this is what makes launch-time steps gated on already-being-authenticated (push
+notification registration, analytics identity refresh) run normally, since the seeding launch alone starts
+out deauthenticated and misses that window. See the comments in `launch.sh` for details.
+
+After it returns, wait ~3 seconds, then verify: screenshot the simulator or use `list_ui_elements` (if
+mobile-mcp is available) and confirm the tab bar is visible (not the login screen), and that the store name
+matches the target site.
+
+## Never commit secrets
+
+Credentials only ever exist as arguments to this one shell invocation and the resulting `SIMCTL_CHILD_*`
+environment variables passed to `simctl launch` — never write them to a file in this repo, a scheme, or any
+other persisted location.
+
+## Known limitations
+
+These stem from the app-side `DEBUG` shortcut itself and are accepted tradeoffs, not bugs in this script:
+
+- **Don't persist these env vars on a personal Xcode scheme.** If set that way instead of via this script,
+  every subsequent debug launch — not just the one you intended — silently re-authenticates and re-syncs.
+  Always prefer invoking `launch.sh` fresh (it only sets them for that one `simctl launch` call).
+- **`wpcom` requires a real `store-id`.** This script validates that, but if you ever set the env vars
+  directly (bypassing this script), a missing/invalid store ID for `wpcom` credentials silently falls back
+  to the self-hosted placeholder site ID, producing a broken/inconsistent session.
+- **No error is surfaced on bad credentials.** Unlike the real login UI, this shortcut doesn't validate role
+  eligibility, WooCommerce installation, or application-password validity. Bad credentials just produce a
+  blank/broken dashboard — check the simulator's console log (`DDLogError`) if the store doesn't load.
+- If you also pass `logout-at-launch` in the same launch, auto-login will silently re-authenticate right
+  after it deauthenticates — the two aren't designed to be combined.

--- a/.claude/skills/auto-login/Scripts/launch.sh
+++ b/.claude/skills/auto-login/Scripts/launch.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+# Launches the already-installed WooCommerce app on a simulator, pre-authenticated into a store.
+# Usage: launch.sh <udid> <site-address> <username> <secret> [auth-type] [store-id]
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <udid> <site-address> <username> <secret> [auth-type: applicationPassword|wpcom] [store-id]" >&2
+  exit 1
+fi
+
+UDID="$1"
+SITE_ADDRESS="$2"
+USERNAME="$3"
+SECRET="$4"
+AUTH_TYPE="${5:-applicationPassword}"
+STORE_ID="${6:-}"
+
+BUNDLE_ID="com.automattic.woocommerce"
+
+if [ "$AUTH_TYPE" != "applicationPassword" ] && [ "$AUTH_TYPE" != "wpcom" ]; then
+  echo "Unrecognized auth-type '$AUTH_TYPE' — must be exactly 'applicationPassword' or 'wpcom'" >&2
+  exit 1
+fi
+
+if [ "$AUTH_TYPE" = "wpcom" ] && [ -z "$STORE_ID" ]; then
+  echo "auth-type 'wpcom' requires a store-id argument" >&2
+  exit 1
+fi
+
+ENV_ARGS=(
+  "SIMCTL_CHILD_DEBUG_LOGIN_SITE_ADDRESS=$SITE_ADDRESS"
+  "SIMCTL_CHILD_DEBUG_LOGIN_USERNAME=$USERNAME"
+  "SIMCTL_CHILD_DEBUG_LOGIN_SECRET=$SECRET"
+  "SIMCTL_CHILD_DEBUG_LOGIN_AUTH_TYPE=$AUTH_TYPE"
+)
+if [ -n "$STORE_ID" ]; then
+  ENV_ARGS+=("SIMCTL_CHILD_DEBUG_LOGIN_STORE_ID=$STORE_ID")
+fi
+
+# Force a fresh cold launch — simctl launch on an already-running process just
+# foregrounds it without re-invoking willFinishLaunchingWithOptions, which would
+# silently ignore these env vars and keep whatever session was already active.
+xcrun simctl terminate "$UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+
+# Seeding launch: this is the one that reads the env vars above and persists
+# credentials + store ID to Keychain/UserDefaults.
+env "${ENV_ARGS[@]}" xcrun simctl launch "$UDID" "$BUNDLE_ID"
+
+# The seeding launch starts out deauthenticated — credentials are only set partway
+# through its willFinishLaunchingWithOptions — so launch-time steps that are gated on
+# already-being-authenticated (push notification registration, analytics identity
+# refresh) miss their window and never get a second chance during that same process.
+# Now that credentials are persisted, relaunch once more WITHOUT the debug env vars:
+# this second launch boots already-authenticated from its very first line, exercising
+# the exact same cold-start path a real login would, so those steps run normally.
+sleep 3
+xcrun simctl terminate "$UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+xcrun simctl launch "$UDID" "$BUNDLE_ID"

--- a/.claude/skills/auto-login/Scripts/launch.sh
+++ b/.claude/skills/auto-login/Scripts/launch.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: launch.sh <udid> <site-address> <username> <secret> [auth-type] [store-id]
 
 if [ "$#" -lt 4 ]; then
-  echo "Usage: $0 <udid> <site-address> <username> <secret> [auth-type: applicationPassword|wpcom] [store-id]" >&2
+  echo "Usage: $0 <udid> <site-address> <username> <secret> [auth-type: wporg|applicationPassword|wpcom] [store-id]" >&2
   exit 1
 fi
 
@@ -13,13 +13,13 @@ UDID="$1"
 SITE_ADDRESS="$2"
 USERNAME="$3"
 SECRET="$4"
-AUTH_TYPE="${5:-applicationPassword}"
+AUTH_TYPE="${5:-wporg}"
 STORE_ID="${6:-}"
 
 BUNDLE_ID="com.automattic.woocommerce"
 
-if [ "$AUTH_TYPE" != "applicationPassword" ] && [ "$AUTH_TYPE" != "wpcom" ]; then
-  echo "Unrecognized auth-type '$AUTH_TYPE' — must be exactly 'applicationPassword' or 'wpcom'" >&2
+if [ "$AUTH_TYPE" != "wporg" ] && [ "$AUTH_TYPE" != "applicationPassword" ] && [ "$AUTH_TYPE" != "wpcom" ]; then
+  echo "Unrecognized auth-type '$AUTH_TYPE' — must be exactly 'wporg', 'applicationPassword', or 'wpcom'" >&2
   exit 1
 fi
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -347,6 +347,13 @@ extension AppDelegate {
         if ProcessConfiguration.shouldSimulatePushNotification {
             UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { _, _ in }
         }
+
+        #if DEBUG
+        if let credentials = ProcessConfiguration.debugAutoLoginCredentials {
+            ServiceLocator.stores.authenticate(credentials: credentials)
+            ServiceLocator.stores.updateDefaultStore(storeID: ProcessConfiguration.debugAutoLoginStoreID)
+        }
+        #endif
     }
 
     func disableAnimationsIfNeeded() {

--- a/WooCommerce/Classes/System/ProcessConfiguration.swift
+++ b/WooCommerce/Classes/System/ProcessConfiguration.swift
@@ -76,13 +76,15 @@ struct ProcessConfiguration {
         switch env["DEBUG_LOGIN_AUTH_TYPE"] {
         case "wpcom":
             return .wpcom(username: username, authToken: secret, siteAddress: siteAddress)
-        default:
+        case "applicationPassword":
             return .applicationPassword(username: username, password: secret, siteAddress: siteAddress)
+        default:
+            return .wporg(username: username, password: secret, siteAddress: siteAddress)
         }
     }
 
     /// Store ID to select alongside `debugAutoLoginCredentials`. Defaults to the self-hosted
-    /// placeholder ID, which is correct for application-password logins.
+    /// placeholder ID, which is correct for wporg/application-password logins.
     static var debugAutoLoginStoreID: Int64 {
         ProcessInfo.processInfo.environment["DEBUG_LOGIN_STORE_ID"].flatMap(Int64.init) ?? WooConstants.placeholderStoreID
     }

--- a/WooCommerce/Classes/System/ProcessConfiguration.swift
+++ b/WooCommerce/Classes/System/ProcessConfiguration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 /// Provides process-based configurations for screenshot generation and UI tests.
 struct ProcessConfiguration {
@@ -59,4 +60,31 @@ struct ProcessConfiguration {
     static var shouldUseMockCardPresentPayment: Bool {
         ProcessInfo.processInfo.arguments.contains("use-mocked-card-present-payment")
     }
+
+    #if DEBUG
+    /// Credentials to auto-authenticate with at launch, for local debugging against a real store
+    /// (e.g. a Jurassic Ninja site) without going through the login UI. Only ever populated when
+    /// running a DEBUG build with the required environment variables set on a personal Xcode scheme
+    /// or `simctl launch` invocation — never checked into the repo.
+    static var debugAutoLoginCredentials: Credentials? {
+        let env = ProcessInfo.processInfo.environment
+        guard let username = env["DEBUG_LOGIN_USERNAME"],
+              let secret = env["DEBUG_LOGIN_SECRET"],
+              let siteAddress = env["DEBUG_LOGIN_SITE_ADDRESS"] else {
+            return nil
+        }
+        switch env["DEBUG_LOGIN_AUTH_TYPE"] {
+        case "wpcom":
+            return .wpcom(username: username, authToken: secret, siteAddress: siteAddress)
+        default:
+            return .applicationPassword(username: username, password: secret, siteAddress: siteAddress)
+        }
+    }
+
+    /// Store ID to select alongside `debugAutoLoginCredentials`. Defaults to the self-hosted
+    /// placeholder ID, which is correct for application-password logins.
+    static var debugAutoLoginStoreID: Int64 {
+        ProcessInfo.processInfo.environment["DEBUG_LOGIN_STORE_ID"].flatMap(Int64.init) ?? WooConstants.placeholderStoreID
+    }
+    #endif
 }


### PR DESCRIPTION
## Description
Repro/debug work today means manually driving the login UI every time after provisioning a test site (e.g. Jurassic Ninja) — slow and repetitive. This adds a `DEBUG`-only shortcut that reads credentials from environment variables at launch so the app can start already authenticated into a given store (site credentials, application password, or WPCom), plus a companion `auto-login` agent skill that drives it on a simulator. `#if DEBUG`-gated; no effect on Release builds or the real login flow.

## Test Steps
1. Build the app for simulator and install it on a booted sim.
2. Get the admin username + real password for a self-hosted test site (e.g. a Jurassic Ninja site).
3. Run the `/auto-login` skill with the simulator UDID, site address, username, and password.
4. Confirm the app lands directly on the store's Dashboard (tab bar visible, not the login screen), with the store name matching.
5. Confirm a Release-configuration build still compiles (the new code is `#if DEBUG`-gated).

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
