### PR TITLE
Scale Tap to Pay setup image on small screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -69,6 +69,7 @@ struct SetUpTapToPayInformationView: View {
     @ObservedObject var viewModel: SetUpTapToPayInformationViewModel
     var showURL: ((URL) -> Void)? = nil
     @State var showingAboutTapToPay: Bool = false
+    @State private var availableHeight: CGFloat = Constants.iPhoneSEPortraitHeight + 1
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
@@ -77,7 +78,15 @@ struct SetUpTapToPayInformationView: View {
     }
 
     var imageMaxHeight: CGFloat {
-        isCompact ? Constants.maxCompactImageHeight : Constants.maxImageHeight
+        guard !isCompact else {
+            return Constants.maxCompactImageHeight
+        }
+
+        guard availableHeight <= Constants.iPhoneSEPortraitHeight else {
+            return Constants.maxImageHeight
+        }
+
+        return availableHeight / Constants.iPhoneSEPortraitHeight * Constants.iPhoneSEImageHeight
     }
 
     var body: some View {
@@ -133,6 +142,11 @@ struct SetUpTapToPayInformationView: View {
             .scrollVerticallyIfNeeded()
         }
         .padding()
+        .onGeometryChange(for: CGFloat.self) { geometry in
+            geometry.size.height
+        } action: { newAvailableHeight in
+            availableHeight = newAvailableHeight
+        }
         .onAppear(perform: viewModel.viewDidAppear)
         .sheet(isPresented: $showingAboutTapToPay) {
             TapToPayEducationView(viewModel: .init(flow: .about, completion: { result in
@@ -148,11 +162,10 @@ struct SetUpTapToPayInformationView: View {
 }
 
 private enum Constants {
-    // maxHeight should be 208, but that hides the button on iPhone SE
-    // TODO: make this 208, or proportional to screen height for small screens
-    // https://github.com/woocommerce/woocommerce-ios/issues/9134
-    static let maxImageHeight: CGFloat = 180
+    static let maxImageHeight: CGFloat = 208
     static let maxCompactImageHeight: CGFloat = 80
+    static let iPhoneSEPortraitHeight: CGFloat = 667
+    static let iPhoneSEImageHeight: CGFloat = 180
     static let hintSpacing: CGFloat = 16
     static let learnMorePadding: CGFloat = 8
 }


### PR DESCRIPTION
Closes: WOOMOB-3564

## Description
Updates the Tap to Pay setup screen so the reader image uses the 208pt design height on normal phones, while keeping the existing smaller size for iPhone SE.

We use `onGeometryChange` to check the size now, no need for a geometry reader.

## Test Steps
1. Open `Menu > Payments > Set Up Tap to Pay on iPhone`
2. Observe that the reader image appears larger and the CTA is still visible.
3. Open the same screen on an iPhone SE-sized simulator and verify the CTA remains visible with a smaller image.
4. Increase Dynamic Type and verify the content can still scroll when needed.

## Screenshots
Note the weird shadows at the bottom of the first two screenshots don't show on the device, just the screenshot.

### Before (large iPhone)
<img width="660" height="1434" alt="before" src="https://github.com/user-attachments/assets/96e10da4-be84-4b13-97c6-21aeec2b1624" />


### After (large iPhone)
<img width="660" height="1434" alt="after" src="https://github.com/user-attachments/assets/02a8fe5b-64d6-4b19-89f4-2cb1f606bce6" />


### iPhone SE
<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-07-14 at 17 01 27" src="https://github.com/user-attachments/assets/58a9e2b7-6b80-430a-84b1-e5d4025084b8" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.