### PR TITLE
[POS][New refunds API] Part 2. POS: v4 refund detection, preview & simplified-create plumbing

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -111,6 +111,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .starReceiptPrinterSupport:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .posRefundsV4:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -251,4 +251,11 @@ public enum FeatureFlag: Int, CaseIterable {
     /// Off by default until the stack is ready to enable for internal builds.
     ///
     case starReceiptPrinterSupport
+
+    /// Enables the WooCommerce v4 refunds API in Point of Sale (server-calculated preview and
+    /// simplified refund creation). When the store doesn't expose the v4 endpoints (older
+    /// WooCommerce or the `rest-api-v4` flag off), POS transparently falls back to the v3 flow.
+    /// Mirrors the Android `WOO_POS_REFUND_V4` work. Off by default until the stack is ready.
+    ///
+    case posRefundsV4
 }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -252,10 +252,5 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case starReceiptPrinterSupport
 
-    /// Enables the WooCommerce v4 refunds API in Point of Sale (server-calculated preview and
-    /// simplified refund creation). When the store doesn't expose the v4 endpoints (older
-    /// WooCommerce or the `rest-api-v4` flag off), POS transparently falls back to the v3 flow.
-    /// Mirrors the Android `WOO_POS_REFUND_V4` work. Off by default until the stack is ready.
-    ///
     case posRefundsV4
 }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
@@ -103,9 +103,6 @@ struct POSRefundSubmissionMapping {
         return (refundItems, fees)
     }
 
-    /// Maps the selected refundable rows to the simplified v4 line items: products send
-    /// `line_item_id` + quantity; fees send `line_item_id` + a tax-inclusive `refund_total`.
-    /// The server computes the monetary values from these, so no client-calculated amount is sent.
     func refundV4LineItems(from selectedItems: [POSRefundSelectableItem],
                            context: PreparedRefundContext) -> [RefundV4LineItem] {
         let components = refundComponents(from: selectedItems, context: context)

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
@@ -103,6 +103,26 @@ struct POSRefundSubmissionMapping {
         return (refundItems, fees)
     }
 
+    /// Maps the selected refundable rows to the simplified v4 line items: products send
+    /// `line_item_id` + quantity; fees send `line_item_id` + a tax-inclusive `refund_total`.
+    /// The server computes the monetary values from these, so no client-calculated amount is sent.
+    func refundV4LineItems(from selectedItems: [POSRefundSelectableItem],
+                           context: PreparedRefundContext) -> [RefundV4LineItem] {
+        let components = refundComponents(from: selectedItems, context: context)
+
+        let productLines = components.items.map {
+            RefundV4LineItem.quantityBased(lineItemID: $0.item.itemID, quantity: Decimal($0.quantity))
+        }
+
+        let feeLines = components.fees.map { fee -> RefundV4LineItem in
+            let total = currencyFormatter.convertToDecimal(fee.total) as Decimal? ?? .zero
+            let totalTax = currencyFormatter.convertToDecimal(fee.totalTax) as Decimal? ?? .zero
+            return RefundV4LineItem.amountBased(lineItemID: fee.feeID, refundTotal: total + totalTax)
+        }
+
+        return productLines + feeLines
+    }
+
     func refundValues(items: [RefundableOrderItem], fees: [OrderFeeLine]) -> (subtotal: Decimal, tax: Decimal, total: Decimal) {
         let itemValues = RefundItemsValuesCalculationUseCase(refundItems: items, currencyFormatter: currencyFormatter).calculateRefundValues()
         let feeValues = RefundFeesCalculationUseCase(fees: fees, currencyFormatter: currencyFormatter).calculateRefundValues()

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -52,39 +52,31 @@ final class POSV4RefundPreviewUseCase {
 
     func previewRefund(siteID: Int64, orderID: Int64, lineItems: [RefundV4LineItem]) async -> Result {
         guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4) else {
-            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — posRefundsV4 flag is off")
             return .fallbackToLocal
         }
 
         let cachedAvailability = availabilityCache.isV4Available(siteID: siteID)
         if cachedAvailability == false {
-            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — v4 cached unavailable for site \(siteID) (an app restart clears the session cache)")
             return .fallbackToLocal
         }
 
         if cachedAvailability == nil, isWooVersionBelowV4Support() {
-            let version = stores.sessionManager.cachedWooCommerceVersion ?? "nil"
-            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — cached WooCommerce version \(version) is below \(minimumWooVersion); probe skipped")
             return .fallbackToLocal
         }
 
         guard lineItems.isNotEmpty else {
-            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — no line items to preview")
             return .fallbackToLocal
         }
 
         switch await dispatchPreview(siteID: siteID, orderID: orderID, lineItems: lineItems) {
         case .success(let preview):
-            DDLogDebug("🔍 POSV4RefundPreview: server preview succeeded — using v4 for site \(siteID)")
             availabilityCache.markV4Available(siteID: siteID)
             return .serverCalculated(preview)
         case .failure(let error):
             if isRouteNotRegistered(error) {
-                DDLogDebug("🔍 POSV4RefundPreview: store doesn't register the v4 route (rest_no_route) — marking site \(siteID) unavailable for this session, falling back to v3")
                 availabilityCache.markV4Unavailable(siteID: siteID)
                 return .fallbackToLocal
             }
-            DDLogDebug("🔍 POSV4RefundPreview: preview failed (\(error)) — surfacing retryable error")
             return .error
         }
     }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -5,30 +5,12 @@ import enum NetworkingCore.DotcomError
 import enum NetworkingCore.NetworkError
 import class WooFoundation.VersionHelpers
 
-/// Detects whether the store exposes the WooCommerce v4 refund endpoints and, when it does, returns
-/// a server-calculated refund preview. Otherwise it falls back to the existing v3 + local-calculation
-/// flow, leaving the merchant experience unchanged.
-///
-/// Gating order (cheapest first):
-/// 1. `posRefundsV4` feature flag off → fall back (no network).
-/// 2. v4 already cached unavailable for this site → fall back (no network).
-/// 3. not yet probed and the cached WooCommerce version is older than 10.9.0 (where v4 shipped)
-///    → fall back without touching the availability cache: the version string is only a cheap,
-///    possibly-stale hint, so the probe stays the single authority on availability, and a
-///    server-confirmed site skips this check entirely.
-/// 4. no line items to preview → fall back.
-/// 5. probe `POST wc/v4/refunds/preview`: a `rest_no_route` response marks v4 unavailable and falls
-///    back; any other error is surfaced as `.error`; success caches availability and returns totals.
-///
 @MainActor
 final class POSV4RefundPreviewUseCase {
 
     enum Result: Equatable {
-        /// The server returned authoritative totals; display them as-is.
         case serverCalculated(RefundPreview)
-        /// v4 isn't available; use the existing v3 + local-calculation flow.
         case fallbackToLocal
-        /// The preview failed for a recoverable reason; the caller should offer a retry.
         case error
     }
 
@@ -37,9 +19,6 @@ final class POSV4RefundPreviewUseCase {
     private let availabilityCache: V4RefundAvailabilityCache
     private let minimumWooVersion: String
 
-    /// The `.shared` default argument touches MainActor-isolated state; that's safe because default
-    /// arguments are evaluated at the call site and every caller of this MainActor-isolated
-    /// initializer is itself MainActor-isolated.
     init(stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          availabilityCache: V4RefundAvailabilityCache = .shared,
@@ -82,20 +61,14 @@ final class POSV4RefundPreviewUseCase {
     }
 
     private func isWooVersionBelowV4Support() -> Bool {
-        // A missing cached version isn't conclusive, so don't skip the probe on it.
         guard let version = stores.sessionManager.cachedWooCommerceVersion else {
             return false
         }
-        // Include dev/beta versions so a `10.9.0-beta`/`-rc` store isn't treated as below 10.9.0
-        // (same choice as `POSTabEligibilityChecker`).
         return !VersionHelpers.isVersionSupported(version: version,
                                                   minimumRequired: minimumWooVersion,
                                                   includesDevAndBetaVersions: true)
     }
 
-    /// `true` only when the store genuinely doesn't register the v4 route (`rest_no_route`), so a
-    /// transient per-order error never disables v4 for the rest of the session. Covers both the
-    /// Jetpack-tunneled (`DotcomError`) and direct REST (`NetworkError`) code paths.
     private func isRouteNotRegistered(_ error: Error) -> Bool {
         if let dotcomError = error as? DotcomError, case .noRestRoute = dotcomError {
             return true

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Yosemite
+import Experiments
+import enum NetworkingCore.DotcomError
+import enum NetworkingCore.NetworkError
+import class WooFoundation.VersionHelpers
+
+/// Detects whether the store exposes the WooCommerce v4 refund endpoints and, when it does, returns
+/// a server-calculated refund preview. Otherwise it falls back to the existing v3 + local-calculation
+/// flow, leaving the merchant experience unchanged.
+///
+/// Gating order (cheapest first):
+/// 1. `posRefundsV4` feature flag off → fall back (no network).
+/// 2. v4 already cached unavailable for this site → fall back (no network).
+/// 3. cached WooCommerce version older than 10.9.0 (where v4 shipped) → mark unavailable, fall back.
+/// 4. no line items to preview → fall back.
+/// 5. probe `POST wc/v4/refunds/preview`: a `rest_no_route` response marks v4 unavailable and falls
+///    back; any other error is surfaced as `.error`; success caches availability and returns totals.
+///
+@MainActor
+final class POSV4RefundPreviewUseCase {
+
+    enum Result: Equatable {
+        /// The server returned authoritative totals; display them as-is.
+        case serverCalculated(RefundPreview)
+        /// v4 isn't available; use the existing v3 + local-calculation flow.
+        case fallbackToLocal
+        /// The preview failed for a recoverable reason; the caller should offer a retry.
+        case error
+    }
+
+    private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
+    private let availabilityCache: V4RefundAvailabilityCache
+    private let minimumWooVersion: String
+
+    init(stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         availabilityCache: V4RefundAvailabilityCache = .shared,
+         minimumWooVersion: String = Constants.minimumWooVersion) {
+        self.stores = stores
+        self.featureFlagService = featureFlagService
+        self.availabilityCache = availabilityCache
+        self.minimumWooVersion = minimumWooVersion
+    }
+
+    func previewRefund(siteID: Int64, orderID: Int64, lineItems: [RefundV4LineItem]) async -> Result {
+        guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4) else {
+            return .fallbackToLocal
+        }
+
+        if availabilityCache.isV4Available(siteID: siteID) == false {
+            return .fallbackToLocal
+        }
+
+        if isWooVersionBelowV4Support() {
+            availabilityCache.markV4Unavailable(siteID: siteID)
+            return .fallbackToLocal
+        }
+
+        guard lineItems.isNotEmpty else {
+            return .fallbackToLocal
+        }
+
+        switch await dispatchPreview(siteID: siteID, orderID: orderID, lineItems: lineItems) {
+        case .success(let preview):
+            availabilityCache.markV4Available(siteID: siteID)
+            return .serverCalculated(preview)
+        case .failure(let error):
+            if isRouteNotRegistered(error) {
+                availabilityCache.markV4Unavailable(siteID: siteID)
+                return .fallbackToLocal
+            }
+            return .error
+        }
+    }
+
+    private func isWooVersionBelowV4Support() -> Bool {
+        // A missing cached version isn't conclusive, so don't skip the probe on it.
+        guard let version = stores.sessionManager.cachedWooCommerceVersion else {
+            return false
+        }
+        return !VersionHelpers.isVersionSupported(version: version, minimumRequired: minimumWooVersion)
+    }
+
+    /// `true` only when the store genuinely doesn't register the v4 route (`rest_no_route`), so a
+    /// transient per-order error never disables v4 for the rest of the session. Covers both the
+    /// Jetpack-tunneled (`DotcomError`) and direct REST (`NetworkError`) code paths.
+    private func isRouteNotRegistered(_ error: Error) -> Bool {
+        if let dotcomError = error as? DotcomError, case .noRestRoute = dotcomError {
+            return true
+        }
+        if let networkError = error as? NetworkError, case .notFound = networkError, networkError.errorCode == "rest_no_route" {
+            return true
+        }
+        return false
+    }
+
+    private func dispatchPreview(siteID: Int64,
+                                 orderID: Int64,
+                                 lineItems: [RefundV4LineItem]) async -> Swift.Result<RefundPreview, Error> {
+        await withCheckedContinuation { continuation in
+            let action = RefundAction.previewRefund(siteID: siteID, orderID: orderID, lineItems: lineItems) { result in
+                continuation.resume(returning: result)
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    private enum Constants {
+        static let minimumWooVersion = "10.9.0"
+    }
+}

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -12,7 +12,10 @@ import class WooFoundation.VersionHelpers
 /// Gating order (cheapest first):
 /// 1. `posRefundsV4` feature flag off → fall back (no network).
 /// 2. v4 already cached unavailable for this site → fall back (no network).
-/// 3. cached WooCommerce version older than 10.9.0 (where v4 shipped) → mark unavailable, fall back.
+/// 3. not yet probed and the cached WooCommerce version is older than 10.9.0 (where v4 shipped)
+///    → fall back without touching the availability cache: the version string is only a cheap,
+///    possibly-stale hint, so the probe stays the single authority on availability, and a
+///    server-confirmed site skips this check entirely.
 /// 4. no line items to preview → fall back.
 /// 5. probe `POST wc/v4/refunds/preview`: a `rest_no_route` response marks v4 unavailable and falls
 ///    back; any other error is surfaced as `.error`; success caches availability and returns totals.
@@ -34,6 +37,9 @@ final class POSV4RefundPreviewUseCase {
     private let availabilityCache: V4RefundAvailabilityCache
     private let minimumWooVersion: String
 
+    /// The `.shared` default argument touches MainActor-isolated state; that's safe because default
+    /// arguments are evaluated at the call site and every caller of this MainActor-isolated
+    /// initializer is itself MainActor-isolated.
     init(stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          availabilityCache: V4RefundAvailabilityCache = .shared,
@@ -49,12 +55,12 @@ final class POSV4RefundPreviewUseCase {
             return .fallbackToLocal
         }
 
-        if availabilityCache.isV4Available(siteID: siteID) == false {
+        let cachedAvailability = availabilityCache.isV4Available(siteID: siteID)
+        if cachedAvailability == false {
             return .fallbackToLocal
         }
 
-        if isWooVersionBelowV4Support() {
-            availabilityCache.markV4Unavailable(siteID: siteID)
+        if cachedAvailability == nil, isWooVersionBelowV4Support() {
             return .fallbackToLocal
         }
 
@@ -80,7 +86,11 @@ final class POSV4RefundPreviewUseCase {
         guard let version = stores.sessionManager.cachedWooCommerceVersion else {
             return false
         }
-        return !VersionHelpers.isVersionSupported(version: version, minimumRequired: minimumWooVersion)
+        // Include dev/beta versions so a `10.9.0-beta`/`-rc` store isn't treated as below 10.9.0
+        // (same choice as `POSTabEligibilityChecker`).
+        return !VersionHelpers.isVersionSupported(version: version,
+                                                  minimumRequired: minimumWooVersion,
+                                                  includesDevAndBetaVersions: true)
     }
 
     /// `true` only when the store genuinely doesn't register the v4 route (`rest_no_route`), so a

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -52,31 +52,39 @@ final class POSV4RefundPreviewUseCase {
 
     func previewRefund(siteID: Int64, orderID: Int64, lineItems: [RefundV4LineItem]) async -> Result {
         guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4) else {
+            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — posRefundsV4 flag is off")
             return .fallbackToLocal
         }
 
         let cachedAvailability = availabilityCache.isV4Available(siteID: siteID)
         if cachedAvailability == false {
+            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — v4 cached unavailable for site \(siteID) (an app restart clears the session cache)")
             return .fallbackToLocal
         }
 
         if cachedAvailability == nil, isWooVersionBelowV4Support() {
+            let version = stores.sessionManager.cachedWooCommerceVersion ?? "nil"
+            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — cached WooCommerce version \(version) is below \(minimumWooVersion); probe skipped")
             return .fallbackToLocal
         }
 
         guard lineItems.isNotEmpty else {
+            DDLogDebug("🔍 POSV4RefundPreview: falling back to v3 — no line items to preview")
             return .fallbackToLocal
         }
 
         switch await dispatchPreview(siteID: siteID, orderID: orderID, lineItems: lineItems) {
         case .success(let preview):
+            DDLogDebug("🔍 POSV4RefundPreview: server preview succeeded — using v4 for site \(siteID)")
             availabilityCache.markV4Available(siteID: siteID)
             return .serverCalculated(preview)
         case .failure(let error):
             if isRouteNotRegistered(error) {
+                DDLogDebug("🔍 POSV4RefundPreview: store doesn't register the v4 route (rest_no_route) — marking site \(siteID) unavailable for this session, falling back to v3")
                 availabilityCache.markV4Unavailable(siteID: siteID)
                 return .fallbackToLocal
             }
+            DDLogDebug("🔍 POSV4RefundPreview: preview failed (\(error)) — surfacing retryable error")
             return .error
         }
     }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -30,20 +30,11 @@ final class POSV4RefundPreviewUseCase {
     }
 
     func previewRefund(siteID: Int64, orderID: Int64, lineItems: [RefundV4LineItem]) async -> Result {
-        guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4) else {
-            return .fallbackToLocal
-        }
-
         let cachedAvailability = availabilityCache.isV4Available(siteID: siteID)
-        if cachedAvailability == false {
-            return .fallbackToLocal
-        }
-
-        if cachedAvailability == nil, isWooVersionBelowV4Support() {
-            return .fallbackToLocal
-        }
-
-        guard lineItems.isNotEmpty else {
+        guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4),
+              lineItems.isNotEmpty,
+              cachedAvailability != false,
+              cachedAvailability == true || !isWooVersionBelowV4Support() else {
             return .fallbackToLocal
         }
 

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/V4RefundAvailabilityCache.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/V4RefundAvailabilityCache.swift
@@ -2,10 +2,13 @@ import Foundation
 
 /// Caches, per site for the app session, whether the store exposes the v4 refund endpoints.
 ///
-/// Keyed by site ID so switching stores never reuses a stale result. A `nil` entry means "not yet
-/// determined" (probe needed); `true`/`false` are the cached outcomes of a probe. The cache is only
-/// marked unavailable on a genuine "route not registered" response, so a transient per-order error
-/// never disables v4 for the rest of the session.
+/// Keyed by site ID so switching stores never reuses a stale result. Application-password
+/// (non-Jetpack) sites all share the same placeholder site ID, so nonpositive IDs are never
+/// cached — those stores probe on every preview rather than risk one store's verdict leaking
+/// into another's. A `nil` entry means "not yet determined" (probe needed); `true`/`false` are
+/// the cached outcomes of a probe. Only a genuine "route not registered" probe response marks a
+/// site unavailable, so a transient per-order error (or a stale locally-cached WooCommerce
+/// version) never disables v4 for the rest of the session.
 ///
 @MainActor
 final class V4RefundAvailabilityCache {
@@ -19,14 +22,23 @@ final class V4RefundAvailabilityCache {
 
     /// Returns `true`/`false` once determined, or `nil` if v4 availability hasn't been probed yet.
     func isV4Available(siteID: Int64) -> Bool? {
-        availabilityBySiteID[siteID]
+        guard siteID > 0 else {
+            return nil
+        }
+        return availabilityBySiteID[siteID]
     }
 
     func markV4Available(siteID: Int64) {
+        guard siteID > 0 else {
+            return
+        }
         availabilityBySiteID[siteID] = true
     }
 
     func markV4Unavailable(siteID: Int64) {
+        guard siteID > 0 else {
+            return
+        }
         availabilityBySiteID[siteID] = false
     }
 }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/V4RefundAvailabilityCache.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/V4RefundAvailabilityCache.swift
@@ -1,26 +1,14 @@
 import Foundation
 
-/// Caches, per site for the app session, whether the store exposes the v4 refund endpoints.
-///
-/// Keyed by site ID so switching stores never reuses a stale result. Application-password
-/// (non-Jetpack) sites all share the same placeholder site ID, so nonpositive IDs are never
-/// cached — those stores probe on every preview rather than risk one store's verdict leaking
-/// into another's. A `nil` entry means "not yet determined" (probe needed); `true`/`false` are
-/// the cached outcomes of a probe. Only a genuine "route not registered" probe response marks a
-/// site unavailable, so a transient per-order error (or a stale locally-cached WooCommerce
-/// version) never disables v4 for the rest of the session.
-///
 @MainActor
 final class V4RefundAvailabilityCache {
 
-    /// App-session-shared instance. Site-keyed, so it is safe to keep for the whole session.
     static let shared = V4RefundAvailabilityCache()
 
     private var availabilityBySiteID: [Int64: Bool] = [:]
 
     init() {}
 
-    /// Returns `true`/`false` once determined, or `nil` if v4 availability hasn't been probed yet.
     func isV4Available(siteID: Int64) -> Bool? {
         guard siteID > 0 else {
             return nil

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/V4RefundAvailabilityCache.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/V4RefundAvailabilityCache.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Caches, per site for the app session, whether the store exposes the v4 refund endpoints.
+///
+/// Keyed by site ID so switching stores never reuses a stale result. A `nil` entry means "not yet
+/// determined" (probe needed); `true`/`false` are the cached outcomes of a probe. The cache is only
+/// marked unavailable on a genuine "route not registered" response, so a transient per-order error
+/// never disables v4 for the rest of the session.
+///
+@MainActor
+final class V4RefundAvailabilityCache {
+
+    /// App-session-shared instance. Site-keyed, so it is safe to keep for the whole session.
+    static let shared = V4RefundAvailabilityCache()
+
+    private var availabilityBySiteID: [Int64: Bool] = [:]
+
+    init() {}
+
+    /// Returns `true`/`false` once determined, or `nil` if v4 availability hasn't been probed yet.
+    func isV4Available(siteID: Int64) -> Bool? {
+        availabilityBySiteID[siteID]
+    }
+
+    func markV4Available(siteID: Int64) {
+        availabilityBySiteID[siteID] = true
+    }
+
+    func markV4Unavailable(siteID: Int64) {
+        availabilityBySiteID[siteID] = false
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -448,7 +448,9 @@ private extension RefundSubmissionUseCase {
     /// the server computes all monetary values. `refund` carries the reason and gateway-refund
     /// choice; its client-calculated amount is not sent.
     ///
-    /// `restockItems` is always sent as `true` to preserve the v3 behaviour (v4 defaults it to `false`).
+    /// `restockItems` is always sent as `true` to preserve the v3 server default (WooCommerce core
+    /// defaults `api_restock` to `true` on v3 and `false` on v4; the Android client makes the same
+    /// choice for the same reason).
     private func submitRefundV4ToSite(refund: Refund,
                                       lineItems: [RefundV4LineItem],
                                       onCompletion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -222,9 +222,6 @@ extension RefundSubmissionUseCase {
         /// Payment Gateway Account for the site (i.e. that can be used to refund).
         let paymentGatewayAccount: PaymentGatewayAccount?
 
-        /// When set, the refund is created via the simplified v4 endpoint sending only these line
-        /// items (the server computes all monetary values). `nil` keeps the existing v3 request.
-        /// The in-person (card reader) part of the flow is unaffected either way.
         let v4LineItems: [RefundV4LineItem]?
 
         init(order: Order,
@@ -444,13 +441,6 @@ private extension RefundSubmissionUseCase {
         trackCreateRefundRequest()
     }
 
-    /// Submits the refund via the simplified v4 endpoint, sending only the line items to refund —
-    /// the server computes all monetary values. `refund` carries the reason and gateway-refund
-    /// choice; its client-calculated amount is not sent.
-    ///
-    /// `restockItems` is always sent as `true` to preserve the v3 server default (WooCommerce core
-    /// defaults `api_restock` to `true` on v3 and `false` on v4; the Android client makes the same
-    /// choice for the same reason).
     private func submitRefundV4ToSite(refund: Refund,
                                       lineItems: [RefundV4LineItem],
                                       onCompletion: @escaping (Result<Void, Error>) -> Void) {
@@ -464,7 +454,6 @@ private extension RefundSubmissionUseCase {
 
             switch result {
             case .success(let createdRefund):
-                // Workaround for https://github.com/woocommerce/woocommerce/issues/33389, same as the v3 path.
                 self.retrieveUpdatedRefundData(refund: createdRefund)
                 onCompletion(.success(()))
                 self.trackCreateRefundRequestSuccess()

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -221,6 +221,23 @@ extension RefundSubmissionUseCase {
 
         /// Payment Gateway Account for the site (i.e. that can be used to refund).
         let paymentGatewayAccount: PaymentGatewayAccount?
+
+        /// When set, the refund is created via the simplified v4 endpoint sending only these line
+        /// items (the server computes all monetary values). `nil` keeps the existing v3 request.
+        /// The in-person (card reader) part of the flow is unaffected either way.
+        let v4LineItems: [RefundV4LineItem]?
+
+        init(order: Order,
+             charge: WCPayCharge?,
+             amount: String,
+             paymentGatewayAccount: PaymentGatewayAccount?,
+             v4LineItems: [RefundV4LineItem]? = nil) {
+            self.order = order
+            self.charge = charge
+            self.amount = amount
+            self.paymentGatewayAccount = paymentGatewayAccount
+            self.v4LineItems = v4LineItems
+        }
     }
 }
 
@@ -397,6 +414,9 @@ private extension RefundSubmissionUseCase {
     ///   - refund: the refund to submit.
     ///   - onCompletion: called when the submission completes.
     func submitRefundToSite(refund: Refund, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        if let v4LineItems = details.v4LineItems {
+            return submitRefundV4ToSite(refund: refund, lineItems: v4LineItems, onCompletion: onCompletion)
+        }
 
         let action = RefundAction.createRefund(siteID: details.order.siteID, orderID: details.order.orderID, refund: refund) { [weak self]
             refundData, error  in
@@ -419,6 +439,38 @@ private extension RefundSubmissionUseCase {
             self.retrieveUpdatedRefundData(refund: refundData)
             onCompletion(.success(()))
             self.trackCreateRefundRequestSuccess()
+        }
+        stores.dispatch(action)
+        trackCreateRefundRequest()
+    }
+
+    /// Submits the refund via the simplified v4 endpoint, sending only the line items to refund —
+    /// the server computes all monetary values. `refund` carries the reason and gateway-refund
+    /// choice; its client-calculated amount is not sent.
+    ///
+    /// `restockItems` is always sent as `true` to preserve the v3 behaviour (v4 defaults it to `false`).
+    private func submitRefundV4ToSite(refund: Refund,
+                                      lineItems: [RefundV4LineItem],
+                                      onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let action = RefundAction.createRefundV4(siteID: details.order.siteID,
+                                                 orderID: details.order.orderID,
+                                                 reason: refund.reason,
+                                                 automaticRefund: refund.createAutomated ?? false,
+                                                 restockItems: true,
+                                                 lineItems: lineItems) { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case .success(let createdRefund):
+                // Workaround for https://github.com/woocommerce/woocommerce/issues/33389, same as the v3 path.
+                self.retrieveUpdatedRefundData(refund: createdRefund)
+                onCompletion(.success(()))
+                self.trackCreateRefundRequestSuccess()
+            case .failure(let error):
+                DDLogError("Error creating v4 refund: \(refund)\nWith Error: \(error)")
+                self.trackCreateRefundRequestFailed(error: error)
+                onCompletion(.failure(error))
+            }
         }
         stores.dispatch(action)
         trackCreateRefundRequest()

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
@@ -150,6 +150,35 @@ final class POSRefundSubmissionMappingTests: XCTestCase {
         XCTAssertEqual(selectableItems[2].lineItemTotal, NSDecimalNumber(string: "3.50").decimalValue)
         XCTAssertEqual(selectableItems[2].totalTax, NSDecimalNumber(string: "0.35").decimalValue)
     }
+
+    func test_refundV4LineItems_maps_products_to_quantities_and_fees_to_tax_inclusive_totals() {
+        // Given
+        let item1 = orderItem(itemID: 10, quantity: 3)
+        let item2 = orderItem(itemID: 20, quantity: 1)
+        let fee = orderFee(feeID: 200, total: "3.50", totalTax: "0.35")
+        let context = makeContext(refundableItems: [
+            RefundableOrderItem(item: item1, quantity: 3),
+            RefundableOrderItem(item: item2, quantity: 1)
+        ], refundableFees: [fee])
+        // Two of item1's three units selected, item2 not selected, and the fee selected.
+        let selectedItems = [
+            selectableItem(itemID: item1.itemID, index: 0),
+            selectableItem(itemID: item1.itemID, index: 1),
+            selectableItem(itemID: fee.feeID, isLumpSum: true, index: 2)
+        ]
+
+        // When
+        let lineItems = sut.refundV4LineItems(from: selectedItems, context: context)
+
+        // Then
+        XCTAssertEqual(lineItems.count, 2)
+        let product = lineItems.first { $0.lineItemID == item1.itemID }
+        XCTAssertEqual(product?.quantity, 2)
+        XCTAssertNil(product?.refundTotal)
+        let feeLine = lineItems.first { $0.lineItemID == fee.feeID }
+        XCTAssertNil(feeLine?.quantity)
+        XCTAssertEqual(feeLine?.refundTotal, NSDecimalNumber(string: "3.85").decimalValue) // 3.50 + 0.35
+    }
 }
 
 private extension POSRefundSubmissionMappingTests {

--- a/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
@@ -41,18 +41,53 @@ struct POSV4RefundPreviewUseCaseTests {
         #expect(stores.receivedActions.isEmpty)
     }
 
-    @Test func previewRefund_when_wc_version_below_minimum_then_marks_unavailable_and_falls_back_without_dispatch() async {
+    @Test func previewRefund_when_wc_version_below_minimum_then_falls_back_without_writing_cache() async {
         // Given
         let cache = V4RefundAvailabilityCache()
-        let (sut, stores, _) = makeSUT(cachedWooVersion: "10.8.0", cache: cache)
+        let (sut, stores, _) = makeSUT(cachedWooVersion: "10.8.0", cache: cache, previewResult: .success(preview()))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then the version hint skips the probe but never carries a probe's permanence.
+        #expect(result == .fallbackToLocal)
+        #expect(stores.receivedActions.isEmpty)
+        #expect(cache.isV4Available(siteID: siteID) == nil)
+
+        // When the cached version is corrected, the next call probes normally.
+        stores.sessionManager.cachedWooCommerceVersion = "10.9.0"
+        let secondResult = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(secondResult == .serverCalculated(preview()))
+        #expect(cache.isV4Available(siteID: siteID) == true)
+    }
+
+    @Test func previewRefund_when_site_cached_available_then_stale_version_hint_is_ignored() async {
+        // Given a server-confirmed site and a (stale) below-minimum version string
+        let cache = V4RefundAvailabilityCache()
+        cache.markV4Available(siteID: siteID)
+        let (sut, _, _) = makeSUT(cachedWooVersion: "10.8.0", cache: cache, previewResult: .success(preview()))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then the probe runs and the confirmed availability is not downgraded.
+        #expect(result == .serverCalculated(preview()))
+        #expect(cache.isV4Available(siteID: siteID) == true)
+    }
+
+    @Test func previewRefund_when_wc_version_is_prerelease_of_minimum_then_probes() async {
+        // Given a beta of the minimum version (10.9.0-beta1 must not read as below 10.9.0)
+        let cache = V4RefundAvailabilityCache()
+        let (sut, _, _) = makeSUT(cachedWooVersion: "10.9.0-beta1", cache: cache, previewResult: .success(preview()))
 
         // When
         let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
 
         // Then
-        #expect(result == .fallbackToLocal)
-        #expect(stores.receivedActions.isEmpty)
-        #expect(cache.isV4Available(siteID: siteID) == false)
+        #expect(result == .serverCalculated(preview()))
+        #expect(cache.isV4Available(siteID: siteID) == true)
     }
 
     @Test func previewRefund_when_wc_version_unknown_then_probes_instead_of_falling_back() async {
@@ -120,6 +155,20 @@ struct POSV4RefundPreviewUseCaseTests {
         // Then
         #expect(result == .fallbackToLocal)
         #expect(cache.isV4Available(siteID: siteID) == false)
+    }
+
+    @Test func previewRefund_when_404_without_rest_no_route_then_returns_error_without_marking_unavailable() async {
+        // Given a genuine missing-resource 404 (not a missing route)
+        let cache = V4RefundAvailabilityCache()
+        let response = Data(#"{"code":"woocommerce_rest_shop_order_invalid_id"}"#.utf8)
+        let (sut, _, _) = makeSUT(cache: cache, previewResult: .failure(NetworkError.notFound(response: response)))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then v4 stays enabled for the session; only `rest_no_route` may disable it.
+        #expect(result == .error)
+        #expect(cache.isV4Available(siteID: siteID) == nil)
     }
 
     @Test func previewRefund_when_other_error_then_returns_error_without_marking_unavailable() async {

--- a/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
@@ -55,7 +55,7 @@ struct POSV4RefundPreviewUseCaseTests {
         #expect(cache.isV4Available(siteID: siteID) == nil)
 
         // When the cached version is corrected, the next call probes normally.
-        stores.sessionManager.cachedWooCommerceVersion = "10.9.0"
+        (stores.sessionManager as? SessionManager)?.cachedWooCommerceVersion = "10.9.0"
         let secondResult = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
 
         // Then

--- a/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
@@ -1,0 +1,176 @@
+import Testing
+import Foundation
+import Yosemite
+import Experiments
+import enum NetworkingCore.DotcomError
+import enum NetworkingCore.NetworkError
+@testable import WooCommerce
+
+@MainActor
+@Suite(.timeLimit(.minutes(5)))
+struct POSV4RefundPreviewUseCaseTests {
+
+    private let siteID: Int64 = 123
+    private let orderID: Int64 = 456
+
+    // MARK: - Gating without a network call
+
+    @Test func previewRefund_when_flag_disabled_then_falls_back_without_dispatch() async {
+        // Given
+        let (sut, stores, _) = makeSUT(flagEnabled: false)
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .fallbackToLocal)
+        #expect(stores.receivedActions.isEmpty)
+    }
+
+    @Test func previewRefund_when_site_cached_unavailable_then_falls_back_without_dispatch() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        cache.markV4Unavailable(siteID: siteID)
+        let (sut, stores, _) = makeSUT(cache: cache)
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .fallbackToLocal)
+        #expect(stores.receivedActions.isEmpty)
+    }
+
+    @Test func previewRefund_when_wc_version_below_minimum_then_marks_unavailable_and_falls_back_without_dispatch() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        let (sut, stores, _) = makeSUT(cachedWooVersion: "10.8.0", cache: cache)
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .fallbackToLocal)
+        #expect(stores.receivedActions.isEmpty)
+        #expect(cache.isV4Available(siteID: siteID) == false)
+    }
+
+    @Test func previewRefund_when_wc_version_unknown_then_probes_instead_of_falling_back() async {
+        // Given a missing cached version isn't conclusive, so the probe decides.
+        let cache = V4RefundAvailabilityCache()
+        let (sut, _, _) = makeSUT(cachedWooVersion: nil, cache: cache, previewResult: .success(preview()))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .serverCalculated(preview()))
+        #expect(cache.isV4Available(siteID: siteID) == true)
+    }
+
+    @Test func previewRefund_when_no_line_items_then_falls_back_without_dispatch() async {
+        // Given
+        let (sut, stores, _) = makeSUT()
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [])
+
+        // Then
+        #expect(result == .fallbackToLocal)
+        #expect(stores.receivedActions.isEmpty)
+    }
+
+    // MARK: - Probe outcomes
+
+    @Test func previewRefund_when_server_returns_preview_then_returns_it_and_marks_available() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        let (sut, _, _) = makeSUT(cache: cache, previewResult: .success(preview()))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .serverCalculated(preview()))
+        #expect(cache.isV4Available(siteID: siteID) == true)
+    }
+
+    @Test func previewRefund_when_dotcom_rest_no_route_then_marks_unavailable_and_falls_back() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        let (sut, _, _) = makeSUT(cache: cache, previewResult: .failure(DotcomError.noRestRoute()))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .fallbackToLocal)
+        #expect(cache.isV4Available(siteID: siteID) == false)
+    }
+
+    @Test func previewRefund_when_network_404_rest_no_route_then_marks_unavailable_and_falls_back() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        let response = Data(#"{"code":"rest_no_route"}"#.utf8)
+        let (sut, _, _) = makeSUT(cache: cache, previewResult: .failure(NetworkError.notFound(response: response)))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .fallbackToLocal)
+        #expect(cache.isV4Available(siteID: siteID) == false)
+    }
+
+    @Test func previewRefund_when_other_error_then_returns_error_without_marking_unavailable() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        let (sut, _, _) = makeSUT(cache: cache, previewResult: .failure(NetworkError.timeout()))
+
+        // When
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then
+        #expect(result == .error)
+        #expect(cache.isV4Available(siteID: siteID) == nil)
+    }
+}
+
+private extension POSV4RefundPreviewUseCaseTests {
+
+    func makeSUT(flagEnabled: Bool = true,
+                 cachedWooVersion: String? = "10.9.0",
+                 cache: V4RefundAvailabilityCache? = nil,
+                 previewResult: Swift.Result<RefundPreview, Error>? = nil)
+    -> (POSV4RefundPreviewUseCase, MockStoresManager, MockFeatureFlagService) {
+        // Resolved in the (main-actor) test body rather than as a default argument: the cache's
+        // initializer is main-actor-isolated, and default arguments are evaluated nonisolated.
+        let cache = cache ?? V4RefundAvailabilityCache()
+        let session = SessionManager.testingInstance
+        session.cachedWooCommerceVersion = cachedWooVersion
+        let stores = MockStoresManager(sessionManager: session)
+        if let previewResult {
+            stores.whenReceivingAction(ofType: RefundAction.self) { action in
+                guard case let .previewRefund(_, _, _, completion) = action else {
+                    return
+                }
+                completion(previewResult)
+            }
+        }
+        let flags = MockFeatureFlagService()
+        flags.isFeatureFlagEnabledReturnValue = [.posRefundsV4: flagEnabled]
+        let sut = POSV4RefundPreviewUseCase(stores: stores,
+                                            featureFlagService: flags,
+                                            availabilityCache: cache,
+                                            minimumWooVersion: "10.9.0")
+        return (sut, stores, flags)
+    }
+
+    func lineItem() -> RefundV4LineItem {
+        .quantityBased(lineItemID: 10, quantity: 1)
+    }
+
+    func preview() -> RefundPreview {
+        RefundPreview(subtotal: 27, tax: 2.43, total: 29.43, maxRefundable: 59, breakdown: .fake())
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/V4RefundAvailabilityCacheTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/V4RefundAvailabilityCacheTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import WooCommerce
+
+@MainActor
+@Suite(.timeLimit(.minutes(5)))
+struct V4RefundAvailabilityCacheTests {
+
+    @Test func availability_is_tristate_and_isolated_per_site() {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        #expect(cache.isV4Available(siteID: 1) == nil)
+
+        // When
+        cache.markV4Available(siteID: 1)
+        cache.markV4Unavailable(siteID: 2)
+
+        // Then
+        #expect(cache.isV4Available(siteID: 1) == true)
+        #expect(cache.isV4Available(siteID: 2) == false)
+        #expect(cache.isV4Available(siteID: 3) == nil)
+    }
+
+    @Test func nonpositive_site_ids_are_never_cached() {
+        // Given application-password (non-Jetpack) sites all share the placeholder site ID, so a
+        // verdict for one such store must never leak into another.
+        let cache = V4RefundAvailabilityCache()
+
+        // When
+        cache.markV4Unavailable(siteID: -1)
+        cache.markV4Available(siteID: 0)
+
+        // Then
+        #expect(cache.isV4Available(siteID: -1) == nil)
+        #expect(cache.isV4Available(siteID: 0) == nil)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -71,6 +71,66 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertFalse(stores.receivedActions.contains(where: { $0 is CardPresentPaymentAction }))
     }
 
+    func test_submitRefund_with_v4_line_items_dispatches_createRefundV4_with_restock_instead_of_v3_create() throws {
+        // Given
+        let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
+                                    charge: nil,
+                                    amount: "2.28",
+                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID),
+                                    v4LineItems: [.quantityBased(lineItemID: 10, quantity: 2)])
+        let useCase = createUseCase(details: details)
+        var receivedRestockItems: Bool?
+        stores.whenReceivingAction(ofType: RefundAction.self) { action in
+            if case let .createRefundV4(_, _, _, _, restockItems, _, completion) = action {
+                receivedRestockItems = restockItems
+                completion(.success(.fake()))
+            }
+        }
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(receivedRestockItems, true)
+        let dispatchedV3Create = stores.receivedActions.contains(where: { action in
+            guard let refundAction = action as? RefundAction, case .createRefund = refundAction else {
+                return false
+            }
+            return true
+        })
+        XCTAssertFalse(dispatchedV3Create)
+    }
+
+    func test_submitRefund_with_v4_line_items_relays_create_failure() throws {
+        // Given
+        let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
+                                    charge: nil,
+                                    amount: "2.28",
+                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID),
+                                    v4LineItems: [.quantityBased(lineItemID: 10, quantity: 2)])
+        let useCase = createUseCase(details: details)
+        stores.whenReceivingAction(ofType: RefundAction.self) { action in
+            if case let .createRefundV4(_, _, _, _, _, _, completion) = action {
+                completion(.failure(NSError(domain: "test", code: 1)))
+            }
+        }
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     func test_submitRefund_with_interac_payment_method_dispatches_CardPresentPaymentActions() throws {
         // Given
         let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),


### PR DESCRIPTION
### Part of a 3-PR stack — review & merge in order

1. #17539 — Part 1 — Yosemite: v4 refund preview + simplified-create data layer
2. **Part 2 — POS: v4 refund detection, preview & simplified-create plumbing ← you are here**
3. #17541 — Part 3 — POS: wire v4 refund preview, detection & creation into the flow

Each part is stacked on the previous, so its diff only shows that part's changes. **Stacked on #17539 — review/merge that first.**

## Description

Part of WOOMOB-2694, WOOMOB-2690 and WOOMOB-2688 — these issues are closed by Part 3, once the whole stack lands. iOS port of the Android stack (woocommerce/woocommerce-android#16123).

Part 2 of 3 of the v4 refunds integration for Woo POS. This adds the POS **domain layer** — the units that Part 3 wires into the flow. On their own they are inert: nothing in the refund flow calls them yet, so the app behaves exactly as before. No user-facing change in this PR.

- **`posRefundsV4` feature flag** — dev + alpha builds only; the release configuration keeps the whole v4 path off.
- **`V4RefundAvailabilityCache`** — caches, per site for the app session, whether the store exposes the v4 refund endpoints. Tri-state: `nil` = not probed yet, `true`/`false` = probe outcome.
- **`POSV4RefundPreviewUseCase`** — detection + preview, gated cheapest-first: flag off → fall back (no network); cached unavailable → fall back; cached WooCommerce version below 10.9.0 → mark unavailable + fall back (an unknown version proceeds — the probe decides); then probes `POST wc/v4/refunds/preview`. A `rest_no_route` response (Jetpack-tunneled `DotcomError.noRestRoute` or direct-REST 404) marks the site unavailable and falls back; any other error surfaces as a retryable `.error`; success caches availability and returns the server totals. The flag is checked **only here** — submission keys off the availability cache, which only a successful probe can set, so flag-off transitively forces v3 everywhere.
- **`POSRefundSubmissionMapping.refundV4LineItems`** — maps the selected rows to the simplified v4 line items (products → `line_item_id` + quantity; fees → tax-inclusive `refund_total`), reusing the same `refundComponents` grouping as the v3 math.
- **`RefundSubmissionUseCase.Details.v4LineItems`** (optional, default `nil`) — when set, the site-create step dispatches `createRefundV4` with `restockItems: true` (v4 defaults restock to `false`, unlike v3 — sending it explicitly preserves the v3 behaviour). The in-person (card reader) part of the flow is untouched; existing callers are unchanged.

## Test Steps

No user-facing change (nothing calls these units until Part 3). Covered by unit tests: `POSV4RefundPreviewUseCaseTests` (all gating branches + probe outcomes), `POSRefundSubmissionMappingTests` (v4 line-item mapping), `RefundSubmissionUseCaseTests` (v4 create dispatch with restock, failure relay).

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
