### PR TITLE
[WOOMOB-3648] Fix DS color tokens and Segmented Control tap handling

### DIFF
--- a/Modules/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/SegmentedControl/StoreSegmentedControl.swift
@@ -65,10 +65,10 @@ public struct StoreSegmentedControl<Value: Hashable>: View {
                     selection = option
                 } label: {
                     Color.clear
+                        .frame(maxWidth: .infinity, minHeight: StoreSize.minimumTapTarget)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .frame(maxWidth: .infinity, minHeight: StoreSize.minimumTapTarget)
-                .contentShape(Rectangle())
                 .accessibilityLabel(title(option))
                 .accessibilityAddTraits(index == selectedIndex ? .isSelected : [])
                 .accessibilityValue(Localization.positionValue(index: index + 1, count: options.count))

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity08.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity08.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.080",
-          "blue": "0.117647",
-          "green": "0.117647",
-          "red": "0.117647"
+          "blue": "0.090196",
+          "green": "0.082353",
+          "red": "0.062745"
         }
       },
       "idiom": "universal"

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity10.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity10.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.100",
-          "blue": "0.117647",
-          "green": "0.117647",
-          "red": "0.117647"
+          "blue": "0.090196",
+          "green": "0.082353",
+          "red": "0.062745"
         }
       },
       "idiom": "universal"

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity16.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity16.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.160",
-          "blue": "0.117647",
-          "green": "0.117647",
-          "red": "0.117647"
+          "blue": "0.090196",
+          "green": "0.082353",
+          "red": "0.062745"
         }
       },
       "idiom": "universal"

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity24.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeStateLayerOnSurfaceOpacity24.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.240",
-          "blue": "0.117647",
-          "green": "0.117647",
-          "red": "0.117647"
+          "blue": "0.090196",
+          "green": "0.082353",
+          "red": "0.062745"
         }
       },
       "idiom": "universal"

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeSurface.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeSurface.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "1.000",
-          "blue": "1.000000",
-          "green": "1.000000",
-          "red": "1.000000"
+          "blue": "0.968627",
+          "green": "0.968627",
+          "red": "0.964706"
         }
       },
       "idiom": "universal"
@@ -17,9 +17,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "1.000",
-          "blue": "0.090196",
-          "green": "0.082353",
-          "red": "0.062745"
+          "blue": "0.152941",
+          "green": "0.137255",
+          "red": "0.113725"
         }
       },
       "idiom": "universal",

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeSurfaceBright.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeSurfaceBright.colorset/Contents.json
@@ -17,9 +17,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "1.000",
-          "blue": "0.152941",
-          "green": "0.137255",
-          "red": "0.113725"
+          "blue": "0.090196",
+          "green": "0.082353",
+          "red": "0.062745"
         }
       },
       "idiom": "universal",

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity08.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity08.colorset/Contents.json
@@ -17,9 +17,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.080",
-          "blue": "1.000000",
-          "green": "1.000000",
-          "red": "1.000000"
+          "blue": "0.611765",
+          "green": "0.274510",
+          "red": "0.427451"
         }
       },
       "idiom": "universal",

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity10.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity10.colorset/Contents.json
@@ -17,9 +17,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.100",
-          "blue": "1.000000",
-          "green": "1.000000",
-          "red": "1.000000"
+          "blue": "0.611765",
+          "green": "0.274510",
+          "red": "0.427451"
         }
       },
       "idiom": "universal",

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity16.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity16.colorset/Contents.json
@@ -17,9 +17,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.160",
-          "blue": "1.000000",
-          "green": "1.000000",
-          "red": "1.000000"
+          "blue": "0.611765",
+          "green": "0.274510",
+          "red": "0.427451"
         }
       },
       "idiom": "universal",

--- a/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity24.colorset/Contents.json
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Color/StoreColorPalette.xcassets/storeTintLayerPrimaryContainerOpacity24.colorset/Contents.json
@@ -17,9 +17,9 @@
         "color-space": "srgb",
         "components": {
           "alpha": "0.240",
-          "blue": "1.000000",
-          "green": "1.000000",
-          "red": "1.000000"
+          "blue": "0.611765",
+          "green": "0.274510",
+          "red": "0.427451"
         }
       },
       "idiom": "universal",


### PR DESCRIPTION
Closes WOOMOB-3648

## Description

Three fixes in `StoreDesignSystem`, all surfaced while validating the WOOMOB-3648 colour-token corrections against the Figma Mobile Design System.

Also, the required hitTarget was applied to the wrong element, which made the segment color only respect the selection change when the tap happened outside the label's boundary. 

## Test Steps

1. Install the app
2. Navigate to Settings/DebugPanel/Design System/Components
3. Open **Segmented Control** and tap between segments, the selection pill moves to the tapped segment.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1125" height="420" alt="before_dark" src="https://github.com/user-attachments/assets/c34bf7c9-0d95-480b-8c31-8c493629778a" /> | <img width="1125" height="420" alt="after_dark" src="https://github.com/user-attachments/assets/cdc51d9e-cbc1-40cc-bd41-e666cc610e1a" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.