### PR TITLE
Fix RTL currency amount ordering

### DIFF
--- a/Modules/Sources/WooFoundationCore/BidirectionalText.swift
+++ b/Modules/Sources/WooFoundationCore/BidirectionalText.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Utilities for formatting bidirectional text in money-related UI.
+public enum BidirectionalText {
+    public static let leftToRightMark = "\u{200E}"
+    public static let rightToLeftMark = "\u{200F}"
+    public static let leftToRightIsolate = "\u{2066}"
+    public static let rightToLeftIsolate = "\u{2067}"
+    public static let popDirectionalIsolate = "\u{2069}"
+
+    public static let defaultNumericSeparators: Set<Character> = [
+        ".",
+        ",",
+        "-",
+        "\u{2212}",
+        "\u{066B}",
+        "\u{066C}"
+    ]
+
+    public static func containsStrongRightToLeftCharacter(in text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x0590...0x08FF, 0xFB1D...0xFDFF, 0xFE70...0xFEFF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    public static func isolateLeftToRight(_ text: String) -> String {
+        leftToRightIsolate + text + popDirectionalIsolate
+    }
+
+    public static func numericSeparators(including separators: [String]) -> Set<Character> {
+        separators.reduce(into: defaultNumericSeparators) { partialResult, separator in
+            partialResult.formUnion(separator)
+        }
+    }
+
+    public static func isolateLeftToRightNumericRuns(in text: String,
+                                                     separators: Set<Character> = defaultNumericSeparators) -> String {
+        guard containsDirectionalControl(in: text) == false else {
+            return text
+        }
+
+        var result = ""
+        var currentRun = ""
+        let characters = Array(text)
+
+        for (index, character) in characters.enumerated() {
+            if character.isNumber || shouldTreatAsNumericSeparator(character, at: index, in: characters, separators: separators) {
+                currentRun.append(character)
+            } else {
+                result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
+                currentRun = ""
+                result.append(character)
+            }
+        }
+
+        result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
+        return result
+    }
+}
+
+private extension BidirectionalText {
+    static func containsDirectionalControl(in text: String) -> Bool {
+        text.contains { directionalControls.contains($0) }
+    }
+
+    static var directionalControls: Set<Character> {
+        [
+            Character(leftToRightMark),
+            Character(rightToLeftMark),
+            Character(leftToRightIsolate),
+            Character(rightToLeftIsolate),
+            Character(popDirectionalIsolate)
+        ]
+    }
+
+    static func shouldTreatAsNumericSeparator(_ character: Character,
+                                              at index: Int,
+                                              in characters: [Character],
+                                              separators: Set<Character>) -> Bool {
+        guard separators.contains(character) else {
+            return false
+        }
+
+        let previousCharacterIsNumber = index > 0 && characters[index - 1].isNumber
+        let nextCharacterIsNumber = index < characters.count - 1 && characters[index + 1].isNumber
+
+        return previousCharacterIsNumber || nextCharacterIsNumber
+    }
+}
+
+private extension String {
+    mutating func appendLeftToRightIsolatedRunIfNeeded(_ run: String) {
+        guard run.isNotEmpty else {
+            return
+        }
+
+        append(BidirectionalText.isolateLeftToRight(run))
+    }
+}

--- a/Modules/Sources/WooFoundationCore/CurrencyFormatter.swift
+++ b/Modules/Sources/WooFoundationCore/CurrencyFormatter.swift
@@ -123,7 +123,7 @@ public class CurrencyFormatter {
         // We want to position the minus sign manually.
         let amount = amount.replacingOccurrences(of: "-", with: "")
 
-        if isNegative && symbol.containsStrongRightToLeftCharacter {
+        if isNegative && BidirectionalText.containsStrongRightToLeftCharacter(in: symbol) {
             return formatNegativeCurrencyWithStrongRightToLeftSymbol(using: amount,
                                                                      currencyPosition: position,
                                                                      currencySymbol: symbol,
@@ -149,17 +149,17 @@ public class CurrencyFormatter {
                                                                    currencySymbol symbol: String,
                                                                    space: String) -> String {
         // Preserve the symbol's RTL base direction while keeping the signed Western-number amount together.
-        let signedAmount = "\(DirectionalControl.leftToRightIsolate)-\(amount)\(DirectionalControl.popDirectionalIsolate)"
+        let signedAmount = BidirectionalText.isolateLeftToRight("-\(amount)")
 
         switch position {
         case .left:
-            return DirectionalControl.rightToLeftMark + symbol + signedAmount
+            return BidirectionalText.rightToLeftMark + symbol + signedAmount
         case .right:
-            return DirectionalControl.rightToLeftMark + signedAmount + symbol
+            return BidirectionalText.rightToLeftMark + signedAmount + symbol
         case .leftSpace:
-            return DirectionalControl.rightToLeftMark + symbol + space + signedAmount
+            return BidirectionalText.rightToLeftMark + symbol + space + signedAmount
         case .rightSpace:
-            return DirectionalControl.rightToLeftMark + signedAmount + space + symbol
+            return BidirectionalText.rightToLeftMark + signedAmount + space + symbol
         }
     }
 
@@ -168,7 +168,7 @@ public class CurrencyFormatter {
             return "-"
         }
 
-        return DirectionalControl.leftToRightMark + "-"
+        return BidirectionalText.leftToRightMark + "-"
     }
 
     /// Applies currency option settings to the amount (as String) for the given currency.
@@ -353,26 +353,6 @@ public class CurrencyFormatter {
                      locale: locale,
                      numberOfDecimals: numberOfDecimals,
                      isNegative: isNegative)
-    }
-}
-
-private enum DirectionalControl {
-    static let leftToRightMark = "\u{200E}"
-    static let rightToLeftMark = "\u{200F}"
-    static let leftToRightIsolate = "\u{2066}"
-    static let popDirectionalIsolate = "\u{2069}"
-}
-
-private extension String {
-    var containsStrongRightToLeftCharacter: Bool {
-        unicodeScalars.contains { scalar in
-            switch scalar.value {
-            case 0x0590...0x08FF, 0xFB1D...0xFDFF, 0xFE70...0xFEFF:
-                return true
-            default:
-                return false
-            }
-        }
     }
 }
 

--- a/Modules/Sources/WooFoundationCore/CurrencyFormatter.swift
+++ b/Modules/Sources/WooFoundationCore/CurrencyFormatter.swift
@@ -110,7 +110,7 @@ public class CurrencyFormatter {
     ///     - currencyPosition: the currency position enum, either right, left, right_space, or left_space.
     ///     - currencySymbol: the currency symbol as a string, to be used with the amount.
     ///     - isNegative: whether the value is negative or not.
-    ///     - locale: the locale that is used to format the currency amount string.
+    ///     - locale: Locale used to protect signed numeric values in right-to-left language contexts. Currency order is derived from store settings.
     ///
     public func formatCurrency(using amount: String,
                                currencyPosition position: CurrencySettings.CurrencyPosition,
@@ -118,46 +118,57 @@ public class CurrencyFormatter {
                                isNegative: Bool,
                                locale: Locale = .current) -> String {
         let space = "\u{00a0}" // unicode equivalent of &nbsp;
-        let negative = isNegative ? "-" : ""
 
         // Remove all occurrences of the minus sign from the string amount.
         // We want to position the minus sign manually.
         let amount = amount.replacingOccurrences(of: "-", with: "")
 
-        // We're relying on the phone's Locale to assist with language direction
-        let languageCode = locale.language.languageCode?.identifier
-
-        // Detect the language direction
-        var languageDirection: Locale.LanguageDirection = .unknown
-        if let language = languageCode {
-            languageDirection = Locale.Language(identifier: language).characterDirection
+        if isNegative && symbol.containsStrongRightToLeftCharacter {
+            return formatNegativeCurrencyWithStrongRightToLeftSymbol(using: amount,
+                                                                     currencyPosition: position,
+                                                                     currencySymbol: symbol,
+                                                                     space: space)
         }
 
-        // For left-to-right languages, such as English
-        guard languageDirection == .rightToLeft else {
-            switch position {
-            case .left:
-                return negative + symbol + amount
-            case .right:
-                return negative + amount + symbol
-            case .leftSpace:
-                return negative + symbol + space + amount
-            case .rightSpace:
-                return negative + amount + space + symbol
-            }
-        }
+        let negative = isNegative ? negativePrefix(for: locale) : ""
 
-        // For right-to-left languages, such as Arabic
         switch position {
         case .left:
-            return amount + negative + symbol
+            return negative + symbol + amount
         case .right:
-            return symbol + negative + amount
+            return negative + amount + symbol
         case .leftSpace:
-            return amount + negative + space + symbol
+            return negative + symbol + space + amount
         case .rightSpace:
-            return symbol + space + negative + amount
+            return negative + amount + space + symbol
         }
+    }
+
+    private func formatNegativeCurrencyWithStrongRightToLeftSymbol(using amount: String,
+                                                                   currencyPosition position: CurrencySettings.CurrencyPosition,
+                                                                   currencySymbol symbol: String,
+                                                                   space: String) -> String {
+        // Preserve the symbol's RTL base direction while keeping the signed Western-number amount together.
+        let signedAmount = "\(DirectionalControl.leftToRightIsolate)-\(amount)\(DirectionalControl.popDirectionalIsolate)"
+
+        switch position {
+        case .left:
+            return DirectionalControl.rightToLeftMark + symbol + signedAmount
+        case .right:
+            return DirectionalControl.rightToLeftMark + signedAmount + symbol
+        case .leftSpace:
+            return DirectionalControl.rightToLeftMark + symbol + space + signedAmount
+        case .rightSpace:
+            return DirectionalControl.rightToLeftMark + signedAmount + space + symbol
+        }
+    }
+
+    private func negativePrefix(for locale: Locale) -> String {
+        guard locale.usesRightToLeftLanguage else {
+            return "-"
+        }
+
+        return DirectionalControl.leftToRightMark + "-"
     }
 
     /// Applies currency option settings to the amount (as String) for the given currency.
@@ -342,5 +353,35 @@ public class CurrencyFormatter {
                      locale: locale,
                      numberOfDecimals: numberOfDecimals,
                      isNegative: isNegative)
+    }
+}
+
+private enum DirectionalControl {
+    static let leftToRightMark = "\u{200E}"
+    static let rightToLeftMark = "\u{200F}"
+    static let leftToRightIsolate = "\u{2066}"
+    static let popDirectionalIsolate = "\u{2069}"
+}
+
+private extension String {
+    var containsStrongRightToLeftCharacter: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x0590...0x08FF, 0xFB1D...0xFDFF, 0xFE70...0xFEFF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+private extension Locale {
+    var usesRightToLeftLanguage: Bool {
+        guard let languageCode = language.languageCode?.identifier else {
+            return false
+        }
+
+        return Locale.Language(identifier: languageCode).characterDirection == .rightToLeft
     }
 }

--- a/Modules/Tests/WooFoundationTests/BidirectionalTextTests.swift
+++ b/Modules/Tests/WooFoundationTests/BidirectionalTextTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import WooFoundation
+
+struct BidirectionalTextTests {
+    @Test func isolateLeftToRightNumericRuns_when_input_contains_arabic_decimal_separator_then_wraps_single_numeric_run() {
+        // Given
+        let separators = BidirectionalText.numericSeparators(including: ["\u{066B}"])
+
+        // When
+        let result = BidirectionalText.isolateLeftToRightNumericRuns(in: "12\u{066B}5%", separators: separators)
+
+        // Then
+        #expect(result == "\(BidirectionalText.leftToRightIsolate)12\u{066B}5\(BidirectionalText.popDirectionalIsolate)%")
+    }
+
+    @Test func isolateLeftToRightNumericRuns_when_input_ends_with_decimal_separator_then_keeps_separator_in_numeric_run() {
+        // When
+        let result = BidirectionalText.isolateLeftToRightNumericRuns(in: "$20.")
+
+        // Then
+        #expect(result == "$\(BidirectionalText.leftToRightIsolate)20.\(BidirectionalText.popDirectionalIsolate)")
+    }
+
+    @Test func isolateLeftToRightNumericRuns_when_input_already_contains_directional_controls_then_returns_input_unchanged() {
+        // Given
+        let formattedAmount = BidirectionalText.rightToLeftMark +
+            BidirectionalText.isolateLeftToRight("-20.00") +
+            "\u{0631}.\u{0642}"
+
+        // When
+        let result = BidirectionalText.isolateLeftToRightNumericRuns(in: formattedAmount)
+
+        // Then
+        #expect(result == formattedAmount)
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.3
 -----
 
+- [*] Fixed RTL currency values showing the currency symbol and minus sign in the wrong order. [https://github.com/woocommerce/woocommerce-ios/pull/17547]
 
 25.2
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -31,11 +31,11 @@ final class OrderPaymentDetailsViewModel {
             return nil
         }
 
-        guard let formattedDiscount = currencyFormatter.formatAmount(order.discountTotal, with: order.currency) else {
+        guard let formattedDiscount = currencyFormatter.formatAmount(order.discountTotal, with: order.currency, isNegative: true) else {
             return nil
         }
 
-        return "-" + formattedDiscount
+        return formattedDiscount
     }
 
     var shouldHideDiscount: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -117,8 +117,6 @@ private struct CollapsibleProductRowCard: View {
     /// Tracks whether the `orderFormBundleProductConfigureCTAShown` event has been tracked to prevent multiple events across view updates.
     @State private var hasTrackedBundleProductConfigureCTAShownEvent: Bool = false
 
-    private let minusSign: String = NumberFormatter().minusSign
-
     private func dismissTooltip() {
         if shouldShowInfoTooltip {
             shouldShowInfoTooltip = false
@@ -360,7 +358,7 @@ private extension CollapsibleProductRowCard {
                     .disabled(isLoading)
                     Spacer()
                     if let discountLabel = viewModel.discountLabel {
-                        Text(minusSign + discountLabel)
+                        Text(discountLabel)
                             .foregroundColor(.green)
                             .shimmering(active: isLoading)
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
@@ -293,7 +293,7 @@ extension CollapsibleProductRowCardViewModel {
         guard let discount else {
             return nil
         }
-        return currencyFormatter.formatAmount(discount)
+        return currencyFormatter.formatAmount(discount, isNegative: true)
     }
 
     var hasDiscount: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
@@ -71,9 +71,10 @@ private extension AddCustomAmountPercentageView {
                 .focused()
                 .focused($focusPercentageInput)
                 .keyboardType(.decimalPad)
+                .environment(\.layoutDirection, .leftToRight)
                 .opacity(0)
 
-                Text(text + "%")
+                Text((text + "%").leftToRightIsolatedNumericRuns)
                     .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(text.isEmpty ? Color(.textSubtle) : Color(.text))
@@ -88,5 +89,45 @@ private extension AddCustomAmountPercentageView {
             }
             .fixedSize(horizontal: false, vertical: true)
         }
+    }
+}
+
+private extension String {
+    var leftToRightIsolatedNumericRuns: String {
+        var result = ""
+        var currentRun = ""
+        let characters = Array(self)
+
+        for (index, character) in characters.enumerated() {
+            if character.isNumber || shouldTreatAsNumericSeparator(character, at: index, in: characters) {
+                currentRun.append(character)
+            } else {
+                result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
+                currentRun = ""
+                result.append(character)
+            }
+        }
+
+        result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
+        return result
+    }
+
+    private func shouldTreatAsNumericSeparator(_ character: Character, at index: Int, in characters: [Character]) -> Bool {
+        guard character == "." || character == "," || character == "-" else {
+            return false
+        }
+
+        let previousCharacterIsNumber = index > 0 && characters[index - 1].isNumber
+        let nextCharacterIsNumber = index < characters.count - 1 && characters[index + 1].isNumber
+
+        return previousCharacterIsNumber || nextCharacterIsNumber
+    }
+
+    mutating func appendLeftToRightIsolatedRunIfNeeded(_ run: String) {
+        guard run.isNotEmpty else {
+            return
+        }
+
+        append("\u{2066}\(run)\u{2069}")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WooFoundation
 
 struct AddCustomAmountPercentageView: View {
     @ObservedObject private(set) var viewModel: AddCustomAmountPercentageViewModel
@@ -74,7 +75,8 @@ private extension AddCustomAmountPercentageView {
                 .environment(\.layoutDirection, .leftToRight)
                 .opacity(0)
 
-                Text((text + "%").leftToRightIsolatedNumericRuns)
+                Text(BidirectionalText.isolateLeftToRightNumericRuns(in: text + "%",
+                                                                     separators: numericTextSeparators))
                     .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(text.isEmpty ? Color(.textSubtle) : Color(.text))
@@ -89,45 +91,11 @@ private extension AddCustomAmountPercentageView {
             }
             .fixedSize(horizontal: false, vertical: true)
         }
-    }
-}
 
-private extension String {
-    var leftToRightIsolatedNumericRuns: String {
-        var result = ""
-        var currentRun = ""
-        let characters = Array(self)
-
-        for (index, character) in characters.enumerated() {
-            if character.isNumber || shouldTreatAsNumericSeparator(character, at: index, in: characters) {
-                currentRun.append(character)
-            } else {
-                result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
-                currentRun = ""
-                result.append(character)
-            }
+        private var numericTextSeparators: Set<Character> {
+            BidirectionalText.numericSeparators(including: [
+                Locale.autoupdatingCurrent.decimalSeparator ?? ""
+            ])
         }
-
-        result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
-        return result
-    }
-
-    private func shouldTreatAsNumericSeparator(_ character: Character, at index: Int, in characters: [Character]) -> Bool {
-        guard character == "." || character == "," || character == "-" else {
-            return false
-        }
-
-        let previousCharacterIsNumber = index > 0 && characters[index - 1].isNumber
-        let nextCharacterIsNumber = index < characters.count - 1 && characters[index + 1].isNumber
-
-        return previousCharacterIsNumber || nextCharacterIsNumber
-    }
-
-    mutating func appendLeftToRightIsolatedRunIfNeeded(_ run: String) {
-        guard run.isNotEmpty else {
-            return
-        }
-
-        append("\u{2066}\(run)\u{2069}")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -28,6 +28,10 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
         priceFieldFormatter.formattedAmount
     }
 
+    var numericTextSeparators: Set<Character> {
+        priceFieldFormatter.numericTextSeparators
+    }
+
     /// Defines the amount text color.
     ///
     var amountTextColor: UIColor {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/PriceFieldFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/PriceFieldFormatter.swift
@@ -12,6 +12,14 @@ class PriceFieldFormatter {
         return amountWithSymbol
     }
 
+    var numericTextSeparators: Set<Character> {
+        BidirectionalText.numericSeparators(including: [
+            storeCurrencySettings.sanitizedDecimalSeparator,
+            userLocale.decimalSeparator ?? "",
+            minusSign
+        ])
+    }
+
     /// Current amount converted to Decimal.
     ///
     var amountDecimal: Decimal {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1280,7 +1280,7 @@ extension EditableOrderViewModel {
             self.taxLineViewModels = taxLineViewModels
             self.taxEducationalDialogViewModel = taxEducationalDialogViewModel
             self.couponCode = couponCode
-            self.discountTotal = "-" + (currencyFormatter.formatAmount(discountTotal) ?? "0.00")
+            self.discountTotal = currencyFormatter.formatAmount(discountTotal, isNegative: true) ?? "-0.00"
             self.shouldShowDiscountTotal = shouldShowDiscountTotal
             self.addNewCouponLineClosure = addNewCouponLineClosure
             self.onGoToCouponsClosure = onGoToCouponsClosure
@@ -2316,7 +2316,7 @@ private extension EditableOrderViewModel {
     func couponLineViewModels(from couponLines: [OrderCouponLine]) -> [CouponLineViewModel] {
         couponLines.map {
             CouponLineViewModel(code: $0.code,
-                                discount: "-" + (currencyFormatter.formatAmount($0.discount) ?? "0.00"),
+                                discount: currencyFormatter.formatAmount($0.discount, isNegative: true) ?? "-0.00",
                                 detailsViewModel: CouponLineDetailsViewModel(code: $0.code,
                                                                              siteID: siteID,
                                                                              didSelectSave: saveCouponLine))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeOrDiscountLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeOrDiscountLineDetailsViewModel.swift
@@ -140,6 +140,12 @@ final class FeeOrDiscountLineDetailsViewModel: ObservableObject {
         currencyFormatter.formatAmount(finalAmountDecimal)
     }
 
+    /// Formatted signed string value of currently entered discount.
+    ///
+    var signedFinalAmountString: String? {
+        currencyFormatter.formatAmount(finalAmountDecimal, isNegative: true)
+    }
+
     /// Returns the formatted string value of a price, substracting the current stored discount entered by the merchant
     ///
     var formattedPriceAfterDiscount: String {
@@ -195,8 +201,6 @@ final class FeeOrDiscountLineDetailsViewModel: ObservableObject {
     /// Currency formatter setup with store settings.
     ///
     private let currencyFormatter: CurrencyFormatter
-
-    private let minusSign: String = NumberFormatter().minusSign
 
     /// Analytics engine.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/DiscountLineDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/DiscountLineDetailsView.swift
@@ -69,6 +69,7 @@ private extension DiscountLineDetailsView {
                 }
                 .focused()
                 .keyboardType(.numbersAndPunctuation)
+                .environment(\.layoutDirection, .leftToRight)
                 .frame(maxWidth: .infinity, minHeight: Layout.rowHeight)
                 .padding([.leading, .trailing], Layout.padding)
                 .overlay {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
@@ -6,8 +6,6 @@ struct ProductDiscountView: View {
     private let viewModel: ProductDiscountViewModel
     @ObservedObject private var discountDetailsViewModel: FeeOrDiscountLineDetailsViewModel
 
-    private let minusSign: String = NumberFormatter().minusSign
-
     @Environment(\.presentationMode) var presentation
 
     init(viewModel: ProductDiscountViewModel) {
@@ -49,8 +47,8 @@ struct ProductDiscountView: View {
                         Text(Localization.discountLabel)
                             .foregroundColor(.secondary)
                         Spacer()
-                        if let discountAmount = discountDetailsViewModel.finalAmountString {
-                            Text(minusSign + discountAmount)
+                        if let discountAmount = discountDetailsViewModel.signedFinalAmountString {
+                            Text(discountAmount)
                                 .foregroundColor(Color(uiColor: .withColorStudio(.green, shade: .shade50)))
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/UnitInputViewModel+BulkUpdatePrice.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/UnitInputViewModel+BulkUpdatePrice.swift
@@ -24,26 +24,10 @@ extension UnitInputViewModel {
                                     "The price for bulk updating all variations. Editable.",
                                     comment: "VoiceOver accessibility hint, informing the user that this field allows to enter the price to use for"
                                     + " bulk updating all variations"),
-                                  unitPosition: currencySettings.currencyUnitPosition,
+                                  unitPosition: currencySettings.priceInputUnitPosition,
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .secondary,
                                   onInputChange: onInputChange)
-    }
-}
-
-private extension CurrencySettings {
-    /// The placement of the currency symbol accordig to the currency settings
-    var currencyUnitPosition: UnitInputViewModel.UnitPosition {
-        switch currencyPosition {
-        case .left:
-            return .beforeInputWithoutSpace
-        case .leftSpace:
-            return .beforeInput
-        case .right:
-            return .afterInputWithoutSpace
-        case .rightSpace:
-            return .afterInput
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -137,7 +137,7 @@ extension CurrencySettings {
     /// Price inputs render the amount and currency symbol in separate views, so Unicode bidirectional reordering
     /// cannot move a strong RTL currency symbol to the same visual side as formatted display strings.
     var priceInputUnitPosition: UnitInputViewModel.UnitPosition {
-        switch (currencyPosition, currencySymbol.containsStrongRightToLeftCharacter) {
+        switch (currencyPosition, BidirectionalText.containsStrongRightToLeftCharacter(in: currencySymbol)) {
         case (.left, false), (.right, true):
             return .beforeInputWithoutSpace
         case (.leftSpace, false), (.rightSpace, true):
@@ -146,19 +146,6 @@ extension CurrencySettings {
             return .afterInputWithoutSpace
         case (.rightSpace, false), (.leftSpace, true):
             return .afterInput
-        }
-    }
-}
-
-private extension String {
-    var containsStrongRightToLeftCharacter: Bool {
-        unicodeScalars.contains { scalar in
-            switch scalar.value {
-            case 0x0590...0x08FF, 0xFB1D...0xFDFF, 0xFE70...0xFEFF:
-                return true
-            default:
-                return false
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -8,15 +8,15 @@ extension Product {
     static func createRegularPriceViewModel(regularPrice: String?,
                                             using currencySettings: CurrencySettings,
                                             onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
-        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        let currencyCode = ServiceLocator.currencySettings.currencyCode
-        let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let thousandsSeparator = ServiceLocator.currencySettings.groupingSeparator
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let currencyCode = currencySettings.currencyCode
+        let unit = currencySettings.symbol(from: currencyCode)
+        let thousandsSeparator = currencySettings.groupingSeparator
         let value: String = {
             guard let regularPrice, regularPrice.isNotEmpty else {
                 return ""
             }
-            return (currencyFormatter.formatAmount(regularPrice, with: unit) ?? "")
+            return (currencyFormatter.formatAmount(regularPrice, with: currencyCode.rawValue) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: thousandsSeparator, with: "")
                 .filter { !$0.isWhitespace }
@@ -26,7 +26,7 @@ extension Product {
                                   value: value,
                                   placeholder: placeholder,
                                   accessibilityHint: Localization.regularPriceAccessibilityHint,
-                                  unitPosition: currencySettings.currencyUnitPosition,
+                                  unitPosition: currencySettings.priceInputUnitPosition,
                                   keyboardType: .numbersAndPunctuation,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .primary,
@@ -36,15 +36,15 @@ extension Product {
     static func createSalePriceViewModel(salePrice: String?,
                                          using currencySettings: CurrencySettings,
                                          onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
-        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        let currencyCode = ServiceLocator.currencySettings.currencyCode
-        let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let thousandsSeparator = ServiceLocator.currencySettings.groupingSeparator
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let currencyCode = currencySettings.currencyCode
+        let unit = currencySettings.symbol(from: currencyCode)
+        let thousandsSeparator = currencySettings.groupingSeparator
         let value: String = {
             guard let salePrice, salePrice.isNotEmpty else {
                 return ""
             }
-            return (currencyFormatter.formatAmount(salePrice, with: unit) ?? "")
+            return (currencyFormatter.formatAmount(salePrice, with: currencyCode.rawValue) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: thousandsSeparator, with: "")
                 .filter { !$0.isWhitespace }
@@ -55,7 +55,7 @@ extension Product {
                                   value: value,
                                   placeholder: placeholder,
                                   accessibilityHint: Localization.salePriceAccessibility,
-                                  unitPosition: currencySettings.currencyUnitPosition,
+                                  unitPosition: currencySettings.priceInputUnitPosition,
                                   keyboardType: .numbersAndPunctuation,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .primary,
@@ -65,15 +65,15 @@ extension Product {
     static func createSubscriptionSignupFeeViewModel(fee: String?,
                                                      using currencySettings: CurrencySettings,
                                                      onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
-        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        let currencyCode = ServiceLocator.currencySettings.currencyCode
-        let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        let thousandsSeparator = ServiceLocator.currencySettings.groupingSeparator
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let currencyCode = currencySettings.currencyCode
+        let unit = currencySettings.symbol(from: currencyCode)
+        let thousandsSeparator = currencySettings.groupingSeparator
         let value: String = {
             guard let fee, fee.isNotEmpty else {
                 return ""
             }
-            return (currencyFormatter.formatAmount(fee, with: unit) ?? "")
+            return (currencyFormatter.formatAmount(fee, with: currencyCode.rawValue) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: thousandsSeparator, with: "")
                 .filter { !$0.isWhitespace }
@@ -84,7 +84,7 @@ extension Product {
                                   value: value,
                                   placeholder: placeholder,
                                   accessibilityHint: Localization.signupFeeAccessibilityHint,
-                                  unitPosition: currencySettings.currencyUnitPosition,
+                                  unitPosition: currencySettings.priceInputUnitPosition,
                                   keyboardType: .numbersAndPunctuation,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .primary,
@@ -131,17 +131,34 @@ extension Product {
     }
 }
 
-private extension CurrencySettings {
-    var currencyUnitPosition: UnitInputViewModel.UnitPosition {
-        switch currencyPosition {
-        case .left:
+extension CurrencySettings {
+    /// The placement of the currency symbol in price input fields.
+    ///
+    /// Price inputs render the amount and currency symbol in separate views, so Unicode bidirectional reordering
+    /// cannot move a strong RTL currency symbol to the same visual side as formatted display strings.
+    var priceInputUnitPosition: UnitInputViewModel.UnitPosition {
+        switch (currencyPosition, currencySymbol.containsStrongRightToLeftCharacter) {
+        case (.left, false), (.right, true):
             return .beforeInputWithoutSpace
-        case .leftSpace:
+        case (.leftSpace, false), (.rightSpace, true):
             return .beforeInput
-        case .right:
+        case (.right, false), (.left, true):
             return .afterInputWithoutSpace
-        case .rightSpace:
+        case (.rightSpace, false), (.leftSpace, true):
             return .afterInput
+        }
+    }
+}
+
+private extension String {
+    var containsStrongRightToLeftCharacter: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x0590...0x08FF, 0xFB1D...0xFDFF, 0xFE70...0xFEFF:
+                return true
+            default:
+                return false
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WooFoundation
 
 /// This numeric Text Field updates the user input to show the formatted amount
 ///
@@ -27,7 +28,8 @@ struct FormattableAmountTextField: View {
                 .environment(\.layoutDirection, .leftToRight)
                 .opacity(0)
 
-            Text(viewModel.formattedAmount.leftToRightIsolatedNumericRuns)
+            Text(BidirectionalText.isolateLeftToRightNumericRuns(in: viewModel.formattedAmount,
+                                                                 separators: viewModel.numericTextSeparators))
                 .font(style.font ?? .system(size: Layout.amountFontSize(size: viewModel.amountTextSize.fontSize, scale: scale), weight: .bold))
                 .foregroundColor(Color(viewModel.amountTextColor))
                 .minimumScaleFactor(0.1)
@@ -57,46 +59,6 @@ extension FormattableAmountTextField {
             textAlignment: .leading,
             font: nil
         )
-    }
-}
-
-private extension String {
-    var leftToRightIsolatedNumericRuns: String {
-        var result = ""
-        var currentRun = ""
-        let characters = Array(self)
-
-        for (index, character) in characters.enumerated() {
-            if character.isNumber || shouldTreatAsNumericSeparator(character, at: index, in: characters) {
-                currentRun.append(character)
-            } else {
-                result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
-                currentRun = ""
-                result.append(character)
-            }
-        }
-
-        result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
-        return result
-    }
-
-    private func shouldTreatAsNumericSeparator(_ character: Character, at index: Int, in characters: [Character]) -> Bool {
-        guard character == "." || character == "," || character == "-" else {
-            return false
-        }
-
-        let previousCharacterIsNumber = index > 0 && characters[index - 1].isNumber
-        let nextCharacterIsNumber = index < characters.count - 1 && characters[index + 1].isNumber
-
-        return previousCharacterIsNumber || nextCharacterIsNumber
-    }
-
-    mutating func appendLeftToRightIsolatedRunIfNeeded(_ run: String) {
-        guard run.isNotEmpty else {
-            return
-        }
-
-        append("\u{2066}\(run)\u{2069}")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
@@ -24,9 +24,10 @@ struct FormattableAmountTextField: View {
                 .focused()
                 .focused($focusAmountInput)
                 .keyboardType(viewModel.allowNegativeNumber ? .numbersAndPunctuation : .decimalPad)
+                .environment(\.layoutDirection, .leftToRight)
                 .opacity(0)
 
-            Text(viewModel.formattedAmount)
+            Text(viewModel.formattedAmount.leftToRightIsolatedNumericRuns)
                 .font(style.font ?? .system(size: Layout.amountFontSize(size: viewModel.amountTextSize.fontSize, scale: scale), weight: .bold))
                 .foregroundColor(Color(viewModel.amountTextColor))
                 .minimumScaleFactor(0.1)
@@ -56,6 +57,46 @@ extension FormattableAmountTextField {
             textAlignment: .leading,
             font: nil
         )
+    }
+}
+
+private extension String {
+    var leftToRightIsolatedNumericRuns: String {
+        var result = ""
+        var currentRun = ""
+        let characters = Array(self)
+
+        for (index, character) in characters.enumerated() {
+            if character.isNumber || shouldTreatAsNumericSeparator(character, at: index, in: characters) {
+                currentRun.append(character)
+            } else {
+                result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
+                currentRun = ""
+                result.append(character)
+            }
+        }
+
+        result.appendLeftToRightIsolatedRunIfNeeded(currentRun)
+        return result
+    }
+
+    private func shouldTreatAsNumericSeparator(_ character: Character, at index: Int, in characters: [Character]) -> Bool {
+        guard character == "." || character == "," || character == "-" else {
+            return false
+        }
+
+        let previousCharacterIsNumber = index > 0 && characters[index - 1].isNumber
+        let nextCharacterIsNumber = index < characters.count - 1 && characters[index + 1].isNumber
+
+        return previousCharacterIsNumber || nextCharacterIsNumber
+    }
+
+    mutating func appendLeftToRightIsolatedRunIfNeeded(_ run: String) {
+        guard run.isNotEmpty else {
+            return
+        }
+
+        append("\u{2066}\(run)\u{2069}")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -71,6 +71,7 @@ final class UnitInputTableViewCell: UITableViewCell {
         onInputChange = viewModel.onInputChange
 
         configureStyle(viewModel.style)
+        configureInputTextDirection(inputFormatter: viewModel.inputFormatter)
         configureInputTextFieldState(enabled: viewModel.isInputEnabled)
 
         rearrangeInputAndUnitStackViewSubviews(using: viewModel.unitPosition)
@@ -168,6 +169,10 @@ private extension UnitInputTableViewCell {
             inputTextField.textAlignment = style == .primary ? .right : .left
             // swiftlint:enable:next inverse_text_alignment
         }
+    }
+
+    func configureInputTextDirection(inputFormatter: UnitInputFormatter) {
+        inputTextField.semanticContentAttribute = inputFormatter is PriceInputFormatter ? .forceLeftToRight : .unspecified
     }
 
     func configureUnitLabel() {

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -343,6 +343,69 @@ class CurrencyFormatterTests: XCTestCase {
         XCTAssertEqual(expectedResult, actualResult)
     }
 
+    func test_formatCurrency_when_locale_is_ltr_and_currency_symbol_is_rtl_then_keeps_negative_amount_ltr() {
+        // Given
+        let currencyPosition = CurrencySettings.CurrencyPosition.right
+        let currencyCode = CurrencyCode.QAR
+        let amount = "1,234.56"
+        let symbol = sampleCurrencySettings.symbol(from: currencyCode)
+        let rightToLeftMark = "\u{200F}"
+        let leftToRightIsolate = "\u{2066}"
+        let popDirectionalIsolate = "\u{2069}"
+
+        // When
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatCurrency(using: amount,
+                            currencyPosition: currencyPosition,
+                            currencySymbol: symbol,
+                            isNegative: true,
+                            locale: Locale(identifier: "en_GB"))
+
+        // Then
+        XCTAssertEqual("\(rightToLeftMark)\(leftToRightIsolate)-1,234.56\(popDirectionalIsolate)\(symbol)", actualResult)
+    }
+
+    func test_formatCurrency_when_locale_is_rtl_and_currency_symbol_is_ltr_then_keeps_negative_amount_ltr() {
+        // Given
+        let currencyPosition = CurrencySettings.CurrencyPosition.right
+        let currencyCode = CurrencyCode.USD
+        let amount = "1,234.56"
+        let symbol = sampleCurrencySettings.symbol(from: currencyCode)
+        let leftToRightMark = "\u{200E}"
+
+        // When
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatCurrency(using: amount,
+                            currencyPosition: currencyPosition,
+                            currencySymbol: symbol,
+                            isNegative: true,
+                            locale: Locale(identifier: "ar"))
+
+        // Then
+        XCTAssertEqual("\(leftToRightMark)-1,234.56\(symbol)", actualResult)
+    }
+
+    func test_formatAmount_when_locale_is_arabic_then_keeps_store_currency_position() {
+        // Given
+        let settings = CurrencySettings(currencyCode: .QAR,
+                                        currencyPosition: .rightSpace,
+                                        thousandSeparator: ",",
+                                        decimalSeparator: ".",
+                                        numberOfDecimals: 2)
+        let formatter = CurrencyFormatter(currencySettings: settings)
+        let rightToLeftMark = "\u{200F}"
+        let leftToRightIsolate = "\u{2066}"
+        let popDirectionalIsolate = "\u{2069}"
+
+        // When
+        let actualResult = formatter.formatAmount(NSDecimalNumber(string: "1234.56"),
+                                                  locale: Locale(identifier: "ar"),
+                                                  isNegative: true)
+
+        // Then
+        XCTAssertEqual("\(rightToLeftMark)\(leftToRightIsolate)-1,234.56\(popDirectionalIsolate) \(settings.currencySymbol)", actualResult)
+    }
+
     // MARK: - Human readable formatter tests
 
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -81,7 +81,9 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     }
 
     func test_discount_value_matches_expectation() {
-        let expectedValue = "-" + CurrencyFormatter(currencySettings: CurrencySettings()).formatAmount(order.discountTotal, with: order.currency)!
+        let expectedValue = CurrencyFormatter(currencySettings: CurrencySettings()).formatAmount(order.discountTotal,
+                                                                                                  with: order.currency,
+                                                                                                  isNegative: true)!
         XCTAssertEqual(viewModel.discountValue, expectedValue)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -135,6 +135,23 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasDiscount)
     }
 
+    func test_discountLabel_when_discount_is_not_nil_then_returns_signed_currency_amount() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .QAR,
+                                                currencyPosition: .right,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let viewModel = createViewModel(discount: 0.50, currencyFormatter: currencyFormatter)
+        let rightToLeftMark = "\u{200F}"
+        let leftToRightIsolate = "\u{2066}"
+        let popDirectionalIsolate = "\u{2069}"
+
+        // Then
+        XCTAssertEqual("\(rightToLeftMark)\(leftToRightIsolate)-0.50\(popDirectionalIsolate)\(currencySettings.currencySymbol)", viewModel.discountLabel)
+    }
+
     // MARK: - `totalPriceAfterDiscountLabel`
 
     func test_totalPriceAfterDiscountLabel_when_product_row_has_one_item_and_discount_then_returns_properly_formatted_price_after_discount() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeOrDiscountLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeOrDiscountLineDetailsViewModelTests.swift
@@ -75,6 +75,32 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currencyPosition, .rightSpace)
     }
 
+    func test_signedFinalAmountString_returns_signed_currency_amount() {
+        // Given
+        let customSettings = CurrencySettings(currencyCode: .QAR,
+                                              currencyPosition: .right,
+                                              thousandSeparator: ",",
+                                              decimalSeparator: ".",
+                                              numberOfDecimals: 2)
+        let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
+                                                          baseAmount: 0,
+                                                          initialTotal: .zero,
+                                                          lineType: .discount,
+                                                          locale: usLocale,
+                                                          storeCurrencySettings: customSettings,
+                                                          didSelectSave: { _ in })
+        let rightToLeftMark = "\u{200F}"
+        let leftToRightIsolate = "\u{2066}"
+        let popDirectionalIsolate = "\u{2069}"
+
+        // When
+        viewModel.updateAmount("12.34")
+
+        // Then
+        XCTAssertEqual("\(rightToLeftMark)\(leftToRightIsolate)-12.34\(popDirectionalIsolate)\(customSettings.currencySymbol)",
+                       viewModel.signedFinalAmountString)
+    }
+
     func test_view_model_formats_amount_with_grouping_separators_correctly() {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/UnitInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/UnitInputViewModelTests.swift
@@ -1,6 +1,7 @@
 import Combine
 import XCTest
 import WooFoundation
+import Yosemite
 @testable import WooCommerce
 
 /// Test cases for `UnitInputViewModelTests`.
@@ -17,5 +18,76 @@ final class UnitInputViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.title, "")
         XCTAssertEqual(viewModel.placeholder, "0.00")
         XCTAssertEqual(viewModel.style, .secondary)
+    }
+
+    func test_regular_price_view_model_when_right_position_and_ltr_currency_symbol_then_places_unit_after_input() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .right,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+
+        // When
+        let viewModel = Product.createRegularPriceViewModel(regularPrice: "20",
+                                                            using: currencySettings,
+                                                            onInputChange: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.unit, "$")
+        XCTAssertEqual(viewModel.unitPosition, .afterInputWithoutSpace)
+    }
+
+    func test_regular_price_view_model_when_right_position_and_rtl_currency_symbol_then_places_unit_before_input() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .QAR,
+                                                currencyPosition: .right,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+
+        // When
+        let viewModel = Product.createRegularPriceViewModel(regularPrice: "20",
+                                                            using: currencySettings,
+                                                            onInputChange: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.unit, currencySettings.currencySymbol)
+        XCTAssertEqual(viewModel.unitPosition, .beforeInputWithoutSpace)
+    }
+
+    func test_regular_price_view_model_when_left_position_and_rtl_currency_symbol_then_places_unit_after_input() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .QAR,
+                                                currencyPosition: .left,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+
+        // When
+        let viewModel = Product.createRegularPriceViewModel(regularPrice: "20",
+                                                            using: currencySettings,
+                                                            onInputChange: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.unit, currencySettings.currencySymbol)
+        XCTAssertEqual(viewModel.unitPosition, .afterInputWithoutSpace)
+    }
+
+    func test_bulk_price_view_model_when_right_space_position_and_rtl_currency_symbol_then_places_unit_before_input() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .QAR,
+                                                currencyPosition: .rightSpace,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+
+        // When
+        let viewModel = UnitInputViewModel.createBulkPriceViewModel(using: currencySettings,
+                                                                    onInputChange: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.unit, currencySettings.currencySymbol)
+        XCTAssertEqual(viewModel.unitPosition, .beforeInput)
     }
 }


### PR DESCRIPTION
Part of: WOOMOB-3530

## Description
WooCommerce settings offer an option to change the position of the currency symbol, and the app uses these settings when displaying money.

The options are Left (default), Right, Left with space, Right with space. However, with RTL currencies, the meanings of these are reversed in WP-admin and stores.

Previously, a negative number could be shown with the currency symbol at the opposite end from positive numbers shown adjacent to it. The position of the `-` sign could also be inconsistent.

This PR keeps the numerals and negative sign as LTR in all circumstances, while applying the position setting to the currency in a locale-respecting manner, i.e. treating it as a "Leading" or "Trailing" toggle.

Where practical, we put the `-` before the currency symbol, however, with mixed RTL and LTR this doesn't really work, so in some cases we fall back to `-` between the currency and the numeral. We never put the `-` after the number, as could happen previously.

I've changed the amounts displayed in Order details, along with the inputs on order details and on the product form.

## Test Steps
1. Configure a store with QAR and set the WooCommerce currency position to Right.
2. On a device using a UK/US locale, check order creation totals, custom discounts/fees, refunds, and product price fields. Negative values should keep the minus sign with the number, and the currency symbol should be shown on the non-standard visual side for a strong RTL symbol (the left).
3. Repeat with an Arabic device language and compare QAR and USD values. Note that the different currencies will be displayed on opposite sides, in both cases, the unnatural position for that currency.
4. In create order custom amount fields and product price fields, type values such as `20.60` and confirm the input remains left-to-right while editing.

Repeat the tests with the currency position setting set to `Left` (you'll need to restart the app) — observe that the currencies are shown on the natural side for each currency.

## Screenshots

### Left position (natural) 

| QAR LTR | QAR RTL |
|---|---|
| <img width="660" height="1434" alt="6 Left QAR LTR" src="https://github.com/user-attachments/assets/3d488026-b632-45d2-a475-c8b81d329db2" /> | <img width="660" height="1434" alt="2 Left QAR RTL" src="https://github.com/user-attachments/assets/c11bd3e3-2f93-4b9b-a0c2-47614c1e26d2" /> |

| USD LTR | USD RTL |
|---|---|
| <img width="660" height="1434" alt="4 Left dollars LTR" src="https://github.com/user-attachments/assets/7b5d579f-b08d-463b-8491-65c6541d4cd3" /> | <img width="660" height="1434" alt="3 Left dollars RTL" src="https://github.com/user-attachments/assets/0e128fbe-0b49-45bc-9e31-b1e83fada5a0" /> |

### Right position

| QAR LTR | QAR RTL |
|---|---|
| <img width="660" height="1434" alt="7 Right QAR LTR" src="https://github.com/user-attachments/assets/d6ebb43e-7249-4ae4-bff5-ab4b8811f07f" /> | <img width="660" height="1434" alt="5 Right QAR RTL" src="https://github.com/user-attachments/assets/61cbeaef-ec77-4ad3-b3fd-4d2c487ef6e9" /> |

| USD LTR | USD RTL |
|---|---|
| <img width="660" height="1434" alt="8 Right dollars LTR" src="https://github.com/user-attachments/assets/fb526eb1-ab9e-45f0-8e04-4fd1bf77a52b" /> | <img width="660" height="1434" alt="1 Right dollars RTL" src="https://github.com/user-attachments/assets/65f5d88e-0733-4f0e-b7b3-080df22a8268" /> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
