### PR TITLE
Fix Collect Payment after order creation on phones

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.3
 -----
+- [*] Order Creation: Fixed Collect Payment not opening payment methods after creating an order on iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17552]
 
 
 25.2

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -232,15 +232,11 @@ final class OrdersRootViewController: UIViewController {
         }
 
         viewModel.onFinishAndCollectPayment = { [weak self] order, paymentMethodsViewModel in
-            self?.dismiss(animated: true) {
+            guard let self else { return }
+
+            self.dismiss(animated: true) { [weak self] in
                 self?.navigateToOrderDetail(order) { [weak self] _ in
-                    guard let self,
-                          let orderDetailsViewController = self.orderDetailsViewController else {
-                        return
-                    }
-                    let paymentMethodsViewController = PaymentMethodsHostingController(viewModel: paymentMethodsViewModel)
-                    paymentMethodsViewController.parentController = orderDetailsViewController
-                    orderDetailsViewController.present(paymentMethodsViewController, animated: true)
+                    self?.presentPaymentMethods(viewModel: paymentMethodsViewModel)
                 }
             }
         }
@@ -643,6 +639,26 @@ private extension OrdersRootViewController {
         ordersViewController.showOrderDetails(order, shouldScrollIfNeeded: true) { _ in
             onCompletion?(true)
         }
+    }
+
+    func presentPaymentMethods(viewModel: PaymentMethodsViewModel) {
+        guard let presenter = paymentMethodsPresenter else {
+            DDLogError("⛔️ Unable to present payment methods after creating order.")
+            return
+        }
+
+        let paymentMethodsViewController = PaymentMethodsHostingController(viewModel: viewModel)
+        paymentMethodsViewController.parentController = presenter
+        presenter.present(paymentMethodsViewController, animated: true)
+    }
+
+    var paymentMethodsPresenter: UIViewController? {
+        if let orderDetailsViewController,
+           orderDetailsViewController.viewIfLoaded?.window != nil {
+            return orderDetailsViewController
+        }
+
+        return navigationController?.visibleViewController ?? navigationController ?? self
     }
 
     var orderDetailsViewController: OrderDetailsViewController? {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -86,13 +86,31 @@ private extension OrdersSplitViewWrapperController {
             .viewControllers.contains(where: { $0 is EmptyStateViewController }) == true
     }
 
-    func showSecondaryView(_ viewController: UIViewController) {
+    func showSecondaryView(_ viewController: UIViewController, onCompletion: (() -> Void)? = nil) {
         // added to remove double details presented bug #11752 https://github.com/woocommerce/woocommerce-ios/pull/11753#discussion_r1463020153
         // - white debugging noticed that ordersViewController.navigationController had multiple orders in the view controllers list
         ordersViewController.navigationController?.popToRootViewController(animated: false)
 
         ordersSplitViewController.setViewController(viewController, for: .secondary)
         ordersSplitViewController.show(.secondary)
+        completeAfterShowingSecondary(onCompletion)
+    }
+
+    func completeAfterShowingSecondary(_ completion: (() -> Void)?) {
+        guard let completion else {
+            return
+        }
+
+        if let transitionCoordinator = ordersSplitViewController.transitionCoordinator,
+           transitionCoordinator.animate(alongsideTransition: nil, completion: { _ in
+                completion()
+           }) {
+            return
+        }
+
+        DispatchQueue.main.async {
+            completion()
+        }
     }
 
     /// This is to update the order detail in split view
@@ -136,8 +154,9 @@ private extension OrdersSplitViewWrapperController {
         else {
             // When showing an order without quick navigation, it simply sets the order details to the secondary view.
             let orderDetailsNavigationController = WooNavigationController(rootViewController: orderDetailsViewController)
-            showSecondaryView(orderDetailsNavigationController)
-            onCompletion?(true)
+            showSecondaryView(orderDetailsNavigationController) {
+                onCompletion?(true)
+            }
             return
         }
 
@@ -150,7 +169,9 @@ private extension OrdersSplitViewWrapperController {
         }
 
         ordersSplitViewController.show(.secondary)
-        onCompletion?(true)
+        completeAfterShowingSecondary {
+            onCompletion?(true)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
WOOMOB-3607

## Description
Fixes the a race condition on the phone order-creation flow where tapping `Collect Payment` creates the order and dismisses the order form, but does not always open the payment methods screen.

The issue is a navigation timing race: the collect-payment callback can run immediately before the order detail controller is reliably visible.

This PR waits for the secondary transition to complete before reporting detail navigation as complete.

## Test Steps
1. On iPhone, open Orders.
2. Create a new order with enough details to collect payment.
3. Tap `Collect Payment`.
4. Confirm the order form dismisses, the created order is shown, and the payment methods screen opens.

## Screenshots


https://github.com/user-attachments/assets/99d5c8d6-2427-443a-8bb1-f50155d7c8b5


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.