### PR TITLE
Improve Store Info widget layout for Dynamic Type

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,8 +5,8 @@
 -----
 - [*] Fixed product saves replacing shortcode-based short descriptions with their rendered output. [https://github.com/woocommerce/woocommerce-ios/pull/17543]
 - [*] Order Creation: Fixed Collect Payment not opening payment methods after creating an order on iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17552]
-
 - [*] Fixed RTL currency values showing the currency symbol and minus sign in the wrong order. [https://github.com/woocommerce/woocommerce-ios/pull/17547]
+- [*] Improved widget display at larger font sizes [https://github.com/woocommerce/woocommerce-ios/pull/17559]
 
 25.2
 -----

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoLargeMetricsContainerView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoLargeMetricsContainerView.swift
@@ -14,9 +14,14 @@ struct StoreInfoLargeMetricsContainerView: View {
         )
     }
 
+    private var usesCondensedLayout: Bool {
+        StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize)
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
-            StoreInfoMetricsLogoHeader(data: data)
+        VStack(alignment: .leading, spacing: Layout.headerSpacing(for: dynamicTypeSize)) {
+            StoreInfoMetricsLogoHeader(data: data,
+                                       showsUpdatedTime: !usesCondensedLayout)
 
             StoreInfoMetricsGrid(metricSlots: visibleMetricSlots,
                                  dateRange: data.dateRange,
@@ -26,7 +31,9 @@ struct StoreInfoLargeMetricsContainerView: View {
     }
 
     private enum Layout {
-        static let headerSpacing = 12.0
+        static func headerSpacing(for dynamicTypeSize: DynamicTypeSize) -> Double {
+            StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize) ? 8.0 : 12.0
+        }
     }
 }
 

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMediumMetricsContainerView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMediumMetricsContainerView.swift
@@ -14,9 +14,14 @@ struct StoreInfoMediumMetricsContainerView: View {
         )
     }
 
+    private var usesCondensedLayout: Bool {
+        StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize)
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-            StoreInfoMetricsLogoHeader(data: data)
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing(for: dynamicTypeSize)) {
+            StoreInfoMetricsLogoHeader(data: data,
+                                       showsUpdatedTime: !usesCondensedLayout)
 
             StoreInfoMetricsGrid(metricSlots: visibleMetricSlots,
                                  dateRange: data.dateRange)
@@ -25,7 +30,9 @@ struct StoreInfoMediumMetricsContainerView: View {
     }
 
     private enum Layout {
-        static let sectionSpacing = 8.0
+        static func sectionSpacing(for dynamicTypeSize: DynamicTypeSize) -> Double {
+            StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize) ? 4.0 : 8.0
+        }
     }
 }
 

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsLogoHeader.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsLogoHeader.swift
@@ -7,13 +7,16 @@ struct StoreInfoMetricsLogoHeader: View {
     let data: StoreInfoData
     private let showsRange: Bool
     private let showsUpdatePrefix: Bool
+    private let showsUpdatedTime: Bool
 
     init(data: StoreInfoData,
          showsRange: Bool = true,
-         showsUpdatePrefix: Bool = true) {
+         showsUpdatePrefix: Bool = true,
+         showsUpdatedTime: Bool = true) {
         self.data = data
         self.showsRange = showsRange
         self.showsUpdatePrefix = showsUpdatePrefix
+        self.showsUpdatedTime = showsUpdatedTime
     }
 
     var body: some View {
@@ -44,10 +47,12 @@ struct StoreInfoMetricsLogoHeader: View {
                     }
                 }
 
-                updatedTimeText
-                    .statRangeStyle()
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+                if showsUpdatedTime {
+                    updatedTimeText
+                        .statRangeStyle()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -3,7 +3,12 @@ import WidgetKit
 
 enum StoreInfoDynamicType {
     static let maximumSize: DynamicTypeSize = .accessibility2
+    static let condensedLayoutThreshold: DynamicTypeSize = .xLarge
     static let accessibilityLayoutThreshold: DynamicTypeSize = .accessibility1
+
+    static func usesCondensedLayout(_ dynamicTypeSize: DynamicTypeSize) -> Bool {
+        dynamicTypeSize >= condensedLayoutThreshold
+    }
 
     static func usesAccessibilityLayout(_ dynamicTypeSize: DynamicTypeSize) -> Bool {
         dynamicTypeSize >= accessibilityLayoutThreshold

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoSmallMetricsContainerView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoSmallMetricsContainerView.swift
@@ -15,18 +15,23 @@ struct StoreInfoSmallMetricsContainerView: View {
     }
 
     private var showsUpdatePrefix: Bool {
-        !StoreInfoDynamicType.usesAccessibilityLayout(dynamicTypeSize)
+        !StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize)
+    }
+
+    private var showsUpdatedTime: Bool {
+        !StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize)
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
+        VStack(alignment: .leading, spacing: Layout.headerSpacing(for: dynamicTypeSize)) {
             StoreInfoMetricsLogoHeader(data: data,
                                        showsRange: false,
-                                       showsUpdatePrefix: showsUpdatePrefix)
+                                       showsUpdatePrefix: showsUpdatePrefix,
+                                       showsUpdatedTime: showsUpdatedTime)
 
-            Spacer(minLength: Layout.metricSpacing)
+            Spacer(minLength: Layout.metricSpacing(for: dynamicTypeSize))
 
-            VStack(alignment: .leading, spacing: Layout.metricSpacing) {
+            VStack(alignment: .leading, spacing: Layout.metricSpacing(for: dynamicTypeSize)) {
                 ForEach(Array(visibleMetricSlots.enumerated()), id: \.offset) { _, slot in
                     MetricSlotView(slot: slot, placeholderMinHeight: Layout.emptyMetricMinHeight) { metric in
                         MetricCellView(metric: WidgetMetricPresenter(metric: metric, dateRange: data.dateRange))
@@ -38,8 +43,14 @@ struct StoreInfoSmallMetricsContainerView: View {
     }
 
     private enum Layout {
-        static let headerSpacing = 6.0
-        static let metricSpacing = 6.0
+        static func headerSpacing(for dynamicTypeSize: DynamicTypeSize) -> Double {
+            StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize) ? 4.0 : 6.0
+        }
+
+        static func metricSpacing(for dynamicTypeSize: DynamicTypeSize) -> Double {
+            StoreInfoDynamicType.usesCondensedLayout(dynamicTypeSize) ? 4.0 : 6.0
+        }
+
         static let emptyMetricMinHeight = 36.0
     }
 }


### PR DESCRIPTION
Closes: WOOMOB-1383

## Description
Store Info widgets could run out of vertical room as Dynamic Type increased, with the medium widget starting to crowd the widget edges even around slightly larger text sizes.

This updates the small, medium, and large Store Info widget layouts to use a condensed layout from `.xLarge` upward. In the condensed layout, the updated-time metadata row is hidden and the surrounding spacing is tightened while keeping the selected metrics visible.

## Test Steps
1. Add the Store Info widget in small, medium, and large sizes.
2. Increase Dynamic Type/Larger Text above the default size.
3. Confirm the widget content has more breathing room and no longer crowds or crops at the widget edges.

## Screenshots
| Size | Before | After |
|---|---|---|
| default | <img width="1320" height="715" alt="before default" src="https://github.com/user-attachments/assets/59f7b7a6-fd69-4522-a121-dba031239fbe" /> | <img width="1320" height="718" alt="default" src="https://github.com/user-attachments/assets/e0c8454d-887b-4482-a494-875d9201eda0" /> |
| larger | <img width="1320" height="704" alt="before larger than default" src="https://github.com/user-attachments/assets/308661df-14c3-41b6-b91d-0d77a99571ec" /> | <img width="1320" height="732" alt="larger than default" src="https://github.com/user-attachments/assets/05105cb6-4095-4a25-b25f-892dae2c5392" /> |
| accessibility | <img width="1320" height="713" alt="before accessibility" src="https://github.com/user-attachments/assets/d55a1fdb-19d0-4018-886a-95f429af1e72" /> | <img width="1320" height="752" alt="accessibility size" src="https://github.com/user-attachments/assets/e54108fe-eead-4842-9024-6902c6143bec" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
