### PR TITLE
[WOOMOB-3563] Fix AI chat context in Zendesk support requests

### DIFF
--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -5,6 +5,11 @@ import UIKit
 /// String: Helper Methods
 ///
 extension String {
+    /// Whether the string contains any non-whitespace or newline characters.
+    var isNonBlank: Bool {
+        !trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// Get quotation marks from Locale
     static var quotes: (String, String) {
         guard

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -21,6 +21,7 @@ final class SupportEscalationCoordinator {
 
     private weak var navigationController: UINavigationController?
     private let additionalAttachmentsProvider: () -> [ZendeskAttachment]
+    private let attachmentProvider: SupportRequestAttachmentProviding
     private let zendeskProvider: ZendeskManagerProtocol
     private let analytics: Analytics
     private let stores: StoresManager
@@ -37,6 +38,7 @@ final class SupportEscalationCoordinator {
     /// - Parameters:
     ///   - navigationController: The navigation controller to present from.
     ///   - additionalAttachmentsProvider: Closure that returns extra attachments (e.g., troubleshooting logs).
+    ///   - attachmentProvider: Composes diagnostics with the application log for each request.
     ///   - zendeskProvider: Zendesk service provider.
     ///   - analytics: Analytics tracker.
     ///   - stores: Stores manager for site info.
@@ -45,6 +47,7 @@ final class SupportEscalationCoordinator {
     ///     update its in-session state.
     init(navigationController: UINavigationController?,
          additionalAttachmentsProvider: @escaping () -> [ZendeskAttachment] = { [] },
+         attachmentProvider: SupportRequestAttachmentProviding = DefaultSupportRequestAttachmentProvider(),
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analytics: Analytics = ServiceLocator.analytics,
          stores: StoresManager = ServiceLocator.stores,
@@ -52,6 +55,7 @@ final class SupportEscalationCoordinator {
          transcriptConsentPresenter: TranscriptConsentPresenter? = nil) {
         self.navigationController = navigationController
         self.additionalAttachmentsProvider = additionalAttachmentsProvider
+        self.attachmentProvider = attachmentProvider
         self.zendeskProvider = zendeskProvider
         self.analytics = analytics
         self.stores = stores
@@ -80,16 +84,17 @@ final class SupportEscalationCoordinator {
         self.chatID = chatID
         self.escalationSiteAddress = siteAddress
         self.hasReceivedBotResponse = hasReceivedBotResponse
+        let transcript = formattedTranscript(transcript)
 
         guard let supportAreaInfo else {
             showSupportForm(transcript: transcript, supportAreaInfo: nil, entryPoint: entryPoint)
             return
         }
 
-        // Only offer direct ticket creation if high confidence, user identity exists, and
-        // a site URL is available. Otherwise the form lets users provide missing details.
-        if supportAreaInfo.isHighConfidence && zendeskProvider.haveUserIdentity && hasSiteAddress {
-            confirmTranscriptConsent(for: supportAreaInfo, entryPoint: entryPoint)
+        // Only offer direct ticket creation if high confidence, a nonempty transcript and user identity exist,
+        // and a site URL is available. Otherwise the form lets users provide missing details.
+        if supportAreaInfo.isHighConfidence && zendeskProvider.haveUserIdentity && hasSiteAddress && transcript != nil {
+            confirmTranscriptConsent(for: supportAreaInfo, transcript: transcript, entryPoint: entryPoint)
         } else {
             showSupportForm(transcript: transcript, supportAreaInfo: supportAreaInfo, entryPoint: entryPoint)
         }
@@ -97,7 +102,7 @@ final class SupportEscalationCoordinator {
 
     // MARK: - Private Methods
 
-    private func showSupportForm(transcript: String, supportAreaInfo: SupportAreaInfo?, entryPoint: SupportChatViewModel.EntryPoint) {
+    private func showSupportForm(transcript: String?, supportAreaInfo: SupportAreaInfo?, entryPoint: SupportChatViewModel.EntryPoint) {
         let attachments = additionalAttachmentsProvider()
 
         let prefilledSubject: String?
@@ -115,7 +120,9 @@ final class SupportEscalationCoordinator {
             sourceTag: Tags.sourceTag,
             additionalTags: additionalTags(for: supportAreaInfo),
             zendeskProvider: zendeskProvider,
+            attachmentProvider: attachmentProvider,
             attachments: attachments,
+            transcript: transcript,
             preselectedArea: supportAreaInfo?.area,
             prefilledSubject: prefilledSubject,
             prefilledSiteAddress: siteAddress,
@@ -146,21 +153,25 @@ final class SupportEscalationCoordinator {
         }
     }
 
-    private func confirmTranscriptConsent(for areaInfo: SupportAreaInfo, entryPoint: SupportChatViewModel.EntryPoint) {
+    private func confirmTranscriptConsent(for areaInfo: SupportAreaInfo,
+                                          transcript: String?,
+                                          entryPoint: SupportChatViewModel.EntryPoint) {
         guard let presentingVC = navigationController?.topViewController else { return }
 
         transcriptConsentPresenter(
             presentingVC,
             { [weak self] in
-                self?.createTicketDirectly(with: areaInfo, entryPoint: entryPoint)
+                self?.createTicketDirectly(with: areaInfo, transcript: transcript, entryPoint: entryPoint)
             },
             { [weak self] in
-                self?.showSupportForm(transcript: areaInfo.transcript, supportAreaInfo: areaInfo, entryPoint: entryPoint)
+                self?.showSupportForm(transcript: transcript, supportAreaInfo: areaInfo, entryPoint: entryPoint)
             }
         )
     }
 
-    private func createTicketDirectly(with areaInfo: SupportAreaInfo, entryPoint: SupportChatViewModel.EntryPoint) {
+    private func createTicketDirectly(with areaInfo: SupportAreaInfo,
+                                      transcript: String?,
+                                      entryPoint: SupportChatViewModel.EntryPoint) {
         guard let presentingVC = navigationController?.topViewController else { return }
 
         let loadingViewController = InProgressViewController(
@@ -168,8 +179,7 @@ final class SupportEscalationCoordinator {
         )
         presentingVC.present(loadingViewController, animated: true)
 
-        let description = [Localization.transcriptHeader, areaInfo.transcript].joined(separator: "\n\n")
-        let attachments = additionalAttachmentsProvider()
+        let attachments = attachmentProvider.attachments(including: additionalAttachmentsProvider())
 
         let siteAddress = siteAddress ?? ""
         let tags = areaInfo.area.datasource.tags + additionalTags(for: areaInfo) + [Tags.sourceTag]
@@ -178,7 +188,7 @@ final class SupportEscalationCoordinator {
             customFields: areaInfo.area.datasource.customFields(siteAddress: siteAddress),
             tags: tags,
             subject: SupportFormViewModel.subject(for: areaInfo.areaType),
-            description: description,
+            description: transcript ?? "",
             attachments: attachments
         )
 
@@ -202,7 +212,7 @@ final class SupportEscalationCoordinator {
                         entryPoint: entryPoint,
                         errorType: Self.errorType(for: error)
                     ))
-                    self?.showSupportForm(transcript: areaInfo.transcript, supportAreaInfo: areaInfo, entryPoint: entryPoint)
+                    self?.showSupportForm(transcript: transcript, supportAreaInfo: areaInfo, entryPoint: entryPoint)
                 }
             }
         }
@@ -251,6 +261,14 @@ final class SupportEscalationCoordinator {
             return siteAddress
         }
         return nil
+    }
+
+    private func formattedTranscript(_ transcript: String?) -> String? {
+        guard let transcript,
+              transcript.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty else {
+            return nil
+        }
+        return [Localization.transcriptHeader, transcript].joined(separator: "\n\n")
     }
 
     private static func errorType(for error: Error) -> String {
@@ -311,8 +329,8 @@ private extension SupportEscalationCoordinator {
             comment: "Title for the alert asking consent to send an AI chat transcript to support"
         )
         static let transcriptConsentMessage = NSLocalizedString(
-            "supportEscalationCoordinator.transcriptConsentMessage",
-            value: "We can create a support request using this chat transcript, or you can open the contact form and enter the details yourself.",
+            "supportEscalationCoordinator.transcriptConsentMessageV2",
+            value: "Both options include this chat transcript. Send the request now, or open the contact form to add more details first.",
             comment: "Message for the alert asking consent to send an AI chat transcript to support"
         )
         static let contactForm = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -265,7 +265,7 @@ final class SupportEscalationCoordinator {
 
     private func formattedTranscript(_ transcript: String?) -> String? {
         guard let transcript,
-              transcript.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty else {
+              transcript.isNonBlank else {
             return nil
         }
         return [Localization.transcriptHeader, transcript].joined(separator: "\n\n")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -301,7 +301,7 @@ final class SupportEscalationCoordinator {
 
 // MARK: - Localization
 
-private extension SupportEscalationCoordinator {
+extension SupportEscalationCoordinator {
     enum Localization {
         static let creatingTicket = NSLocalizedString(
             "supportEscalationCoordinator.creatingTicket",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -155,6 +155,12 @@ struct SupportForm: View {
                             )
                             .cornerRadius(Layout.cornerRadius)
                             .accessibilityLabel(Localization.message)
+
+                        if viewModel.shouldShowTranscriptDisclosure {
+                            Text(Localization.transcriptDisclosure)
+                                .foregroundStyle(Color(.secondaryLabel))
+                                .captionStyle()
+                        }
                     }
                     .accessibilityElement(children: .contain)
                 }
@@ -228,6 +234,11 @@ private extension SupportForm {
         static let subject = NSLocalizedString("Subject", comment: "Subject title on the support form")
         static let siteAddress = NSLocalizedString("Site Address", comment: "Site Address title on the support form")
         static let message = NSLocalizedString("Message", comment: "Message on the support form")
+        static let transcriptDisclosure = NSLocalizedString(
+            "supportForm.aiChatTranscriptDisclosure",
+            value: "Your AI support chat transcript will also be included with this request.",
+            comment: "Disclosure below the support form message editor when an AI chat transcript will be included"
+        )
         static let submitRequest = NSLocalizedString("Submit Support Request", comment: "Button title to submit a support request.")
 
         static let supportRequestSent = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -77,7 +77,7 @@ public final class SupportFormViewModel: ObservableObject {
 
     /// Whether the form should disclose that an AI chat transcript will be included.
     var shouldShowTranscriptDisclosure: Bool {
-        transcript?.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty == true
+        transcript?.isNonBlank == true
     }
 
     /// Called when a ticket is successfully created.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -60,7 +60,7 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     private let zendeskProvider: ZendeskManagerProtocol
 
-    private let applicationLogsProvider: ApplicationLogProvider
+    private let attachmentProvider: SupportRequestAttachmentProviding
 
     /// Handles the communication with Tracks..
     ///
@@ -71,6 +71,14 @@ public final class SupportFormViewModel: ObservableObject {
     private let defaultSite: Site?
 
     private let attachments: [ZendeskAttachment]
+
+    /// Immutable transcript context appended to the editable message when the request is submitted.
+    private let transcript: String?
+
+    /// Whether the form should disclose that an AI chat transcript will be included.
+    var shouldShowTranscriptDisclosure: Bool {
+        transcript?.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty == true
+    }
 
     /// Called when a ticket is successfully created.
     private let onTicketCreated: (() -> Void)?
@@ -110,9 +118,10 @@ public final class SupportFormViewModel: ObservableObject {
          additionalTags: [String] = [],
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analyticsProvider: Analytics = ServiceLocator.analytics,
-         applicationLogsProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider,
+         attachmentProvider: SupportRequestAttachmentProviding = DefaultSupportRequestAttachmentProvider(),
          defaultSite: Site? = ServiceLocator.stores.sessionManager.defaultSite,
          attachments: [ZendeskAttachment] = [],
+         transcript: String? = nil,
          preselectedArea: Area? = nil,
          prefilledSubject: String? = nil,
          prefilledSiteAddress: String? = nil,
@@ -124,9 +133,10 @@ public final class SupportFormViewModel: ObservableObject {
         self.additionalTags = additionalTags
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
-        self.applicationLogsProvider = applicationLogsProvider
+        self.attachmentProvider = attachmentProvider
         self.defaultSite = defaultSite
         self.attachments = attachments
+        self.transcript = transcript
         self.area = preselectedArea
         self.onTicketCreated = onTicketCreated
         self.onTicketCreationFailed = onTicketCreationFailed
@@ -177,8 +187,8 @@ public final class SupportFormViewModel: ObservableObject {
                                             customFields: area.datasource.customFields(siteAddress: siteAddress),
                                             tags: assembleTags(),
                                             subject: subject,
-                                            description: description,
-                                            attachments: wrapAttachments())
+                                            description: requestDescription,
+                                            attachments: attachmentProvider.attachments(including: attachments))
         zendeskProvider.createSupportRequest(request) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
@@ -261,14 +271,11 @@ private extension SupportFormViewModel {
         shouldShowIdentityInput = true
     }
 
-    func wrapAttachments() -> [ZendeskAttachment] {
-        guard let applicationLogs = applicationLogsProvider.applicationLogs()?.data(using: .utf8) else {
-            return []
+    var requestDescription: String {
+        guard shouldShowTranscriptDisclosure, let transcript else {
+            return description
         }
-
-        return attachments + [ZendeskAttachment(data: applicationLogs,
-                                                filename: "application_log.txt",
-                                                contentType: "text/plain")]
+        return [description, transcript].joined(separator: "\n\n")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportRequestAttachmentProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportRequestAttachmentProvider.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Composes the complete attachment list for a Zendesk support request.
+protocol SupportRequestAttachmentProviding {
+    func attachments(including attachments: [ZendeskAttachment]) -> [ZendeskAttachment]
+}
+
+/// Appends the full application log to support-request attachments when available.
+final class DefaultSupportRequestAttachmentProvider: SupportRequestAttachmentProviding {
+    private enum Constants {
+        static let applicationLogFilename = "application_log.txt"
+        static let plainTextContentType = "text/plain"
+    }
+
+    private let applicationLogProvider: ApplicationLogProvider
+
+    init(applicationLogProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider) {
+        self.applicationLogProvider = applicationLogProvider
+    }
+
+    func attachments(including attachments: [ZendeskAttachment]) -> [ZendeskAttachment] {
+        guard attachments.contains(where: { $0.filename == Constants.applicationLogFilename }) == false,
+              let applicationLogs = applicationLogProvider.applicationLogs(),
+              applicationLogs.isNotEmpty,
+              let applicationLogData = applicationLogs.data(using: .utf8) else {
+            return attachments
+        }
+
+        return attachments + [ZendeskAttachment(data: applicationLogData,
+                                                filename: Constants.applicationLogFilename,
+                                                contentType: Constants.plainTextContentType)]
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportRequestAttachmentProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportRequestAttachmentProvider.swift
@@ -6,7 +6,7 @@ protocol SupportRequestAttachmentProviding {
 }
 
 /// Appends the full application log to support-request attachments when available.
-final class DefaultSupportRequestAttachmentProvider: SupportRequestAttachmentProviding {
+struct DefaultSupportRequestAttachmentProvider: SupportRequestAttachmentProviding {
     private enum Constants {
         static let applicationLogFilename = "application_log.txt"
         static let plainTextContentType = "text/plain"

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportAreaInfo.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportAreaInfo.swift
@@ -15,9 +15,6 @@ struct SupportAreaInfo {
     /// The support topic returned by the bot for ticket tagging.
     let topic: String?
 
-    /// Full chat transcript.
-    let transcript: String
-
     /// Pre-fetched system status report, if available.
     let systemStatusReport: String?
 
@@ -29,13 +26,11 @@ struct SupportAreaInfo {
          area: SupportFormViewModel.Area,
          confidence: SupportAreaConfidence,
          topic: String? = nil,
-         transcript: String,
          systemStatusReport: String? = nil) {
         self.areaType = areaType
         self.area = area
         self.confidence = confidence
         self.topic = topic
-        self.transcript = transcript
         self.systemStatusReport = systemStatusReport
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -751,7 +751,6 @@ final class SupportChatViewModel {
                 area: mappedArea,
                 confidence: supportArea.confidence,
                 topic: supportArea.topic,
-                transcript: transcript,
                 systemStatusReport: systemStatusReport
             )
         } else {

--- a/WooCommerce/WooCommerceTests/Mocks/MockApplicationLogProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockApplicationLogProvider.swift
@@ -1,0 +1,9 @@
+@testable import WooCommerce
+
+struct MockApplicationLogProvider: ApplicationLogProvider {
+    let logs: String?
+
+    func applicationLogs(cappedTo: Int?) -> String? {
+        logs
+    }
+}

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -26,6 +26,9 @@ final class MockZendeskManager: ZendeskManagerProtocol {
     ///
     private(set) var latestInvokedCustomFields: [Int64: String] = [:]
 
+    /// Retains the complete latest request for assertions about descriptions and attachments.
+    private(set) var latestSupportRequest: ZendeskSupportRequest?
+
     func showNewRequestIfPossible(from controller: UIViewController, with sourceTag: String?) {
         let invocation = NewRequestIfPossibleInvocation(controller: controller, sourceTag: sourceTag)
         newRequestIfPossibleInvocations.append(invocation)
@@ -106,6 +109,7 @@ extension MockZendeskManager {
 
     func createSupportRequest(_ request: WooCommerce.ZendeskSupportRequest,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        latestSupportRequest = request
         latestInvokedTags = request.tags
         latestInvokedCustomFields = request.customFields
         if let stubbedCreateSupportRequestResult {

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -345,7 +345,7 @@ struct SupportEscalationCoordinatorTests {
                                            filename: "connectivitytest_log.txt",
                                            contentType: "text/plain")
         let attachmentProvider = DefaultSupportRequestAttachmentProvider(
-            applicationLogProvider: StubApplicationLogProvider(logs: "Application log")
+            applicationLogProvider: MockApplicationLogProvider(logs: "Application log")
         )
         let navigationController = UINavigationController(rootViewController: UIViewController())
         let coordinator = makeCoordinator(
@@ -726,13 +726,5 @@ private extension SupportEscalationCoordinatorTests {
             area: SupportFormViewModel.area(for: .mobileApp),
             confidence: .low
         )
-    }
-
-    private struct StubApplicationLogProvider: ApplicationLogProvider {
-        let logs: String?
-
-        func applicationLogs(cappedTo: Int?) -> String? {
-            logs
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -9,7 +9,7 @@ struct SupportEscalationCoordinatorTests {
 
     // MARK: - Routing Tests
 
-    @Test func handleEscalation_when_supportAreaInfo_is_nil_then_shows_support_form() {
+    @Test func handleEscalation_when_supportAreaInfo_is_nil_then_shows_support_form() throws {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
@@ -23,6 +23,7 @@ struct SupportEscalationCoordinatorTests {
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+        try assertSupportFormRetainsTranscript(navigationController, zendesk: zendesk)
     }
 
     @Test func supportForm_when_no_bot_response_then_excludes_aiSkip_tag() {
@@ -68,7 +69,7 @@ struct SupportEscalationCoordinatorTests {
         #expect(viewModel?.siteAddress == "https://prelogin.example.com")
     }
 
-    @Test func handleEscalation_when_high_confidence_and_has_identity_then_creates_ticket_directly_after_transcript_consent() {
+    @Test func handleEscalation_when_high_confidence_and_has_identity_then_creates_ticket_directly_after_transcript_consent() throws {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
@@ -85,6 +86,9 @@ struct SupportEscalationCoordinatorTests {
         #expect(zendesk.latestInvokedTags.contains("in_app_support_escalate"))
         #expect(zendesk.latestInvokedTags.contains("ai_skip"))
         #expect(zendesk.latestInvokedTags.contains("woo_mobile_issue_orders"))
+        let description = try #require(zendesk.latestSupportRequest?.description)
+        #expect(description == expectedFormattedTranscript)
+        #expect(description.components(separatedBy: "Test transcript").count == 2)
     }
 
     @Test func handleEscalation_when_high_confidence_and_has_identity_then_asks_for_transcript_consent_before_creating_ticket() {
@@ -139,7 +143,13 @@ struct SupportEscalationCoordinatorTests {
         #expect(zendesk.latestInvokedTags.isEmpty)
         let viewModel = try #require(supportFormViewModel(from: navigationController))
         #expect(viewModel.description.isEmpty)
+        #expect(viewModel.shouldShowTranscriptDisclosure)
+        #expect(viewModel.submitButtonDisabled)
         #expect(viewModel.subject == SupportFormViewModel.subject(for: .mobileApp))
+
+        viewModel.description = "Additional details"
+        viewModel.submitSupportRequest()
+        #expect(zendesk.latestSupportRequest?.description == "Additional details\n\n\(expectedFormattedTranscript)")
     }
 
     @Test func handleEscalation_when_transcript_consent_cancelled_then_takes_no_action() {
@@ -168,7 +178,7 @@ struct SupportEscalationCoordinatorTests {
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController } == false)
     }
 
-    @Test func handleEscalation_when_high_confidence_but_no_identity_then_shows_support_form() {
+    @Test func handleEscalation_when_high_confidence_but_no_identity_then_shows_support_form() throws {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: nil, email: nil, haveUserIdentity: false)
@@ -183,9 +193,34 @@ struct SupportEscalationCoordinatorTests {
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+        try assertSupportFormRetainsTranscript(navigationController, zendesk: zendesk)
     }
 
-    @Test func handleEscalation_when_high_confidence_but_no_site_address_then_shows_support_form() {
+    @Test func handleEscalation_when_logged_out_then_support_form_retains_transcript() throws {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: nil, email: nil, haveUserIdentity: false)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(
+            navigationController: navigationController,
+            zendesk: zendesk,
+            stores: stores
+        )
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .preLogin,
+                                     siteAddress: "https://prelogin.example.com")
+
+        // Then
+        try assertSupportFormRetainsTranscript(navigationController, zendesk: zendesk)
+    }
+
+    @Test func handleEscalation_when_high_confidence_but_no_site_address_then_shows_support_form() throws {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
@@ -211,6 +246,7 @@ struct SupportEscalationCoordinatorTests {
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+        try assertSupportFormRetainsTranscript(navigationController, zendesk: zendesk)
     }
 
     @Test func handleEscalation_when_preLogin_has_site_address_then_can_create_ticket_directly_after_transcript_consent() {
@@ -239,7 +275,7 @@ struct SupportEscalationCoordinatorTests {
         #expect(zendesk.latestInvokedCustomFields.values.contains("https://prelogin.example.com"))
     }
 
-    @Test func handleEscalation_when_medium_confidence_then_shows_support_form() {
+    @Test func handleEscalation_when_medium_confidence_then_shows_support_form() throws {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
@@ -254,9 +290,10 @@ struct SupportEscalationCoordinatorTests {
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+        try assertSupportFormRetainsTranscript(navigationController, zendesk: zendesk)
     }
 
-    @Test func handleEscalation_when_low_confidence_then_shows_support_form() {
+    @Test func handleEscalation_when_low_confidence_then_shows_support_form() throws {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
@@ -271,6 +308,62 @@ struct SupportEscalationCoordinatorTests {
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+        try assertSupportFormRetainsTranscript(navigationController, zendesk: zendesk)
+    }
+
+    @Test func handleEscalation_when_transcript_is_whitespace_then_form_has_no_disclosure_or_empty_header() throws {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController, zendesk: zendesk)
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: " \n ",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .helpAndSupport)
+
+        // Then
+        let viewModel = try #require(supportFormViewModel(from: navigationController))
+        #expect(viewModel.shouldShowTranscriptDisclosure == false)
+        #expect(viewModel.description.isEmpty)
+        viewModel.area = viewModel.areas.first
+        viewModel.subject = "Subject"
+        viewModel.siteAddress = "https://example.com"
+        viewModel.description = "Additional details"
+        viewModel.submitSupportRequest()
+        #expect(zendesk.latestSupportRequest?.description == "Additional details")
+    }
+
+    @Test func createTicketDirectly_includes_connectivity_diagnostic_and_application_log() throws {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let diagnostic = ZendeskAttachment(data: Data("Diagnostic".utf8),
+                                           filename: "connectivitytest_log.txt",
+                                           contentType: "text/plain")
+        let attachmentProvider = DefaultSupportRequestAttachmentProvider(
+            applicationLogProvider: StubApplicationLogProvider(logs: "Application log")
+        )
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(
+            navigationController: navigationController,
+            additionalAttachmentsProvider: { [diagnostic] },
+            attachmentProvider: attachmentProvider,
+            zendesk: zendesk
+        )
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .helpAndSupport)
+
+        // Then
+        let request = try #require(zendesk.latestSupportRequest)
+        #expect(request.attachments.map(\.filename) == ["connectivitytest_log.txt", "application_log.txt"])
     }
 
     // MARK: - Ticket Persistence Tests
@@ -364,6 +457,24 @@ struct SupportEscalationCoordinatorTests {
 
         // Then
         #expect(markTicketCreatedCalled == false)
+    }
+
+    @Test func createTicketDirectly_when_request_fails_then_fallback_form_retains_same_transcript() throws {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .failure(NSError(domain: "Test", code: 500)))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController, zendesk: zendesk)
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .helpAndSupport)
+
+        // Then
+        try assertSupportFormRetainsTranscript(navigationController, zendesk: zendesk)
     }
 
     // MARK: - Analytics Tests
@@ -519,6 +630,8 @@ struct SupportEscalationCoordinatorTests {
 
 private extension SupportEscalationCoordinatorTests {
     func makeCoordinator(navigationController: UINavigationController? = nil,
+                         additionalAttachmentsProvider: @escaping () -> [ZendeskAttachment] = { [] },
+                         attachmentProvider: SupportRequestAttachmentProviding = DefaultSupportRequestAttachmentProvider(),
                          zendesk: MockZendeskManager,
                          analyticsProvider: MockAnalyticsProvider = MockAnalyticsProvider(),
                          stores: StoresManager = MockStoresManager(
@@ -528,6 +641,8 @@ private extension SupportEscalationCoordinatorTests {
                             SupportEscalationCoordinatorTests.sendTicketConsentPresenter) -> SupportEscalationCoordinator {
         SupportEscalationCoordinator(
             navigationController: navigationController,
+            additionalAttachmentsProvider: additionalAttachmentsProvider,
+            attachmentProvider: attachmentProvider,
             zendeskProvider: zendesk,
             analytics: WooAnalytics(analyticsProvider: analyticsProvider),
             stores: stores,
@@ -553,6 +668,28 @@ private extension SupportEscalationCoordinatorTests {
             .viewModel
     }
 
+    func assertSupportFormRetainsTranscript(_ navigationController: UINavigationController,
+                                            zendesk: MockZendeskManager) throws {
+        let viewModel = try #require(supportFormViewModel(from: navigationController))
+        #expect(viewModel.shouldShowTranscriptDisclosure)
+        #expect(viewModel.description.isEmpty)
+        viewModel.area = viewModel.area ?? viewModel.areas.first
+        viewModel.subject = viewModel.subject.isEmpty ? "Subject" : viewModel.subject
+        viewModel.siteAddress = viewModel.siteAddress.isEmpty ? "https://example.com" : viewModel.siteAddress
+        viewModel.description = "Additional details"
+        viewModel.submitSupportRequest()
+        #expect(zendesk.latestSupportRequest?.description == "Additional details\n\n\(expectedFormattedTranscript)")
+    }
+
+    var expectedFormattedTranscript: String {
+        let header = NSLocalizedString(
+            "supportEscalationCoordinator.transcriptHeader",
+            value: "Following is the transcript of an in-app AI support chat session:",
+            comment: "Header text before the chat transcript in support ticket description"
+        )
+        return [header, "Test transcript"].joined(separator: "\n\n")
+    }
+
     func assertLastProperties(_ analyticsProvider: MockAnalyticsProvider,
                               event: String,
                               include expectedProperties: [String: Any]) {
@@ -571,8 +708,7 @@ private extension SupportEscalationCoordinatorTests {
             areaType: .mobileApp,
             area: SupportFormViewModel.area(for: .mobileApp),
             confidence: .high,
-            topic: "woo_mobile_issue_orders",
-            transcript: "Test transcript"
+            topic: "woo_mobile_issue_orders"
         )
     }
 
@@ -580,8 +716,7 @@ private extension SupportEscalationCoordinatorTests {
         SupportAreaInfo(
             areaType: .mobileApp,
             area: SupportFormViewModel.area(for: .mobileApp),
-            confidence: .medium,
-            transcript: "Test transcript"
+            confidence: .medium
         )
     }
 
@@ -589,8 +724,15 @@ private extension SupportEscalationCoordinatorTests {
         SupportAreaInfo(
             areaType: .mobileApp,
             area: SupportFormViewModel.area(for: .mobileApp),
-            confidence: .low,
-            transcript: "Test transcript"
+            confidence: .low
         )
+    }
+
+    private struct StubApplicationLogProvider: ApplicationLogProvider {
+        let logs: String?
+
+        func applicationLogs(cappedTo: Int?) -> String? {
+            logs
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -682,12 +682,7 @@ private extension SupportEscalationCoordinatorTests {
     }
 
     var expectedFormattedTranscript: String {
-        let header = NSLocalizedString(
-            "supportEscalationCoordinator.transcriptHeader",
-            value: "Following is the transcript of an in-app AI support chat session:",
-            comment: "Header text before the chat transcript in support ticket description"
-        )
-        return [header, "Test transcript"].joined(separator: "\n\n")
+        [SupportEscalationCoordinator.Localization.transcriptHeader, "Test transcript"].joined(separator: "\n\n")
     }
 
     func assertLastProperties(_ analyticsProvider: MockAnalyticsProvider,

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -253,7 +253,7 @@ final class SupportFormViewModelTests: XCTestCase {
                                            filename: "connectivitytest_log.txt",
                                            contentType: "text/plain")
         let attachmentProvider = DefaultSupportRequestAttachmentProvider(
-            applicationLogProvider: StubApplicationLogProvider(logs: "Application log")
+            applicationLogProvider: MockApplicationLogProvider(logs: "Application log")
         )
         let viewModel = SupportFormViewModel(areas: Self.sampleAreas(),
                                              zendeskProvider: zendesk,
@@ -282,13 +282,5 @@ private extension SupportFormViewModelTests {
             .init(title: "Area 1", datasource: MockDataSource()),
             .init(title: "Area 2", datasource: MockDataSource())
         ]
-    }
-
-    private struct StubApplicationLogProvider: ApplicationLogProvider {
-        let logs: String?
-
-        func applicationLogs(cappedTo: Int?) -> String? {
-            logs
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -193,6 +193,81 @@ final class SupportFormViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.siteAddress, defaultSite.url)
     }
+
+    func test_transcript_context_does_not_enable_submit_when_editable_message_is_empty() {
+        // Given
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas(), transcript: "Formatted transcript")
+
+        // When
+        viewModel.area = viewModel.areas.first
+        viewModel.subject = "Subject"
+        viewModel.siteAddress = "site-address"
+        viewModel.description = ""
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowTranscriptDisclosure)
+        XCTAssertTrue(viewModel.submitButtonDisabled)
+    }
+
+    func test_submitSupportRequest_appends_immutable_transcript_after_user_message() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let transcript = "Transcript header\n\nTest transcript"
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas(),
+                                             zendeskProvider: zendesk,
+                                             transcript: transcript)
+        viewModel.area = viewModel.areas.first
+        viewModel.subject = "Subject"
+        viewModel.siteAddress = "site-address"
+        viewModel.description = "Additional details"
+
+        // When
+        viewModel.submitSupportRequest()
+
+        // Then
+        XCTAssertEqual(zendesk.latestSupportRequest?.description, "Additional details\n\n\(transcript)")
+        XCTAssertEqual(zendesk.latestSupportRequest?.description.components(separatedBy: "Test transcript").count, 2)
+    }
+
+    func test_submitSupportRequest_when_transcript_is_whitespace_then_does_not_add_disclosure_or_transcript_separator() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas(),
+                                             zendeskProvider: zendesk,
+                                             transcript: " \n ")
+        viewModel.area = viewModel.areas.first
+        viewModel.description = "Additional details"
+
+        // When
+        viewModel.submitSupportRequest()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowTranscriptDisclosure)
+        XCTAssertEqual(zendesk.latestSupportRequest?.description, "Additional details")
+    }
+
+    func test_submitSupportRequest_includes_diagnostic_and_application_log_attachments() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let diagnostic = ZendeskAttachment(data: Data("Diagnostic".utf8),
+                                           filename: "connectivitytest_log.txt",
+                                           contentType: "text/plain")
+        let attachmentProvider = DefaultSupportRequestAttachmentProvider(
+            applicationLogProvider: StubApplicationLogProvider(logs: "Application log")
+        )
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas(),
+                                             zendeskProvider: zendesk,
+                                             attachmentProvider: attachmentProvider,
+                                             attachments: [diagnostic])
+        viewModel.area = viewModel.areas.first
+
+        // When
+        viewModel.submitSupportRequest()
+
+        // Then
+        XCTAssertEqual(zendesk.latestSupportRequest?.attachments.map(\.filename),
+                       ["connectivitytest_log.txt", "application_log.txt"])
+    }
 }
 
 private extension SupportFormViewModelTests {
@@ -207,5 +282,13 @@ private extension SupportFormViewModelTests {
             .init(title: "Area 1", datasource: MockDataSource()),
             .init(title: "Area 2", datasource: MockDataSource())
         ]
+    }
+
+    private struct StubApplicationLogProvider: ApplicationLogProvider {
+        let logs: String?
+
+        func applicationLogs(cappedTo: Int?) -> String? {
+            logs
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportRequestAttachmentProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportRequestAttachmentProviderTests.swift
@@ -87,11 +87,3 @@ struct SupportRequestAttachmentProviderTests {
         #expect(attachments.map(\.filename) == ["connectivitytest_log.txt"])
     }
 }
-
-private struct MockApplicationLogProvider: ApplicationLogProvider {
-    let logs: String?
-
-    func applicationLogs(cappedTo: Int?) -> String? {
-        logs
-    }
-}

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportRequestAttachmentProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportRequestAttachmentProviderTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import WooCommerce
+
+struct SupportRequestAttachmentProviderTests {
+    @Test func attachments_when_application_logs_are_available_then_appends_full_log() throws {
+        // Given
+        let logs = "First log line\nSecond log line"
+        let provider = DefaultSupportRequestAttachmentProvider(
+            applicationLogProvider: MockApplicationLogProvider(logs: logs)
+        )
+
+        // When
+        let attachments = provider.attachments(including: [])
+
+        // Then
+        let applicationLog = try #require(attachments.first)
+        #expect(attachments.count == 1)
+        #expect(applicationLog.filename == "application_log.txt")
+        #expect(applicationLog.contentType == "text/plain")
+        #expect(applicationLog.data == Data(logs.utf8))
+    }
+
+    @Test func attachments_when_diagnostic_is_supplied_then_preserves_it_and_appends_application_log() {
+        // Given
+        let diagnostic = ZendeskAttachment(data: Data("Diagnostic".utf8),
+                                           filename: "connectivitytest_log.txt",
+                                           contentType: "text/plain")
+        let provider = DefaultSupportRequestAttachmentProvider(
+            applicationLogProvider: MockApplicationLogProvider(logs: "Application log")
+        )
+
+        // When
+        let attachments = provider.attachments(including: [diagnostic])
+
+        // Then
+        #expect(attachments.map(\.filename) == ["connectivitytest_log.txt", "application_log.txt"])
+    }
+
+    @Test func attachments_when_application_log_is_already_supplied_then_does_not_duplicate_it() throws {
+        // Given
+        let existingLog = ZendeskAttachment(data: Data("Existing log".utf8),
+                                            filename: "application_log.txt",
+                                            contentType: "text/plain")
+        let provider = DefaultSupportRequestAttachmentProvider(
+            applicationLogProvider: MockApplicationLogProvider(logs: "Replacement log")
+        )
+
+        // When
+        let attachments = provider.attachments(including: [existingLog])
+
+        // Then
+        let applicationLog = try #require(attachments.first)
+        #expect(attachments.count == 1)
+        #expect(applicationLog.data == Data("Existing log".utf8))
+    }
+
+    @Test func attachments_when_application_logs_are_missing_then_preserves_supplied_attachments() {
+        // Given
+        let diagnostic = ZendeskAttachment(data: Data("Diagnostic".utf8),
+                                           filename: "connectivitytest_log.txt",
+                                           contentType: "text/plain")
+        let provider = DefaultSupportRequestAttachmentProvider(
+            applicationLogProvider: MockApplicationLogProvider(logs: nil)
+        )
+
+        // When
+        let attachments = provider.attachments(including: [diagnostic])
+
+        // Then
+        #expect(attachments.map(\.filename) == ["connectivitytest_log.txt"])
+    }
+
+    @Test func attachments_when_application_logs_are_empty_then_preserves_supplied_attachments() {
+        // Given
+        let diagnostic = ZendeskAttachment(data: Data("Diagnostic".utf8),
+                                           filename: "connectivitytest_log.txt",
+                                           contentType: "text/plain")
+        let provider = DefaultSupportRequestAttachmentProvider(
+            applicationLogProvider: MockApplicationLogProvider(logs: "")
+        )
+
+        // When
+        let attachments = provider.attachments(including: [diagnostic])
+
+        // Then
+        #expect(attachments.map(\.filename) == ["connectivitytest_log.txt"])
+    }
+}
+
+private struct MockApplicationLogProvider: ApplicationLogProvider {
+    let logs: String?
+
+    func applicationLogs(cappedTo: Int?) -> String? {
+        logs
+    }
+}


### PR DESCRIPTION
## Description

WOOMOB-3563

AI chat escalations could lose the transcript when routing through the Contact Form, and application logs were only composed consistently for direct Zendesk submissions.

This change:

- shares attachment composition across both submission paths, preserving caller attachments and appending the full `application_log.txt` exactly once
- captures and formats the AI transcript once, then preserves it through direct submission, Contact Form routing, identity/site fallbacks, and direct-request failure fallback
- keeps Contact Form notes editable while appending the immutable transcript to the final Zendesk description
- clarifies transcript inclusion in the consent alert and Contact Form disclosure
- adds coverage for attachment fallbacks, transcript routing, and duplicate prevention

## Test Steps

From a logged out state with no contact email:

1. Escalate an AI support chat containing a transcript and choose **Send Request**.
2. Confirm the Zendesk request contains the transcript once and one `application_log.txt` attachment.
3. Repeat the escalation, choose **Contact Form**, add a message, and submit.
4. Confirm the description contains the user message followed by a blank line and the immutable transcript, and that diagnostics coexist with one `application_log.txt`.

Repeat the above from logged in state

## Screenshots
<img width="960" height="573" alt="Screenshot 2026-07-21 at 13 03 14" src="https://github.com/user-attachments/assets/aa271921-0fe4-4dab-935d-25d8219e670d" />
<img width="956" height="385" alt="Screenshot 2026-07-21 at 13 03 01" src="https://github.com/user-attachments/assets/0d6f614a-df4d-4239-8d48-a868358aea98" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
