### PR TITLE
Fix claude-analysis pipeline upload failing on secret interpolation

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -18,8 +18,12 @@ steps:
       - "/tmp/buildkite_logs_${BUILDKITE_BUILD_ID}.txt"
     plugins:
       - $CLAUDE_PLUGIN:
-          api_key: "$ANTHROPIC_API_KEY"
-          buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
+          # Escape with `$$` so these secrets are interpolated when the analysis job runs, not
+          # when `upload-claude-analysis.sh` uploads this pipeline. Buildkite refuses to upload a
+          # pipeline that embeds values interpolated from secret env vars, which was failing the
+          # "Check for Build Failures" job on every build that had a real failure.
+          api_key: "$$ANTHROPIC_API_KEY"
+          buildkite_api_token: "$$BUILDKITE_TOKEN_FOR_CLAUDE"
           analysis_level: "build"
           build_log_mode: "failed"
           trigger: "on-failure"


### PR DESCRIPTION
## Description
`upload-claude-analysis.sh` uploads `.buildkite/claude-analysis.yml` whenever a build has a real failure, but Buildkite blocks the upload because the pipeline embeds values interpolated from secret env vars (`api_key: "$ANTHROPIC_API_KEY"`), erroring with *"contains values interpolated from the following secret environment variables: [ANTHROPIC_API_KEY], and cannot be uploaded"*. As a result the "Check for Build Failures and Run Claude Analysis" job fails on **every failing build**, and the analysis never runs.

Escape the two secret references with `$$` so they interpolate when the analysis job runs (where the secrets exist) instead of at upload time — the secret values stay out of the uploaded pipeline definition.

## Test Steps
The vulnerable path only runs on a build with a real (non-Danger) failure, so it can't be exercised by a green build. Verified via the stacked PR which temporarily adds a deliberately-failing step to trigger the upload.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.