### PR TITLE
Sort order custom fields by metadata ID

### DIFF
--- a/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -120,7 +120,7 @@ extension Storage.Order: ReadOnlyConvertible {
                      refunds: orderRefunds,
                      fees: orderFeeLines,
                      taxes: orderTaxLines,
-                     customFields: orderCustomFields,
+                     customFields: orderCustomFields.sorted { $0.metadataID < $1.metadataID },
                      renewalSubscriptionID: renewalSubscriptionID,
                      appliedGiftCards: orderGiftCards,
                      attributionInfo: attributionInfo?.toReadOnly(),

--- a/Modules/Tests/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -276,6 +276,24 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         XCTAssertEqual(storageCustomField.toReadOnly(), customField)
     }
 
+    func test_it_sorts_order_custom_fields_by_metadata_id_when_converting_from_storage() throws {
+        // Given
+        let customFields = [
+            MetaData(metadataID: 3, key: "Third", value: "Value 3"),
+            MetaData(metadataID: 1, key: "First", value: "Value 1"),
+            MetaData(metadataID: 2, key: "Second", value: "Value 2")
+        ]
+        let order = makeOrder().copy(siteID: 3, orderID: 98, customFields: customFields)
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+
+        // When
+        useCase.upsert([order])
+
+        // Then
+        let storageOrder = try XCTUnwrap(viewStorage.loadOrder(siteID: 3, orderID: 98))
+        XCTAssertEqual(storageOrder.toReadOnly().customFields.map { $0.metadataID }, [1, 2, 3])
+    }
+
     func test_it_replaces_existing_order_custom_field_in_storage() throws {
         // Given
         let originalCustomField = MetaData(metadataID: 1, key: "Key", value: "Value")


### PR DESCRIPTION
## Description
Closes: WOOMOB-3465

Order custom fields are stored in Core Data as a `Set`, so converting them back to the Yosemite model without sorting can produce non-deterministic ordering. This sorts order custom fields by `metadataID` during storage-to-read-only conversion, matching the existing product custom field behavior.

## Test Steps

1. Set a few custom fields on an order (you can do this in WP-Admin, it's good to have at least 3)
2. Open the order in the app and open `Custom fields` – note the ordering of the fields
3. Close it, and open again – note that the field sequence has not changed
4. Go back to the order list, pull to refresh, and check again.
5. Add another custom field in WP-Admin, then check again; observe that it's shown at the end of the list.

## Screenshots


https://github.com/user-attachments/assets/1022288e-a7db-480f-a9c7-612ebad7f7d1


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
