### PR TITLE
Display dash rather than zero when we cannot format product row prices, or empty

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCardPriceSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCardPriceSummaryViewModel.swift
@@ -59,7 +59,10 @@ extension CollapsibleProductCardPriceSummaryViewModel {
         guard let price = pricedIndividually ? price : "0" else {
             return nil
         }
-        let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
+        guard let priceDecimal = currencyFormatter.convertToDecimal(price)?.decimalValue else {
+            return "-"
+        }
+        let productSubtotal = quantity * priceDecimal
         return currencyFormatter.formatAmount(productSubtotal)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -205,7 +205,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         guard let price else {
             return nil
         }
-        let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
+        guard let priceDecimal = currencyFormatter.convertToDecimal(price)?.decimalValue else {
+            return "-"
+        }
+        let productSubtotal = quantity * priceDecimal
         let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal)
 
         guard let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -143,7 +143,7 @@ final class ProductRowViewModelTests: XCTestCase {
         assertEqual("-", viewModel.priceAndDiscountsLabel)
     }
 
-    func test_view_model_creates_expected_label_for_product_with_no_price() {
+    func test_view_model_creates_dash_label_for_product_with_no_price() {
         // Given
         let price = ""
         let product = Product.fake().copy(price: price)
@@ -153,9 +153,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, currencyFormatter: currencyFormatter)
 
         // Then
-        let expectedPriceLabel = "$0.00"
-        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedPriceLabel),
-                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
+        assertEqual("-", viewModel.priceAndDiscountsLabel)
     }
 
     func test_view_model_creates_expected_product_details_label_for_variable_product() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -130,6 +130,19 @@ final class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
+    func test_priceAndDiscountsLabel_when_price_is_non_numeric_then_returns_dash() {
+        // Given
+        let price = "not-a-number"
+        let product = Product.fake().copy(price: price)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, currencyFormatter: currencyFormatter)
+
+        // Then
+        assertEqual("-", viewModel.priceAndDiscountsLabel)
+    }
+
     func test_view_model_creates_expected_label_for_product_with_no_price() {
         // Given
         let price = ""

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/CollapsibleProductCardPriceSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/CollapsibleProductCardPriceSummaryViewModelTests.swift
@@ -89,4 +89,19 @@ final class CollapsibleProductCardPriceSummaryViewModelTests: XCTestCase {
         // Then
         assertEqual("$0.00", viewModel.priceBeforeDiscountsLabel)
     }
+
+    func test_priceBeforeDiscountsLabel_when_price_is_non_numeric_then_returns_dash() {
+        // Given
+        let price = "not-a-number"
+        let quantity: Decimal = 8
+
+        // When
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: true,
+                                                                    isSubscriptionProduct: false,
+                                                                    quantity: quantity,
+                                                                    price: price)
+
+        // Then
+        assertEqual("-", viewModel.priceBeforeDiscountsLabel)
+    }
 }


### PR DESCRIPTION
## Description
Closes WOOMOB-3600

We default to show `0` in the product row prices if we cannot format it properly or prices are empty, instead we'll show `-`

## Test Steps
- CI should pass
- Optional: Update ProductRowViewModel.swift and CollapsibleProductCardPriceSummaryViewModel.swift to force a non-numeric value, then create an order and when selecting products observe a dash is present where price should be.
```diff
- self.price = pricedIndividually ? price : "0"
+ self.price = "abc"
```

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-07-20 at 13 11 13" src="https://github.com/user-attachments/assets/dec349ad-a0cf-464a-9c16-4a5b85f78405" />
