### PR TITLE
Fix Bundler 4 dependency setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ namespace :dependencies do
 
   namespace :bundle do
     task :check do
-      sh 'bundle check --path=${BUNDLE_PATH:-vendor/bundle} > /dev/null', verbose: false do |ok, _res|
+      sh 'BUNDLE_PATH=${BUNDLE_PATH:-vendor/bundle} bundle check > /dev/null', verbose: false do |ok, _res|
         next if ok
 
         # bundle check exits with a non zero code if install is needed
@@ -38,7 +38,7 @@ namespace :dependencies do
     end
 
     task :install do
-      sh 'bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}'
+      sh 'BUNDLE_PATH=${BUNDLE_PATH:-vendor/bundle} bundle install --jobs=3 --retry=3'
     end
     CLOBBER << 'vendor/bundle'
     CLOBBER << '.bundle'


### PR DESCRIPTION
## Description
Fixes the Bundler 4 failure reported while testing #17484.

Bundler 4 removed the remembered `--path` option, so the dependency Rake tasks now provide `BUNDLE_PATH` as an environment fallback, defaulting to `vendor/bundle`. Bundler continues to use the repository's existing `.bundle/config` setting when it is present because local configuration has higher priority.

## Test Steps
1. Run `bundle install`.
2. Run `bundle exec rake dependencies`.
3. Confirm dependency setup completes without a removed `--path` error.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
