### PR TITLE
Fix order creation showing subscription details for non-subscription variations

### DIFF
--- a/Modules/Sources/Networking/Model/Product/ProductType+Subscription.swift
+++ b/Modules/Sources/Networking/Model/Product/ProductType+Subscription.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public extension ProductType {
+
+    /// Whether this product type represents a subscription (simple or variable subscription).
+    ///
+    var isSubscription: Bool {
+        self == .subscription || self == .variableSubscription
+    }
+}

--- a/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
+++ b/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
@@ -2,11 +2,19 @@ import Foundation
 import enum Yosemite.SubscriptionPeriod
 import enum Yosemite.ProductType
 
+extension ProductType {
+
+    /// Whether this product type represents a subscription (simple or variable subscription).
+    var isSubscription: Bool {
+        self == .subscription || self == .variableSubscription
+    }
+}
+
 extension ProductFormDataModel {
 
     /// Whether to treat this product as a subscription for display purposes.
     var isSubscriptionProduct: Bool {
-        productType == .subscription || productType == .variableSubscription
+        productType.isSubscription
     }
 
     /// Returns the formatted subscription period info in readable text.

--- a/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
+++ b/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
@@ -2,14 +2,6 @@ import Foundation
 import enum Yosemite.SubscriptionPeriod
 import enum Yosemite.ProductType
 
-extension ProductType {
-
-    /// Whether this product type represents a subscription (simple or variable subscription).
-    var isSubscription: Bool {
-        self == .subscription || self == .variableSubscription
-    }
-}
-
 extension ProductFormDataModel {
 
     /// Whether to treat this product as a subscription for display purposes.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -738,7 +738,7 @@ final class EditableOrderViewModel: ObservableObject {
                                                                   hasParentProduct: item.parent != nil,
                                                                   isReadOnly: isReadOnly,
                                                                   isConfigurable: isProductConfigurable,
-                                                                  productSubscriptionDetails: product.subscription,
+                                                                  productSubscriptionDetails: product.productType.isSubscription ? product.subscription : nil,
                                                                   imageURL: product.imageURL,
                                                                   name: product.name,
                                                                   sku: product.sku,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -416,12 +416,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
         let productTypeLabel: String? = isConfigurable ? product.productType.description: nil
 
-        let productSubscriptionDetails: ProductSubscription?
-        if product.productType == .subscription || product.productType == .variableSubscription {
-            productSubscriptionDetails = product.subscription
-        } else {
-            productSubscriptionDetails = nil
-        }
+        let productSubscriptionDetails: ProductSubscription? = product.productType.isSubscription ? product.subscription : nil
 
         self.init(id: id,
                   productOrVariationID: product.productID,
@@ -452,7 +447,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      discount: Decimal? = nil,
                      name: String,
                      quantity: Decimal = 1,
-                     productSubscriptionDetails: ProductSubscription? = nil,
+                     isSubscriptionProduct: Bool = false,
                      displayMode: VariationDisplayMode,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      pricedIndividually: Bool = true,
@@ -465,13 +460,9 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             imageURL = nil
         }
 
-        // Checks if the product variation contains Subscription-type Product meta data
-        let productSubscriptionDetails: ProductSubscription?
-        if productVariation.subscription != nil {
-            productSubscriptionDetails = productVariation.subscription
-        } else {
-            productSubscriptionDetails = nil
-        }
+        // Only show Subscription-type details when the parent is a subscription product,
+        // not merely when the variation carries leftover `_subscription_*` meta data.
+        let productSubscriptionDetails: ProductSubscription? = isSubscriptionProduct ? productVariation.subscription : nil
 
         self.init(id: id,
                   productOrVariationID: productVariation.productVariationID,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -42,6 +42,11 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     private let productAttributes: [ProductAttribute]
 
+    /// Whether the parent product is a subscription product. Used to decide if variation rows
+    /// should surface subscription details, rather than relying on leftover `_subscription_*` meta data.
+    ///
+    private let isSubscriptionProduct: Bool
+
     /// All purchasable product variations for the product.
     ///
     @Published private var productVariations: [ProductVariation] = []
@@ -122,6 +127,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          productID: Int64,
          productName: String,
          productAttributes: [ProductAttribute],
+         isSubscriptionProduct: Bool = false,
          allowedProductVariationIDs: [Int64] = [],
          selectedProductVariationIDs: [Int64] = [],
          orderSyncState: Published<OrderSyncState>.Publisher? = nil,
@@ -133,6 +139,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.productID = productID
         self.productName = productName
         self.productAttributes = productAttributes
+        self.isSubscriptionProduct = isSubscriptionProduct
         self.orderSyncState = orderSyncState
         self.storageManager = storageManager
         self.stores = stores
@@ -160,6 +167,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   productID: product.productID,
                   productName: product.name,
                   productAttributes: product.attributesForVariations,
+                  isSubscriptionProduct: product.productType.isSubscription,
                   allowedProductVariationIDs: allowedProductVariationIDs,
                   selectedProductVariationIDs: selectedProductVariationIDs,
                   orderSyncState: orderSyncState,
@@ -334,6 +342,7 @@ private extension ProductVariationSelectorViewModel {
                 let selectedState: ProductRow.SelectedState = selectedIDs.contains(variation.productVariationID) ? .selected : .notSelected
                 return ProductRowViewModel(productVariation: variation,
                                            name: ProductVariationFormatter().generateName(for: variation, from: self.productAttributes),
+                                           isSubscriptionProduct: self.isSubscriptionProduct,
                                            displayMode: .stock,
                                            selectedState: selectedState)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -422,7 +422,7 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productSubscriptionDetails?.trialPeriod, fakeSubscription.trialPeriod)
     }
 
-    func test_productRow_variation_when_product_type_is_subscription_and_contains_subscription_metadata_then_productRow_variation_has_subscription_metadata() {
+    func test_productRow_variation_when_parent_is_subscription_and_has_metadata_then_has_subscription_details() {
         // Given
         let rowID = Int64(0)
         let fakeSubscription: ProductSubscription = createFakeSubscription()
@@ -432,13 +432,41 @@ final class ProductRowViewModelTests: XCTestCase {
                                                             subscription: fakeSubscription)
 
         // When
-        let viewModel = ProductRowViewModel(id: rowID, productVariation: productVariation, name: name, displayMode: .stock)
+        let viewModel = ProductRowViewModel(id: rowID,
+                                            productVariation: productVariation,
+                                            name: name,
+                                            isSubscriptionProduct: true,
+                                            displayMode: .stock)
 
         // Then
         XCTAssertEqual(viewModel.id, rowID)
         XCTAssertEqual(viewModel.productOrVariationID, productVariation.productVariationID)
         XCTAssertEqual(viewModel.name, name)
         XCTAssertNotNil(viewModel.productSubscriptionDetails)
+    }
+
+    func test_productRow_variation_when_parent_is_not_subscription_but_has_stale_metadata_then_has_no_details() {
+        // Given
+        let rowID = Int64(0)
+        let fakeSubscription: ProductSubscription = createFakeSubscription()
+        let name = "Blue - Any Size"
+        // A variation of a plain (non-subscription) variable product that still carries leftover `_subscription_*` meta data.
+        let productVariation = ProductVariation.fake().copy(productVariationID: 12,
+                                                            attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")],
+                                                            subscription: fakeSubscription)
+
+        // When
+        let viewModel = ProductRowViewModel(id: rowID,
+                                            productVariation: productVariation,
+                                            name: name,
+                                            isSubscriptionProduct: false,
+                                            displayMode: .stock)
+
+        // Then
+        XCTAssertEqual(viewModel.id, rowID)
+        XCTAssertEqual(viewModel.productOrVariationID, productVariation.productVariationID)
+        XCTAssertEqual(viewModel.name, name)
+        XCTAssertNil(viewModel.productSubscriptionDetails)
     }
 
     func test_productRow_when_product_type_is_not_subscription_but_contains_subscription_metadata_then_productRow_has_no_subscription_metadata() {


### PR DESCRIPTION
## Description
Fixes WOOMOB-3458.

In order creation, adding a variation of a **plain (non-subscription) variable product** that carries leftover `_subscription_*` metadata incorrectly showed subscription details (recurring price, sign-up fee, subscription conditions) instead of a plain price. This is behind the `subscriptionsInOrderCreationUI` feature flag.

**Root cause:** the ProductSelector variation row gated the subscription UI on the mere *presence* of subscription metadata (`productVariation.subscription != nil`) rather than the product type. WOOMOB-3432 fixed the same class of bug on the product-editor side by gating on product type.

**Changes:**
- Added a shared `ProductType.isSubscription` helper and refactored `ProductFormDataModel.isSubscriptionProduct` to use it.
- `ProductVariationSelectorViewModel` now derives `isSubscriptionProduct` from the parent product's type and passes it down to each variation row.
- `ProductRowViewModel`'s variation init gates `productSubscriptionDetails` on that flag (replacing a previously unused/shadowed parameter). Also DRY'd the sibling product init to use the new helper.
- `EditableOrderViewModel` product path now gates on `product.productType.isSubscription` for consistency.

## Test Steps
Requires WooCommerce Subscriptions active and the `subscriptionsInOrderCreationUI` feature flag enabled.

1. In wp-admin, create a **Variable Subscription** product with a few variations (recurring price, sign-up fee, billing period), then **change its type to plain Variable** and save. This leaves the `_subscription_*` metadata on the variations.
2. In the app: **Orders → new order → Add Product**, tap that product, open its **variations list**.
3. **Expected:** each variation row shows a **plain price only** — no recurring price, sign-up fee, or subscription conditions.
4. **Positive control:** repeat with a genuine **Variable Subscription** product; its variation rows **should still show** subscription details.

Automated: `ProductRowViewModelTests` covers both the positive case and the stale-metadata bug case.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not needed — behind the `subscriptionsInOrderCreationUI` feature flag and low reachability.)