### PR TITLE
[POS][New refunds API] Part 5. Seed v4 refund availability from the REST index routes

### DIFF
--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -279,6 +279,9 @@ private extension POSRefundSubmissionAdaptor {
 
     private func loadPreparedRefundSnapshot(for order: POSOrder) async throws -> PreparedRefundSnapshot {
         let fullOrder = try await orderService.loadOrder(orderID: order.id)
+        Task { [v4RefundPreviewUseCase] in
+            await v4RefundPreviewUseCase.seedAvailabilityFromSiteRoutesIfNeeded(siteID: fullOrder.siteID)
+        }
         let refunds = try await loadDetailedRefunds(for: fullOrder)
         let fetchedCharge = try await fetchChargeIfNeeded(for: fullOrder)
         let charge = fetchedCharge.map { refundMapping.normalizedForPOSInteracRefund(charge: $0) }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -14,22 +14,57 @@ final class POSV4RefundPreviewUseCase {
         case error
     }
 
+    typealias SiteAPILoader = @MainActor (Int64) async throws -> SiteAPI
+
     private let refundService: RefundServiceProtocol
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
     private let availabilityCache: V4RefundAvailabilityCache
     private let minimumWooVersion: String
+    private let siteAPILoader: SiteAPILoader
+    private var routeSeedingTasks: [Int64: Task<Void, Never>] = [:]
 
     init(refundService: RefundServiceProtocol,
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          availabilityCache: V4RefundAvailabilityCache = .shared,
-         minimumWooVersion: String = Constants.minimumWooVersion) {
+         minimumWooVersion: String = Constants.minimumWooVersion,
+         siteAPILoader: SiteAPILoader? = nil) {
         self.refundService = refundService
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.availabilityCache = availabilityCache
         self.minimumWooVersion = minimumWooVersion
+        self.siteAPILoader = siteAPILoader ?? Self.makeSiteAPILoader(stores: stores)
+    }
+
+    /// Marks v4 available when the site's REST index lists the v4 refund routes, which only register
+    /// when the server `rest-api-v4` flag is enabled — a reliable *positive* signal that beats a stale
+    /// cached WooCommerce version. Route absence or an index fetch failure writes nothing: security
+    /// plugins can filter the index, so the preview probe's 404 remains the only negative signal.
+    /// At most one index fetch per site per session, off the preview's critical path.
+    func seedAvailabilityFromSiteRoutesIfNeeded(siteID: Int64) async {
+        guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4),
+              availabilityCache.isV4Available(siteID: siteID) == nil else {
+            return
+        }
+
+        if let seedingTask = routeSeedingTasks[siteID] {
+            return await seedingTask.value
+        }
+
+        let seedingTask = Task {
+            do {
+                let siteAPI = try await siteAPILoader(siteID)
+                if siteAPI.hasV4RefundsRoutes {
+                    availabilityCache.markV4Available(siteID: siteID)
+                }
+            } catch {
+                DDLogError("⛔️ Could not check the site REST index for v4 refund routes: \(error)")
+            }
+        }
+        routeSeedingTasks[siteID] = seedingTask
+        await seedingTask.value
     }
 
     func previewRefund(siteID: Int64, orderID: Int64, lineItems: [RefundV4LineItem]) async -> Result {
@@ -73,7 +108,30 @@ final class POSV4RefundPreviewUseCase {
         return false
     }
 
+    private static func makeSiteAPILoader(stores: StoresManager) -> SiteAPILoader {
+        { siteID in
+            try await withCheckedThrowingContinuation { continuation in
+                let action = SettingAction.retrieveSiteAPI(siteID: siteID) { result in
+                    continuation.resume(with: result)
+                }
+                stores.dispatch(action)
+            }
+        }
+    }
+
     private enum Constants {
         static let minimumWooVersion = "10.9.0"
+    }
+}
+
+private extension SiteAPI {
+    /// The v4 refund routes (`/wc/v4/refunds`, `/wc/v4/refunds/preview`) register only when the
+    /// server `rest-api-v4` feature flag is enabled.
+    var hasV4RefundsRoutes: Bool {
+        routes.contains { $0.hasPrefix(Constants.v4RefundsRoutePrefix) }
+    }
+
+    enum Constants {
+        static let v4RefundsRoutePrefix = "/wc/v4/refunds"
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
@@ -241,7 +241,8 @@ private extension POSRefundSubmissionAdaptorTests {
                                                        stores: stores,
                                                        featureFlagService: flags,
                                                        availabilityCache: V4RefundAvailabilityCache(),
-                                                       minimumWooVersion: "10.9.0")
+                                                       minimumWooVersion: "10.9.0",
+                                                       siteAPILoader: { _ in throw MockManualRefundService.MockError.notStubbed })
 
         let orderService = MockPOSOrderService()
         orderService.orderToReturn = order(quantity: orderQuantity)

--- a/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
@@ -183,18 +183,137 @@ struct POSV4RefundPreviewUseCaseTests {
         #expect(result == .error)
         #expect(cache.isV4Available(siteID: siteID) == nil)
     }
+
+    // MARK: - Seeding availability from the REST index routes
+
+    @Test func seedAvailability_when_index_lists_v4_refund_routes_then_marks_available() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        let loader = MockSiteAPILoader(result: .success(siteAPI(routes: ["/wc/v3/orders", "/wc/v4/refunds", "/wc/v4/refunds/preview"])))
+        let (sut, _, _) = makeSUT(cache: cache, siteAPILoader: loader)
+
+        // When
+        await sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+
+        // Then
+        #expect(cache.isV4Available(siteID: siteID) == true)
+        #expect(loader.callCount == 1)
+    }
+
+    @Test func seedAvailability_when_route_present_then_stale_version_hint_no_longer_blocks_preview() async {
+        // Given a stale below-minimum version that would gate the probe off
+        let cache = V4RefundAvailabilityCache()
+        let loader = MockSiteAPILoader(result: .success(siteAPI(routes: ["/wc/v4/refunds/preview"])))
+        let (sut, _, _) = makeSUT(cachedWooVersion: "10.8.0",
+                                  cache: cache,
+                                  previewResult: .success(preview()),
+                                  siteAPILoader: loader)
+
+        // When the routes are seeded before the preview
+        await sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+        let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
+
+        // Then the seeded availability overrides the stale version hint
+        #expect(result == .serverCalculated(preview()))
+    }
+
+    @Test func seedAvailability_when_routes_missing_then_cache_stays_unresolved() async {
+        // Given an index without the v4 refund routes (flag off server-side, or a filtered index)
+        let cache = V4RefundAvailabilityCache()
+        let loader = MockSiteAPILoader(result: .success(siteAPI(routes: ["/wc/v3/orders", "/wc/v3/orders/(?P<order_id>[\\d]+)/refunds"])))
+        let (sut, _, _) = makeSUT(cache: cache, siteAPILoader: loader)
+
+        // When
+        await sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+
+        // Then absence is inconclusive: the probe stays the only negative signal
+        #expect(cache.isV4Available(siteID: siteID) == nil)
+    }
+
+    @Test func seedAvailability_when_index_fetch_fails_then_cache_stays_unresolved() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        let loader = MockSiteAPILoader(result: .failure(NetworkError.timeout()))
+        let (sut, _, _) = makeSUT(cache: cache, siteAPILoader: loader)
+
+        // When
+        await sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+
+        // Then
+        #expect(cache.isV4Available(siteID: siteID) == nil)
+    }
+
+    @Test func seedAvailability_when_availability_already_cached_then_skips_the_fetch() async {
+        // Given
+        let cache = V4RefundAvailabilityCache()
+        cache.markV4Unavailable(siteID: siteID)
+        let loader = MockSiteAPILoader(result: .success(siteAPI(routes: ["/wc/v4/refunds"])))
+        let (sut, _, _) = makeSUT(cache: cache, siteAPILoader: loader)
+
+        // When
+        await sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+
+        // Then the cached (probe-derived) verdict is never overridden or re-checked
+        #expect(loader.callCount == 0)
+        #expect(cache.isV4Available(siteID: siteID) == false)
+    }
+
+    @Test func seedAvailability_when_flag_disabled_then_skips_the_fetch() async {
+        // Given
+        let loader = MockSiteAPILoader(result: .success(siteAPI(routes: ["/wc/v4/refunds"])))
+        let (sut, _, _) = makeSUT(flagEnabled: false, siteAPILoader: loader)
+
+        // When
+        await sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+
+        // Then
+        #expect(loader.callCount == 0)
+    }
+
+    @Test func seedAvailability_is_attempted_at_most_once_per_site() async {
+        // Given an index without the v4 routes, so the cache stays nil after the first attempt
+        let cache = V4RefundAvailabilityCache()
+        let loader = MockSiteAPILoader(result: .success(siteAPI(routes: ["/wc/v3/orders"])))
+        let (sut, _, _) = makeSUT(cache: cache, siteAPILoader: loader)
+
+        // When seeding twice concurrently and once more afterwards
+        async let first: Void = sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+        async let second: Void = sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+        _ = await (first, second)
+        await sut.seedAvailabilityFromSiteRoutesIfNeeded(siteID: siteID)
+
+        // Then only one index fetch ever happens
+        #expect(loader.callCount == 1)
+    }
 }
 
 private extension POSV4RefundPreviewUseCaseTests {
 
+    @MainActor
+    final class MockSiteAPILoader {
+        private let result: Swift.Result<SiteAPI, Error>
+        private(set) var callCount = 0
+
+        init(result: Swift.Result<SiteAPI, Error>) {
+            self.result = result
+        }
+
+        func load(siteID: Int64) async throws -> SiteAPI {
+            callCount += 1
+            return try result.get()
+        }
+    }
+
     func makeSUT(flagEnabled: Bool = true,
                  cachedWooVersion: String? = "10.9.0",
                  cache: V4RefundAvailabilityCache? = nil,
-                 previewResult: Swift.Result<RefundPreview, Error>? = nil)
+                 previewResult: Swift.Result<RefundPreview, Error>? = nil,
+                 siteAPILoader: MockSiteAPILoader? = nil)
     -> (POSV4RefundPreviewUseCase, MockRefundService, MockStoresManager) {
         // Resolved in the (main-actor) test body rather than as a default argument: the cache's
         // initializer is main-actor-isolated, and default arguments are evaluated nonisolated.
         let cache = cache ?? V4RefundAvailabilityCache()
+        let loader = siteAPILoader ?? MockSiteAPILoader(result: .failure(MockRefundService.MockError.notStubbed))
         let session = SessionManager.testingInstance
         session.cachedWooCommerceVersion = cachedWooVersion
         let stores = MockStoresManager(sessionManager: session)
@@ -206,7 +325,8 @@ private extension POSV4RefundPreviewUseCaseTests {
                                             stores: stores,
                                             featureFlagService: flags,
                                             availabilityCache: cache,
-                                            minimumWooVersion: "10.9.0")
+                                            minimumWooVersion: "10.9.0",
+                                            siteAPILoader: { try await loader.load(siteID: $0) })
         return (sut, service, stores)
     }
 
@@ -216,5 +336,9 @@ private extension POSV4RefundPreviewUseCaseTests {
 
     func preview() -> RefundPreview {
         RefundPreview(subtotal: 27, tax: 2.43, total: 29.43, maxRefundable: 59, breakdown: .fake())
+    }
+
+    func siteAPI(routes: [String]) -> SiteAPI {
+        SiteAPI(siteID: siteID, namespaces: [], applicationPasswordAvailable: false, routes: routes)
     }
 }


### PR DESCRIPTION
### Part of the v4 refunds stack — review & merge in order

1. #17539 — Part 1 — Yosemite: v4 refund preview + simplified-create data layer
2. #17540 — Part 2 — POS: v4 refund detection, preview & simplified-create plumbing
3. #17541 — Part 3 — POS: wire v4 refund preview, detection & creation into the flow
4. #17568 — Part 4 — adopt end-to-end async for the v4 data layer
5. **← you are here** — Part 5 — positive-only route-check seeding

## Description

Closes WOOMOB-3623. Implements the route-check idea from [this review comment on Part 2](https://github.com/woocommerce/woocommerce-ios/pull/17540#discussion_r3597085648).

With an empty per-site availability cache, v4 detection gates on `cachedWooCommerceVersion`, which is read from the last-synced system-plugins record. If the store upgraded WooCommerce after the app's last sync, the version gate falls back to v3 **every time and never probes** — v4 stays silently disabled for the whole session. The REST index fixes this: the v4 refund routes only register when the server `rest-api-v4` flag is on, so `/wc/v4/refunds*` in the (fields-filtered) index is a reliable *positive* signal.

- `POSV4RefundPreviewUseCase.seedAvailabilityFromSiteRoutesIfNeeded(siteID:)` — fetches the index via `SettingAction.retrieveSiteAPI` (same data `hasTerminalPaymentPreparationRoute` uses), marks the site available when the routes are present. **Positive-only**: absence or a fetch failure writes nothing, since security plugins can filter the index — the preview probe's 404 stays the only negative signal.
- Runs at most **once per site per session** (in-flight tasks deduped), fired fire-and-forget from `loadPreparedRefundSnapshot` — during refund preparation, before the merchant reaches the review screen, so nothing waits on it. The preview never blocks on the seed; if it hasn't landed, current behavior applies.
- A seeded cache short-circuits the version gate via the existing `cachedAvailability == true` guard leg.

Android counterpart: WOOMOB-3624.

## Test Steps

Covered by 7 new tests in `POSV4RefundPreviewUseCaseTests` (route present → marked available; stale 10.8 version + seeded routes → server-calculated preview; route absent / fetch error → cache untouched; cached verdict or disabled flag → no fetch; concurrent + repeated seeds → single fetch).

For a smoke test: on a WC 10.9 site with `rest-api-v4` enabled, make the cached Woo version stale (e.g. sync plugins on 10.8, upgrade the site, relaunch the app without a plugin sync), start a POS refund — totals should be server-calculated rather than falling back to local math.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.