### PR TITLE
Fix per-product discount wrongly including order coupon value

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -677,7 +677,7 @@ final class EditableOrderViewModel: ObservableObject {
             return nil
         }
 
-        let itemDiscount = currentDiscount(on: item)
+        let itemDiscount = currentProductDiscount(on: item)
         let passingDiscountValue = itemDiscount > 0 ? itemDiscount : nil
 
         if item.variationID != 0,
@@ -2165,7 +2165,7 @@ private extension EditableOrderViewModel {
                                                          bundleConfiguration: bundleConfiguration,
                                                          allProducts: Array(allProducts),
                                                          allProductVariations: allProductVariations,
-                                                         defaultDiscount: currentDiscount(on: item))
+                                                         defaultDiscount: currentProductDiscount(on: item))
     }
 
     /// Creates the configuration related to adding a discount to a product. If the feature shouldn't be shown it returns `nil`
@@ -2178,7 +2178,7 @@ private extension EditableOrderViewModel {
         }
 
         return .init(
-            addedDiscount: currentDiscount(on: orderItem),
+            addedDiscount: currentProductDiscount(on: orderItem),
             baseAmountForDiscountPercentage: subTotalDecimal as Decimal,
             onSave: { [weak self] discount in
                 guard let discount else {
@@ -2200,6 +2200,16 @@ private extension EditableOrderViewModel {
         }
 
         return subtotal.subtracting(total) as Decimal
+    }
+
+    /// Calculates the product discount on an order item, excluding coupon effects.
+    ///
+    func currentProductDiscount(on item: OrderItem) -> Decimal {
+        guard orderSynchronizer.order.coupons.isEmpty else {
+            return 0
+        }
+
+        return currentDiscount(on: item)
     }
 
     /// Creates `ProductRowViewModels` ready to be used as product rows.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -632,6 +632,46 @@ final class EditableOrderViewModelTests: XCTestCase {
         assertEqual(expectedDiscount, productRow?.productRow.discount)
     }
 
+    func test_createProductRowViewModel_does_not_set_product_discount_when_order_has_coupon() throws {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let orderItem = OrderItem.fake().copy(productID: product.productID, quantity: 1, price: 10, subtotal: "10", total: "9")
+        let coupon = OrderCouponLine(couponID: 1, code: "coupon", discount: "1", discountTax: "0")
+        let order = Order.fake().copy(siteID: sampleSiteID, items: [orderItem], coupons: [coupon])
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: order),
+                                               storageManager: storageManager)
+
+        // When
+        let productRow = viewModel.createProductRowViewModel(for: orderItem)
+
+        // Then
+        XCTAssertNil(productRow?.productRow.discount)
+    }
+
+    func test_updating_product_quantity_does_not_preserve_coupon_discount_as_product_discount() throws {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "10", purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let orderItem = OrderItem.fake().copy(itemID: 1, productID: product.productID, quantity: 1, price: 10, subtotal: "10", total: "9")
+        let coupon = OrderCouponLine(couponID: 1, code: "coupon", discount: "1", discountTax: "0")
+        let order = Order.fake().copy(siteID: sampleSiteID, items: [orderItem], coupons: [coupon])
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: order),
+                                               storageManager: storageManager,
+                                               quantityDebounceDuration: 0)
+
+        // When
+        viewModel.productRows[0].productRow.stepperViewModel.incrementQuantity()
+
+        // Then
+        waitUntil {
+            viewModel.productRows[0].productRow.stepperViewModel.quantity == 2
+        }
+        XCTAssertEqual(viewModel.productRows[0].productRow.discount, nil)
+    }
+
     func test_view_model_is_updated_when_custom_amount_is_added_to_order() {
         // Given
         let customAmountName = "Test"


### PR DESCRIPTION
## Description

When building product rows in the editable order flow, we inferred a product discount from `OrderItem.subtotal - OrderItem.total`. That works if we add a direct per-product discount, however it also reduces the item fields when a coupon is applied to the order as if it were an item-level discount.

## Changes

Update `EditableOrderViewModel` so product discount display and product update defaults only infer product discounts from `subtotal - total` when the order has no coupons. Coupon amounts continue to be represented through coupon lines/payment totals.

## Test Steps
- Add a breakpoint to `WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift:681`
- Create an order, add a product, add a coupon to the order. Observe in console that `OrderItem` data stays the same, but the product-row discount changes from `Optional(1)` to `nil`:

After:
```
(lldb) po orderSynchronizer.order.coupons.isEmpty
false
(lldb) po itemDiscount
▿ 0
(lldb) po passingDiscountValue
nil
```

For comparison, before would output: 
```
(lldb) po orderSynchronizer.order.coupons.isEmpty
false
(lldb) po itemDiscount
▿ 1
po passingDiscountValue
Optional(1)
```
- Smoke test nothing appears off in the order summary when adding discounts or coupons, ie:
  - Coupons/product discounts show appropriately in the order.
  - Increasing/decreasing product quantity respects order coupon conditions. 
  - Product discounts only affects the product.

## Screenshots

<img width="800" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-07-14 at 12 40 49" src="https://github.com/user-attachments/assets/d81ed55b-213b-4d37-aa1c-41c8f0e18695" />
