### PR TITLE
[WOOMOB-3587] Migrate product duplication to the core endpoint

### DIFF
--- a/Modules/Sources/Networking/Mapper/ProductDuplicateMapper.swift
+++ b/Modules/Sources/Networking/Mapper/ProductDuplicateMapper.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Maps the raw WooCommerce core product duplication response to only the duplicated product ID.
+struct ProductDuplicateMapper: Mapper {
+    func map(response: Data) throws -> Int64 {
+        let decoder = JSONDecoder()
+        let productID: Int64
+
+        if hasDataEnvelope(in: response) {
+            productID = try decoder.decode(ProductDuplicateEnvelope.self, from: response).product.id
+        } else {
+            productID = try decoder.decode(DuplicatedProduct.self, from: response).id
+        }
+
+        guard productID > 0 else {
+            throw ProductDuplicateMapperError.invalidProductID
+        }
+        return productID
+    }
+}
+
+private enum ProductDuplicateMapperError: Error {
+    case invalidProductID
+}
+
+private struct DuplicatedProduct: Decodable {
+    let id: Int64
+}
+
+private struct ProductDuplicateEnvelope: Decodable {
+    let product: DuplicatedProduct
+
+    private enum CodingKeys: String, CodingKey {
+        case product = "data"
+    }
+}

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -6,6 +6,7 @@ import Foundation
 ///
 public protocol ProductsRemoteProtocol {
     func addProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void)
+    func duplicateProduct(siteID: Int64, productID: Int64, completion: @escaping (Result<Int64, Error>) -> Void)
     func deleteProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
     func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
     func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int) async throws -> [Product]
@@ -132,6 +133,24 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         } catch {
             completion(.failure(error))
         }
+    }
+
+    /// Duplicates a product using the WooCommerce core endpoint.
+    ///
+    /// The response is intentionally mapped only to the duplicated product ID because the endpoint returns
+    /// a raw core product representation rather than the canonical REST API product representation.
+    public func duplicateProduct(siteID: Int64, productID: Int64, completion: @escaping (Result<Int64, Error>) -> Void) {
+        let path = "\(Path.products)/\(productID)/duplicate"
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true,
+                                     shouldRetryViaJetpackOnRESTFailure: false)
+        let mapper = ProductDuplicateMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
     }
 
     /// Deletes a specific `Product`.

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -182,7 +182,10 @@ public class AlamofireNetwork: Network {
                             self?.responseData(for: request, completion: completion)
                         },
                         onCompletion: {
-                            completion(response.value, response.networkingError)
+                            let error = self?.transportOriginErrorIfNeeded(response.networkingError,
+                                                                           originalRequest: request,
+                                                                           convertedRequest: convertedRequest)
+                            completion(response.value, error ?? response.networkingError)
                         }
                     )
                 }
@@ -212,7 +215,11 @@ public class AlamofireNetwork: Network {
                             self?.responseData(for: request, completion: completion)
                         },
                         onCompletion: {
-                            if let error = response.networkingError {
+                            let error = self?.transportOriginErrorIfNeeded(response.networkingError,
+                                                                           originalRequest: request,
+                                                                           convertedRequest: convertedRequest)
+                                ?? response.networkingError
+                            if let error {
                                 completion(.failure(error))
                             } else {
                                 completion(response.result.mapError { $0 })
@@ -242,7 +249,9 @@ public class AlamofireNetwork: Network {
         errorHandler.flagSiteAsUnsupportedForAppPasswordIfNeeded(originalRequest: request, failure: failure)
 
         if let error = response.networkingError {
-            throw error
+            throw transportOriginErrorIfNeeded(error,
+                                               originalRequest: request,
+                                               convertedRequest: convertedRequest) ?? error
         }
         switch response.result {
             case .success(let data):
@@ -279,7 +288,11 @@ public class AlamofireNetwork: Network {
                                 }
                             },
                             onCompletion: {
-                                if let error = response.networkingError {
+                                let error = self?.transportOriginErrorIfNeeded(response.networkingError,
+                                                                               originalRequest: request,
+                                                                               convertedRequest: convertedRequest)
+                                    ?? response.networkingError
+                                if let error {
                                     promise(.success(.failure(error)))
                                 } else {
                                     promise(.success(response.result.mapError { $0 }))
@@ -379,6 +392,20 @@ private extension AlamofireNetwork {
 // MARK: Helper methods for error handling
 //
 private extension AlamofireNetwork {
+    /// Attaches the effective transport to errors from non-replayable requests after retry classification.
+    /// The immutable `convertedRequest` is the request that actually produced the response.
+    func transportOriginErrorIfNeeded(_ error: Error?,
+                                      originalRequest: URLRequestConvertible,
+                                      convertedRequest: URLRequestConvertible) -> Error? {
+        guard let networkError = error as? NetworkError,
+              convertedRequest is RESTRequest,
+              let jetpackRequest = originalRequest as? JetpackRequest,
+              jetpackRequest.shouldRetryViaJetpackOnRESTFailure == false else {
+            return nil
+        }
+        return NonReplayableRESTRequestError(networkError: networkError)
+    }
+
     func convertRequestIfNeeded(_ request: URLRequestConvertible) -> URLRequestConvertible {
         if errorHandler.isRequestRetried(request) {
             return request // do not convert
@@ -403,6 +430,11 @@ private extension AlamofireNetwork {
         guard request is RESTRequest, let discoveryTask else { return }
         await discoveryTask.value
     }
+}
+
+/// Carries the immutable effective transport of a non-replayable request to `Remote` error mapping.
+struct NonReplayableRESTRequestError: Error {
+    let networkError: NetworkError
 }
 
 // MARK: `RequestProcessorDelegate` conformance

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -57,6 +57,7 @@ final class AlamofireNetworkErrorHandler {
                                    failure: Error?) -> Bool {
         guard let error = failure,
               let request = originalRequest as? JetpackRequest,
+              request.shouldRetryViaJetpackOnRESTFailure,
               convertedRequest is RESTRequest,
               let convertedURLRequest = try? convertedRequest.asURLRequest(),
               case .some(.wpcom) = self.credentials else {

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -327,6 +327,10 @@ private extension Remote {
     /// Maps an error from `network.responseData` so that the request's corresponding error can be returned.
     ///
     func mapNetworkError(error: Error, for request: Request) -> Error {
+        if let contextualError = error as? NonReplayableRESTRequestError {
+            return contextualError.networkError
+        }
+
         guard let networkError = error as? NetworkError else {
             return error
         }

--- a/Modules/Sources/NetworkingCore/Requests/JetpackRequest.swift
+++ b/Modules/Sources/NetworkingCore/Requests/JetpackRequest.swift
@@ -36,6 +36,10 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
     ///
     private let availableAsRESTRequest: Bool
 
+    /// Whether a converted REST request may be retried through the Jetpack tunnel after a failure.
+    ///
+    let shouldRetryViaJetpackOnRESTFailure: Bool
+
     /// Whether this request should allow cellular access.
     ///
     private let allowsCellularAccess: Bool
@@ -47,6 +51,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
                  path: String,
                  requestParameters: RequestParameters,
                  availableAsRESTRequest: Bool = false,
+                 shouldRetryViaJetpackOnRESTFailure: Bool = true,
                  allowsCellularAccess: Bool = true) {
         if [.mark1, .mark2].contains(wooApiVersion) {
             DDLogWarn("⚠️ You are using an older version of the Woo REST API: \(wooApiVersion.rawValue), for path: \(path)")
@@ -58,6 +63,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
         self.path = path
         self.requestParameters = requestParameters
         self.availableAsRESTRequest = availableAsRESTRequest
+        self.shouldRetryViaJetpackOnRESTFailure = shouldRetryViaJetpackOnRESTFailure
         self.allowsCellularAccess = allowsCellularAccess
     }
 
@@ -70,6 +76,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
     ///     - path: RPC that should be called.
     ///     - parameters: Collection of Key/Value parameters, to be forwarded to the Jetpack Connected site.
     ///     - availableAsRESTRequest: Whether the request should be transformed to a REST request if application password is available.
+    ///     - shouldRetryViaJetpackOnRESTFailure: Whether a failed converted REST request may be retried through the Jetpack tunnel.
     ///     - allowsCellularAccess: Whether the request should allow cellular data access.
     ///
     public init(wooApiVersion: WooAPIVersion,
@@ -79,6 +86,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
          path: String,
          parameters: RequestParameterDictionary? = nil,
          availableAsRESTRequest: Bool = false,
+         shouldRetryViaJetpackOnRESTFailure: Bool = true,
          allowsCellularAccess: Bool = true) {
         self.init(wooApiVersion: wooApiVersion,
                   method: method,
@@ -87,6 +95,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
                   path: path,
                   requestParameters: RequestParameters(parameters),
                   availableAsRESTRequest: availableAsRESTRequest,
+                  shouldRetryViaJetpackOnRESTFailure: shouldRetryViaJetpackOnRESTFailure,
                   allowsCellularAccess: allowsCellularAccess)
     }
 
@@ -97,6 +106,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
          path: String,
          parameters: [String: Value],
          availableAsRESTRequest: Bool = false,
+         shouldRetryViaJetpackOnRESTFailure: Bool = true,
          allowsCellularAccess: Bool = true) {
         self.init(wooApiVersion: wooApiVersion,
                   method: method,
@@ -105,6 +115,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
                   path: path,
                   requestParameters: RequestParameters(parameters),
                   availableAsRESTRequest: availableAsRESTRequest,
+                  shouldRetryViaJetpackOnRESTFailure: shouldRetryViaJetpackOnRESTFailure,
                   allowsCellularAccess: allowsCellularAccess)
     }
 
@@ -115,6 +126,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
          path: String,
          parameters: RequestParameterConvertibleDictionary,
          availableAsRESTRequest: Bool = false,
+         shouldRetryViaJetpackOnRESTFailure: Bool = true,
          allowsCellularAccess: Bool = true) {
         self.init(wooApiVersion: wooApiVersion,
                   method: method,
@@ -123,6 +135,7 @@ public struct JetpackRequest: Request, RESTRequestConvertible {
                   path: path,
                   requestParameters: RequestParameters(parameters),
                   availableAsRESTRequest: availableAsRESTRequest,
+                  shouldRetryViaJetpackOnRESTFailure: shouldRetryViaJetpackOnRESTFailure,
                   allowsCellularAccess: allowsCellularAccess)
     }
 

--- a/Modules/Sources/Yosemite/Actions/ProductAction.swift
+++ b/Modules/Sources/Yosemite/Actions/ProductAction.swift
@@ -95,6 +95,10 @@ public enum ProductAction: Action {
     ///
     case addProduct(product: Product, onCompletion: (Result<Product, ProductUpdateError>) -> Void)
 
+    /// Duplicates a Product using the WooCommerce core endpoint and returns the new product ID.
+    ///
+    case duplicateProduct(siteID: Int64, productID: Int64, onCompletion: (Result<Int64, ProductDuplicateError>) -> Void)
+
     /// Delete an existing Product.
     ///
     case deleteProduct(siteID: Int64, productID: Int64, onCompletion: (Result<Product, ProductUpdateError>) -> Void)

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -43,6 +43,8 @@ public class ProductStore: Store {
         switch action {
         case .addProduct(let product, let onCompletion):
             addProduct(product: product, onCompletion: onCompletion)
+        case .duplicateProduct(let siteID, let productID, let onCompletion):
+            duplicateProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .deleteProduct(let siteID, let productID, let onCompletion):
             deleteProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .resetStoredProducts(let onCompletion):
@@ -469,6 +471,13 @@ private extension ProductStore {
                     onCompletion(.success(storageProduct.toReadOnly()))
                 }
             }
+        }
+    }
+
+    /// Duplicates a product using the WooCommerce core endpoint.
+    func duplicateProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Int64, ProductDuplicateError>) -> Void) {
+        remote.duplicateProduct(siteID: siteID, productID: productID) { result in
+            onCompletion(result.mapError(ProductDuplicateError.init))
         }
     }
 
@@ -1358,6 +1367,44 @@ extension ProductStore {
     ///
     func upsertStoredProduct(readOnlyProduct: Networking.Product, in storage: StorageType) {
         upsertStoredProducts(readOnlyProducts: [readOnlyProduct], in: storage)
+    }
+}
+
+/// An error that occurs while duplicating a Product with the WooCommerce core endpoint.
+///
+public enum ProductDuplicateError: Error, Equatable {
+    /// The core duplication endpoint is conclusively unavailable on this store.
+    case endpointUnavailable
+
+    /// Any other failure. The underlying error is retained because duplication is non-idempotent and must not be retried with the legacy flow.
+    case unknown(error: AnyError)
+
+    init(error: Error) {
+        if let dotcomError = error as? DotcomError,
+           case .noRestRoute = dotcomError {
+            self = .endpointUnavailable
+            return
+        }
+
+        if let networkError = error as? NetworkError,
+           case .notFound = networkError,
+           networkError.errorCode == "rest_no_route" {
+            self = .endpointUnavailable
+            return
+        }
+
+        self = .unknown(error: error.toAnyError)
+    }
+}
+
+extension ProductDuplicateError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .endpointUnavailable:
+            return nil
+        case .unknown(let error):
+            return error.localizedDescription
+        }
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Mocks/MockURLProtocol.swift
+++ b/Modules/Tests/NetworkingTests/Mocks/MockURLProtocol.swift
@@ -5,22 +5,55 @@ import XCTest
 extension MockURLProtocol {
     /// Stores the mocks for `URLRequest`s in memory to be used in `MockURLProtocol`.
     final class Mocks {
+        private static let lock = NSLock()
         private static var responsesByRequestURL: [String: (response: AnyCodable, statusCode: Int)] = [:]
+        private static var recordedRequests: [URLRequest] = []
+        private static var requestReceivedHandler: ((URLRequest) -> Void)?
+
+        static var requests: [URLRequest] {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedRequests
+        }
+
+        static func reset() {
+            lock.lock()
+            defer { lock.unlock() }
+            responsesByRequestURL.removeAll()
+            recordedRequests.removeAll()
+            requestReceivedHandler = nil
+        }
+
+        /// Installs a hook invoked after a request is recorded and before its mocked response is delivered.
+        static func whenRequestIsReceived(_ handler: @escaping (URLRequest) -> Void) {
+            lock.lock()
+            defer { lock.unlock() }
+            requestReceivedHandler = handler
+        }
 
         /// Mocks the response of a given request.
         static func mockResponse(_ response: AnyCodable, statusCode: Int, for request: URLRequest) {
             guard let url = request.url?.absoluteString else {
                 return
             }
+            lock.lock()
+            defer { lock.unlock() }
             responsesByRequestURL[url] = (response: response, statusCode: statusCode)
         }
 
         /// Returns the response for a request if it has been mocked.
         static func response(for request: URLRequest) -> (response: Data?, statusCode: Int)? {
-            guard let url = request.url?.absoluteString,
-                  let response = responsesByRequestURL[url] else {
+            guard let url = request.url?.absoluteString else {
                 return nil
             }
+            let result: (response: (response: AnyCodable, statusCode: Int)?, handler: ((URLRequest) -> Void)?) = {
+                lock.lock()
+                defer { lock.unlock() }
+                recordedRequests.append(request)
+                return (responsesByRequestURL[url], requestReceivedHandler)
+            }()
+            result.handler?(request)
+            guard let response = result.response else { return nil }
 
             do {
                 let encoder = JSONEncoder()

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -102,6 +102,22 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         }
     }
 
+    func test_shouldRetryJetpackRequest_returns_false_when_request_disallows_retry_through_jetpack() {
+        // Given
+        let jetpackRequest = createJetpackRequest(siteID: 123, shouldRetryViaJetpackOnRESTFailure: false)
+        let restRequest = createRESTRequest()
+
+        // When
+        let shouldRetry = errorHandler.shouldRetryJetpackRequest(
+            originalRequest: jetpackRequest,
+            convertedRequest: restRequest,
+            failure: createNetworkError()
+        )
+
+        // Then
+        XCTAssertFalse(shouldRetry)
+    }
+
     func test_shouldRetryJetpackRequest_returns_false_for_unexpected_errors() {
         // Given
         let jetpackRequest = createJetpackRequest(siteID: 123)
@@ -717,13 +733,14 @@ private extension AlamofireNetworkErrorHandlerTests {
         return Credentials.wpcom(username: "test", authToken: "token", siteAddress: "https://example.com")
     }
 
-    func createJetpackRequest(siteID: Int64) -> JetpackRequest {
+    func createJetpackRequest(siteID: Int64, shouldRetryViaJetpackOnRESTFailure: Bool = true) -> JetpackRequest {
         return JetpackRequest(
             wooApiVersion: .mark3,
             method: .get,
             siteID: siteID,
             path: "test",
-            availableAsRESTRequest: true
+            availableAsRESTRequest: true,
+            shouldRetryViaJetpackOnRESTFailure: shouldRetryViaJetpackOnRESTFailure
         )
     }
 

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -13,6 +13,7 @@ final class AlamofireNetworkTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        MockURLProtocol.Mocks.reset()
         userDefaults = UserDefaults(suiteName: UUID().uuidString)
     }
 
@@ -599,6 +600,84 @@ final class AlamofireNetworkTests: XCTestCase {
         XCTAssertNotNil(result.1)
         let networkError = result.1 as? NetworkError
         XCTAssertEqual(networkError?.errorCode, "failed")
+    }
+
+    func test_duplicateProduct_direct_failure_remains_NetworkError_when_conversion_switches_to_tunnel_while_request_is_in_flight() throws {
+        // Given
+        let siteID: Int64 = 112
+        let productID: Int64 = 282
+        let path = "products/\(productID)/duplicate"
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true,
+                                     shouldRetryViaJetpackOnRESTFailure: false)
+        let directRequest = try XCTUnwrap(request.asRESTRequest(with: "https://example.com")?.asURLRequest())
+        let tunnelRequest = try request.asURLRequest()
+        MockURLProtocol.Mocks.mockResponse(["error": "rest_no_route", "message": "No route found"], statusCode: 500, for: directRequest)
+        MockURLProtocol.Mocks.mockResponse(["id": 3946], statusCode: 200, for: tunnelRequest)
+        let selectedSite = CurrentValueSubject<JetpackSite?, Never>(
+            JetpackSite(siteID: siteID, siteAddress: "https://example.com", applicationPasswordAvailable: true)
+        )
+        let network = AlamofireNetwork(credentials: createWPComCredentials(),
+                                       selectedSite: selectedSite.eraseToAnyPublisher(),
+                                       appPasswordSupportState: Just(true).eraseToAnyPublisher(),
+                                       userDefaults: userDefaults,
+                                       sessionManager: createSessionWithMockURLProtocol())
+        let remote = ProductsRemote(network: network)
+        let conversionSwitched = expectation(description: "Conversion changed to the Jetpack tunnel")
+        MockURLProtocol.Mocks.whenRequestIsReceived { receivedRequest in
+            guard receivedRequest.url == directRequest.url else { return }
+            selectedSite.send(nil)
+            conversionSwitched.fulfill()
+        }
+
+        // When
+        let result = waitFor { promise in
+            remote.duplicateProduct(siteID: siteID, productID: productID, completion: promise)
+        }
+        wait(for: [conversionSwitched], timeout: 1)
+
+        // Then
+        XCTAssertEqual((result.failure as? NetworkError)?.responseCode, 500)
+        XCTAssertEqual((result.failure as? NetworkError)?.errorCode, "rest_no_route")
+        let directRequests = MockURLProtocol.Mocks.requests.filter { $0.url == directRequest.url }
+        let tunnelRequests = MockURLProtocol.Mocks.requests.filter { $0.url == tunnelRequest.url }
+        XCTAssertEqual(directRequests.count, 1)
+        XCTAssertEqual(directRequests.first?.httpMethod, "POST")
+        XCTAssertTrue(directRequests.first?.httpBody?.isEmpty ?? true)
+        XCTAssertTrue(tunnelRequests.isEmpty)
+    }
+
+    func test_duplicateProduct_tunneled_no_route_response_maps_to_DotcomError() throws {
+        // Given
+        let siteID: Int64 = 113
+        let productID: Int64 = 282
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: "products/\(productID)/duplicate",
+                                     parameters: nil,
+                                     availableAsRESTRequest: true,
+                                     shouldRetryViaJetpackOnRESTFailure: false)
+        let tunnelRequest = try request.asURLRequest()
+        MockURLProtocol.Mocks.mockResponse(["error": "rest_no_route", "message": "No route found"], statusCode: 200, for: tunnelRequest)
+        let network = AlamofireNetwork(credentials: createWPComCredentials(),
+                                       selectedSite: nil,
+                                       appPasswordSupportState: nil,
+                                       sessionManager: createSessionWithMockURLProtocol())
+        let remote = ProductsRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.duplicateProduct(siteID: siteID, productID: productID, completion: promise)
+        }
+
+        // Then
+        XCTAssertEqual(result.failure as? DotcomError, DotcomError.noRestRoute())
+        XCTAssertEqual(MockURLProtocol.Mocks.requests.filter { $0.url == tunnelRequest.url }.count, 1)
     }
 
     func test_responseData_does_not_retry_when_credentials_not_wpcom() throws {

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -140,6 +140,124 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertEqual(result?.isFailure, true)
     }
 
+    // MARK: - Duplicate Product
+
+    func test_duplicateProduct_maps_only_the_product_ID_from_the_raw_core_response() throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/duplicate", filename: "product-duplicate")
+
+        // When
+        var result: Result<Int64, Error>?
+        waitForExpectation { expectation in
+            remote.duplicateProduct(siteID: sampleSiteID, productID: sampleProductID) {
+                result = $0
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(try result?.get(), 3946)
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        XCTAssertEqual(request.path, "products/\(sampleProductID)/duplicate")
+        XCTAssertEqual(request.method, .post)
+        XCTAssertTrue(request.requestParameters.isEmpty)
+        let directRequest = try XCTUnwrap(request.asRESTRequest(with: "https://example.com")?.asURLRequest())
+        XCTAssertNil(directRequest.httpBody)
+    }
+
+    func test_duplicateProduct_maps_only_the_product_ID_from_a_tunneled_response_envelope() throws {
+        // Given
+        let response = Data(#"{"data":{"id":3946,"name":"Product (Copy)","meta_data":[{"key":"custom","value":"value"}]}}"#.utf8)
+
+        // When
+        let productID = try ProductDuplicateMapper().map(response: response)
+
+        // Then
+        XCTAssertEqual(productID, 3946)
+    }
+
+    func test_duplicateProduct_rejects_an_invalid_product_ID() {
+        // Given
+        let response = Data(#"{"id":0,"name":"Product (Copy)"}"#.utf8)
+
+        // Then
+        XCTAssertThrowsError(try ProductDuplicateMapper().map(response: response))
+    }
+
+    func test_duplicateProduct_rejects_a_negative_product_ID() {
+        // Given
+        let response = Data(#"{"id":-1,"name":"Product (Copy)"}"#.utf8)
+
+        // Then
+        XCTAssertThrowsError(try ProductDuplicateMapper().map(response: response))
+    }
+
+    func test_duplicateProduct_rejects_a_missing_product_ID() {
+        // Given
+        let response = Data(#"{"name":"Product (Copy)"}"#.utf8)
+
+        // Then
+        XCTAssertThrowsError(try ProductDuplicateMapper().map(response: response))
+    }
+
+    func test_duplicateProduct_rejects_a_malformed_response() {
+        // Given
+        let response = Data("not-json".utf8)
+
+        // Then
+        XCTAssertThrowsError(try ProductDuplicateMapper().map(response: response))
+    }
+
+    func test_duplicateProduct_rejects_nonpositive_product_IDs_in_a_tunneled_response_envelope() {
+        for productID in [0, -1] {
+            // Given
+            let response = Data(#"{"data":{"id":\#(productID),"name":"Product (Copy)"}}"#.utf8)
+
+            // Then
+            XCTAssertThrowsError(try ProductDuplicateMapper().map(response: response))
+        }
+    }
+
+    func test_duplicateProduct_relays_direct_REST_notFound_error() {
+        // Given
+        let remote = ProductsRemote(network: network)
+        let response = Data(#"{"code":"rest_no_route","message":"No route found","data":{"status":404}}"#.utf8)
+        let expectedError = NetworkError.notFound(response: response)
+        network.simulateError(requestUrlSuffix: "products/\(sampleProductID)/duplicate", error: expectedError)
+
+        // When
+        var result: Result<Int64, Error>?
+        waitForExpectation { expectation in
+            remote.duplicateProduct(siteID: sampleSiteID, productID: sampleProductID) {
+                result = $0
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(result?.failure as? NetworkError, expectedError)
+    }
+
+    func test_duplicateProduct_relays_tunneled_noRestRoute_error() {
+        // Given
+        let remote = ProductsRemote(network: network)
+        let expectedError = DotcomError.noRestRoute()
+        network.simulateError(requestUrlSuffix: "products/\(sampleProductID)/duplicate", error: expectedError)
+
+        // When
+        var result: Result<Int64, Error>?
+        waitForExpectation { expectation in
+            remote.duplicateProduct(siteID: sampleSiteID, productID: sampleProductID) {
+                result = $0
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(result?.failure as? DotcomError, expectedError)
+    }
+
     // MARK: - Delete Product
 
     func test_deleteProduct_with_success_mock_returns_a_product() {

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/product-duplicate.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/product-duplicate.json
@@ -1,0 +1,19 @@
+{
+    "id": 3946,
+    "name": "Product (Copy)",
+    "slug": "",
+    "status": "draft",
+    "meta_data": [
+        {
+            "key": "custom_key",
+            "value": "custom_value"
+        }
+    ],
+    "images": [
+        {
+            "id": 12,
+            "src": "https://example.com/image.jpg"
+        }
+    ],
+    "variations": [3947, 3948]
+}

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -36,6 +36,9 @@ final class MockProductsRemote {
     /// The results to return based on the given site ID in `addProduct`
     private var addProductResultsBySiteID = [Int64: Result<Product, Error>]()
 
+    /// The results to return based on the given site and product IDs in `duplicateProduct`
+    private var duplicateProductResultsByKey = [ResultKey: Result<Int64, Error>]()
+
     /// The results to return based on the given site ID in `deleteProduct`
     private var deleteProductResultsBySiteID = [Int64: Result<Product, Error>]()
 
@@ -64,6 +67,9 @@ final class MockProductsRemote {
     /// The number of times that `loadProduct()` was invoked.
     private(set) var invocationCountOfLoadProduct: Int = 0
 
+    /// The number of times that `duplicateProduct()` was invoked.
+    private(set) var invocationCountOfDuplicateProduct: Int = 0
+
     /// The last requested page size for popular products
     private(set) var lastRequestedPageSize: Int?
 
@@ -88,6 +94,13 @@ final class MockProductsRemote {
     ///
     func whenAddingProduct(siteID: Int64, thenReturn result: Result<Product, Error>) {
         addProductResultsBySiteID[siteID] = result
+    }
+
+    /// Set the value passed to the `completion` block if `duplicateProduct()` is called.
+    ///
+    func whenDuplicatingProduct(siteID: Int64, productID: Int64, thenReturn result: Result<Int64, Error>) {
+        let key = ResultKey(siteID: siteID, productIDs: [productID])
+        duplicateProductResultsByKey[key] = result
     }
 
     /// Set the value passed to the `completion` block if `deleteProduct()` is called.
@@ -196,6 +209,22 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for site ID \(product.siteID)")
+            }
+        }
+    }
+
+    func duplicateProduct(siteID: Int64, productID: Int64, completion: @escaping (Result<Int64, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+
+            self.invocationCountOfDuplicateProduct += 1
+            let key = ResultKey(siteID: siteID, productIDs: [productID])
+            if let result = self.duplicateProductResultsByKey[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
             }
         }
     }

--- a/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
@@ -154,6 +154,82 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(result?.isFailure, true)
     }
 
+    // MARK: - ProductAction.duplicateProduct
+
+    func test_duplicateProduct_returns_the_duplicated_product_ID() throws {
+        // Given
+        let remote = MockProductsRemote()
+        let duplicatedProductID: Int64 = 999
+        remote.whenDuplicatingProduct(siteID: sampleSiteID, productID: sampleProductID, thenReturn: .success(duplicatedProductID))
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        var result: Result<Int64, ProductDuplicateError>?
+        waitForExpectation { expectation in
+            let action = ProductAction.duplicateProduct(siteID: sampleSiteID, productID: sampleProductID) {
+                result = $0
+                expectation.fulfill()
+            }
+            productStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(try result?.get(), duplicatedProductID)
+        XCTAssertEqual(remote.invocationCountOfDuplicateProduct, 1)
+    }
+
+    func test_duplicateProduct_maps_Dotcom_noRestRoute_to_endpointUnavailable() {
+        assertDuplicateProductError(DotcomError.noRestRoute(), equals: .endpointUnavailable)
+    }
+
+    func test_duplicateProduct_maps_notFound_NetworkError_with_rest_no_route_code_to_endpointUnavailable() {
+        let response = Data(#"{"code":"rest_no_route","message":"No route found","data":{"status":404}}"#.utf8)
+        let error = NetworkError.notFound(response: response)
+        assertDuplicateProductError(error, equals: .endpointUnavailable)
+    }
+
+    func test_duplicateProduct_preserves_non_route_errors_as_terminal_unknown_error() {
+        let response = Data(#"{"code":"woocommerce_rest_product_invalid_id","message":"Invalid product ID","data":{"status":404}}"#.utf8)
+        let error = NetworkError.notFound(response: response)
+        assertDuplicateProductError(error, equals: .unknown(error: AnyError(error)))
+    }
+
+    func test_duplicateProduct_preserves_non_notFound_NetworkError_with_rest_no_route_code_as_terminal_unknown_error() {
+        let response = Data(#"{"code":"rest_no_route","message":"No route found","data":{"status":500}}"#.utf8)
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500, response: response)
+        assertDuplicateProductError(error, equals: .unknown(error: AnyError(error)))
+    }
+
+    func test_duplicateProduct_preserves_generic_transport_error_as_terminal_unknown_error() {
+        let error = URLError(.networkConnectionLost)
+        assertDuplicateProductError(error, equals: .unknown(error: AnyError(error)))
+    }
+
+    func test_duplicateProduct_does_not_classify_WordPress_error_code_without_notFound_NetworkError_as_endpointUnavailable() {
+        let error = WordPressApiError.unknown(code: "rest_no_route", message: "No route found")
+        assertDuplicateProductError(error, equals: .unknown(error: AnyError(error)))
+    }
+
+    private func assertDuplicateProductError(_ error: Error, equals expectedError: ProductDuplicateError) {
+        // Given
+        let remote = MockProductsRemote()
+        remote.whenDuplicatingProduct(siteID: sampleSiteID, productID: sampleProductID, thenReturn: .failure(error))
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        var result: Result<Int64, ProductDuplicateError>?
+        waitForExpectation { expectation in
+            let action = ProductAction.duplicateProduct(siteID: sampleSiteID, productID: sampleProductID) {
+                result = $0
+                expectation.fulfill()
+            }
+            productStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(result?.failure, expectedError)
+    }
+
     // MARK: - ProductAction.deleteProduct
 
     func test_deleteProduct_deletes_the_stored_product() throws {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.3
 -----
+- [*] Product duplication now uses WooCommerce's built-in copy flow when available, with compatibility support for older stores. [https://github.com/woocommerce/woocommerce-ios/pull/17551]
 
 
 25.2

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -29,35 +29,58 @@ final class ProductFormRemoteActionUseCase {
                     successEventName: WooAnalyticsStat = .addProductSuccess,
                     failureEventName: WooAnalyticsStat = .addProductFailed,
                     onCompletion: @escaping AddProductCompletion) {
-        let updatedProduct = EditableProductModel(product: product.product.copy(password: password))
-        addProductRemotely(product: updatedProduct) { productResult in
-            switch productResult {
-            case .failure(let error):
-                ServiceLocator.analytics.track(failureEventName, withError: error)
-                onCompletion(.failure(error))
-            case .success(let product):
-                // `self` is retained because the use case is not usually strongly held.
-                self.updatePasswordRemotely(product: product, password: password) { passwordResult in
-                    switch passwordResult {
-                    case .failure(let error):
-                        ServiceLocator.analytics.track(failureEventName, withError: error)
-                        onCompletion(.failure(.passwordCannotBeUpdated))
-                    case .success(let password):
-                        ServiceLocator.analytics.track(successEventName)
-                        onCompletion(.success(ResultData(product: product, password: password)))
-                    }
-                }
-            }
+        addProduct(product: product,
+                   password: password,
+                   successEventName: successEventName,
+                   failureEventName: failureEventName,
+                   trackAnalytics: true) { result, _ in
+            onCompletion(result)
         }
     }
 
-    /// Adds a copy of the input product remotely. The new product will have an updated name, no SKU and its status will be Draft.
+    /// Duplicates a product remotely, using the core endpoint when available and a compatibility fallback on older stores.
     /// - Parameters:
     ///   - originalProduct: The product to be duplicated remotely.
-    ///   - onCompletion: Called when the remote process finishes.
+    ///   - password: Optional password of the duplicated product.
+    ///   - onCompletion: Called when the complete duplication flow finishes.
     func duplicateProduct(originalProduct: EditableProductModel,
                           password: String?,
                           onCompletion: @escaping DuplicateProductCompletion) {
+        let trackedCompletion: (_ result: Result<ResultData, ProductUpdateError>, _ analyticsError: Error?) -> Void = { result, analyticsError in
+            switch result {
+            case .success:
+                ServiceLocator.analytics.track(.duplicateProductSuccess)
+            case .failure(let error):
+                ServiceLocator.analytics.track(.duplicateProductFailed, withError: analyticsError ?? error)
+            }
+            onCompletion(result)
+        }
+
+        let action = ProductAction.duplicateProduct(siteID: originalProduct.siteID, productID: originalProduct.productID) { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case .success(let duplicatedProductID):
+                self.retrieveDuplicatedProduct(id: duplicatedProductID,
+                                                siteID: originalProduct.siteID,
+                                                password: password,
+                                                onCompletion: trackedCompletion)
+            case .failure(.endpointUnavailable):
+                self.duplicateProductUsingLegacyFlow(originalProduct: originalProduct,
+                                                     password: password,
+                                                     onCompletion: trackedCompletion)
+            case .failure(.unknown(let error)):
+                trackedCompletion(.failure(.unknown(error: error)), error)
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    /// Compatibility fallback for stores where the core duplication endpoint is conclusively unavailable.
+    private func duplicateProductUsingLegacyFlow(originalProduct: EditableProductModel,
+                                                 password: String?,
+                                                 onCompletion: @escaping (_ result: Result<ResultData, ProductUpdateError>,
+                                                                          _ analyticsError: Error?) -> Void) {
         let productModelToSave: EditableProductModel = {
             let newName = String(format: Localization.copyProductName, originalProduct.name)
             let copiedProduct = originalProduct.product.copy(
@@ -72,13 +95,11 @@ final class ProductFormRemoteActionUseCase {
             return EditableProductModel(product: copiedProduct)
         }()
 
-        let successEventName: WooAnalyticsStat = .duplicateProductSuccess
-        let failureEventName: WooAnalyticsStat = .duplicateProductFailed
-
         addProduct(product: productModelToSave,
                    password: password,
-                   successEventName: successEventName,
-                   failureEventName: failureEventName) { [weak self] result in
+                   successEventName: .duplicateProductSuccess,
+                   failureEventName: .duplicateProductFailed,
+                   trackAnalytics: false) { [weak self] result, analyticsError in
             guard let self else { return }
             switch result {
             case .success(let data):
@@ -90,16 +111,16 @@ final class ProductFormRemoteActionUseCase {
                                       siteID: data.product.siteID)
 
                 // Wrap completion to optimistically inject custom fields so the UI shows them immediately.
-                let onCompletionWithCustomFields: DuplicateProductCompletion = { result in
+                let onCompletionWithCustomFields = { (result: Result<ResultData, ProductUpdateError>, analyticsError: Error?) in
                     onCompletion(result.map { data in
                         ResultData(product: EditableProductModel(product: data.product.product.copy(customFields: originalCustomFields)),
                                    password: data.password)
-                    })
+                    }, analyticsError)
                 }
 
                 let variableTypes: [ProductType] = [.variable, .variableSubscription]
                 guard variableTypes.contains(data.product.productType) else {
-                    return onCompletionWithCustomFields(.success(data))
+                    return onCompletionWithCustomFields(.success(data), nil)
                 }
                 self.duplicateVariations(originalProduct.product.variations,
                                          from: originalProduct.productID,
@@ -107,15 +128,48 @@ final class ProductFormRemoteActionUseCase {
                                          onCompletion: { result in
                     switch result {
                     case .success(let product):
-                        ServiceLocator.analytics.track(successEventName)
-                        onCompletionWithCustomFields(.success(ResultData(product: product, password: data.password)))
+                        onCompletionWithCustomFields(.success(ResultData(product: product, password: data.password)), nil)
                     case .failure(let error):
-                        ServiceLocator.analytics.track(failureEventName, withError: error)
-                        onCompletionWithCustomFields(.failure(error))
+                        onCompletionWithCustomFields(.failure(error), error)
                     }
                 })
             case .failure(let error):
-                onCompletion(.failure(error))
+                onCompletion(.failure(error), analyticsError)
+            }
+        }
+    }
+
+    private func addProduct(product: EditableProductModel,
+                            password: String?,
+                            successEventName: WooAnalyticsStat,
+                            failureEventName: WooAnalyticsStat,
+                            trackAnalytics: Bool,
+                            onCompletion: @escaping (_ result: Result<ResultData, ProductUpdateError>,
+                                                     _ analyticsError: Error?) -> Void) {
+        let updatedProduct = EditableProductModel(product: product.product.copy(password: password))
+        addProductRemotely(product: updatedProduct) { productResult in
+            switch productResult {
+            case .failure(let error):
+                if trackAnalytics {
+                    ServiceLocator.analytics.track(failureEventName, withError: error)
+                }
+                onCompletion(.failure(error), error)
+            case .success(let product):
+                // `self` is retained because the use case is not usually strongly held.
+                self.updatePasswordRemotely(product: product, password: password) { passwordResult in
+                    switch passwordResult {
+                    case .failure(let error):
+                        if trackAnalytics {
+                            ServiceLocator.analytics.track(failureEventName, withError: error)
+                        }
+                        onCompletion(.failure(.passwordCannotBeUpdated), error)
+                    case .success(let password):
+                        if trackAnalytics {
+                            ServiceLocator.analytics.track(successEventName)
+                        }
+                        onCompletion(.success(ResultData(product: product, password: password)), nil)
+                    }
+                }
             }
         }
     }
@@ -200,6 +254,22 @@ final class ProductFormRemoteActionUseCase {
 }
 
 private extension ProductFormRemoteActionUseCase {
+    func retrieveDuplicatedProduct(id: Int64,
+                                   siteID: Int64,
+                                   password: String?,
+                                   onCompletion: @escaping (_ result: Result<ResultData, ProductUpdateError>,
+                                                            _ analyticsError: Error?) -> Void) {
+        let action = ProductAction.retrieveProduct(siteID: siteID, productID: id) { result in
+            switch result {
+            case .success(let product):
+                onCompletion(.success(ResultData(product: EditableProductModel(product: product), password: password)), nil)
+            case .failure(let error):
+                onCompletion(.failure(.unknown(error: AnyError(error))), error)
+            }
+        }
+        stores.dispatch(action)
+    }
+
     func addProductRemotely(product: EditableProductModel, onCompletion: @escaping (Result<EditableProductModel, ProductUpdateError>) -> Void) {
         let updateProductAction = ProductAction.addProduct(product: product.product) { result in
             switch result {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Yosemite
+import protocol WooFoundation.Analytics
 
 import YosemiteTestHelpers
 @testable import WooCommerce
@@ -8,6 +9,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
     typealias ResultData = ProductFormRemoteActionUseCase.ResultData
     private var storesManager: MockStoresManager!
     private var storageManager: MockStorageManager!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var originalAnalytics: Analytics!
     private let siteID: Int64 = 123
     private let pluginName = "WooCommerce"
     private let pluginSlug = "woocommerce"
@@ -17,11 +20,17 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         storesManager = MockStoresManager(sessionManager: SessionManager.testingInstance)
         storesManager.sessionManager.setStoreId(siteID)
         storageManager = MockStorageManager()
+        originalAnalytics = ServiceLocator.analytics
+        analyticsProvider = MockAnalyticsProvider()
+        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
     }
 
     override func tearDown() {
         storesManager = nil
         storageManager = nil
+        ServiceLocator.setAnalytics(originalAnalytics)
+        analyticsProvider = nil
+        originalAnalytics = nil
         super.tearDown()
     }
 
@@ -46,6 +55,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
         XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: password)))
+        XCTAssertEqual(analyticsProvider.receivedEvents.filter { $0 == WooAnalyticsStat.addProductSuccess.rawValue },
+                       [WooAnalyticsStat.addProductSuccess.rawValue])
     }
 
     func test_adding_product_with_a_password_unsuccessfully_returns_failure_result_with_password_error() {
@@ -105,6 +116,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
         XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.invalidSKU))
+        XCTAssertEqual(analyticsProvider.receivedEvents.filter { $0 == WooAnalyticsStat.addProductFailed.rawValue },
+                       [WooAnalyticsStat.addProductFailed.rawValue])
     }
 
     // MARK: - Editing a product (`addProduct`)
@@ -399,6 +412,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         // When
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
+            case .duplicateProduct(_, _, let onCompletion):
+                onCompletion(.failure(.endpointUnavailable))
             case .addProduct(let product, _):
                 copiedProductName = product.name
                 copiedProductStatusKey = product.statusKey
@@ -429,6 +444,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         // When
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
+            case .duplicateProduct(_, _, let onCompletion):
+                onCompletion(.failure(.endpointUnavailable))
             case .addProduct(let product, _):
                 copiedProductSlug = product.slug
                 copiedProductPermalink = product.permalink
@@ -451,9 +468,10 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         let product = Product.fake()
         let model = EditableProductModel(product: product)
         let password = "wo0oo!"
+        let passwordError = NSError(domain: "PasswordUpdate", code: 100)
         let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
         mockAddProduct(result: .success(product))
-        mockUpdatePassword(result: .failure(NSError(domain: "", code: 100, userInfo: nil)))
+        mockUpdatePassword(result: .failure(passwordError))
 
         // When
         var result: Result<ResultData, ProductUpdateError>?
@@ -465,6 +483,9 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
         XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.passwordCannotBeUpdated))
+        XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductFailed.rawValue])
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["error_domain"] as? String, passwordError.domain)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["error_code"] as? String, String(passwordError.code))
     }
 
     func test_duplicating_product_without_a_password_successfully_does_not_trigger_password_action_and_returns_success_result() {
@@ -484,6 +505,7 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
         XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: nil)))
+        XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductSuccess.rawValue])
     }
 
     func test_duplicating_product_unsuccessfully_does_not_trigger_password_action_and_returns_failure_result_with_product_error() {
@@ -503,6 +525,7 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
         XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.invalidSKU))
+        XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductFailed.rawValue])
     }
 
     func test_duplicating_product_with_custom_fields_dispatches_metadata_update_action() throws {
@@ -545,10 +568,221 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertEqual(returnedProduct.product.customFields, customFields)
     }
 
-    func test_duplicating_variable_product_triggers_retrieving_original_product_variations_and_creating_new_variations_for_duplicated_product() {
+    func test_core_duplicate_fetches_canonical_product_without_dispatching_legacy_copy_actions_for_supported_product_types() throws {
+        for productType in [ProductType.simple, .variable, .subscription, .variableSubscription] {
+            // Given
+            storesManager.reset()
+            analyticsProvider.clearEvents()
+            let sourceProductID: Int64 = 5
+            let duplicatedProductID: Int64 = 99
+            let source = Product.fake().copy(siteID: siteID,
+                                             productID: sourceProductID,
+                                             productTypeKey: productType.rawValue,
+                                             variations: [11, 12],
+                                             customFields: [MetaData(metadataID: 1, key: "custom_key", value: "source_value")])
+            let canonicalDuplicate = source.copy(productID: duplicatedProductID,
+                                                 name: "Server Copy",
+                                                 slug: "server-copy",
+                                                 permalink: "https://example.com/product/server-copy")
+            storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+                switch action {
+                case let .duplicateProduct(receivedSiteID, receivedProductID, onCompletion):
+                    XCTAssertEqual(receivedSiteID, self.siteID)
+                    XCTAssertEqual(receivedProductID, sourceProductID)
+                    onCompletion(.success(duplicatedProductID))
+                case let .retrieveProduct(receivedSiteID, receivedProductID, onCompletion):
+                    XCTAssertEqual(receivedSiteID, self.siteID)
+                    XCTAssertEqual(receivedProductID, duplicatedProductID)
+                    XCTAssertTrue(self.duplicateAnalyticsEvents.isEmpty)
+                    onCompletion(.success(canonicalDuplicate))
+                case .addProduct:
+                    XCTFail("Core duplication must not create a second product with the legacy endpoint")
+                default:
+                    break
+                }
+            }
+            let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+
+            // When
+            var result: Result<ResultData, ProductUpdateError>?
+            useCase.duplicateProduct(originalProduct: EditableProductModel(product: source), password: "secret") {
+                result = $0
+            }
+
+            // Then
+            let resultData = try XCTUnwrap(result?.get())
+            XCTAssertEqual(resultData.product, EditableProductModel(product: canonicalDuplicate))
+            XCTAssertEqual(resultData.password, "secret")
+            XCTAssertEqual(storesManager.receivedActions.compactMap { $0 as? ProductAction }.count, 2)
+            XCTAssertFalse(storesManager.receivedActions.contains { $0 is MetaDataAction })
+            XCTAssertFalse(storesManager.receivedActions.contains { $0 is ProductVariationAction })
+            XCTAssertFalse(storesManager.receivedActions.contains { $0 is SitePostAction })
+            XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductSuccess.rawValue])
+        }
+    }
+
+    func test_core_duplicate_failure_is_terminal_and_does_not_run_legacy_fallback() {
         // Given
+        let underlyingError = NSError(domain: "ProductDuplicate", code: 500)
+        let product = Product.fake().copy(siteID: siteID, productID: 5)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .duplicateProduct(_, _, onCompletion):
+                onCompletion(.failure(.unknown(error: AnyError(underlyingError))))
+            case .addProduct, .retrieveProduct:
+                XCTFail("Ambiguous duplication failures must not trigger another product request")
+            default:
+                break
+            }
+        }
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+
+        // When
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: EditableProductModel(product: product), password: nil) {
+            result = $0
+        }
+
+        // Then
+        XCTAssertEqual(result, .failure(.unknown(error: AnyError(underlyingError))))
+        XCTAssertEqual(storesManager.receivedActions.compactMap { $0 as? ProductAction }.count, 1)
+        XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductFailed.rawValue])
+    }
+
+    func test_core_duplicate_canonical_retrieval_failure_is_terminal_and_does_not_run_legacy_fallback() {
+        // Given
+        let underlyingError = NSError(domain: "ProductRetrieve", code: 500)
+        let product = Product.fake().copy(siteID: siteID, productID: 5)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .duplicateProduct(_, _, onCompletion):
+                onCompletion(.success(99))
+            case let .retrieveProduct(_, _, onCompletion):
+                onCompletion(.failure(underlyingError))
+            case .addProduct:
+                XCTFail("A failed canonical fetch after duplication must not create another product")
+            default:
+                break
+            }
+        }
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+
+        // When
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: EditableProductModel(product: product), password: nil) {
+            result = $0
+        }
+
+        // Then
+        XCTAssertEqual(result, .failure(.unknown(error: AnyError(underlyingError))))
+        XCTAssertEqual(storesManager.receivedActions.compactMap { $0 as? ProductAction }.count, 2)
+        XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductFailed.rawValue])
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["error_domain"] as? String, underlyingError.domain)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["error_code"] as? String, String(underlyingError.code))
+    }
+
+    func test_legacy_fallback_preserves_images_and_does_not_mutate_subscription_source_product() throws {
+        // Given
+        let images = [ProductImage(imageID: 12,
+                                   dateCreated: Date(),
+                                   dateModified: Date(),
+                                   src: "https://example.com/source.jpg",
+                                   name: "source",
+                                   alt: "Source image")]
+        let source = Product.fake().copy(siteID: siteID,
+                                         productID: 5,
+                                         slug: "source-product",
+                                         permalink: "https://example.com/product/source-product",
+                                         productTypeKey: ProductType.subscription.rawValue,
+                                         images: images)
+        let sourceModel = EditableProductModel(product: source)
+        var submittedProduct: Product?
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .duplicateProduct(_, _, onCompletion):
+                onCompletion(.failure(.endpointUnavailable))
+            case let .addProduct(product, onCompletion):
+                submittedProduct = product
+                onCompletion(.success(product.copy(productID: 99)))
+            default:
+                break
+            }
+        }
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+
+        // When
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: sourceModel, password: nil) {
+            result = $0
+        }
+
+        // Then
+        XCTAssertEqual(submittedProduct?.images, images)
+        XCTAssertEqual(submittedProduct?.slug, "")
+        XCTAssertEqual(submittedProduct?.permalink, "")
+        XCTAssertEqual(sourceModel, EditableProductModel(product: source))
+        XCTAssertEqual(try result?.get().product.product.images, images)
+    }
+
+    func test_legacy_fallback_for_variable_product_types_recreates_variations() {
+        for productType in [ProductType.variable, .variableSubscription] {
+            assertLegacyFallbackRecreatesVariations(for: productType)
+        }
+    }
+
+    func test_legacy_fallback_variable_product_failure_tracks_one_failure_only_after_final_retrieval_fails() {
+        // Given
+        let variationID: Int64 = 11
+        let source = Product.fake().copy(siteID: siteID,
+                                         productID: 2,
+                                         productTypeKey: ProductType.variable.rawValue,
+                                         variations: [variationID])
+        let copiedProduct = source.copy(productID: 13)
+        let retrievalError = NSError(domain: "ProductRetrieve", code: 500)
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .retrieveProductVariation(_, _, _, onCompletion):
+                onCompletion(.success(ProductVariation.fake().copy(productVariationID: variationID)))
+            case let .createProductVariation(_, _, _, onCompletion):
+                onCompletion(.success(ProductVariation.fake().copy(productVariationID: 99)))
+            default:
+                break
+            }
+        }
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .duplicateProduct(_, _, onCompletion):
+                onCompletion(.failure(.endpointUnavailable))
+            case let .addProduct(_, onCompletion):
+                onCompletion(.success(copiedProduct))
+            case let .retrieveProduct(_, _, onCompletion):
+                XCTAssertTrue(self.duplicateAnalyticsEvents.isEmpty)
+                onCompletion(.failure(retrievalError))
+            default:
+                break
+            }
+        }
+
+        // When
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: EditableProductModel(product: source), password: nil) {
+            result = $0
+        }
+        waitUntil { result != nil }
+
+        // Then
+        XCTAssertEqual(result, .failure(.unknown(error: AnyError(retrievalError))))
+        XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductFailed.rawValue])
+    }
+}
+
+private extension ProductFormRemoteActionUseCaseTests {
+    func assertLegacyFallbackRecreatesVariations(for productType: ProductType) {
+        // Given
+        analyticsProvider.clearEvents()
         let testVariationIDs: [Int64] = [11, 20, 35]
-        let product = Product.fake().copy(productID: 2, productTypeKey: ProductType.variable.rawValue, variations: testVariationIDs)
+        let product = Product.fake().copy(productID: 2, productTypeKey: productType.rawValue, variations: testVariationIDs)
         let model = EditableProductModel(product: product)
 
         var retrievedVariationIDs: [Int64] = []
@@ -560,8 +794,7 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
                 onCompletion(.success(ProductVariation.fake().copy(productVariationID: variationID)))
             case let .createProductVariation(_, _, _, onCompletion):
                 createdVariationCount += 1
-                let fakeVariation = ProductVariation.fake().copy(productVariationID: Int64.random(in: 99..<999))
-                onCompletion(.success(fakeVariation))
+                onCompletion(.success(ProductVariation.fake().copy(productVariationID: Int64.random(in: 99..<999))))
             default:
                 break
             }
@@ -571,9 +804,12 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         let finalProduct = copiedProduct.copy(variations: testVariationIDs)
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case .addProduct(_, let onCompletion):
+            case let .duplicateProduct(_, _, onCompletion):
+                onCompletion(.failure(.endpointUnavailable))
+            case let .addProduct(_, onCompletion):
                 onCompletion(.success(copiedProduct))
-            case .retrieveProduct(_, _, let onCompletion):
+            case let .retrieveProduct(_, _, onCompletion):
+                XCTAssertTrue(self.duplicateAnalyticsEvents.isEmpty)
                 onCompletion(.success(finalProduct))
             default:
                 break
@@ -583,25 +819,34 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         // When
         let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
         var result: Result<ResultData, ProductUpdateError>?
-        useCase.duplicateProduct(originalProduct: model, password: nil) { aResult in
-            result = aResult
+        useCase.duplicateProduct(originalProduct: model, password: nil) {
+            result = $0
         }
         waitUntil {
-            createdVariationCount == 3 &&
-            result != nil
+            createdVariationCount == testVariationIDs.count && result != nil
         }
 
         // Then
         XCTAssertEqual(retrievedVariationIDs.sorted(), testVariationIDs.sorted())
         XCTAssertEqual(result?.isSuccess, true)
+        XCTAssertEqual(duplicateAnalyticsEvents, [WooAnalyticsStat.duplicateProductSuccess.rawValue])
     }
-}
 
-private extension ProductFormRemoteActionUseCaseTests {
+    var duplicateAnalyticsEvents: [String] {
+        analyticsProvider.receivedEvents.filter {
+            $0 == WooAnalyticsStat.duplicateProductSuccess.rawValue || $0 == WooAnalyticsStat.duplicateProductFailed.rawValue
+        }
+    }
+
     func mockAddProduct(result: Result<Product, ProductUpdateError>) {
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
-            if case let ProductAction.addProduct(_, onCompletion) = action {
+            switch action {
+            case let .duplicateProduct(_, _, onCompletion):
+                onCompletion(.failure(.endpointUnavailable))
+            case let .addProduct(_, onCompletion):
                 onCompletion(result)
+            default:
+                break
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -274,9 +274,14 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         let productImagesUploader = MockProductImageUploader()
         let viewModel = createViewModel(product: originalProduct, formType: .edit, productImagesUploader: productImagesUploader)
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
-            if case let ProductAction.addProduct(productToSave, onCompletion) = action {
+            switch action {
+            case let .duplicateProduct(_, _, onCompletion):
+                onCompletion(.failure(.endpointUnavailable))
+            case let .addProduct(productToSave, onCompletion):
                 // Simulate the server returning the duplicate with a new ID and copied name.
                 onCompletion(.success(productToSave.copy(productID: 456, name: "Original Copy")))
+            default:
+                break
             }
         }
 


### PR DESCRIPTION
WOOMOB-3587

## Description
Migrate product duplication to `POST /wc/v3/products/{id}/duplicate` while preserving the existing iOS navigation, draft-editing UX, and analytics.

The core response is deliberately mapped only to the duplicated product ID. The app then retrieves that ID through the normal `ProductAction.retrieveProduct` path so the destination screen receives the canonical cached product. The legacy client-side copy remains available only when the endpoint is conclusively absent: either a tunneled `DotcomError.noRestRoute` or a direct REST HTTP 404 whose API code is exactly `rest_no_route`. Invalid IDs, server failures, network failures, and ambiguous errors remain terminal.

Because duplication is non-idempotent, the request opts out of automatic direct-REST-to-Jetpack replay. Networking records the immutable transport that executed the request so a direct failure cannot later be revalidated as a tunneled error if application-password state changes while the request is in flight.

The compatibility path continues to preserve custom fields, images/source isolation, cleared slug/permalink, subscription-like products, and variable-product variation recreation. Duplicate analytics now emit exactly one terminal success or failure after the complete core or fallback flow, while normal add-product analytics remain unchanged.

## Test Steps

### Mock setup

1. Start WireMock: `./API-Mocks/scripts/start.sh 8282`.
2. Launch `com.automattic.woocommerce` with `logout-at-launch disable-animations mocked-wpcom-api -ui_testing -mocks-port 8282`.
3. Log in to `http://yourwoosite.com` with `t@wp.com`, password `pw`, and OTP `123456`.
4. Register each scenario as a priority-1 runtime mapping through `POST http://localhost:8282/__admin/mappings`, reset the request journal with `DELETE http://localhost:8282/__admin/requests`, and test one scenario at a time. In this mocked environment, match the outer Jetpack request:
   - URL: `POST /rest/v1.1/jetpack-blogs/161477129/rest-api/`
   - Duplicate body matcher: `.*path=/wc/v3/products/2130/duplicate%26_method%3Dpost.*`
   - Legacy add body matcher: `.*path=/wc/v3/products%26_method%3Dpost.*`
   - Canonical retrieval matcher: URL/query containing `path=/wc/v3/products/3946%26_method%3Dget`

The outer Jetpack POST contains the tunnel envelope, so it is not literally bodyless. Its logical duplicate request must contain `_method=post` and no endpoint parameters beyond the empty `{}` body. When testing direct REST/application-password transport instead, verify one literal empty-body `POST /wp-json/wc/v3/products/2130/duplicate`.

### A. Supported endpoint

1. Stub the logical duplicate POST with HTTP 200 and `{"data":{"id":3946}}`.
2. Stub the canonical product GET for ID `3946` using the normal product response shape: ID `3946`, name `Black Coral shades (Copy)`, status `draft`, and copied image/price/inventory/type.
3. Open Products → Black Coral shades → More options → Duplicate.
4. Verify progress appears, the canonical copied Draft opens, and the source remains unchanged.
5. Verify the journal contains exactly one logical `/products/2130/duplicate` POST followed by one canonical GET for product `3946`, with no legacy add-product POST.

### B. Endpoint absent — safe legacy fallback

1. Stub the logical duplicate POST with HTTP 404 and this exact response:

```json
{"code":"rest_no_route","message":"No route was found matching the URL and request method.","data":{"status":404}}
```

2. Stub exactly one logical legacy add-product POST (`/wc/v3/products&_method=post`) with a canonical copied product: a fresh ID, name `Black Coral shades (Copy)`, status `draft`, and copied image/price/inventory/type.
3. Reset the journal, invoke Duplicate once, and verify progress appears and exactly one new Draft opens.
4. Return to Products and verify there is only one copy and the source remains unchanged.
5. Verify journal order/count: one `/duplicate` attempt followed by one legacy add-product request; no second duplication request. A canonical GET is not expected for the simple legacy result unless the existing flow requires one.

### C. Invalid-product 404 — terminal

1. Remove the Scenario B mappings and stub the logical duplicate POST with HTTP 404 and this exact response:

```json
{"code":"woocommerce_rest_product_invalid_id","message":"Invalid product ID.","data":{"status":404}}
```

2. Reset the journal and invoke Duplicate once from the unchanged source product.
3. Verify the app shows `Cannot duplicate product`, remains on the source, and creates no Draft.
4. Verify the journal contains exactly one `/duplicate` request and zero legacy add-product requests.

### Automated verification

- Networking suite: 140 tests passed.
- Yosemite `ProductStoreTests`: 113 tests passed, plus the focused final error-mapping rerun.
- App `ProductFormRemoteActionUseCaseTests`: 25 tests passed.
- Full WooCommerce `build-for-testing`: succeeded.
- Direct SwiftLint: passed.
- `git diff --check`: passed.
- WireMock simulator verification: supported endpoint, exact `rest_no_route` fallback, and exact invalid-product terminal failure all passed.
- A final Fastlane rerun could not start because the locally pinned `fastlane-plugin-wpmreleasetoolkit`/`nokogiri` gems were unavailable; it did not reach test execution.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
