### PR TITLE
Screenshots CI robustness experiments (stacked on #17520)

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -77,23 +77,6 @@ jobs:
         name: "screenshot-log-${{ matrix.language }}-${{ matrix.mode }}"
         path: fastlane/logs
 
-    # TODO: Temporary — remove once the app crash during capture is diagnosed (AINFRA-2682).
-    - name: Collect Crash Reports
-      if: failure()
-      run: |
-        mkdir -p crash-reports
-        cp -R "$HOME/Library/Logs/DiagnosticReports/." crash-reports/ 2>/dev/null || true
-        find "$HOME/Library/Developer/CoreSimulator/Devices" -path '*/DiagnosticReports/*' \
-          \( -name '*.ips' -o -name '*.crash' \) -exec cp {} crash-reports/ \; 2>/dev/null || true
-        ls -la crash-reports || true
-    - name: Upload Crash Reports
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: "crash-reports-${{ matrix.language }}-${{ matrix.mode }}"
-        path: crash-reports/
-        if-no-files-found: ignore
-
     - name: Archive Generated Screenshots
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -19,8 +19,6 @@ jobs:
     - name: "Set up Ruby"
       uses: ruby/setup-ruby@v1
       with:
-        # TODO: Drop once #17484 bumps `.ruby-version` to 3.4.9 (setup-ruby then reads it by default).
-        ruby-version: 3.4.9
         bundler-cache: true
 
     - name: Install App Dependencies
@@ -57,8 +55,6 @@ jobs:
     - name: "Set up Ruby"
       uses: ruby/setup-ruby@v1
       with:
-        # TODO: Drop once #17484 bumps `.ruby-version` to 3.4.9 (setup-ruby then reads it by default).
-        ruby-version: 3.4.9
         bundler-cache: true
 
     - name: Download Build Products
@@ -141,9 +137,6 @@ jobs:
       - name: "Set up Ruby"
         uses: ruby/setup-ruby@v1
         with:
-          # Unlike the build/capture jobs, stay on `.ruby-version` here: `create_promo_screenshots`
-          # needs rmagick 4.3.0, which does not load on Ruby 3.4 (it drops `observer` from the
-          # default gems). #17484 must bump rmagick when it moves the project to 3.4.9.
           bundler-cache: true
 
       - name: Download Generated Screenshots

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@
 source 'https://rubygems.org'
 
 group :screenshots, optional: true do
-  gem 'rmagick', '~> 4.1'
+  # rmagick 5+ is required on Ruby 3.4: 4.x fails to load because it uses `observer`,
+  # which Ruby 3.4 dropped from its default gems. Needed by `create_promo_screenshots`.
+  gem 'rmagick', '~> 6.0'
 end
 
 gem 'danger-dangermattic', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,4 +397,4 @@ DEPENDENCIES
   xcode-install
 
 BUNDLED WITH
-   2.6.8
+  4.0.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,7 @@ GEM
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    observer (0.1.2)
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -289,6 +290,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pkg-config (1.6.5)
     plist (3.7.2)
     prime (0.1.4)
       forwardable
@@ -312,7 +314,9 @@ GEM
       uber (< 0.2.0)
     retriable (3.8.0)
     rexml (3.4.4)
-    rmagick (4.3.0)
+    rmagick (6.3.0)
+      observer (~> 0.1)
+      pkg-config (~> 1.4)
     rouge (3.28.0)
     rubocop (1.88.2)
       json (~> 2.3)
@@ -387,10 +391,10 @@ DEPENDENCIES
   fastlane-plugin-wpmreleasetoolkit (~> 14.10)
   openssl (~> 4.0)
   rake (~> 13.4)
-  rmagick (~> 4.1)
+  rmagick (~> 6.0)
   rubocop (~> 1.88)
   rubocop-rake (~> 0.6)
   xcode-install
 
 BUNDLED WITH
-  4.0.15
+   2.6.8

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1129,10 +1129,11 @@ platform :ios do
       # "snapshot of accessibility hierarchy" on the iOS 26.x simulator, where WebKit and
       # WebCore both register `UIAccessibilityLoaderWebShared` — the duplicate class makes AX
       # queries intermittently time out. The app itself is fine; the retries usually absorb it,
-      # but a locale can still occasionally fail. Revisit once CI moves to a newer Xcode (#17484).
-      number_of_retries: 3,
+      # but a locale can still occasionally fail. Xcode 26.6 (#17484) did not fix it, so retry
+      # generously — a re-run is otherwise needed whenever a single locale trips the timeout.
+      number_of_retries: 6,
 
-      # But fail completely after those 3 retries
+      # But fail completely after those retries
       stop_after_first_error: true,
 
       # Allow the caller to invoke dark mode


### PR DESCRIPTION
Stacked on #17520 — these are more experiments toward a robustly-green Screenshots workflow.