### PR TITLE
Fix Collect Payment navigation after order creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,11 @@
 -----
 
 
+25.1.1
+------
+- [*] Fixed Collect Payment from order creation closing without opening the payment method flow on phones. [https://github.com/woocommerce/woocommerce-ios/pull/17557]
+
+
 25.1
 -----
 - [Internal] Track Woo push token deletion results (woo_push_token_delete_success/error). [https://github.com/woocommerce/woocommerce-ios/pull/17477]

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -237,15 +237,11 @@ final class OrdersRootViewController: UIViewController {
         }
 
         viewModel.onFinishAndCollectPayment = { [weak self] order, paymentMethodsViewModel in
-            self?.dismiss(animated: true) {
+            guard let self else { return }
+
+            self.dismiss(animated: true) { [weak self] in
                 self?.navigateToOrderDetail(order) { [weak self] _ in
-                    guard let self,
-                          let orderDetailsViewController = self.orderDetailsViewController else {
-                        return
-                    }
-                    let paymentMethodsViewController = PaymentMethodsHostingController(viewModel: paymentMethodsViewModel)
-                    paymentMethodsViewController.parentController = orderDetailsViewController
-                    orderDetailsViewController.present(paymentMethodsViewController, animated: true)
+                    self?.presentPaymentMethods(viewModel: paymentMethodsViewModel)
                 }
             }
         }
@@ -658,6 +654,26 @@ private extension OrdersRootViewController {
         ordersViewController.showOrderDetails(order, shouldScrollIfNeeded: true) { _ in
             onCompletion?(true)
         }
+    }
+
+    func presentPaymentMethods(viewModel: PaymentMethodsViewModel) {
+        guard let presenter = paymentMethodsPresenter else {
+            DDLogError("⛔️ Unable to present payment methods after creating order.")
+            return
+        }
+
+        let paymentMethodsViewController = PaymentMethodsHostingController(viewModel: viewModel)
+        paymentMethodsViewController.parentController = presenter
+        presenter.present(paymentMethodsViewController, animated: true)
+    }
+
+    var paymentMethodsPresenter: UIViewController? {
+        if let orderDetailsViewController,
+           orderDetailsViewController.viewIfLoaded?.window != nil {
+            return orderDetailsViewController
+        }
+
+        return navigationController?.visibleViewController ?? navigationController ?? self
     }
 
     var orderDetailsViewController: OrderDetailsViewController? {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -86,13 +86,31 @@ private extension OrdersSplitViewWrapperController {
             .viewControllers.contains(where: { $0 is EmptyStateViewController }) == true
     }
 
-    func showSecondaryView(_ viewController: UIViewController) {
+    func showSecondaryView(_ viewController: UIViewController, onCompletion: (() -> Void)? = nil) {
         // added to remove double details presented bug #11752 https://github.com/woocommerce/woocommerce-ios/pull/11753#discussion_r1463020153
         // - white debugging noticed that ordersViewController.navigationController had multiple orders in the view controllers list
         ordersViewController.navigationController?.popToRootViewController(animated: false)
 
         ordersSplitViewController.setViewController(viewController, for: .secondary)
         ordersSplitViewController.show(.secondary)
+        completeAfterShowingSecondary(onCompletion)
+    }
+
+    func completeAfterShowingSecondary(_ completion: (() -> Void)?) {
+        guard let completion else {
+            return
+        }
+
+        if let transitionCoordinator = ordersSplitViewController.transitionCoordinator,
+           transitionCoordinator.animate(alongsideTransition: nil, completion: { _ in
+                completion()
+           }) {
+            return
+        }
+
+        DispatchQueue.main.async {
+            completion()
+        }
     }
 
     /// This is to update the order detail in split view
@@ -136,8 +154,9 @@ private extension OrdersSplitViewWrapperController {
         else {
             // When showing an order without quick navigation, it simply sets the order details to the secondary view.
             let orderDetailsNavigationController = WooNavigationController(rootViewController: orderDetailsViewController)
-            showSecondaryView(orderDetailsNavigationController)
-            onCompletion?(true)
+            showSecondaryView(orderDetailsNavigationController) {
+                onCompletion?(true)
+            }
             return
         }
 
@@ -150,7 +169,9 @@ private extension OrdersSplitViewWrapperController {
         }
 
         ordersSplitViewController.show(.secondary)
-        onCompletion?(true)
+        completeAfterShowingSecondary {
+            onCompletion?(true)
+        }
     }
 }
 


### PR DESCRIPTION
Closes: WOOMOB-3607

## Description
Backports the Collect Payment navigation fix onto the 25.1.1 release branch.

When an order is created from the phone order creation flow using Collect Payment, the app should dismiss order creation and immediately open the payment method flow for the saved order. This keeps the collect-payment intent with the order creation flow and routes the saved order through the orders root navigation after dismissal.

## Test Steps
1. Use a phone on iOS 26, open Orders > +, and add something to it.
2. Tap `Collect Payment`.
3. Confirm the order creation screen dismisses and the payment method flow opens for the new order.

## Screenshots


https://github.com/user-attachments/assets/2689031f-19f8-4473-8f1a-4844006a70f7




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.