### PR TITLE
[WOOMOB-3348] Add Segment Control component to the Store Design System

### DIFF
--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/Badge/StoreBadge.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/Badge/StoreBadge.swift
@@ -21,7 +21,7 @@ public struct StoreBadge: View {
         }
         .foregroundStyle(tone.appearance.foreground)
         .padding(.horizontal, StorePadding.p3)
-        .frame(minHeight: Constants.minHeight)
+        .frame(minHeight: StoreSize.badgeHeight)
         .background(tone.appearance.background ?? .clear)
         .clipShape(RoundedRectangle(cornerRadius: StoreRadius.medium))
         .overlay {
@@ -35,10 +35,6 @@ public struct StoreBadge: View {
 
 private extension StoreBadge {
     enum Constants {
-        // Figma's 8pt top/bottom padding sits around cap-height-trimmed text (8+8+8 = 24).
-        // SwiftUI's Text isn't cap-trimmed, so we hit that 24pt height via minHeight rather
-        // than literal vertical padding (which would overshoot). Matches Android's heightIn(min: 24).
-        static let minHeight: CGFloat = 24
         static let iconSize: StoreIconSize = .extraSmall
     }
 }

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/Button/StoreButtonStyle.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/Button/StoreButtonStyle.swift
@@ -37,7 +37,7 @@ private struct StoreButtonStyleBody: View {
             }
             .contentShape(Rectangle())
             .opacity(configuration.isPressed ? Constants.pressedOpacity : Constants.fullOpacity)
-            .animation(.easeOut(duration: Constants.pressAnimationDuration), value: configuration.isPressed)
+            .animation(.easeOut(duration: StoreMotion.pressDuration), value: configuration.isPressed)
     }
 
     private var backgroundColor: Color {
@@ -63,6 +63,5 @@ private extension StoreButtonStyleBody {
     enum Constants {
         static let fullOpacity: Double = 1
         static let pressedOpacity: Double = 0.7
-        static let pressAnimationDuration: TimeInterval = 0.15
     }
 }

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/Checkbox/StoreCheckboxStyle.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/Checkbox/StoreCheckboxStyle.swift
@@ -42,7 +42,7 @@ private struct StoreCheckboxStyleBody: View {
         .frame(minWidth: StoreSize.minimumTapTarget, minHeight: StoreSize.minimumTapTarget)
         .contentShape(Rectangle())
         .opacity(isPressed ? Constants.pressedOpacity : 1)
-        .animation(.easeOut(duration: Constants.pressAnimationDuration), value: isPressed)
+        .animation(.easeOut(duration: StoreMotion.pressDuration), value: isPressed)
     }
 
     @ViewBuilder private var glyph: some View {
@@ -84,6 +84,5 @@ private extension StoreCheckboxStyleBody {
         /// The box side, from the Figma "Size/Large Increased" token (24 pt).
         static let side = StoreIconSize.largeIncreased.value
         static let pressedOpacity: Double = 0.7
-        static let pressAnimationDuration: TimeInterval = 0.15
     }
 }

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
@@ -3,9 +3,8 @@ import SwiftUI
 /// A horizontal control with mutually exclusive segments for switching between related views.
 ///
 /// - Note: A single appearance and size — the design defines no variants or sizes, so none are
-///   modelled. Each segment is its own button (the selected one carries `.isSelected`); the track
-///   height follows the segment's cap-height rather than a literal vertical padding, and the
-///   per-segment hit target is below the 44 pt minimum by design, as with other compact controls.
+///   modelled. The selected segment carries `.isSelected`. Each segment's tap target is a full
+///   ≥44 pt button, while the visible track keeps its compact design height, centered within it.
 public struct StoreSegmentedControl<Value: Hashable>: View {
     @Binding private var selection: Value
     private let options: [Value]
@@ -29,41 +28,62 @@ public struct StoreSegmentedControl<Value: Hashable>: View {
     }
 
     public var body: some View {
+        ZStack {
+            track
+            segments
+        }
+        .animation(reduceMotion ? nil : .easeOut(duration: StoreMotion.selectionDuration), value: selection)
+    }
+
+    /// The visible capsule and the selected pill, sized to the compact design height. Accessibility is
+    /// exposed by ``segments`` — this layer is decorative, so it's hidden from VoiceOver.
+    private var track: some View {
         HStack(spacing: StoreSpacing.s0) {
-            ForEach(Array(options.enumerated()), id: \.element) { index, option in
-                segment(for: option, at: index)
+            ForEach(Array(options.enumerated()), id: \.element) { _, option in
+                pill(for: option)
             }
         }
         .padding(StorePadding.p1)
         .background(Color.storeTintLayerPrimaryContainerOpacity16)
         .clipShape(RoundedRectangle(cornerRadius: StoreRadius.full))
-        .animation(reduceMotion ? nil : .easeOut(duration: StoreMotion.selectionDuration), value: selection)
+        .accessibilityHidden(true)
     }
 
-    @ViewBuilder
-    private func segment(for option: Value, at index: Int) -> some View {
-        let isSelected = option == selection
-        Button {
-            selection = option
-        } label: {
-            Text(title(option))
-                .storeTextStyle(isSelected ? Constants.selectedTextStyle : Constants.unselectedTextStyle)
-                .foregroundStyle(isSelected ? Color.storeOnSurface : Color.storeOnPrimaryContainer)
-                .lineLimit(1)
-                .frame(maxWidth: .infinity)
-                .frame(minHeight: StoreSize.segmentedControlHeight)
-                .background {
-                    if isSelected {
-                        RoundedRectangle(cornerRadius: StoreRadius.extraLarge)
-                            .fill(Color.storeSurface)
-                            .matchedGeometryEffect(id: Constants.selectionID, in: selectionNamespace)
-                    }
+    /// Full-height (≥44 pt) transparent buttons overlaid on each segment, so the tap target meets the
+    /// HIG minimum while the visible ``track`` keeps its compact design height.
+    private var segments: some View {
+        HStack(spacing: StoreSpacing.s0) {
+            ForEach(Array(options.enumerated()), id: \.element) { index, option in
+                Button {
+                    selection = option
+                } label: {
+                    Color.clear
                 }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, minHeight: StoreSize.minimumTapTarget)
                 .contentShape(Rectangle())
+                .accessibilityLabel(title(option))
+                .accessibilityAddTraits(option == selection ? .isSelected : [])
+                .accessibilityValue(Localization.positionValue(index: index + 1, count: options.count))
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-        .accessibilityValue(Localization.positionValue(index: index + 1, count: options.count))
+    }
+
+    private func pill(for option: Value) -> some View {
+        let isSelected = option == selection
+        return Text(title(option))
+            .storeTextStyle(isSelected ? Constants.selectedTextStyle : Constants.unselectedTextStyle)
+            .foregroundStyle(isSelected ? Color.storeOnSurface : Color.storeOnPrimaryContainer)
+            .lineLimit(1)
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: StoreSize.segmentedControlHeight)
+            .background {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: StoreRadius.extraLarge)
+                        .fill(Color.storeSurface)
+                        .matchedGeometryEffect(id: Constants.selectionID, in: selectionNamespace)
+                }
+            }
     }
 }
 

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+/// A horizontal control with mutually exclusive segments for switching between related views.
+///
+/// - Note: A single appearance and size — the design defines no variants or sizes, so none are
+///   modelled. Each segment is its own button (the selected one carries `.isSelected`); the track
+///   height follows the segment's cap-height rather than a literal vertical padding, and the
+///   per-segment hit target is below the 44 pt minimum by design, as with other compact controls.
+public struct StoreSegmentedControl<Value: Hashable>: View {
+    @Binding private var selection: Value
+    private let options: [Value]
+    private let title: (Value) -> String
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Namespace private var selectionNamespace
+
+    /// - Parameters:
+    ///   - selection: The currently selected option.
+    ///   - options: The segments, in display order. Each `Value` is the segment's identity (like a
+    ///     `Picker` tag) and must be unique — but `title` may repeat, so two segments can show the
+    ///     same text as long as their underlying value differs.
+    ///   - title: The label shown for a given option.
+    public init(selection: Binding<Value>,
+                options: [Value],
+                title: @escaping (Value) -> String) {
+        self._selection = selection
+        self.options = options
+        self.title = title
+    }
+
+    public var body: some View {
+        HStack(spacing: StoreSpacing.s0) {
+            ForEach(Array(options.enumerated()), id: \.element) { index, option in
+                segment(for: option, at: index)
+            }
+        }
+        .padding(StorePadding.p1)
+        .background(Color.storeTintLayerPrimaryContainerOpacity16)
+        .clipShape(RoundedRectangle(cornerRadius: StoreRadius.full))
+        .animation(reduceMotion ? nil : .easeOut(duration: StoreMotion.selectionDuration), value: selection)
+    }
+
+    @ViewBuilder
+    private func segment(for option: Value, at index: Int) -> some View {
+        let isSelected = option == selection
+        Button {
+            selection = option
+        } label: {
+            Text(title(option))
+                .storeTextStyle(isSelected ? Constants.selectedTextStyle : Constants.unselectedTextStyle)
+                .foregroundStyle(isSelected ? Color.storeOnSurface : Color.storeOnPrimaryContainer)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: StoreSize.segmentedControlHeight)
+                .background {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: StoreRadius.extraLarge)
+                            .fill(Color.storeSurface)
+                            .matchedGeometryEffect(id: Constants.selectionID, in: selectionNamespace)
+                    }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(Localization.positionValue(index: index + 1, count: options.count))
+    }
+}
+
+/// File-scoped rather than nested in ``StoreSegmentedControl`` because a generic type can't hold
+/// static stored properties.
+private enum Constants {
+    static let selectedTextStyle: StoreTextStyle = .bodySmall.emphasized
+    static let unselectedTextStyle: StoreTextStyle = .bodySmall
+    static let selectionID = "selectedSegment"
+}
+
+private enum Localization {
+    /// The positional context VoiceOver reads alongside a segment's label and selected state, e.g.
+    /// "2 of 5" — a segmented control conveys position, which the label alone doesn't.
+    static func positionValue(index: Int, count: Int) -> String {
+        let format = NSLocalizedString(
+            "storeSegmentedControl.accessibilityValue.position",
+            value: "%1$d of %2$d",
+            comment: "VoiceOver position of a segment in a segmented control. %1$d is the position, %2$d the total count."
+        )
+        return String.localizedStringWithFormat(format, index, count)
+    }
+}

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
@@ -14,10 +14,10 @@ public struct StoreSegmentedControl<Value: Hashable>: View {
     @Namespace private var selectionNamespace
 
     /// - Parameters:
-    ///   - selection: The currently selected option.
-    ///   - options: The segments, in display order. Each `Value` is the segment's identity (like a
-    ///     `Picker` tag) and must be unique — but `title` may repeat, so two segments can show the
-    ///     same text as long as their underlying value differs.
+    ///   - selection: The selected option, expected to be one of `options`. If it isn't (e.g. `options`
+    ///     changed and dropped it), no segment is shown selected until one is tapped.
+    ///   - options: The segments, in display order. The design supports 2–5. Each `Value` is the
+    ///     segment's identity (like a `Picker` tag) and should be unique.
     ///   - title: The label shown for a given option.
     public init(selection: Binding<Value>,
                 options: [Value],
@@ -35,12 +35,19 @@ public struct StoreSegmentedControl<Value: Hashable>: View {
         .animation(reduceMotion ? nil : .easeOut(duration: StoreMotion.selectionDuration), value: selection)
     }
 
+    /// The position of the segment matching `selection`, or `nil` when it isn't among `options`.
+    /// Resolving to a single index keeps duplicate values from selecting more than one segment (the
+    /// first match wins) and an absent selection from selecting any.
+    private var selectedIndex: Int? {
+        options.firstIndex(of: selection)
+    }
+
     /// The visible capsule and the selected pill, sized to the compact design height. Accessibility is
     /// exposed by ``segments`` — this layer is decorative, so it's hidden from VoiceOver.
     private var track: some View {
         HStack(spacing: StoreSpacing.s0) {
-            ForEach(Array(options.enumerated()), id: \.element) { _, option in
-                pill(for: option)
+            ForEach(Array(options.enumerated()), id: \.offset) { index, option in
+                pill(for: option, isSelected: index == selectedIndex)
             }
         }
         .padding(StorePadding.p1)
@@ -53,7 +60,7 @@ public struct StoreSegmentedControl<Value: Hashable>: View {
     /// HIG minimum while the visible ``track`` keeps its compact design height.
     private var segments: some View {
         HStack(spacing: StoreSpacing.s0) {
-            ForEach(Array(options.enumerated()), id: \.element) { index, option in
+            ForEach(Array(options.enumerated()), id: \.offset) { index, option in
                 Button {
                     selection = option
                 } label: {
@@ -63,15 +70,14 @@ public struct StoreSegmentedControl<Value: Hashable>: View {
                 .frame(maxWidth: .infinity, minHeight: StoreSize.minimumTapTarget)
                 .contentShape(Rectangle())
                 .accessibilityLabel(title(option))
-                .accessibilityAddTraits(option == selection ? .isSelected : [])
+                .accessibilityAddTraits(index == selectedIndex ? .isSelected : [])
                 .accessibilityValue(Localization.positionValue(index: index + 1, count: options.count))
             }
         }
     }
 
-    private func pill(for option: Value) -> some View {
-        let isSelected = option == selection
-        return Text(title(option))
+    private func pill(for option: Value, isSelected: Bool) -> some View {
+        Text(title(option))
             .storeTextStyle(isSelected ? Constants.selectedTextStyle : Constants.unselectedTextStyle)
             .foregroundStyle(isSelected ? Color.storeOnSurface : Color.storeOnPrimaryContainer)
             .lineLimit(1)

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Tokens/Motion/StoreMotion.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Tokens/Motion/StoreMotion.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Design-system animation durations, centralized so components animate consistently.
+public enum StoreMotion {
+    /// Press / state-change feedback on interactive controls.
+    public static let pressDuration: TimeInterval = 0.15
+    /// A selection indicator moving between options (e.g. a segmented-control pill).
+    public static let selectionDuration: TimeInterval = 0.2
+}

--- a/StoreDesignSystem/Sources/StoreDesignSystem/Tokens/Size/StoreSize.swift
+++ b/StoreDesignSystem/Sources/StoreDesignSystem/Tokens/Size/StoreSize.swift
@@ -4,4 +4,11 @@ public enum StoreSize {
     /// Minimum interactive (touch-target) size — the Apple HIG minimum. A platform accessibility
     /// constant rather than a Figma design value, centralized so every interactive component shares it.
     public static let minimumTapTarget: CGFloat = 44
+
+    /// Heights for compact controls whose design defines height via vertical padding around
+    /// cap-height-trimmed text. SwiftUI's `Text` isn't cap-trimmed, so components pin these as a
+    /// `minHeight` floor instead of literal vertical padding, which would overshoot. Centralized so a
+    /// new component reuses the pattern rather than reintroducing its own literal.
+    public static let badgeHeight: CGFloat = 24
+    public static let segmentedControlHeight: CGFloat = 32
 }

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
@@ -34,6 +34,7 @@ private struct ComponentsView: View {
             NavigationLink("Button") { ButtonComponentView() }
             NavigationLink("Checkbox") { CheckboxComponentView() }
             NavigationLink("NoticeBanner") { NoticeBannerComponentView() }
+            NavigationLink("Segmented Control") { SegmentedControlComponentView() }
             NavigationLink("Tooltip") { TooltipComponentView() }
         }
         .navigationTitle("Components")

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/SegmentedControlComponentView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/SegmentedControlComponentView.swift
@@ -1,0 +1,47 @@
+#if DEBUG || ALPHA
+import SwiftUI
+import StoreDesignSystem
+
+struct SegmentedControlComponentView: View {
+    private enum SegmentCount: Int, CaseIterable, Identifiable {
+        case two = 2
+        case three = 3
+        case four = 4
+        case five = 5
+
+        var id: Self { self }
+        var title: String { "\(rawValue)" }
+    }
+
+    @State private var segmentCount: SegmentCount = .three
+    @State private var selection = 0
+    @State private var isEnabled = true
+
+    var body: some View {
+        ComponentDemoScaffold(title: "Segmented Control") {
+            Picker("Segments", selection: $segmentCount) {
+                ForEach(SegmentCount.allCases) { option in
+                    Text(option.title).tag(option)
+                }
+            }
+            Toggle("Enabled", isOn: $isEnabled)
+        } preview: {
+            StoreSegmentedControl(selection: $selection,
+                                  options: Array(0..<segmentCount.rawValue)) { index in
+                "Label \(index + 1)"
+            }
+            .disabled(!isEnabled)
+            .padding(.horizontal)
+            .onChange(of: segmentCount) { _, _ in
+                selection = 0
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SegmentedControlComponentView()
+    }
+}
+#endif


### PR DESCRIPTION
Closes WOOMOB-3348

## Description

Adds **`StoreSegmentedControl`**, the segmented control in the new Woo Mobile Design System (`StoreDesignSystem`) — a horizontal row of mutually-exclusive segments for switching between related views.

**The API — a value-generic SwiftUI control (Picker-style):**
```swift
StoreSegmentedControl(selection: $tab, options: Tab.allCases) { $0.title }
StoreSegmentedControl(selection: $index, options: [0, 1, 2]) { "Item \($0 + 1)" }
```

- **Model** — 2–5 mutually-exclusive segments, single selection. Generic over any `Hashable` value; the label is a `Value -> String` closure, so the value is the identity and labels may repeat.
- **Styling** — a tinted track with a `Surface` pill that slides to the selected segment, `Body/Small` labels (emphasized when selected). Design tokens only, light + dark.
- **Shared tokens** — extracts the animation durations into a new `StoreMotion` (`StoreButton` / `StoreCheckbox` now use it) and centralises the cap-trim compact heights into `StoreSize` (`StoreBadge` now uses it).
- **Demo** — added to the in-app Design System screen (Components -> Segmented Control) with a segment-count picker and an enabled toggle.

## Test Steps

1. Install app
2. **Settings -> Debug -> Design System -> Components -> Segmented Control**.
3. Change the **Segments** picker (2–5) and tap between segments — the pill slides to the selection.
4. Toggle **Enabled** off and confirm taps are ignored.
5. Switch the system appearance to dark and confirm the light/dark treatments.

## Screenshots

| Light | Dark |
| --- | --- |
| <img width="256" height="554" alt="ScreenRecording_07-17-2026 15-51-14_1" src="https://github.com/user-attachments/assets/327196bf-4023-4642-97b6-f7bd188ec443" /> | <img width="256" height="554" alt="ScreenRecording_07-17-2026 15-51-36_1" src="https://github.com/user-attachments/assets/7e6615b1-54ee-49bd-8fec-3c02c90184ac" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
