### PR TITLE
POS payment analytics unit test Improvements

### DIFF
--- a/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
@@ -103,8 +103,13 @@ final class POSCollectOrderPaymentAnalyticsAdaptor: POSCollectOrderPaymentAnalyt
         resetCheckoutTapCountTracker()
     }
 
-    func trackPaymentFailure(with error: any Error) { }
-    func trackPaymentCancelation(cancelationSource: WooAnalyticsEvent.InPersonPayments.CancellationSource) { }
+    func trackPaymentFailure(with error: any Error) {
+        resetProcessingPaymentTracking()
+    }
+
+    func trackPaymentCancelation(cancelationSource: WooAnalyticsEvent.InPersonPayments.CancellationSource) {
+        resetProcessingPaymentTracking()
+    }
     func trackEmailTapped() { }
     func trackReceiptPrintTapped() { }
     func trackReceiptPrintSuccess() { }

--- a/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
@@ -15,6 +15,8 @@ final class POSCollectOrderPaymentAnalyticsAdaptor: POSCollectOrderPaymentAnalyt
 
     private let analytics: POSAnalyticsProviding
 
+    private let currentTimestamp: () -> TimeInterval
+
     private var paymentGatewayAccount: PaymentGatewayAccount?
     private let configuration: CardPresentPaymentsConfiguration
     private var connectedReader: CardReader?
@@ -23,9 +25,11 @@ final class POSCollectOrderPaymentAnalyticsAdaptor: POSCollectOrderPaymentAnalyt
     }
 
     init(analytics: POSAnalyticsProviding,
-         configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration) {
+         configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
+         currentTimestamp: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }) {
         self.analytics = analytics
         self.configuration = configuration
+        self.currentTimestamp = currentTimestamp
     }
 
     func preflightResultReceived(_ result: CardReaderPreflightResult?) {
@@ -111,7 +115,7 @@ final class POSCollectOrderPaymentAnalyticsAdaptor: POSCollectOrderPaymentAnalyt
         // Any action that is considered as user starting an iteraction resets any ongoing counter
         resetAllCountersOnInteractionStarted()
         analytics.track(.pointOfSaleInteractionWithCustomerStarted)
-        customerInteractionStarted = Date().timeIntervalSince1970
+        customerInteractionStarted = currentTimestamp()
     }
 
     func trackOrderSyncSuccess() {
@@ -151,11 +155,11 @@ final class POSCollectOrderPaymentAnalyticsAdaptor: POSCollectOrderPaymentAnalyt
 // Helpers
 private extension POSCollectOrderPaymentAnalyticsAdaptor {
     func trackCurrentTime() -> Double {
-        Date().timeIntervalSince1970
+        currentTimestamp()
     }
 
     func calculateElapsedTimeInMilliseconds(since start: Double) -> Double {
-        let end = Date().timeIntervalSince1970
+        let end = currentTimestamp()
         return floor((end - start) * 1000)
     }
 

--- a/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
@@ -159,6 +159,10 @@ private extension POSCollectOrderPaymentAnalyticsAdaptor {
     }
 
     func calculateElapsedTimeInMilliseconds(since start: Double) -> Double {
+        guard start > 0 else {
+            return 0
+        }
+
         let end = currentTimestamp()
         return floor((end - start) * 1000)
     }

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -90,7 +90,7 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "2000.0")
     }
 
-    @Test func analytics_when_reader_becomes_ready_then_reports_elapsed_time_since_order_sync() {
+    @Test func test_track_card_reader_ready_when_order_sync_succeeded_then_tracks_waiting_time_in_seconds() {
         // Given
         let clock = TestClock()
         let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
@@ -102,7 +102,7 @@ struct POSCollectOrderPaymentAnalyticsTests {
         sut.trackCustomerInteractionStarted()
         clock.now = 510 // order synced
         sut.trackOrderSyncSuccess()
-        clock.now = 513 // reader ready -> tracks waiting time (513 - 510)
+        clock.now = 513 // reader ready -> waiting_time is tracked in seconds: 513 - 510
         sut.trackCardReaderReady()
 
         // Then

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -139,6 +139,56 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(properties("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == ["1000.0", "3000.0"])
     }
 
+    @Test func test_track_payment_failure_when_card_reader_was_tapped_then_next_attempt_records_new_card_tapped_timestamp() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
+
+        // When
+        clock.now = 1000
+        sut.trackCustomerInteractionStarted()
+        clock.now = 1001
+        sut.trackCardReaderTapped()
+        clock.now = 1002
+        sut.trackPaymentFailure(with: TestError())
+
+        clock.now = 1005
+        sut.trackCardReaderTapped()
+        clock.now = 1008
+        sut.trackSuccessfulCardPayment(capturedPaymentData: capturedPaymentData)
+
+        // Then
+        #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "3000.0")
+    }
+
+    @Test func test_track_payment_cancelation_when_card_reader_was_tapped_then_next_attempt_records_new_card_tapped_timestamp() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
+
+        // When
+        clock.now = 1000
+        sut.trackCustomerInteractionStarted()
+        clock.now = 1001
+        sut.trackCardReaderTapped()
+        clock.now = 1002
+        sut.trackPaymentCancelation(cancelationSource: .other)
+
+        clock.now = 1005
+        sut.trackCardReaderTapped()
+        clock.now = 1008
+        sut.trackSuccessfulCardPayment(capturedPaymentData: capturedPaymentData)
+
+        // Then
+        #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "3000.0")
+    }
+
     @Test func test_track_card_reader_ready_when_order_sync_succeeded_then_tracks_waiting_time_in_seconds() {
         // Given
         let clock = TestClock()
@@ -177,6 +227,8 @@ struct POSCollectOrderPaymentAnalyticsTests {
 }
 
 private extension POSCollectOrderPaymentAnalyticsTests {
+    struct TestError: Error { }
+
     func property(_ key: String, in eventName: String) -> String? {
         analytics.events.first(where: { $0.eventName == eventName })?.properties[key] as? String
     }

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -44,6 +44,25 @@ struct POSCollectOrderPaymentAnalyticsTests {
         })
     }
 
+    @Test func analytics_when_successful_card_payment_has_unset_timing_markers_then_reports_zero_elapsed_milliseconds() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
+
+        // When
+        clock.now = 1000
+        sut.trackSuccessfulCardPayment(capturedPaymentData: capturedPaymentData)
+
+        // Then
+        #expect(property("milliseconds_since_customer_interaction_started", in: "card_present_collect_payment_success") == "0.0")
+        #expect(property("milliseconds_since_order_sync_success", in: "card_present_collect_payment_success") == "0.0")
+        #expect(property("milliseconds_since_reader_ready_to_collect_payment", in: "card_present_collect_payment_success") == "0.0")
+        #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "0.0")
+    }
+
     @Test func analytics_when_successful_card_payment_then_reports_correct_elapsed_milliseconds() {
         // Given
         let clock = TestClock()

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -2,10 +2,15 @@
 import protocol WooFoundation.Analytics
 import struct Yosemite.CardPresentPaymentsConfiguration
 import enum WooFoundation.CountryCode
+import Foundation
 import Testing
 
 struct POSCollectOrderPaymentAnalyticsTests {
     private let analytics: MockPOSAnalytics
+
+    private final class TestClock {
+        var now: TimeInterval = 0
+    }
 
     init() {
         analytics = MockPOSAnalytics()
@@ -37,5 +42,74 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(expectedProperties.allSatisfy { key in
             analytics.events.map(\.properties).contains(where: { $0.keys.contains(key) })
         })
+    }
+
+    @Test func analytics_when_successful_card_payment_then_reports_correct_elapsed_milliseconds() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
+
+        // When
+        clock.now = 1000 // customer interaction started
+        sut.trackCustomerInteractionStarted()
+        clock.now = 1001 // order synced
+        sut.trackOrderSyncSuccess()
+        clock.now = 1002 // reader ready
+        sut.trackCardReaderReady()
+        clock.now = 1003 // card tapped
+        sut.trackCardReaderTapped()
+        clock.now = 1005 // payment success
+        sut.trackSuccessfulCardPayment(capturedPaymentData: capturedPaymentData)
+
+        // Then
+        #expect(property("milliseconds_since_customer_interaction_started", in: "card_present_collect_payment_success") == "5000.0")
+        #expect(property("milliseconds_since_order_sync_success", in: "card_present_collect_payment_success") == "4000.0")
+        #expect(property("milliseconds_since_reader_ready_to_collect_payment", in: "card_present_collect_payment_success") == "3000.0")
+        #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "2000.0")
+    }
+
+    @Test func analytics_when_reader_becomes_ready_then_reports_elapsed_time_since_order_sync() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+
+        // When
+        clock.now = 500 // customer interaction started (resets counters)
+        sut.trackCustomerInteractionStarted()
+        clock.now = 510 // order synced
+        sut.trackOrderSyncSuccess()
+        clock.now = 513 // reader ready -> tracks waiting time (513 - 510)
+        sut.trackCardReaderReady()
+
+        // Then
+        #expect(property("waiting_time", in: "reader_ready_for_card_payment") == "3.0")
+    }
+
+    @Test func analytics_when_successful_cash_payment_then_reports_correct_elapsed_milliseconds() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+
+        // When
+        clock.now = 2000 // customer interaction started
+        sut.trackCustomerInteractionStarted()
+        clock.now = 2001 // cash payment success -> floor((2001 - 2000) * 1000) = 1000
+        sut.trackSuccessfulCashPayment()
+
+        // Then
+        #expect(property("milliseconds_since_customer_interaction_started", in: "cash_collect_payment_success") == "1000.0")
+    }
+}
+
+private extension POSCollectOrderPaymentAnalyticsTests {
+    func property(_ key: String, in eventName: String) -> String? {
+        analytics.events.first(where: { $0.eventName == eventName })?.properties[key] as? String
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -44,7 +44,7 @@ struct POSCollectOrderPaymentAnalyticsTests {
         })
     }
 
-    @Test func analytics_when_successful_card_payment_has_unset_timing_markers_then_reports_zero_elapsed_milliseconds() {
+    @Test func test_track_successful_card_payment_when_timing_markers_are_unset_then_reports_zero_elapsed_milliseconds() {
         // Given
         let clock = TestClock()
         let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
@@ -63,7 +63,7 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "0.0")
     }
 
-    @Test func analytics_when_successful_card_payment_then_reports_correct_elapsed_milliseconds() {
+    @Test func test_track_successful_card_payment_when_timing_markers_are_set_then_reports_correct_elapsed_milliseconds() {
         // Given
         let clock = TestClock()
         let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
@@ -208,7 +208,7 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(property("waiting_time", in: "reader_ready_for_card_payment") == "3.0")
     }
 
-    @Test func analytics_when_successful_cash_payment_then_reports_correct_elapsed_milliseconds() {
+    @Test func test_track_successful_cash_payment_when_customer_interaction_started_then_reports_correct_elapsed_milliseconds() {
         // Given
         let clock = TestClock()
         let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -90,6 +90,55 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "2000.0")
     }
 
+    @Test func test_track_card_reader_tapped_when_processing_event_repeats_then_preserves_first_card_tapped_timestamp() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
+
+        // When
+        clock.now = 1000
+        sut.trackCustomerInteractionStarted()
+        clock.now = 1001
+        sut.trackCardReaderTapped()
+        clock.now = 1004
+        sut.trackCardReaderTapped()
+        clock.now = 1006
+        sut.trackSuccessfulCardPayment(capturedPaymentData: capturedPaymentData)
+
+        // Then
+        #expect(property("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == "5000.0")
+    }
+
+    @Test func test_track_card_reader_tapped_when_success_and_new_customer_interaction_occur_then_records_new_card_tapped_timestamp() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
+
+        // When
+        clock.now = 1000
+        sut.trackCustomerInteractionStarted()
+        clock.now = 1001
+        sut.trackCardReaderTapped()
+        clock.now = 1002
+        sut.trackSuccessfulCardPayment(capturedPaymentData: capturedPaymentData)
+
+        clock.now = 2000
+        sut.trackCustomerInteractionStarted()
+        clock.now = 2001
+        sut.trackCardReaderTapped()
+        clock.now = 2004
+        sut.trackSuccessfulCardPayment(capturedPaymentData: capturedPaymentData)
+
+        // Then
+        #expect(properties("milliseconds_since_card_tapped", in: "card_present_collect_payment_success") == ["1000.0", "3000.0"])
+    }
+
     @Test func test_track_card_reader_ready_when_order_sync_succeeded_then_tracks_waiting_time_in_seconds() {
         // Given
         let clock = TestClock()
@@ -130,5 +179,14 @@ struct POSCollectOrderPaymentAnalyticsTests {
 private extension POSCollectOrderPaymentAnalyticsTests {
     func property(_ key: String, in eventName: String) -> String? {
         analytics.events.first(where: { $0.eventName == eventName })?.properties[key] as? String
+    }
+
+    func properties(_ key: String, in eventName: String) -> [String] {
+        analytics.events.compactMap { event in
+            guard event.eventName == eventName else {
+                return nil
+            }
+            return event.properties[key] as? String
+        }
     }
 }


### PR DESCRIPTION
Closes WOOMOB-3591

## Description
Injects a testable `currentTimestamp` clock into `POSCollectOrderPaymentAnalyticsAdaptor` so the event timing can be unit-tested.

## Test Steps
No production behavior change, CI should pass

## Screenshots
N/A
