### PR TITLE
Extract Product Detail row routing into ProductFormRowActionHandler

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormNavigating.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormNavigating.swift
@@ -1,0 +1,69 @@
+import UIKit
+
+/// Navigation performed in response to interactions with the Product form's content (rows,
+/// inline cell actions, and the "Add more details" bottom sheet).
+///
+/// This is the seam that decouples *what the user interacted with* (routed by
+/// `ProductFormRowActionHandler`) from *how the screen navigates* (implemented today by
+/// `ProductFormViewController`). Only content-reachable navigation lives here; navigation-bar,
+/// more-options action sheet, and save/publish/delete flows stay owned by the view controller.
+protocol ProductFormNavigating: AnyObject {
+    /// Opens the WP.com privacy settings, shown when the images row is tapped on a private store.
+    func openPrivacySettings()
+
+    func editProductDescription()
+
+    func showProductDescriptionAI()
+
+    /// Opens the legal page linked from the AI-generated content disclaimer.
+    func openAILegalPage(url: URL)
+
+    func displayBlaze()
+
+    func showProductImages()
+
+    func editPriceSettings()
+
+    func showCustomFields()
+
+    func showReviews()
+
+    func showDownloadableFiles()
+
+    func editLinkedProducts()
+
+    /// Opens the product type selector. `sourceView` anchors the bottom sheet popover on iPad.
+    func editProductType(sourceView: UIView?)
+
+    func editShippingSettings()
+
+    func editInventorySettings()
+
+    func navigateToAddOns()
+
+    func editCategories()
+
+    func editTags()
+
+    func editShortDescription()
+
+    func editExternalLink()
+
+    func editSimplifiedInventory()
+
+    func editGroupedProducts()
+
+    func showVariations()
+
+    func editAttributes()
+
+    func showBundledProducts()
+
+    func showCompositeComponents()
+
+    func showSubscriptionFreeTrialSettings()
+
+    func showSubscriptionExpirySettings()
+
+    func showQuantityRules()
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRowActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRowActionHandler.swift
@@ -1,0 +1,234 @@
+import UIKit
+import Yosemite
+import protocol WooFoundation.Analytics
+
+/// Routes interactions with the Product form's content to navigation, applying the same
+/// editability/actionability guards and analytics as the legacy `didSelectRowAt` implementation.
+///
+/// Extracted from `ProductFormViewController` so the routing is unit-testable (guard → log →
+/// navigate) and consumable by a renderer that is not a `UIViewController`. The behavior here is a
+/// faithful, behavior-preserving move of the previous inline logic.
+final class ProductFormRowActionHandler {
+    private let analytics: Analytics
+    private let eventLogger: ProductFormEventLoggerProtocol
+    private weak var navigator: ProductFormNavigating?
+
+    init(analytics: Analytics,
+         eventLogger: ProductFormEventLoggerProtocol,
+         navigator: ProductFormNavigating?) {
+        self.analytics = analytics
+        self.eventLogger = eventLogger
+        self.navigator = navigator
+    }
+
+    /// Handles selection of a row in the primary fields section.
+    /// - Parameter shouldShowBlazeIntroView: current value of the view model's Blaze intro flag,
+    ///   used to decide whether the Blaze entry-point-tapped event is tracked.
+    func handlePrimaryFieldRowSelection(_ row: ProductFormSection.PrimaryFieldRow,
+                                        shouldShowBlazeIntroView: Bool) {
+        switch row {
+        case .images(_, let isStorePublic, _, _):
+            guard isStorePublic else {
+                navigator?.openPrivacySettings()
+                return
+            }
+        case .description(_, let isEditable, _):
+            guard isEditable else {
+                return
+            }
+            eventLogger.logDescriptionTapped()
+            navigator?.editProductDescription()
+        case .promoteWithBlaze:
+            if !shouldShowBlazeIntroView {
+                analytics.track(event: .Blaze.blazeEntryPointTapped(source: .productDetailPromoteButton))
+            }
+            navigator?.displayBlaze()
+        default:
+            break
+        }
+    }
+
+    /// Handles selection of a row in the settings section.
+    /// - Parameters:
+    ///   - productID: current product ID, used for the add-ons tapped event.
+    ///   - sourceView: the tapped cell, used to anchor the product type selector popover on iPad.
+    func handleSettingsRowSelection(_ row: ProductFormSection.SettingsRow,
+                                    productID: Int64,
+                                    sourceView: UIView?) {
+        switch row {
+        case .price(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            eventLogger.logPriceSettingsTapped()
+            navigator?.editPriceSettings()
+        case .customFields:
+            analytics.track(.productDetailCustomFieldsTapped)
+            navigator?.showCustomFields()
+        case .reviews:
+            analytics.track(.productDetailViewReviewsTapped)
+            navigator?.showReviews()
+        case .downloadableFiles(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewDownloadableFilesTapped)
+            navigator?.showDownloadableFiles()
+        case .linkedProducts(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewLinkedProductsTapped)
+            navigator?.editLinkedProducts()
+        case .productType(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewProductTypeTapped)
+            navigator?.editProductType(sourceView: sourceView)
+        case .shipping(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            eventLogger.logShippingSettingsTapped()
+            navigator?.editShippingSettings()
+        case .inventory(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            eventLogger.logInventorySettingsTapped()
+            navigator?.editInventorySettings()
+        case .addOns(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(event: .ProductDetailAddOns.productAddOnsButtonTapped(productID: productID))
+            navigator?.navigateToAddOns()
+        case .categories(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewCategoriesTapped)
+            navigator?.editCategories()
+        case .tags(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewTagsTapped)
+            navigator?.editTags()
+        case .shortDescription(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewShortDescriptionTapped)
+            navigator?.editShortDescription()
+        case .externalURL(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewExternalProductLinkTapped)
+            navigator?.editExternalLink()
+        case .simplifiedInventory(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewSKUTapped)
+            navigator?.editSimplifiedInventory()
+        case .groupedProducts(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            analytics.track(.productDetailViewGroupedProductsTapped)
+            navigator?.editGroupedProducts()
+        case .variations(let viewModel):
+            guard viewModel.isActionable else {
+                return
+            }
+            analytics.track(.productDetailViewVariationsTapped)
+            navigator?.showVariations()
+        case .noPriceWarning(let viewModel):
+            guard viewModel.isActionable else {
+                return
+            }
+            analytics.track(.productDetailViewVariationsTapped)
+            navigator?.showVariations()
+        case .attributes(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            navigator?.editAttributes()
+        case .status:
+            break
+        case .bundledProducts(_, let isActionable):
+            guard isActionable else {
+                return
+            }
+            analytics.track(event: .ProductDetail.bundledProductsTapped())
+            navigator?.showBundledProducts()
+        case .components(_, let isActionable):
+            guard isActionable else {
+                return
+            }
+            analytics.track(event: .ProductDetail.componentsTapped())
+            navigator?.showCompositeComponents()
+        case .subscriptionFreeTrial(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            eventLogger.logSubscriptionsFreeTrialTapped()
+            navigator?.showSubscriptionFreeTrialSettings()
+        case .subscriptionExpiry(_, let isEditable):
+            guard isEditable else {
+                return
+            }
+            eventLogger.logSubscriptionsExpirationDateTapped()
+            navigator?.showSubscriptionExpirySettings()
+        case .noVariationsWarning:
+            return // This warning is not actionable.
+        case .quantityRules:
+            eventLogger.logQuantityRulesTapped()
+            navigator?.showQuantityRules()
+        }
+    }
+
+    /// Handles selection of an action in the "Add more details" bottom sheet.
+    func handleMoreDetailsAction(_ action: ProductFormBottomSheetAction) {
+        switch action {
+        case .editInventorySettings:
+            eventLogger.logInventorySettingsTapped()
+            navigator?.editInventorySettings()
+        case .editShippingSettings:
+            eventLogger.logShippingSettingsTapped()
+            navigator?.editShippingSettings()
+        case .editCategories:
+            analytics.track(.productDetailViewCategoriesTapped)
+            navigator?.editCategories()
+        case .editTags:
+            analytics.track(.productDetailViewTagsTapped)
+            navigator?.editTags()
+        case .editShortDescription:
+            analytics.track(.productDetailViewShortDescriptionTapped)
+            navigator?.editShortDescription()
+        case .editSimplifiedInventory:
+            analytics.track(.productDetailViewSKUTapped)
+            navigator?.editSimplifiedInventory()
+        case .editLinkedProducts:
+            analytics.track(.productDetailViewLinkedProductsTapped)
+            navigator?.editLinkedProducts()
+        case .editReviews:
+            analytics.track(.productDetailViewReviewsTapped)
+            navigator?.showReviews()
+        case .editDownloadableFiles:
+            analytics.track(.productDetailViewDownloadableFilesTapped)
+            navigator?.showDownloadableFiles()
+        case .editCustomFields:
+            navigator?.showCustomFields()
+        }
+    }
+
+    /// Handles the "Add image" CTA in the images cell.
+    func handleAddImageTapped() {
+        eventLogger.logImageTapped()
+        navigator?.showProductImages()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRowActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRowActionHandler.swift
@@ -13,7 +13,7 @@ final class ProductFormRowActionHandler {
     private let eventLogger: ProductFormEventLoggerProtocol
     private weak var navigator: ProductFormNavigating?
 
-    init(analytics: Analytics,
+    init(analytics: Analytics = ServiceLocator.analytics,
          eventLogger: ProductFormEventLoggerProtocol,
          navigator: ProductFormNavigating?) {
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRowActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRowActionHandler.swift
@@ -231,4 +231,19 @@ final class ProductFormRowActionHandler {
         eventLogger.logImageTapped()
         navigator?.showProductImages()
     }
+
+    /// Handles the "Write with AI" button in the description cell.
+    func handleDescriptionAITapped() {
+        navigator?.showProductDescriptionAI()
+    }
+
+    /// Handles the call-to-action of the linked-products promo card.
+    func handleLinkedProductsPromoTapped() {
+        navigator?.editLinkedProducts()
+    }
+
+    /// Handles the "Learn more" link in the AI-generated content disclaimer.
+    func handleAILegalPageTapped(url: URL) {
+        navigator?.openAILegalPage(url: url)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -18,8 +18,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let eventLogger: ProductFormEventLoggerProtocol
 
     /// Routes interactions with the form content (rows, inline cell actions, more-details sheet) to navigation.
-    private lazy var rowActionHandler = ProductFormRowActionHandler(analytics: ServiceLocator.analytics,
-                                                                    eventLogger: eventLogger,
+    private lazy var rowActionHandler = ProductFormRowActionHandler(eventLogger: eventLogger,
                                                                     navigator: self)
 
     private var product: ProductModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -17,6 +17,11 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let viewModel: ViewModel
     private let eventLogger: ProductFormEventLoggerProtocol
 
+    /// Routes interactions with the form content (rows, inline cell actions, more-details sheet) to navigation.
+    private lazy var rowActionHandler = ProductFormRowActionHandler(analytics: ServiceLocator.analytics,
+                                                                    eventLogger: eventLogger,
+                                                                    navigator: self)
+
     private var product: ProductModel {
         viewModel.productModel
     }
@@ -448,175 +453,34 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         let section = tableViewModel.sections[indexPath.section]
         switch section {
         case .primaryFields(let rows):
-            let row = rows[indexPath.row]
-            switch row {
-            case .images(_, let isStorePublic, _, _):
-                guard isStorePublic else {
-                    presentURL(URLs.wpComPrivacySettings)
-                    return
-                }
-            case .description(_, let isEditable, _):
-                guard isEditable else {
-                    return
-                }
-                eventLogger.logDescriptionTapped()
-                editProductDescription()
-            case .promoteWithBlaze:
-                if !viewModel.shouldShowBlazeIntroView {
-                    ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .productDetailPromoteButton))
-                }
-                displayBlaze()
-            default:
-                break
-            }
+            rowActionHandler.handlePrimaryFieldRowSelection(rows[indexPath.row],
+                                                            shouldShowBlazeIntroView: viewModel.shouldShowBlazeIntroView)
         case .settings(let rows):
-            let row = rows[indexPath.row]
-            switch row {
-            case .price(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                eventLogger.logPriceSettingsTapped()
-                editPriceSettings()
-            case .customFields:
-                ServiceLocator.analytics.track(.productDetailCustomFieldsTapped)
-                showCustomFields()
-            case .reviews:
-                ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
-                showReviews()
-            case .downloadableFiles(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewDownloadableFilesTapped)
-                showDownloadableFiles()
-            case .linkedProducts(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewLinkedProductsTapped)
-                editLinkedProducts()
-            case .productType(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewProductTypeTapped)
-                let cell = tableView.cellForRow(at: indexPath)
-                editProductType(cell: cell)
-            case .shipping(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                eventLogger.logShippingSettingsTapped()
-                editShippingSettings()
-            case .inventory(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                eventLogger.logInventorySettingsTapped()
-                editInventorySettings()
-            case .addOns(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(event: .ProductDetailAddOns.productAddOnsButtonTapped(productID: product.productID))
-                navigateToAddOns()
-            case .categories(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewCategoriesTapped)
-                editCategories()
-            case .tags(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewTagsTapped)
-                editTags()
-            case .shortDescription(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewShortDescriptionTapped)
-                editShortDescription()
-            case .externalURL(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewExternalProductLinkTapped)
-                editExternalLink()
-                break
-            case .simplifiedInventory(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewSKUTapped)
-                editSimplifiedInventory()
-                break
-            case .groupedProducts(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewGroupedProductsTapped)
-                editGroupedProducts()
-                break
-            case .variations(let row):
-                guard row.isActionable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
-                showVariations()
-            case .noPriceWarning(let viewModel):
-                guard viewModel.isActionable else {
-                    return
-                }
-                ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
-                showVariations()
-            case .attributes(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-                editAttributes()
-            case .status:
-                break
-            case .bundledProducts(_, let isActionable):
-                guard isActionable else {
-                    return
-                }
-                ServiceLocator.analytics.track(event: .ProductDetail.bundledProductsTapped())
-                showBundledProducts()
-            case .components(_, let isActionable):
-                guard isActionable else {
-                    return
-                }
-                ServiceLocator.analytics.track(event: .ProductDetail.componentsTapped())
-                showCompositeComponents()
-            case .subscriptionFreeTrial(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-
-                eventLogger.logSubscriptionsFreeTrialTapped()
-                showSubscriptionFreeTrialSettings()
-            case .subscriptionExpiry(_, let isEditable):
-                guard isEditable else {
-                    return
-                }
-
-                eventLogger.logSubscriptionsExpirationDateTapped()
-                showSubscriptionExpirySettings()
-            case .noVariationsWarning:
-                return // This warning is not actionable.
-            case .quantityRules:
-                eventLogger.logQuantityRulesTapped()
-                showQuantityRules()
-                return
-            }
+            rowActionHandler.handleSettingsRowSelection(rows[indexPath.row],
+                                                        productID: product.productID,
+                                                        sourceView: tableView.cellForRow(at: indexPath))
         }
     }
 
     @objc private func shareProduct() {
         displayShareProduct(from: shareBarButtonItem, analyticSource: .productForm)
+    }
+}
+
+// MARK: - ProductFormNavigating
+//
+// Navigation performed in response to interactions with the form content, routed via
+// `ProductFormRowActionHandler`. The remaining navigation methods that satisfy this protocol
+// live in the `MARK: Action - …` extensions below.
+extension ProductFormViewController: ProductFormNavigating {
+    /// Opens the WP.com privacy settings, shown when the images row is tapped on a private store.
+    func openPrivacySettings() {
+        presentURL(URLs.wpComPrivacySettings)
+    }
+
+    /// Opens the legal page linked from the AI-generated content disclaimer.
+    func openAILegalPage(url: URL) {
+        WebviewHelper.launch(url.absoluteString, with: self)
     }
 }
 
@@ -958,16 +822,14 @@ private extension ProductFormViewController {
             self?.showProductDescriptionAI()
         }
         tableViewDataSource.openAILegalPageAction = { [weak self] url in
-            guard let self else { return }
-            WebviewHelper.launch(url.absoluteString, with: self)
+            self?.openAILegalPage(url: url)
         }
         tableViewDataSource.configureActions(onNameChange: { [weak self] name in
             self?.onEditProductNameCompletion(newName: name ?? "")
         }, onStatusChange: { [weak self] isEnabled in
             self?.onEditStatusCompletion(isEnabled: isEnabled)
         }, onAddImage: { [weak self] in
-            self?.eventLogger.logImageTapped()
-            self?.showProductImages()
+            self?.rowActionHandler.handleAddImageTapped()
         }, onFailedImageUpload: { [weak self] asset, error in
             self?.displayImageUploadErrorAlert(error: error, for: asset)
         })
@@ -993,39 +855,9 @@ private extension ProductFormViewController {
         let viewProperties = BottomSheetListSelectorViewProperties(subtitle: title)
         let actions = viewModel.actionsFactory.bottomSheetActions()
         let dataSource = ProductFormBottomSheetListSelectorCommand(actions: actions) { [weak self] action in
-                                                                    self?.dismiss(animated: true) { [weak self] in
-                                                                        switch action {
-                                                                        case .editInventorySettings:
-                                                                            self?.eventLogger.logInventorySettingsTapped()
-                                                                            self?.editInventorySettings()
-                                                                        case .editShippingSettings:
-                                                                            self?.eventLogger.logShippingSettingsTapped()
-                                                                            self?.editShippingSettings()
-                                                                        case .editCategories:
-                                                                            ServiceLocator.analytics.track(.productDetailViewCategoriesTapped)
-                                                                            self?.editCategories()
-                                                                        case .editTags:
-                                                                            ServiceLocator.analytics.track(.productDetailViewTagsTapped)
-                                                                            self?.editTags()
-                                                                        case .editShortDescription:
-                                                                            ServiceLocator.analytics.track(.productDetailViewShortDescriptionTapped)
-                                                                            self?.editShortDescription()
-                                                                        case .editSimplifiedInventory:
-                                                                            ServiceLocator.analytics.track(.productDetailViewSKUTapped)
-                                                                            self?.editSimplifiedInventory()
-                                                                        case .editLinkedProducts:
-                                                                            ServiceLocator.analytics.track(.productDetailViewLinkedProductsTapped)
-                                                                            self?.editLinkedProducts()
-                                                                        case .editReviews:
-                                                                            ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
-                                                                            self?.showReviews()
-                                                                        case .editDownloadableFiles:
-                                                                            ServiceLocator.analytics.track(.productDetailViewDownloadableFilesTapped)
-                                                                            self?.showDownloadableFiles()
-                                                                        case .editCustomFields:
-                                                                            self?.showCustomFields()
-                                                                        }
-                                                                    }
+            self?.dismiss(animated: true) { [weak self] in
+                self?.rowActionHandler.handleMoreDetailsAction(action)
+            }
         }
         let listSelectorPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: dataSource)
         listSelectorPresenter.show(from: self, sourceView: button.titleLabel ?? button, arrowDirections: .down)
@@ -1039,7 +871,7 @@ private extension ProductFormViewController {
 
 // MARK: Navigation actions
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func saveProduct(status: ProductStatus? = nil, onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void = { _ in }) {
         let productStatus = status ?? product.status
         let messageType = viewModel.saveMessageType(for: productStatus)
@@ -1476,7 +1308,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Images
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showProductImages() {
         let imagesViewController = ProductImagesViewController(product: product,
                                                                productImageActionHandler: productImageActionHandler,
@@ -1512,7 +1344,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Description
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editProductDescription() {
         let isAIGenerationEnabled = aiEligibilityChecker.isFeatureEnabled(.description)
         let editorViewController = EditorFactory().productDescriptionEditor(product: product,
@@ -1542,7 +1374,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Product Description AI
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showProductDescriptionAI() {
         guard let navigationController else {
             return
@@ -1563,7 +1395,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Price Settings
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editPriceSettings() {
         let priceSettingsViewController = ProductPriceSettingsViewController(product: product) { [weak self] in
             self?.onEditPriceSettingsCompletion(regularPrice: $0,
@@ -1612,7 +1444,7 @@ private extension ProductFormViewController {
 }
 
 // MARK: Action - Show Custom Fields
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showCustomFields() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1639,7 +1471,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Show Product Reviews Settings
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showReviews() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1652,8 +1484,8 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Type Settings
 //
-private extension ProductFormViewController {
-    func editProductType(cell: UITableViewCell?) {
+extension ProductFormViewController {
+    func editProductType(sourceView: UIView?) {
         let title = NSLocalizedString("Change product type",
                                       comment: "Message title of bottom sheet for selecting a product type")
         let viewProperties = BottomSheetListSelectorViewProperties(subtitle: title)
@@ -1681,13 +1513,13 @@ private extension ProductFormViewController {
             })
         }
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command, initialPosition: .expanded)
-        productTypesListPresenter.show(from: self, sourceView: cell, arrowDirections: .any)
+        productTypesListPresenter.show(from: self, sourceView: sourceView, arrowDirections: .any)
     }
 }
 
 // MARK: Action - Edit Product Shipping Settings
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editShippingSettings() {
         let shippingSettingsViewController = ProductShippingSettingsViewController(product: product) {
             [weak self] weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges in
@@ -1725,7 +1557,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Inventory Settings
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editInventorySettings() {
         let inventorySettingsViewController = ProductInventorySettingsViewController(product: product) { [weak self] data in
             self?.onEditInventorySettingsCompletion(data: data)
@@ -1757,7 +1589,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Short Description
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editShortDescription() {
         let editorViewController = EditorFactory().productShortDescriptionEditor(product: product) { [weak self] content, _ in
             self?.onEditShortDescriptionCompletion(newShortDescription: content)
@@ -1782,7 +1614,7 @@ private extension ProductFormViewController {
 // MARK: Action - Edit Product Categories
 //
 
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editCategories() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1813,7 +1645,7 @@ private extension ProductFormViewController {
 // MARK: Action - Edit Product Tags
 //
 
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editTags() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1843,7 +1675,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product SKU
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editSimplifiedInventory() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1870,7 +1702,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Linked Products
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editLinkedProducts() {
         let linkedProductsViewController = LinkedProductsViewController(product: product) { [weak self] upsellIDs, crossSellIDs, hasUnsavedChanges in
             self?.onEditLinkedProductsCompletion(upsellIDs: upsellIDs, crossSellIDs: crossSellIDs, hasUnsavedChanges: hasUnsavedChanges)
@@ -1896,7 +1728,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Grouped Products (Grouped Products Only)
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editGroupedProducts() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1931,7 +1763,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product External Link
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func editExternalLink() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1969,7 +1801,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Downloads
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showDownloadableFiles() {
         guard let product = product as? EditableProductModel else {
             return
@@ -1996,7 +1828,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Edit Product Variation Attributes
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     /// Edit the product attributes or the variation attributes depending on the product model type.
     ///
     func editAttributes() {
@@ -2063,7 +1895,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - View Add-ons
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func navigateToAddOns() {
         guard let product = product as? EditableProductModel else {
             return
@@ -2076,7 +1908,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Show Product Variations
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showVariations() {
         guard let currentProduct = viewModel.productModel as? EditableProductModel else {
             return
@@ -2094,7 +1926,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Show Bundled Products
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showBundledProducts() {
         guard let product = product as? EditableProductModel else {
             return
@@ -2107,7 +1939,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Show Composite Product Components
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showCompositeComponents() {
         guard let product = product as? EditableProductModel else {
             return
@@ -2120,7 +1952,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Show Subscription Free trial Settings
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showSubscriptionFreeTrialSettings() {
         guard let subscription = product.subscription else {
             return
@@ -2153,7 +1985,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Show Subscription expiry settings
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showSubscriptionExpirySettings() {
         guard let subscription = product.subscription else {
             return
@@ -2183,7 +2015,7 @@ private extension ProductFormViewController {
 
 // MARK: Action - Show Quantity Rules
 //
-private extension ProductFormViewController {
+extension ProductFormViewController {
     func showQuantityRules() {
         let quantityRulesViewModel = QuantityRulesViewModel(product: product) { [weak self] rules, hasUnsavedChanges in
             defer {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -842,19 +842,22 @@ private extension ProductFormViewController {
         updateTooltipPresenter()
     }
 
+    /// Content interactions route through `rowActionHandler`. The exceptions stay VC-bound on
+    /// purpose: `onNameChange`/`onStatusChange` are view-model data mutations (not navigation),
+    /// `reloadLinkedPromoAction` is a table rebuild, and `onFailedImageUpload` presents error UI.
     func updateDataSourceActions() {
         tableViewDataSource.openLinkedProductsAction = { [weak self] in
-            self?.editLinkedProducts()
+            self?.rowActionHandler.handleLinkedProductsPromoTapped()
         }
         tableViewDataSource.reloadLinkedPromoAction = { [weak self] in
             guard let self else { return }
             self.reloadLinkedPromoCell()
         }
         tableViewDataSource.descriptionAIAction = { [weak self] in
-            self?.showProductDescriptionAI()
+            self?.rowActionHandler.handleDescriptionAITapped()
         }
         tableViewDataSource.openAILegalPageAction = { [weak self] url in
-            self?.openAILegalPage(url: url)
+            self?.rowActionHandler.handleAILegalPageTapped(url: url)
         }
         tableViewDataSource.configureActions(onNameChange: { [weak self] name in
             self?.onEditProductNameCompletion(newName: name ?? "")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -482,6 +482,38 @@ extension ProductFormViewController: ProductFormNavigating {
     func openAILegalPage(url: URL) {
         WebviewHelper.launch(url.absoluteString, with: self)
     }
+
+    func displayBlaze() {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+            return
+        }
+
+        guard let navigationController else {
+            DDLogError("⛔️ Missing parent controller to show Blaze campaign creation form.")
+            return
+        }
+
+        let coordinator = BlazeCampaignCreationCoordinator(
+            siteID: site.siteID,
+            siteURL: site.url,
+            productID: product.productID,
+            source: .productDetailPromoteButton,
+            shouldShowIntro: viewModel.shouldShowBlazeIntroView,
+            navigationController: navigationController,
+            onCampaignCreated: { [weak self] in
+                /// Re-sync Blaze campaigns to update storage items.
+                ServiceLocator.stores.dispatch(BlazeAction.synchronizeCampaignsList(
+                    siteID: site.siteID,
+                    skip: 0,
+                    limit: PaginationTracker.Defaults.pageSize) { _ in
+                        self?.updateFormTableContent()
+                    }
+                )
+            }
+        )
+        coordinator.start()
+        blazeCampaignCreationCoordinator = coordinator
+    }
 }
 
 // MARK: - Configuration
@@ -871,7 +903,7 @@ private extension ProductFormViewController {
 
 // MARK: Navigation actions
 //
-extension ProductFormViewController {
+private extension ProductFormViewController {
     func saveProduct(status: ProductStatus? = nil, onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void = { _ in }) {
         let productStatus = status ?? product.status
         let messageType = viewModel.saveMessageType(for: productStatus)
@@ -1108,38 +1140,6 @@ extension ProductFormViewController {
         navigationController?.pushViewController(viewController, animated: true)
     }
 
-    func displayBlaze() {
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
-            return
-        }
-
-        guard let navigationController else {
-            DDLogError("⛔️ Missing parent controller to show Blaze campaign creation form.")
-            return
-        }
-
-        let coordinator = BlazeCampaignCreationCoordinator(
-            siteID: site.siteID,
-            siteURL: site.url,
-            productID: product.productID,
-            source: .productDetailPromoteButton,
-            shouldShowIntro: viewModel.shouldShowBlazeIntroView,
-            navigationController: navigationController,
-            onCampaignCreated: { [weak self] in
-                /// Re-sync Blaze campaigns to update storage items.
-                ServiceLocator.stores.dispatch(BlazeAction.synchronizeCampaignsList(
-                    siteID: site.siteID,
-                    skip: 0,
-                    limit: PaginationTracker.Defaults.pageSize) { _ in
-                        self?.updateFormTableContent()
-                    }
-                )
-            }
-        )
-        coordinator.start()
-        blazeCampaignCreationCoordinator = coordinator
-    }
-
     func trackVariationRemoveButtonTapped() {
         guard let variation = (product as? EditableProductVariationModel)?.productVariation else {
             return
@@ -1318,7 +1318,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(imagesViewController, animated: true)
     }
 
-    func onEditProductImagesCompletion(images: [ProductImage], hasChangedData: Bool) {
+    private func onEditProductImagesCompletion(images: [ProductImage], hasChangedData: Bool) {
         defer {
             navigationController?.popViewController(animated: true)
         }
@@ -1361,7 +1361,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(editorViewController, animated: true)
     }
 
-    func onEditProductDescriptionCompletion(newDescription: String) {
+    private func onEditProductDescriptionCompletion(newDescription: String) {
         let hasChangedData = newDescription != product.description
         ServiceLocator.analytics.track(.productDescriptionDoneButtonTapped, withProperties: ["has_changed_data": hasChangedData])
 
@@ -1412,7 +1412,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(priceSettingsViewController, animated: true)
     }
 
-    func onEditPriceSettingsCompletion(regularPrice: String?,
+    private func onEditPriceSettingsCompletion(regularPrice: String?,
                                        subscriptionPeriod: SubscriptionPeriod?,
                                        subscriptionPeriodInterval: String?,
                                        subscriptionSignupFee: String?,
@@ -1533,7 +1533,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(shippingSettingsViewController, animated: true)
     }
 
-    func onEditShippingSettingsCompletion(weight: String?,
+    private func onEditShippingSettingsCompletion(weight: String?,
                                           dimensions: ProductDimensions,
                                           oneTimeShipping: Bool?,
                                           shippingClass: String?,
@@ -1565,7 +1565,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(inventorySettingsViewController, animated: true)
     }
 
-    func onEditInventorySettingsCompletion(data: ProductInventoryEditableData) {
+    private func onEditInventorySettingsCompletion(data: ProductInventoryEditableData) {
         defer {
             navigationController?.popViewController(animated: true)
         }
@@ -1597,7 +1597,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(editorViewController, animated: true)
     }
 
-    func onEditShortDescriptionCompletion(newShortDescription: String) {
+    private func onEditShortDescriptionCompletion(newShortDescription: String) {
         defer {
             navigationController?.popViewController(animated: true)
         }
@@ -1626,7 +1626,7 @@ extension ProductFormViewController {
         show(categoryListViewController, sender: self)
     }
 
-    func onEditCategoriesCompletion(categories: [ProductCategory]) {
+    private func onEditCategoriesCompletion(categories: [ProductCategory]) {
         guard let product = product as? EditableProductModel else {
             return
         }
@@ -1657,7 +1657,7 @@ extension ProductFormViewController {
         show(tagsViewController, sender: self)
     }
 
-    func onEditTagsCompletion(tags: [ProductTag]) {
+    private func onEditTagsCompletion(tags: [ProductTag]) {
         guard let product = product as? EditableProductModel else {
             return
         }
@@ -1687,7 +1687,7 @@ extension ProductFormViewController {
         show(viewController, sender: self)
     }
 
-    func onEditInventoryCompletion(sku: String?, globalUniqueIdentifier: String?) {
+    private func onEditInventoryCompletion(sku: String?, globalUniqueIdentifier: String?) {
         defer {
             navigationController?.popViewController(animated: true)
         }
@@ -1710,7 +1710,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(linkedProductsViewController, animated: true)
     }
 
-    func onEditLinkedProductsCompletion(upsellIDs: [Int64],
+    private func onEditLinkedProductsCompletion(upsellIDs: [Int64],
                                         crossSellIDs: [Int64],
                                         hasUnsavedChanges: Bool) {
         defer {
@@ -1745,7 +1745,7 @@ extension ProductFormViewController {
         show(viewController, sender: self)
     }
 
-    func onEditGroupedProductsCompletion(groupedProductIDs: [Int64]) {
+    private func onEditGroupedProductsCompletion(groupedProductIDs: [Int64]) {
         guard let product = product as? EditableProductModel else {
             return
         }
@@ -1775,7 +1775,7 @@ extension ProductFormViewController {
         show(viewController, sender: self)
     }
 
-    func onEditExternalLinkCompletion(externalURL: String?, buttonText: String) {
+    private func onEditExternalLinkCompletion(externalURL: String?, buttonText: String) {
         guard let product = product as? EditableProductModel else {
             return
         }
@@ -1813,7 +1813,7 @@ extension ProductFormViewController {
         navigationController?.pushViewController(downloadFileListViewController, animated: true)
     }
 
-    func onAddEditDownloadsCompletion(data: ProductDownloadsEditableData,
+    private func onAddEditDownloadsCompletion(data: ProductDownloadsEditableData,
                                       hasUnsavedChanges: Bool) {
         defer {
             navigationController?.popViewController(animated: true)
@@ -1846,7 +1846,7 @@ extension ProductFormViewController {
 
     /// Navigate to edit product attributes
     ///
-    func editProductAttributes() {
+    private func editProductAttributes() {
         guard let productModel = product as? EditableProductModel else {
             return
         }
@@ -1858,7 +1858,7 @@ extension ProductFormViewController {
         show(attributesViewController, sender: self)
     }
 
-    func editVariationAttributes() {
+    private func editVariationAttributes() {
         guard let productVariationModel = product as? EditableProductVariationModel else {
             return
         }
@@ -1869,7 +1869,7 @@ extension ProductFormViewController {
         show(attributePickerViewController, sender: self)
     }
 
-    func onEditVariationAttributesCompletion(attributes: [ProductVariationAttribute]) {
+    private func onEditVariationAttributesCompletion(attributes: [ProductVariationAttribute]) {
         guard let productVariation = product as? EditableProductVariationModel else {
             return
         }
@@ -1887,7 +1887,7 @@ extension ProductFormViewController {
 
     /// Perform necessary actions when an attribute is created or updated.
     ///
-    func onAttributeUpdated(attributesViewController: UIViewController, updatedProduct: Product) {
+    private func onAttributeUpdated(attributesViewController: UIViewController, updatedProduct: Product) {
         viewModel.updateProductVariations(from: updatedProduct)
         navigationController?.popToViewController(attributesViewController, animated: true)
     }
@@ -1966,7 +1966,7 @@ extension ProductFormViewController {
         show(viewController, sender: self)
     }
 
-    func onEditSubscriptionFreeTrialSettings(trialLength: String,
+    private func onEditSubscriptionFreeTrialSettings(trialLength: String,
                                              trialPeriod: SubscriptionPeriod,
                                              hasUnsavedChanges: Bool) {
         defer {
@@ -1998,7 +1998,7 @@ extension ProductFormViewController {
         show(viewController, sender: self)
     }
 
-    func onEditSubscriptionExpirySettings(length: String,
+    private func onEditSubscriptionExpirySettings(length: String,
                                           hasUnsavedChanges: Bool) {
         defer {
             navigationController?.popViewController(animated: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRowActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRowActionHandlerTests.swift
@@ -1,0 +1,414 @@
+import Testing
+import UIKit
+import Yosemite
+import protocol WooFoundation.Analytics
+@testable import WooCommerce
+
+/// Tests for `ProductFormRowActionHandler`, the routing seam extracted from
+/// `ProductFormViewController.tableView(_:didSelectRowAt:)`.
+///
+/// The handler operates on `ProductFormSection` rows, which are identical for `Product` and
+/// `ProductVariation` (the concrete model only affects how the navigation destinations are built,
+/// which is out of the handler's scope). Its behavior is therefore model-agnostic by construction
+/// and a single suite covers both.
+///
+/// Coverage is exhaustive at the routing layer: every settings row, every primary-field row, and
+/// every "Add more details" action is asserted for its guard, analytics, and navigation — this is
+/// the completeness guarantee that live E2E (which is product-type-conditional) cannot give.
+struct ProductFormRowActionHandlerTests {
+
+    // MARK: - Settings rows — happy path (every case)
+
+    @Test func every_settings_row_routes_navigation_and_analytics_correctly() {
+        // Each case is exercised in its actionable/editable state and asserts the exact ordered
+        // sequence of event-logger + navigation calls and the exact analytics events.
+        let cases: [SettingsCase] = [
+            .init("price",
+                  .price(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["log:price", "editPriceSettings"], analytics: []),
+            .init("customFields",
+                  .customFields(viewModel: settingsViewModel()),
+                  recorder: ["showCustomFields"], analytics: [stat(.productDetailCustomFieldsTapped)]),
+            .init("reviews",
+                  .reviews(viewModel: settingsViewModel(), ratingCount: 0, averageRating: ""),
+                  recorder: ["showReviews"], analytics: [stat(.productDetailViewReviewsTapped)]),
+            .init("productType",
+                  .productType(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editProductType"], analytics: [stat(.productDetailViewProductTypeTapped)]),
+            .init("shipping",
+                  .shipping(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["log:shipping", "editShippingSettings"], analytics: []),
+            .init("inventory",
+                  .inventory(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["log:inventory", "editInventorySettings"], analytics: []),
+            .init("addOns",
+                  .addOns(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["navigateToAddOns"], analytics: [stat(.productDetailViewProductAddOnsTapped)]),
+            .init("categories",
+                  .categories(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editCategories"], analytics: [stat(.productDetailViewCategoriesTapped)]),
+            .init("tags",
+                  .tags(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editTags"], analytics: [stat(.productDetailViewTagsTapped)]),
+            .init("shortDescription",
+                  .shortDescription(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editShortDescription"], analytics: [stat(.productDetailViewShortDescriptionTapped)]),
+            .init("externalURL",
+                  .externalURL(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editExternalLink"], analytics: [stat(.productDetailViewExternalProductLinkTapped)]),
+            .init("simplifiedInventory",
+                  .simplifiedInventory(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editSimplifiedInventory"], analytics: [stat(.productDetailViewSKUTapped)]),
+            .init("groupedProducts",
+                  .groupedProducts(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editGroupedProducts"], analytics: [stat(.productDetailViewGroupedProductsTapped)]),
+            .init("downloadableFiles",
+                  .downloadableFiles(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["showDownloadableFiles"], analytics: [stat(.productDetailViewDownloadableFilesTapped)]),
+            .init("linkedProducts",
+                  .linkedProducts(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editLinkedProducts"], analytics: [stat(.productDetailViewLinkedProductsTapped)]),
+            .init("variations",
+                  .variations(viewModel: settingsViewModel(isActionable: true)),
+                  recorder: ["showVariations"], analytics: [stat(.productDetailViewVariationsTapped)]),
+            .init("noPriceWarning",
+                  .noPriceWarning(viewModel: warningViewModel(isActionable: true)),
+                  recorder: ["showVariations"], analytics: [stat(.productDetailViewVariationsTapped)]),
+            .init("attributes",
+                  .attributes(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["editAttributes"], analytics: []),
+            .init("bundledProducts",
+                  .bundledProducts(viewModel: settingsViewModel(), isActionable: true),
+                  recorder: ["showBundledProducts"],
+                  analytics: [WooAnalyticsEvent.ProductDetail.bundledProductsTapped().statName.rawValue]),
+            .init("components",
+                  .components(viewModel: settingsViewModel(), isActionable: true),
+                  recorder: ["showCompositeComponents"],
+                  analytics: [WooAnalyticsEvent.ProductDetail.componentsTapped().statName.rawValue]),
+            .init("subscriptionFreeTrial",
+                  .subscriptionFreeTrial(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["log:freeTrial", "showSubscriptionFreeTrialSettings"], analytics: []),
+            .init("subscriptionExpiry",
+                  .subscriptionExpiry(viewModel: settingsViewModel(), isEditable: true),
+                  recorder: ["log:expiry", "showSubscriptionExpirySettings"], analytics: []),
+            .init("quantityRules",
+                  .quantityRules(viewModel: settingsViewModel()),
+                  recorder: ["log:quantityRules", "showQuantityRules"], analytics: []),
+            // Non-navigating rows.
+            .init("status",
+                  .status(viewModel: .init(viewModel: settingsViewModel(), isSwitchOn: true, isActionable: true), isEditable: true),
+                  recorder: [], analytics: []),
+            .init("noVariationsWarning",
+                  .noVariationsWarning(viewModel: warningViewModel(isActionable: true)),
+                  recorder: [], analytics: [])
+        ]
+
+        for testCase in cases {
+            // Given
+            let (handler, env) = makeHandler()
+
+            // When
+            handler.handleSettingsRowSelection(testCase.row, productID: 1, sourceView: nil)
+
+            // Then
+            #expect(env.recorder.events == testCase.expectedRecorder, "row: \(testCase.name)")
+            #expect(env.analyticsProvider.receivedEvents == testCase.expectedAnalytics, "row: \(testCase.name)")
+        }
+    }
+
+    // MARK: - Settings rows — guards (every guarded case is a no-op when blocked)
+
+    @Test func every_guarded_settings_row_is_a_no_op_when_not_actionable() {
+        // Rows blocked either by `isEditable: false` or `isActionable: false` must not log,
+        // track, or navigate.
+        let blockedRows: [(String, ProductFormSection.SettingsRow)] = [
+            ("price", .price(viewModel: settingsViewModel(), isEditable: false)),
+            ("productType", .productType(viewModel: settingsViewModel(), isEditable: false)),
+            ("shipping", .shipping(viewModel: settingsViewModel(), isEditable: false)),
+            ("inventory", .inventory(viewModel: settingsViewModel(), isEditable: false)),
+            ("addOns", .addOns(viewModel: settingsViewModel(), isEditable: false)),
+            ("categories", .categories(viewModel: settingsViewModel(), isEditable: false)),
+            ("tags", .tags(viewModel: settingsViewModel(), isEditable: false)),
+            ("shortDescription", .shortDescription(viewModel: settingsViewModel(), isEditable: false)),
+            ("externalURL", .externalURL(viewModel: settingsViewModel(), isEditable: false)),
+            ("simplifiedInventory", .simplifiedInventory(viewModel: settingsViewModel(), isEditable: false)),
+            ("groupedProducts", .groupedProducts(viewModel: settingsViewModel(), isEditable: false)),
+            ("downloadableFiles", .downloadableFiles(viewModel: settingsViewModel(), isEditable: false)),
+            ("linkedProducts", .linkedProducts(viewModel: settingsViewModel(), isEditable: false)),
+            ("attributes", .attributes(viewModel: settingsViewModel(), isEditable: false)),
+            ("subscriptionFreeTrial", .subscriptionFreeTrial(viewModel: settingsViewModel(), isEditable: false)),
+            ("subscriptionExpiry", .subscriptionExpiry(viewModel: settingsViewModel(), isEditable: false)),
+            ("variations", .variations(viewModel: settingsViewModel(isActionable: false))),
+            ("noPriceWarning", .noPriceWarning(viewModel: warningViewModel(isActionable: false))),
+            ("bundledProducts", .bundledProducts(viewModel: settingsViewModel(), isActionable: false)),
+            ("components", .components(viewModel: settingsViewModel(), isActionable: false))
+        ]
+
+        for (name, row) in blockedRows {
+            // Given
+            let (handler, env) = makeHandler()
+
+            // When
+            handler.handleSettingsRowSelection(row, productID: 1, sourceView: nil)
+
+            // Then
+            #expect(env.recorder.events.isEmpty, "row: \(name)")
+            #expect(env.analyticsProvider.receivedEvents.isEmpty, "row: \(name)")
+        }
+    }
+
+    @Test func settings_productType_forwards_source_view_anchor() {
+        // Given
+        let (handler, env) = makeHandler()
+        let anchor = UIView()
+
+        // When
+        handler.handleSettingsRowSelection(.productType(viewModel: settingsViewModel(), isEditable: true),
+                                           productID: 1,
+                                           sourceView: anchor)
+
+        // Then — the tapped cell is forwarded so the product-type selector popover can anchor to it.
+        #expect(env.navigator.lastProductTypeSourceView === anchor)
+    }
+
+    @Test func settings_addOns_forwards_product_id_in_tracked_properties() {
+        // Given
+        let (handler, env) = makeHandler()
+
+        // When
+        handler.handleSettingsRowSelection(.addOns(viewModel: settingsViewModel(), isEditable: true),
+                                           productID: 42,
+                                           sourceView: nil)
+
+        // Then
+        #expect(env.analyticsProvider.receivedProperties.contains { properties in
+            properties.values.contains { "\($0)" == "42" }
+        })
+    }
+
+    // MARK: - Primary field rows (every actionable case)
+
+    @Test func primary_description_respects_editability_and_logs_before_navigating() {
+        // Editable
+        let (editableHandler, editableEnv) = makeHandler()
+        editableHandler.handlePrimaryFieldRowSelection(.description(description: "x", isEditable: true, isDescriptionAIEnabled: false),
+                                                       shouldShowBlazeIntroView: false)
+        #expect(editableEnv.recorder.events == ["log:description", "editProductDescription"])
+
+        // Not editable
+        let (blockedHandler, blockedEnv) = makeHandler()
+        blockedHandler.handlePrimaryFieldRowSelection(.description(description: "x", isEditable: false, isDescriptionAIEnabled: false),
+                                                      shouldShowBlazeIntroView: false)
+        #expect(blockedEnv.recorder.events.isEmpty)
+        #expect(blockedEnv.analyticsProvider.receivedEvents.isEmpty)
+    }
+
+    @Test func primary_images_opens_privacy_settings_only_on_private_store() {
+        // Private store — images row opens privacy settings.
+        let (privateHandler, privateEnv) = makeHandler()
+        privateHandler.handlePrimaryFieldRowSelection(
+            .images(isEditable: true, isStorePublic: false, allowsMultiple: true, isVariation: false),
+            shouldShowBlazeIntroView: false)
+        #expect(privateEnv.recorder.events == ["openPrivacySettings"])
+
+        // Public store — images row is not selectable.
+        let (publicHandler, publicEnv) = makeHandler()
+        publicHandler.handlePrimaryFieldRowSelection(
+            .images(isEditable: true, isStorePublic: true, allowsMultiple: true, isVariation: false),
+            shouldShowBlazeIntroView: false)
+        #expect(publicEnv.recorder.events.isEmpty)
+    }
+
+    @Test func primary_promoteWithBlaze_tracks_entry_point_only_when_intro_is_not_shown() {
+        // Intro path navigates without tracking the entry-point-tapped event.
+        let (introHandler, introEnv) = makeHandler()
+        introHandler.handlePrimaryFieldRowSelection(.promoteWithBlaze, shouldShowBlazeIntroView: true)
+        #expect(introEnv.recorder.events == ["displayBlaze"])
+        #expect(introEnv.analyticsProvider.receivedEvents.isEmpty)
+
+        // Direct path tracks exactly the entry-point event, then navigates.
+        let (directHandler, directEnv) = makeHandler()
+        directHandler.handlePrimaryFieldRowSelection(.promoteWithBlaze, shouldShowBlazeIntroView: false)
+        #expect(directEnv.recorder.events == ["displayBlaze"])
+        #expect(directEnv.analyticsProvider.receivedEvents ==
+                [WooAnalyticsEvent.Blaze.blazeEntryPointTapped(source: .productDetailPromoteButton).statName.rawValue])
+    }
+
+    @Test func primary_non_actionable_rows_do_nothing() {
+        // Rows handled by the `default` branch (name, variationName, descriptionAI, learnMoreAboutAI,
+        // linkedProductsPromo, separator) are not row-selection actions.
+        let (handler, env) = makeHandler()
+
+        handler.handlePrimaryFieldRowSelection(.name(name: "n", isEditable: true, productStatus: .published),
+                                               shouldShowBlazeIntroView: false)
+        handler.handlePrimaryFieldRowSelection(.separator, shouldShowBlazeIntroView: false)
+
+        #expect(env.recorder.events.isEmpty)
+        #expect(env.analyticsProvider.receivedEvents.isEmpty)
+    }
+
+    // MARK: - "Add more details" bottom sheet (every action)
+
+    @Test func every_more_details_action_routes_navigation_and_analytics_correctly() {
+        let cases: [(String, ProductFormBottomSheetAction, [String], [String])] = [
+            ("editInventorySettings", .editInventorySettings, ["log:inventory", "editInventorySettings"], []),
+            ("editShippingSettings", .editShippingSettings, ["log:shipping", "editShippingSettings"], []),
+            ("editCategories", .editCategories, ["editCategories"], [stat(.productDetailViewCategoriesTapped)]),
+            ("editTags", .editTags, ["editTags"], [stat(.productDetailViewTagsTapped)]),
+            ("editShortDescription", .editShortDescription, ["editShortDescription"], [stat(.productDetailViewShortDescriptionTapped)]),
+            ("editSimplifiedInventory", .editSimplifiedInventory, ["editSimplifiedInventory"], [stat(.productDetailViewSKUTapped)]),
+            ("editLinkedProducts", .editLinkedProducts, ["editLinkedProducts"], [stat(.productDetailViewLinkedProductsTapped)]),
+            ("editReviews", .editReviews, ["showReviews"], [stat(.productDetailViewReviewsTapped)]),
+            ("editDownloadableFiles", .editDownloadableFiles, ["showDownloadableFiles"], [stat(.productDetailViewDownloadableFilesTapped)]),
+            ("editCustomFields", .editCustomFields, ["showCustomFields"], [])
+        ]
+
+        for (name, action, expectedRecorder, expectedAnalytics) in cases {
+            // Given
+            let (handler, env) = makeHandler()
+
+            // When
+            handler.handleMoreDetailsAction(action)
+
+            // Then
+            #expect(env.recorder.events == expectedRecorder, "action: \(name)")
+            #expect(env.analyticsProvider.receivedEvents == expectedAnalytics, "action: \(name)")
+        }
+    }
+
+    // MARK: - Add image CTA
+
+    @Test func addImageTapped_logs_then_navigates() {
+        // Given
+        let (handler, env) = makeHandler()
+
+        // When
+        handler.handleAddImageTapped()
+
+        // Then
+        #expect(env.recorder.events == ["log:image", "showProductImages"])
+    }
+}
+
+// MARK: - Test helpers
+
+private extension ProductFormRowActionHandlerTests {
+    struct SettingsCase {
+        let name: String
+        let row: ProductFormSection.SettingsRow
+        let expectedRecorder: [String]
+        let expectedAnalytics: [String]
+
+        init(_ name: String,
+             _ row: ProductFormSection.SettingsRow,
+             recorder: [String],
+             analytics: [String]) {
+            self.name = name
+            self.row = row
+            self.expectedRecorder = recorder
+            self.expectedAnalytics = analytics
+        }
+    }
+
+    struct Environment {
+        let recorder: Recorder
+        let navigator: SpyProductFormNavigator
+        let analyticsProvider: MockAnalyticsProvider
+    }
+
+    func makeHandler() -> (ProductFormRowActionHandler, Environment) {
+        let recorder = Recorder()
+        let navigator = SpyProductFormNavigator(recorder: recorder)
+        let eventLogger = SpyProductFormEventLogger(recorder: recorder)
+        let analyticsProvider = MockAnalyticsProvider()
+        // Isolated opt-in defaults so events are not dropped by `WooAnalytics`'s opt-in gate,
+        // regardless of the simulator's ambient analytics setting.
+        let userDefaults = UserDefaults(suiteName: "ProductFormRowActionHandlerTests-\(UUID().uuidString)")!
+        userDefaults.set(true, forKey: "userOptedInAnalytics")
+        let handler = ProductFormRowActionHandler(analytics: WooAnalytics(analyticsProvider: analyticsProvider,
+                                                                          userDefaults: userDefaults),
+                                                  eventLogger: eventLogger,
+                                                  navigator: navigator)
+        return (handler, Environment(recorder: recorder, navigator: navigator, analyticsProvider: analyticsProvider))
+    }
+
+    func settingsViewModel(isActionable: Bool = true) -> ProductFormSection.SettingsRow.ViewModel {
+        .init(icon: UIImage(), title: "title", details: "details", isActionable: isActionable)
+    }
+
+    func warningViewModel(isActionable: Bool) -> ProductFormSection.SettingsRow.WarningViewModel {
+        .init(icon: UIImage(), title: "title", isActionable: isActionable)
+    }
+
+    func stat(_ stat: WooAnalyticsStat) -> String {
+        stat.rawValue
+    }
+}
+
+/// Ordered sink shared by the navigator and event-logger spies so tests can assert the
+/// guard → log → navigate sequence within a single `handle` call.
+private final class Recorder {
+    private(set) var events: [String] = []
+    func record(_ event: String) {
+        events.append(event)
+    }
+}
+
+private final class SpyProductFormEventLogger: ProductFormEventLoggerProtocol {
+    private let recorder: Recorder
+    init(recorder: Recorder) {
+        self.recorder = recorder
+    }
+
+    func logDescriptionTapped() { recorder.record("log:description") }
+    func logImageTapped() { recorder.record("log:image") }
+    func logPriceSettingsTapped() { recorder.record("log:price") }
+    func logInventorySettingsTapped() { recorder.record("log:inventory") }
+    func logShippingSettingsTapped() { recorder.record("log:shipping") }
+    func logUpdateButtonTapped() { recorder.record("log:update") }
+    func logQuantityRulesTapped() { recorder.record("log:quantityRules") }
+    func logSubscriptionsFreeTrialTapped() { recorder.record("log:freeTrial") }
+    func logSubscriptionsExpirationDateTapped() { recorder.record("log:expiry") }
+    func logQuantityRulesDoneButtonTapped(hasUnsavedChanges: Bool) { recorder.record("log:quantityRulesDone") }
+}
+
+private final class SpyProductFormNavigator: ProductFormNavigating {
+    private let recorder: Recorder
+    private(set) var lastProductTypeSourceView: UIView?
+
+    init(recorder: Recorder) {
+        self.recorder = recorder
+    }
+
+    func openPrivacySettings() { recorder.record("openPrivacySettings") }
+    func editProductDescription() { recorder.record("editProductDescription") }
+    func showProductDescriptionAI() { recorder.record("showProductDescriptionAI") }
+    func openAILegalPage(url: URL) { recorder.record("openAILegalPage") }
+    func displayBlaze() { recorder.record("displayBlaze") }
+    func showProductImages() { recorder.record("showProductImages") }
+    func editPriceSettings() { recorder.record("editPriceSettings") }
+    func showCustomFields() { recorder.record("showCustomFields") }
+    func showReviews() { recorder.record("showReviews") }
+    func showDownloadableFiles() { recorder.record("showDownloadableFiles") }
+    func editLinkedProducts() { recorder.record("editLinkedProducts") }
+    func editProductType(sourceView: UIView?) {
+        lastProductTypeSourceView = sourceView
+        recorder.record("editProductType")
+    }
+    func editShippingSettings() { recorder.record("editShippingSettings") }
+    func editInventorySettings() { recorder.record("editInventorySettings") }
+    func navigateToAddOns() { recorder.record("navigateToAddOns") }
+    func editCategories() { recorder.record("editCategories") }
+    func editTags() { recorder.record("editTags") }
+    func editShortDescription() { recorder.record("editShortDescription") }
+    func editExternalLink() { recorder.record("editExternalLink") }
+    func editSimplifiedInventory() { recorder.record("editSimplifiedInventory") }
+    func editGroupedProducts() { recorder.record("editGroupedProducts") }
+    func showVariations() { recorder.record("showVariations") }
+    func editAttributes() { recorder.record("editAttributes") }
+    func showBundledProducts() { recorder.record("showBundledProducts") }
+    func showCompositeComponents() { recorder.record("showCompositeComponents") }
+    func showSubscriptionFreeTrialSettings() { recorder.record("showSubscriptionFreeTrialSettings") }
+    func showSubscriptionExpirySettings() { recorder.record("showSubscriptionExpirySettings") }
+    func showQuantityRules() { recorder.record("showQuantityRules") }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRowActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRowActionHandlerTests.swift
@@ -189,46 +189,52 @@ struct ProductFormRowActionHandlerTests {
     // MARK: - Primary field rows (every actionable case)
 
     @Test func primary_description_respects_editability_and_logs_before_navigating() {
-        // Editable
+        // Given
         let (editableHandler, editableEnv) = makeHandler()
+        let (blockedHandler, blockedEnv) = makeHandler()
+
+        // When
         editableHandler.handlePrimaryFieldRowSelection(.description(description: "x", isEditable: true, isDescriptionAIEnabled: false),
                                                        shouldShowBlazeIntroView: false)
-        #expect(editableEnv.recorder.events == ["log:description", "editProductDescription"])
-
-        // Not editable
-        let (blockedHandler, blockedEnv) = makeHandler()
         blockedHandler.handlePrimaryFieldRowSelection(.description(description: "x", isEditable: false, isDescriptionAIEnabled: false),
                                                       shouldShowBlazeIntroView: false)
+
+        // Then — editable logs then navigates; non-editable is a no-op.
+        #expect(editableEnv.recorder.events == ["log:description", "editProductDescription"])
         #expect(blockedEnv.recorder.events.isEmpty)
         #expect(blockedEnv.analyticsProvider.receivedEvents.isEmpty)
     }
 
     @Test func primary_images_opens_privacy_settings_only_on_private_store() {
-        // Private store — images row opens privacy settings.
-        let (privateHandler, privateEnv) = makeHandler()
-        privateHandler.handlePrimaryFieldRowSelection(
+        // Given
+        let (privateStoreHandler, privateStoreEnv) = makeHandler()
+        let (publicStoreHandler, publicStoreEnv) = makeHandler()
+
+        // When
+        privateStoreHandler.handlePrimaryFieldRowSelection(
             .images(isEditable: true, isStorePublic: false, allowsMultiple: true, isVariation: false),
             shouldShowBlazeIntroView: false)
-        #expect(privateEnv.recorder.events == ["openPrivacySettings"])
-
-        // Public store — images row is not selectable.
-        let (publicHandler, publicEnv) = makeHandler()
-        publicHandler.handlePrimaryFieldRowSelection(
+        publicStoreHandler.handlePrimaryFieldRowSelection(
             .images(isEditable: true, isStorePublic: true, allowsMultiple: true, isVariation: false),
             shouldShowBlazeIntroView: false)
-        #expect(publicEnv.recorder.events.isEmpty)
+
+        // Then — a private store's images row opens privacy settings; a public store's is not selectable.
+        #expect(privateStoreEnv.recorder.events == ["openPrivacySettings"])
+        #expect(publicStoreEnv.recorder.events.isEmpty)
     }
 
     @Test func primary_promoteWithBlaze_tracks_entry_point_only_when_intro_is_not_shown() {
-        // Intro path navigates without tracking the entry-point-tapped event.
+        // Given
         let (introHandler, introEnv) = makeHandler()
+        let (directHandler, directEnv) = makeHandler()
+
+        // When
         introHandler.handlePrimaryFieldRowSelection(.promoteWithBlaze, shouldShowBlazeIntroView: true)
+        directHandler.handlePrimaryFieldRowSelection(.promoteWithBlaze, shouldShowBlazeIntroView: false)
+
+        // Then — the intro path navigates without tracking; the direct path tracks the entry-point event, then navigates.
         #expect(introEnv.recorder.events == ["displayBlaze"])
         #expect(introEnv.analyticsProvider.receivedEvents.isEmpty)
-
-        // Direct path tracks exactly the entry-point event, then navigates.
-        let (directHandler, directEnv) = makeHandler()
-        directHandler.handlePrimaryFieldRowSelection(.promoteWithBlaze, shouldShowBlazeIntroView: false)
         #expect(directEnv.recorder.events == ["displayBlaze"])
         #expect(directEnv.analyticsProvider.receivedEvents ==
                 [WooAnalyticsEvent.Blaze.blazeEntryPointTapped(source: .productDetailPromoteButton).statName.rawValue])
@@ -358,9 +364,12 @@ private extension ProductFormRowActionHandlerTests {
         let eventLogger = SpyProductFormEventLogger(recorder: recorder)
         let analyticsProvider = MockAnalyticsProvider()
         // Isolated opt-in defaults so events are not dropped by `WooAnalytics`'s opt-in gate,
-        // regardless of the simulator's ambient analytics setting.
-        let userDefaults = UserDefaults(suiteName: "ProductFormRowActionHandlerTests-\(UUID().uuidString)")!
-        userDefaults.set(true, forKey: "userOptedInAnalytics")
+        // regardless of the simulator's ambient analytics setting. The suite name is fixed and
+        // wiped before use so runs don't accumulate persistent domains.
+        let suiteName = "ProductFormRowActionHandlerTests"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaults[.userOptedInAnalytics] = true
         let handler = ProductFormRowActionHandler(analytics: WooAnalytics(analyticsProvider: analyticsProvider,
                                                                           userDefaults: userDefaults),
                                                   eventLogger: eventLogger,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRowActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRowActionHandlerTests.swift
@@ -276,7 +276,7 @@ struct ProductFormRowActionHandlerTests {
         }
     }
 
-    // MARK: - Add image CTA
+    // MARK: - Inline cell actions
 
     @Test func addImageTapped_logs_then_navigates() {
         // Given
@@ -287,6 +287,42 @@ struct ProductFormRowActionHandlerTests {
 
         // Then
         #expect(env.recorder.events == ["log:image", "showProductImages"])
+    }
+
+    @Test func descriptionAITapped_navigates_without_tracking() {
+        // Given
+        let (handler, env) = makeHandler()
+
+        // When
+        handler.handleDescriptionAITapped()
+
+        // Then
+        #expect(env.recorder.events == ["showProductDescriptionAI"])
+        #expect(env.analyticsProvider.receivedEvents.isEmpty)
+    }
+
+    @Test func linkedProductsPromoTapped_navigates_without_tracking() {
+        // Given
+        let (handler, env) = makeHandler()
+
+        // When
+        handler.handleLinkedProductsPromoTapped()
+
+        // Then
+        #expect(env.recorder.events == ["editLinkedProducts"])
+        #expect(env.analyticsProvider.receivedEvents.isEmpty)
+    }
+
+    @Test func aiLegalPageTapped_navigates_without_tracking() {
+        // Given
+        let (handler, env) = makeHandler()
+
+        // When
+        handler.handleAILegalPageTapped(url: URL(string: "https://automattic.com/ai-guidelines/")!)
+
+        // Then
+        #expect(env.recorder.events == ["openAILegalPage"])
+        #expect(env.analyticsProvider.receivedEvents.isEmpty)
     }
 }
 

--- a/docs/product-detail-ds-decoupling-plan.md
+++ b/docs/product-detail-ds-decoupling-plan.md
@@ -1,0 +1,216 @@
+# Product Detail — DS decoupling / preparation plan
+
+Preparation step for the RFC "Adopting the design system in the iOS app". Covers the
+**Decoupling** step for the easier of the two coupled UIKit screens: **Product Detail**
+(`ProductFormViewController`). Order Detail is the harder sibling and is out of scope here.
+
+> Revised after a principal-engineer review. Amendments from that review are folded in and
+> called out inline as **[review]**.
+
+## Objective
+
+Bring Product Detail to a *switchable* state so the DS feature flag can decide, at the
+container level, whether the screen renders via **today's `UITableView`** or via a **new
+SwiftUI DS view** — both sharing the *same presentation state + business logic*. Flag off must
+return today's UI unchanged. This plan covers only the behavior-preserving preparation; building
+the SwiftUI DS view is the later "Migrate" step.
+
+Success criteria for the preparation:
+- Flag off ⇒ Product Detail is behaviorally identical to today.
+- The presentation state (`[ProductFormSection]`) and the tap→navigation/analytics routing are
+  consumable by a renderer that is **not** a `UIViewController`.
+- The extracted seams are unit-tested; the currently-untested tap routing gains coverage.
+- No SwiftUI view is built yet; the legacy renderer is the only consumer, proving the seam.
+
+## What exists today
+
+| Type | Role | View-agnostic? | Tested? |
+|---|---|---|---|
+| `ProductFormViewModelProtocol` (+ `ProductFormViewModel`, `ProductVariationFormViewModel`) | **Business logic**: product state, updates, save/delete/duplicate, `canX()` checks, observables | Yes | Yes (Observables/Save/Updates/Changes tests) |
+| `DefaultProductFormTableViewModel` (`ProductFormTableViewModel` protocol) | Builds `[ProductFormSection]` from product + `actionsFactory` | Mostly — row VMs carry `UIImage`/`UIColor` | **Yes, heavily** (`DefaultProductFormTableViewModelTests`, ~915 LOC) |
+| `ProductFormViewController<ViewModel>` | UIKit host: table, tap handling, rebuild/observation, ~35 nav methods, nav bar, more-options sheet, save/publish/preview, tooltip, image uploader | No | No (only an image-uploader test) |
+| `ProductFormTableViewDataSource` | `UITableViewDataSource`: row → UIKit cell + inline action closures | No | No |
+
+The RFC's "already has a sections/row model and an action-routing seam" is true for the
+**sections model** (the shared, tested seam). The **action-routing seam is aspirational** — routing
+is currently fused into the view controller.
+
+## Couplings that block a SwiftUI renderer
+
+1. **Tap/action routing fused in the VC.** `didSelectRowAt` (`ProductFormViewController.swift:445-616`)
+   — ~170-line switch interleaving editability guards, analytics, and direct nav calls. More routing
+   lives as inline DataSource closures (`updateDataSourceActions` `:949-974`; wired at
+   `ProductFormTableViewDataSource.swift:32-35,178-186,276,320,369-374`) and in
+   `moreDetailsButtonTapped` (`:990-1032`, its own 7-action routing table + analytics).
+2. **Rebuild + observation fused in the VC** (`:814-985`) — six subscriptions plus three rebuild
+   paths that draw from *different* sources: `onProductUpdated` rebuilds from the **emitted** product
+   (`:879-886`), while `onImageStatusesUpdated`/`updateFormTableContent`/`reloadLinkedPromoCell`
+   rebuild from **current** `viewModel.productModel` (`:910,920,871`).
+3. **Row VMs carry UIKit types** — `icon: UIImage`, `tintColor: UIColor?`
+   (`ProductFormTableViewModel.swift:57-61`); rows map to concrete UIKit cells.
+
+**[review] Additional couplings the first draft under-weighted:**
+4. **View-state drives whether to rebuild.** The "don't reload while typing" behavior depends on
+   `view.window == nil` (`:834`) — a *view-layer* signal governing a *presentation-state* decision.
+   This is the main threat to Step 2 (see below); it cannot simply "move into" a presenter.
+5. **Lossy `Equatable`.** `ProductFormSection.SettingsRow.ViewModel.==` compares only
+   `icon/title/details` and ignores `tintColor/isActionable/numberOfLinesForDetails/hideSeparator`
+   (`ProductFormTableViewModel.swift:114-119`). Harmless today (VC always `reloadData()`), but a
+   landmine if a section stream ever adds `.removeDuplicates()` — it would swallow real updates
+   (e.g. a status toggle flipping only `isActionable`).
+6. **Popover/cell anchors.** `editProductType(cell:)` presents from `sourceView: cell` (`:504,1684`)
+   and the more-options sheet from a `barButtonItem` (`:424-425`). The anchor must be captured
+   *semantically at tap time*; a handler cannot resolve a cell later, and SwiftUI has no cell.
+7. **Dual analytics channels.** Routing mixes `eventLogger.log*Tapped()`
+   (`ProductFormEventLoggerProtocol`) and `ServiceLocator.analytics.track(...)`, with per-case
+   ordering that differs (guard-then-log vs log-unconditionally; `.externalURL` even has dead code
+   `:547-548`). "Verbatim" means injecting **both** and preserving order per case.
+8. **`HostingConfigurationTableViewCell` precedent** already exists (`HostingTableViewCell.swift:59`,
+   used by Order Detail's `OrderDetailsDataSource` + Settings). See "Alternative" below.
+
+## Plan — incremental, each step ships on `trunk`, flag stays off
+
+### Step 0 — Backfill *section-output* characterization only  **[review: rescoped]**
+- Audit/extend `DefaultProductFormTableViewModelTests` across representative configs (simple /
+  variable / external / grouped / bundle / composite / subscription; editable vs readonly; private
+  WPCom store; description-AI on).
+- **Do not** pretend to characterize tap routing here — it is not testable through the nib-backed,
+  ServiceLocator-saturated VC (`:107-127`) before extraction. Its coverage arrives *with* Step 1,
+  written against the extracted handler and verified against the pre-extraction switch by review.
+
+### Step 1 — Extract the action-routing seam (highest test value)
+- Introduce a semantic action currency (intent) covering **only** the switchable surface: the
+  ~row-tap cases, the DataSource inline closures, and the more-details sheet actions. Each intent
+  **captures its anchor semantically at creation time** (for product-type popover / share).
+- `ProductFormRowActionHandler`: given an intent, (a) applies the editability guard, (b) fires the
+  moved-verbatim analytics via **both** injected `eventLogger` and `Analytics`, preserving per-case
+  guard→log→navigate ordering, (c) calls `ProductFormNavigating` for the push/present.
+- **`ProductFormNavigating` is scoped to the row-actionable + inline-closure + more-details set only**
+  (~20 methods). **[review]** Nav-bar / action-sheet chrome (`displayProductSettings`,
+  `duplicateProduct`, `deleteProduct`, `displayShareProduct`, `publishProduct`, `saveProductAsDraft`,
+  `displayProductPreview`, the more-options sheet) **stays in the VC** — Step 3 keeps it there, so
+  moving it behind the protocol is churn with no switchability payoff.
+- Rewire `didSelectRowAt` → `sections[indexPath] → intent → handler.handle(intent)`; funnel the
+  DataSource closures + more-details actions into the same handler.
+- Tests: `MockAnalytics` + `MockEventLogger` + a spy `ProductFormNavigating`, asserting
+  **guard→log→navigate ordering and the no-op-when-not-editable cases** — not merely "nav X fired".
+
+#### Scope boundary — which nav methods go behind `ProductFormNavigating`
+Only methods reachable **from the table content** (rows, inline cell closures, or the "Add more
+details" bottom sheet) go on the protocol — because only those are what a SwiftUI content renderer
+will call. Nav-bar buttons, the more-options action sheet, and save/publish/delete flows stay
+owned by the VC (Step 3 keeps them there), so they are **not** added to the protocol, moved, or
+routed through the handler. Rule: *reachable from content ⇒ on the protocol* (even if chrome also
+calls it); *reachable only from chrome ⇒ stays on the VC*.
+
+- **Behind `ProductFormNavigating`** (from `didSelectRowAt` `:445-616`, `updateDataSourceActions`
+  `:949-974`, `moreDetailsButtonTapped` `:990-1032`): `editProductDescription`,
+  `showProductDescriptionAI`, `displayBlaze`, `showProductImages`, `presentURL`(privacy),
+  `editPriceSettings`, `showCustomFields`, `showReviews`, `showDownloadableFiles`,
+  `editLinkedProducts`, `editProductType(cell:)`, `editShippingSettings`, `editInventorySettings`,
+  `navigateToAddOns`, `editCategories`, `editTags`, `editShortDescription`, `editExternalLink`,
+  `editSimplifiedInventory`, `editGroupedProducts`, `showVariations`, `editAttributes`,
+  `showBundledProducts`, `showCompositeComponents`, `showSubscriptionFreeTrialSettings`,
+  `showSubscriptionExpirySettings`, `showQuantityRules`, plus the closure targets
+  `reloadLinkedPromoCell` / name-change / status-change / `displayImageUploadErrorAlert`.
+- **Stays on the VC as chrome** (from nav bar `:1357+` / more-options sheet `:357-428` / save flow):
+  `publishProduct`, `saveProductAsDraft`, `saveProduct`(`AndLogEvent`), `displayProductPreview`
+  (via `saveDraftAndDisplayProductPreview`), `displayWebViewForProductInStore`, `displayShareProduct`,
+  `displayProductSettings`, `duplicateProduct`, `displayDeleteProductAlert`/`deleteProduct`,
+  `presentMoreOptionsActionSheet`, `displayProductSavingErrorAlert`, `displayError`/`displayErrorAlert`.
+
+Method *bodies* for the protocol set still live on the VC (it implements `ProductFormNavigating`),
+so chrome that also calls them keeps working with no duplication.
+
+### Step 2 — Extract the section/observation presenter  **[review: reshaped — weakest part of v1]**
+- Introduce a `@MainActor` `ProductFormContentPresenter` (generic over `ProductModel`) owning the
+  `ViewModel` + `ProductImageActionHandler` + currency + AI flag, receiving upstream on main
+  (`addUpdateObserver` `:171` and the VM publishers give no main guarantee).
+- It hosts the subscriptions and **replicates each rebuild trigger explicitly** — preserving that
+  `onProductUpdated` rebuilds from the emitted product while the others rebuild from current
+  `productModel`. A single naïve `product → sections` pipeline collapses this distinction and is
+  forbidden.
+- **The typing-suppression decision stays view-owned.** A plain `@Published sections` cannot
+  reproduce the `view.window == nil` gate (`:830-838`) without leaking window state into the
+  presenter. So the presenter exposes **distinct signals** (e.g. `sectionsDidRebuild` vs
+  `nameChangedOffscreen`) *or* takes an injected `isVisible`/`isEditing` provider, and the VC keeps
+  the "reload only when not actively editing" call. Do **not** claim `$sections` preserves it
+  transparently.
+- **Forbid `.removeDuplicates()`** on the section stream until the lossy `Equatable`
+  (`ProductFormTableViewModel.swift:114-119`) is fixed — otherwise real updates are dropped.
+- Convention note: AGENTS.md prefers `@Observable` (Observation) for new VMs; `@Published`/
+  `ObservableObject` here is a deliberate legacy bridge (Combine sinks for the VC, observable by a
+  future SwiftUI view) — call the deviation out rather than let it read as endorsed.
+- Test win: "given product state X ⇒ sections Y; re-emits on trigger Z; suppresses name-only while
+  editing" becomes unit-testable without a `UIViewController`.
+
+### Step 3 — Rendering seam + flag (no new UI)
+- Add `FeatureFlag.productDetailDesignSystem` (default off) to `FeatureFlag.swift` +
+  `DefaultFeatureFlagService.swift`.
+- Extract the table setup into a legacy content renderer conforming to `ProductFormContentRendering`
+  (inputs: the section signals + the `ProductFormRowActionHandler`). The VC keeps nav bar,
+  more-options sheet, save/publish/preview/delete, keyboard avoidance, tooltip, image uploader.
+- **Centralize the flag decision in one factory function** covering all four call sites
+  (`ProductDetailsFactory.swift:51`, `ProductVariationDetailsFactory.swift:56`,
+  `ProductVariationsViewController.swift:565`, `AddProductCoordinator.swift:273`) so it can't drift
+  four ways. Note `ProductVariationsViewController` is both a call site and is pushed reentrantly
+  from the VC's `showVariations()` (`:2085`).
+- Exit: flag off ⇒ identical screen, now driven by the extracted presenter + handler.
+
+### Step 4 — (Migration, out of scope) Build the SwiftUI DS view against the presenter's section
+signals + `handler`, install under the flag. Listed only for continuity.
+
+## PR breakdown — 2 PRs
+The <300 non-test LOC Danger gate is intentionally waived for this work; PR-1 will be large and
+needs a size waiver on review. The split is by "extract everything (behavior-preserving)" then
+"make it switchable".
+
+- **PR-1 — Decouple + test (no flag; legacy table stays the only renderer).**
+  - `ProductFormNavigating` protocol + VC conformance (relocate the content-reachable method bodies).
+  - Intent enum + `ProductFormRowActionHandler`; rewire `didSelectRowAt`, the DataSource inline
+    closures, and the "Add more details" sheet through it.
+  - `ProductFormContentPresenter` — move the six subscriptions + three rebuild paths out of the VC,
+    keeping the `view.window`/typing-suppression decision view-owned; forbid `.removeDuplicates()`.
+  - All new unit tests: handler guard→log→navigate ordering (`MockAnalytics`/`MockEventLogger`/nav
+    spy) and presenter trigger→re-emit incl. name-only suppression.
+  - Verification bar: flag does not exist yet; table renders exactly as today. This is the
+    "prove nothing changed" PR — hence all tests land here.
+- **PR-2 — Make it switchable (flag + seam + call sites).**
+  - `ProductFormContentRendering` protocol; wrap the existing table as the legacy renderer.
+  - `FeatureFlag.productDetailDesignSystem` (default off) in `FeatureFlag.swift` +
+    `DefaultFeatureFlagService.swift`.
+  - Centralize the flag decision in one factory across the 4 call sites.
+  - Verification bar: flag off ⇒ identical screen, now driven through the seam. No SwiftUI view yet.
+
+Escape hatch: if PR-1 review gets unwieldy, split the presenter back into its own PR (→ 3 PRs).
+Every new test must exercise **both** `Product` and `ProductVariation` specializations.
+
+## What stays untestable (accept it)  **[review]**
+Nav method *bodies* (they build/push UIKit VCs — the spy only proves the right intent fired),
+tooltip target-point math (`:738-755`), keyboard-avoidance constraints (`:709-724`), cell
+self-sizing `beginUpdates/endUpdates` (`:1508-1509`). Out of scope; the screen does not become
+broadly unit-testable — the *routing and section logic* do.
+
+## Alternative weighed: per-cell SwiftUI hosting  **[review: must be justified]**
+The app already hosts SwiftUI inside this exact `UITableView` pattern via
+`HostingConfigurationTableViewCell`/`HostingTableViewCell` (Order Detail, Settings). A lower-risk
+first increment: keep the entire UIKit host (`didSelectRowAt`, observations, rebuild) and swap only
+*per-row cell rendering* to DS SwiftUI cells. This sidesteps the Step-2 presenter extraction and the
+whole typing-suppression hazard for v1.
+
+Trade-off (state honestly): it does **not** deliver the RFC's "screen renders via a SwiftUI DS view
+that is not a UIViewController" and does not remove the UIKit host — so it is not container-level
+switchable. **Decision:** this plan pursues the container-swap because the RFC's flag switches the
+whole view (sectioned layout + cells) rendered in SwiftUI; per-cell hosting is retained as the
+documented fallback / possible first increment if Step 2 proves too risky.
+
+## Open decisions for implementation
+1. Row value types: keep `ProductFormSection` (+ thin SwiftUI adapter for `UIImage`→`Image`,
+   `UIColor`→`Color`) vs. introduce pure view-agnostic types now. RFC says "duplicate minimal"; DS
+   icons are likely DS assets, so *some* mapping is unavoidable.
+2. Intent granularity: dedicated `ProductFormRowAction` enum vs. reuse `PrimaryFieldRow`/`SettingsRow`
+   as the action currency.
+3. Navigation ownership: keep VC as `ProductFormNavigating` impl (surgical) vs. extract a Coordinator
+   (matches convention, larger blast radius).
+4. `isLinkedProductsPromoEnabled` lives on the concrete `ProductFormViewModel` (`:1082`), not the
+   protocol — the generic presenter can't reach it cleanly; decide how the promo reload is triggered.

--- a/docs/product-detail-ds-decoupling-plan.md
+++ b/docs/product-detail-ds-decoupling-plan.md
@@ -1,11 +1,8 @@
-# Product Detail — DS decoupling / preparation plan
+# Product Detail — design system decoupling plan
 
 Preparation step for the RFC "Adopting the design system in the iOS app". Covers the
 **Decoupling** step for the easier of the two coupled UIKit screens: **Product Detail**
 (`ProductFormViewController`). Order Detail is the harder sibling and is out of scope here.
-
-> Revised after a principal-engineer review. Amendments from that review are folded in and
-> called out inline as **[review]**.
 
 ## Objective
 
@@ -19,198 +16,126 @@ Success criteria for the preparation:
 - Flag off ⇒ Product Detail is behaviorally identical to today.
 - The presentation state (`[ProductFormSection]`) and the tap→navigation/analytics routing are
   consumable by a renderer that is **not** a `UIViewController`.
-- The extracted seams are unit-tested; the currently-untested tap routing gains coverage.
-- No SwiftUI view is built yet; the legacy renderer is the only consumer, proving the seam.
+- The extracted seams are unit-tested; the previously untested tap routing gains coverage.
+- No SwiftUI view is built as part of the preparation; the legacy renderer stays the only consumer.
 
-## What exists today
+## Starting point
 
 | Type | Role | View-agnostic? | Tested? |
 |---|---|---|---|
 | `ProductFormViewModelProtocol` (+ `ProductFormViewModel`, `ProductVariationFormViewModel`) | **Business logic**: product state, updates, save/delete/duplicate, `canX()` checks, observables | Yes | Yes (Observables/Save/Updates/Changes tests) |
-| `DefaultProductFormTableViewModel` (`ProductFormTableViewModel` protocol) | Builds `[ProductFormSection]` from product + `actionsFactory` | Mostly — row VMs carry `UIImage`/`UIColor` | **Yes, heavily** (`DefaultProductFormTableViewModelTests`, ~915 LOC) |
+| `DefaultProductFormTableViewModel` (`ProductFormTableViewModel` protocol) | Builds `[ProductFormSection]` from product + `actionsFactory` | Mostly — row VMs carry `UIImage`/`UIColor` | Yes (`DefaultProductFormTableViewModelTests`, ~915 LOC) |
 | `ProductFormViewController<ViewModel>` | UIKit host: table, tap handling, rebuild/observation, ~35 nav methods, nav bar, more-options sheet, save/publish/preview, tooltip, image uploader | No | No (only an image-uploader test) |
 | `ProductFormTableViewDataSource` | `UITableViewDataSource`: row → UIKit cell + inline action closures | No | No |
 
-The RFC's "already has a sections/row model and an action-routing seam" is true for the
-**sections model** (the shared, tested seam). The **action-routing seam is aspirational** — routing
-is currently fused into the view controller.
+The sections model was already the shared, tested seam. The action routing was fused into the
+view controller and untested — that is what the preparation extracts.
 
 ## Couplings that block a SwiftUI renderer
 
-1. **Tap/action routing fused in the VC.** `didSelectRowAt` (`ProductFormViewController.swift:445-616`)
-   — ~170-line switch interleaving editability guards, analytics, and direct nav calls. More routing
-   lives as inline DataSource closures (`updateDataSourceActions` `:949-974`; wired at
-   `ProductFormTableViewDataSource.swift:32-35,178-186,276,320,369-374`) and in
-   `moreDetailsButtonTapped` (`:990-1032`, its own 7-action routing table + analytics).
-2. **Rebuild + observation fused in the VC** (`:814-985`) — six subscriptions plus three rebuild
-   paths that draw from *different* sources: `onProductUpdated` rebuilds from the **emitted** product
-   (`:879-886`), while `onImageStatusesUpdated`/`updateFormTableContent`/`reloadLinkedPromoCell`
-   rebuild from **current** `viewModel.productModel` (`:910,920,871`).
-3. **Row VMs carry UIKit types** — `icon: UIImage`, `tintColor: UIColor?`
-   (`ProductFormTableViewModel.swift:57-61`); rows map to concrete UIKit cells.
-
-**[review] Additional couplings the first draft under-weighted:**
-4. **View-state drives whether to rebuild.** The "don't reload while typing" behavior depends on
-   `view.window == nil` (`:834`) — a *view-layer* signal governing a *presentation-state* decision.
-   This is the main threat to Step 2 (see below); it cannot simply "move into" a presenter.
+1. **Tap/action routing fused in the VC.** `didSelectRowAt` — a ~170-line switch interleaving
+   editability guards, analytics, and direct nav calls. More routing lives as inline DataSource
+   closures (`updateDataSourceActions`) and in `moreDetailsButtonTapped` (its own 7-action routing
+   table + analytics).
+2. **Rebuild + observation fused in the VC** — six subscriptions plus three rebuild paths that draw
+   from *different* sources: `onProductUpdated` rebuilds from the **emitted** product, while
+   `onImageStatusesUpdated`/`updateFormTableContent`/`reloadLinkedPromoCell` rebuild from **current**
+   `viewModel.productModel`.
+3. **Row VMs carry UIKit types** — `icon: UIImage`, `tintColor: UIColor?`; rows map to concrete
+   UIKit cells. A SwiftUI renderer can consume these via `Image(uiImage:)`/`Color(uiColor:)`; a
+   token-mapping layer arrives with the DS view.
+4. **View state drives whether to rebuild.** The "don't reload while typing" behavior depends on
+   `view.window == nil` — a *view-layer* signal governing a *presentation-state* decision. It
+   cannot simply move into a presenter; the decision must stay view-owned.
 5. **Lossy `Equatable`.** `ProductFormSection.SettingsRow.ViewModel.==` compares only
-   `icon/title/details` and ignores `tintColor/isActionable/numberOfLinesForDetails/hideSeparator`
-   (`ProductFormTableViewModel.swift:114-119`). Harmless today (VC always `reloadData()`), but a
-   landmine if a section stream ever adds `.removeDuplicates()` — it would swallow real updates
-   (e.g. a status toggle flipping only `isActionable`).
-6. **Popover/cell anchors.** `editProductType(cell:)` presents from `sourceView: cell` (`:504,1684`)
-   and the more-options sheet from a `barButtonItem` (`:424-425`). The anchor must be captured
-   *semantically at tap time*; a handler cannot resolve a cell later, and SwiftUI has no cell.
-7. **Dual analytics channels.** Routing mixes `eventLogger.log*Tapped()`
-   (`ProductFormEventLoggerProtocol`) and `ServiceLocator.analytics.track(...)`, with per-case
-   ordering that differs (guard-then-log vs log-unconditionally; `.externalURL` even has dead code
-   `:547-548`). "Verbatim" means injecting **both** and preserving order per case.
-8. **`HostingConfigurationTableViewCell` precedent** already exists (`HostingTableViewCell.swift:59`,
-   used by Order Detail's `OrderDetailsDataSource` + Settings). See "Alternative" below.
+   `icon/title/details` and ignores `tintColor/isActionable/numberOfLinesForDetails/hideSeparator`.
+   Harmless while the VC always `reloadData()`s, but a landmine if a section stream ever adds
+   `.removeDuplicates()` — real updates would be swallowed. Rule: no dedup until the `Equatable`
+   is fixed.
+6. **Popover/cell anchors.** `editProductType` presents from the tapped cell and the more-options
+   sheet from a `barButtonItem`. Anchors must be captured at tap time; a SwiftUI renderer has no
+   cell.
+7. **Dual analytics channels.** Routing mixes `eventLogger.log*Tapped()` and
+   `ServiceLocator.analytics.track(...)`, with per-case ordering that differs. Both channels must
+   be preserved per case, in order.
 
 ## Plan — incremental, each step ships on `trunk`, flag stays off
 
-### Step 0 — Backfill *section-output* characterization only  **[review: rescoped]**
-- Audit/extend `DefaultProductFormTableViewModelTests` across representative configs (simple /
-  variable / external / grouped / bundle / composite / subscription; editable vs readonly; private
-  WPCom store; description-AI on).
-- **Do not** pretend to characterize tap routing here — it is not testable through the nib-backed,
-  ServiceLocator-saturated VC (`:107-127`) before extraction. Its coverage arrives *with* Step 1,
-  written against the extracted handler and verified against the pre-extraction switch by review.
+### Step 1 — Extract the action-routing seam (PR-1, this branch)
+- `ProductFormRowActionHandler` routes every content interaction: row selections (primary +
+  settings), the "Add more details" sheet actions, and the inline cell actions (add image,
+  description AI, linked-products promo, AI legal link). Guards → analytics (both channels,
+  order preserved) → navigation.
+- The handler consumes the existing `ProductFormSection` row enums directly — no parallel intent
+  enum; both the legacy table and a future SwiftUI view speak `ProductFormSection`.
+- `ProductFormNavigating` protocol carries the navigation; the VC implements it. Scope is limited
+  to content-reachable navigation: nav-bar / more-options-sheet / save-publish-delete chrome stays
+  on the VC (a DS content renderer never invokes those).
+- Interactions that are *not* navigation stay VC-bound by design: name/status changes (view-model
+  data mutations), linked-promo reload (table rebuild), failed-upload alert (error UI).
+- Tests: exhaustive per-case unit coverage (every settings row, primary row, more-details action,
+  and inline action) asserting guards, analytics, and guard→log→navigate ordering.
 
-### Step 1 — Extract the action-routing seam (highest test value)
-- Introduce a semantic action currency (intent) covering **only** the switchable surface: the
-  ~row-tap cases, the DataSource inline closures, and the more-details sheet actions. Each intent
-  **captures its anchor semantically at creation time** (for product-type popover / share).
-- `ProductFormRowActionHandler`: given an intent, (a) applies the editability guard, (b) fires the
-  moved-verbatim analytics via **both** injected `eventLogger` and `Analytics`, preserving per-case
-  guard→log→navigate ordering, (c) calls `ProductFormNavigating` for the push/present.
-- **`ProductFormNavigating` is scoped to the row-actionable + inline-closure + more-details set only**
-  (~20 methods). **[review]** Nav-bar / action-sheet chrome (`displayProductSettings`,
-  `duplicateProduct`, `deleteProduct`, `displayShareProduct`, `publishProduct`, `saveProductAsDraft`,
-  `displayProductPreview`, the more-options sheet) **stays in the VC** — Step 3 keeps it there, so
-  moving it behind the protocol is churn with no switchability payoff.
-- Rewire `didSelectRowAt` → `sections[indexPath] → intent → handler.handle(intent)`; funnel the
-  DataSource closures + more-details actions into the same handler.
-- Tests: `MockAnalytics` + `MockEventLogger` + a spy `ProductFormNavigating`, asserting
-  **guard→log→navigate ordering and the no-op-when-not-editable cases** — not merely "nav X fired".
+### Step 2 — Extract the section/observation presenter (PR-1b)
+- A `@MainActor` `ProductFormContentPresenter` (generic over `ProductModel`) owning the
+  subscriptions, replicating each rebuild trigger explicitly (preserving which product source each
+  rebuild path reads from).
+- The typing-suppression decision stays view-owned: the presenter exposes distinct signals (or
+  takes an injected `isVisible`/`isEditing` provider) and the VC keeps the "reload only when not
+  actively editing" call. A plain `@Published sections` cannot reproduce the `view.window == nil`
+  gate without leaking view state.
+- No `.removeDuplicates()` on the section stream (see coupling 5).
+- Note: `@Published`/Combine here is a deliberate bridge for the legacy VC; the project's
+  preference for `@Observable` applies to new view models, and the DS view can observe either.
 
-#### Scope boundary — which nav methods go behind `ProductFormNavigating`
-Only methods reachable **from the table content** (rows, inline cell closures, or the "Add more
-details" bottom sheet) go on the protocol — because only those are what a SwiftUI content renderer
-will call. Nav-bar buttons, the more-options action sheet, and save/publish/delete flows stay
-owned by the VC (Step 3 keeps them there), so they are **not** added to the protocol, moved, or
-routed through the handler. Rule: *reachable from content ⇒ on the protocol* (even if chrome also
-calls it); *reachable only from chrome ⇒ stays on the VC*.
-
-- **Behind `ProductFormNavigating`** (from `didSelectRowAt` `:445-616`, `updateDataSourceActions`
-  `:949-974`, `moreDetailsButtonTapped` `:990-1032`): `editProductDescription`,
-  `showProductDescriptionAI`, `displayBlaze`, `showProductImages`, `presentURL`(privacy),
-  `editPriceSettings`, `showCustomFields`, `showReviews`, `showDownloadableFiles`,
-  `editLinkedProducts`, `editProductType(cell:)`, `editShippingSettings`, `editInventorySettings`,
-  `navigateToAddOns`, `editCategories`, `editTags`, `editShortDescription`, `editExternalLink`,
-  `editSimplifiedInventory`, `editGroupedProducts`, `showVariations`, `editAttributes`,
-  `showBundledProducts`, `showCompositeComponents`, `showSubscriptionFreeTrialSettings`,
-  `showSubscriptionExpirySettings`, `showQuantityRules`, plus the closure targets
-  `reloadLinkedPromoCell` / name-change / status-change / `displayImageUploadErrorAlert`.
-- **Stays on the VC as chrome** (from nav bar `:1357+` / more-options sheet `:357-428` / save flow):
-  `publishProduct`, `saveProductAsDraft`, `saveProduct`(`AndLogEvent`), `displayProductPreview`
-  (via `saveDraftAndDisplayProductPreview`), `displayWebViewForProductInStore`, `displayShareProduct`,
-  `displayProductSettings`, `duplicateProduct`, `displayDeleteProductAlert`/`deleteProduct`,
-  `presentMoreOptionsActionSheet`, `displayProductSavingErrorAlert`, `displayError`/`displayErrorAlert`.
-
-Method *bodies* for the protocol set still live on the VC (it implements `ProductFormNavigating`),
-so chrome that also calls them keeps working with no duplication.
-
-### Step 2 — Extract the section/observation presenter  **[review: reshaped — weakest part of v1]**
-- Introduce a `@MainActor` `ProductFormContentPresenter` (generic over `ProductModel`) owning the
-  `ViewModel` + `ProductImageActionHandler` + currency + AI flag, receiving upstream on main
-  (`addUpdateObserver` `:171` and the VM publishers give no main guarantee).
-- It hosts the subscriptions and **replicates each rebuild trigger explicitly** — preserving that
-  `onProductUpdated` rebuilds from the emitted product while the others rebuild from current
-  `productModel`. A single naïve `product → sections` pipeline collapses this distinction and is
-  forbidden.
-- **The typing-suppression decision stays view-owned.** A plain `@Published sections` cannot
-  reproduce the `view.window == nil` gate (`:830-838`) without leaking window state into the
-  presenter. So the presenter exposes **distinct signals** (e.g. `sectionsDidRebuild` vs
-  `nameChangedOffscreen`) *or* takes an injected `isVisible`/`isEditing` provider, and the VC keeps
-  the "reload only when not actively editing" call. Do **not** claim `$sections` preserves it
-  transparently.
-- **Forbid `.removeDuplicates()`** on the section stream until the lossy `Equatable`
-  (`ProductFormTableViewModel.swift:114-119`) is fixed — otherwise real updates are dropped.
-- Convention note: AGENTS.md prefers `@Observable` (Observation) for new VMs; `@Published`/
-  `ObservableObject` here is a deliberate legacy bridge (Combine sinks for the VC, observable by a
-  future SwiftUI view) — call the deviation out rather than let it read as endorsed.
-- Test win: "given product state X ⇒ sections Y; re-emits on trigger Z; suppresses name-only while
-  editing" becomes unit-testable without a `UIViewController`.
-
-### Step 3 — Rendering seam + flag (no new UI)
-- Add `FeatureFlag.productDetailDesignSystem` (default off) to `FeatureFlag.swift` +
+### Step 3 — Rendering seam + flag
+- `FeatureFlag.productDetailDesignSystem` (default off) in `FeatureFlag.swift` +
   `DefaultFeatureFlagService.swift`.
-- Extract the table setup into a legacy content renderer conforming to `ProductFormContentRendering`
-  (inputs: the section signals + the `ProductFormRowActionHandler`). The VC keeps nav bar,
-  more-options sheet, save/publish/preview/delete, keyboard avoidance, tooltip, image uploader.
-- **Centralize the flag decision in one factory function** covering all four call sites
-  (`ProductDetailsFactory.swift:51`, `ProductVariationDetailsFactory.swift:56`,
-  `ProductVariationsViewController.swift:565`, `AddProductCoordinator.swift:273`) so it can't drift
-  four ways. Note `ProductVariationsViewController` is both a call site and is pushed reentrantly
-  from the VC's `showVariations()` (`:2085`).
-- Exit: flag off ⇒ identical screen, now driven by the extracted presenter + handler.
+- Extract the table setup into a legacy content renderer conforming to a small
+  `ProductFormContentRendering` protocol (inputs: the section signals + the handler). The VC keeps
+  nav bar, more-options sheet, save/publish/preview/delete, keyboard avoidance, tooltip, image
+  uploader.
+- Centralize the flag decision in one factory covering all four call sites
+  (`ProductDetailsFactory`, `ProductVariationDetailsFactory`, `ProductVariationsViewController`,
+  `AddProductCoordinator`). Note `ProductVariationsViewController` is both a call site and is
+  pushed reentrantly from the VC's `showVariations()`.
 
-### Step 4 — (Migration, out of scope) Build the SwiftUI DS view against the presenter's section
-signals + `handler`, install under the flag. Listed only for continuity.
+### Step 4 — Migrate (out of scope)
+Build the SwiftUI DS view against the presenter's section signals + the handler, install under the
+flag. A spike has confirmed a SwiftUI view can consume `ProductFormSection` +
+`ProductFormRowActionHandler` + `ProductFormNavigating` without changes to the seam.
 
-## PR breakdown — 2 PRs
-The <300 non-test LOC Danger gate is intentionally waived for this work; PR-1 will be large and
-needs a size waiver on review. The split is by "extract everything (behavior-preserving)" then
-"make it switchable".
+## PR breakdown
+The <300 non-test LOC Danger gate is knowingly exceeded by PR-1; it needs a size waiver on review.
 
-- **PR-1 — Decouple + test (no flag; legacy table stays the only renderer).**
-  - `ProductFormNavigating` protocol + VC conformance (relocate the content-reachable method bodies).
-  - Intent enum + `ProductFormRowActionHandler`; rewire `didSelectRowAt`, the DataSource inline
-    closures, and the "Add more details" sheet through it.
-  - `ProductFormContentPresenter` — move the six subscriptions + three rebuild paths out of the VC,
-    keeping the `view.window`/typing-suppression decision view-owned; forbid `.removeDuplicates()`.
-  - All new unit tests: handler guard→log→navigate ordering (`MockAnalytics`/`MockEventLogger`/nav
-    spy) and presenter trigger→re-emit incl. name-only suppression.
-  - Verification bar: flag does not exist yet; table renders exactly as today. This is the
-    "prove nothing changed" PR — hence all tests land here.
-- **PR-2 — Make it switchable (flag + seam + call sites).**
-  - `ProductFormContentRendering` protocol; wrap the existing table as the legacy renderer.
-  - `FeatureFlag.productDetailDesignSystem` (default off) in `FeatureFlag.swift` +
-    `DefaultFeatureFlagService.swift`.
-  - Centralize the flag decision in one factory across the 4 call sites.
-  - Verification bar: flag off ⇒ identical screen, now driven through the seam. No SwiftUI view yet.
+- **PR-1 — routing extraction + exhaustive tests** (this branch). Flag does not exist yet; the
+  table renders exactly as today. After PR-1 the screen is **not yet switchable** — that arrives
+  with Steps 2–3.
+- **PR-1b — presenter extraction.**
+- **PR-2 — flag + rendering seam + centralized factory.**
 
-Escape hatch: if PR-1 review gets unwieldy, split the presenter back into its own PR (→ 3 PRs).
-Every new test must exercise **both** `Product` and `ProductVariation` specializations.
+Every new test must exercise behavior valid for both `Product` and `ProductVariation`
+specializations (the handler operates on `ProductFormSection` rows, which are shared).
 
-## What stays untestable (accept it)  **[review]**
-Nav method *bodies* (they build/push UIKit VCs — the spy only proves the right intent fired),
-tooltip target-point math (`:738-755`), keyboard-avoidance constraints (`:709-724`), cell
-self-sizing `beginUpdates/endUpdates` (`:1508-1509`). Out of scope; the screen does not become
-broadly unit-testable — the *routing and section logic* do.
+## What stays untestable (accepted)
+Navigation method *bodies* (they build/push UIKit view controllers — spies prove the right intent
+fired, not that the destination is correct), tooltip target-point math, keyboard-avoidance
+constraints, cell self-sizing `beginUpdates/endUpdates`. The *routing and section logic* become
+unit-testable; the whole screen does not.
 
-## Alternative weighed: per-cell SwiftUI hosting  **[review: must be justified]**
-The app already hosts SwiftUI inside this exact `UITableView` pattern via
-`HostingConfigurationTableViewCell`/`HostingTableViewCell` (Order Detail, Settings). A lower-risk
-first increment: keep the entire UIKit host (`didSelectRowAt`, observations, rebuild) and swap only
-*per-row cell rendering* to DS SwiftUI cells. This sidesteps the Step-2 presenter extraction and the
-whole typing-suppression hazard for v1.
+## Alternative considered: per-cell SwiftUI hosting
+`HostingConfigurationTableViewCell`/`HostingTableViewCell` (used by Order Detail and Settings)
+would allow swapping only per-row cell rendering to DS SwiftUI cells while keeping the entire UIKit
+host. Lower risk, but it does not deliver the RFC's container-level switch (the whole sectioned
+layout rendered in SwiftUI) and does not remove the UIKit host. This plan pursues the
+container-swap; per-cell hosting remains the documented fallback if Step 2 proves too risky.
 
-Trade-off (state honestly): it does **not** deliver the RFC's "screen renders via a SwiftUI DS view
-that is not a UIViewController" and does not remove the UIKit host — so it is not container-level
-switchable. **Decision:** this plan pursues the container-swap because the RFC's flag switches the
-whole view (sectioned layout + cells) rendered in SwiftUI; per-cell hosting is retained as the
-documented fallback / possible first increment if Step 2 proves too risky.
-
-## Open decisions for implementation
-1. Row value types: keep `ProductFormSection` (+ thin SwiftUI adapter for `UIImage`→`Image`,
-   `UIColor`→`Color`) vs. introduce pure view-agnostic types now. RFC says "duplicate minimal"; DS
-   icons are likely DS assets, so *some* mapping is unavoidable.
-2. Intent granularity: dedicated `ProductFormRowAction` enum vs. reuse `PrimaryFieldRow`/`SettingsRow`
-   as the action currency.
-3. Navigation ownership: keep VC as `ProductFormNavigating` impl (surgical) vs. extract a Coordinator
-   (matches convention, larger blast radius).
-4. `isLinkedProductsPromoEnabled` lives on the concrete `ProductFormViewModel` (`:1082`), not the
-   protocol — the generic presenter can't reach it cleanly; decide how the promo reload is triggered.
+## Open decisions
+1. Row value types: keep `ProductFormSection` (+ a thin SwiftUI adapter for `UIImage`→`Image`,
+   `UIColor`→`Color`) vs. introduce pure view-agnostic types when the DS view lands. DS icons are
+   likely DS assets, so some mapping is unavoidable.
+2. Navigation ownership: the VC implements `ProductFormNavigating` today (surgical); extracting a
+   Coordinator is a possible follow-up.
+3. `isLinkedProductsPromoEnabled` lives on the concrete `ProductFormViewModel`, not the protocol —
+   the presenter (generic over `ProductModel`) can't reach it cleanly; decide how the promo reload
+   is triggered when Step 2 lands.


### PR DESCRIPTION
Part 1 of the Product Detail preparation for the design system migration (internal RFC: "Adopting the design system in the iOS app", teamkiwip2 P2, 2026-07-08). The plan lives in `docs/product-detail-ds-decoupling-plan.md`.

## Description

For the DS feature flag to switch Product Detail's view layer, the screen's tap routing can't live inside `ProductFormViewController` — a SwiftUI renderer can't reach a ~170-line `didSelectRowAt` switch. This PR extracts that routing into a testable seam, behavior-preserving:

- `ProductFormRowActionHandler` routes every content interaction — row selections, the "Add more details" sheet actions, and the inline cell actions (add image, description AI, linked-products promo, AI legal link). Per case it applies the same editability/actionability guard, fires the same analytics (both channels: `eventLogger` and `Analytics`, same order), and navigates through the new `ProductFormNavigating` protocol, which the view controller implements.
- The handler consumes the existing `ProductFormSection` row enums directly — no parallel intent enum, so both the legacy table and a future SwiftUI view speak the same model.
- Scope is content-reachable navigation only. Nav-bar, more-options action sheet, and save/publish/delete flows stay on the view controller — a DS content renderer never invokes those. Name/status changes (view-model mutations), the promo reload, and the upload-error alert also stay VC-bound on purpose.
- The routing — previously untested — now has exhaustive per-case unit coverage: every settings row, primary row, more-details action, and inline action, asserting guard → log → navigate ordering.

After this PR the screen is **not yet switchable** — that arrives with the follow-ups (presenter extraction, then flag + rendering seam; see the plan doc). A throwaway spike confirmed a SwiftUI view can consume `ProductFormSection` + the handler + `ProductFormNavigating` with no changes to the seam (not committed).

Faithfulness was verified three ways: the exhaustive unit tests, a case-by-case audit of the handler against trunk's `didSelectRowAt` (guards, analytics events, ordering, popover anchor — no deviations), and a live sweep on a sample store tapping 17 row types across simple/downloadable, variable, grouped, and external products.

Heads-up: the non-test diff exceeds the Danger size gate. Splitting further would separate the routing from its protocol, which reviews worse — the diff is one mechanical extraction plus its plan doc.

## Test Steps

1. Open any product from the Products tab.
2. Tap through a few rows (Description, Price, Inventory, Categories, Product type) — each pushes the same editor as before; the Product type selector still anchors to the tapped cell on iPad.
3. Tap "Add more details" and pick an action — the editor opens after the sheet dismisses.
4. On a read-only product (e.g. an unsupported type), rows don't navigate.
5. Unit tests: `WooCommerceTests/ProductFormRowActionHandlerTests`.

## Screenshots

N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.