### PR TITLE
[WOOMOB-2671] Fix Product Tags undo crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.3
 -----
+- [*] Fixed a crash when undoing pasted product tags containing tabs or extra whitespace. [https://github.com/woocommerce/woocommerce-ios/pull/17592]
 - [*] Point of Sale: once the local catalog has fully synced, POS opens instantly without waiting on network checks and also works offline. [https://github.com/woocommerce/woocommerce-ios/pull/17498]
 - [*] Order Creation: fixed custom amount fields losing entered values and keyboard focus after rotating an iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17550]
 - [Internal] Reduce app binary size by converting the Tap to Pay education artwork to PNGs (~45 MB smaller compiled asset catalog). [https://github.com/woocommerce/woocommerce-ios/pull/17560]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -336,10 +336,13 @@ private extension ProductTagsViewController {
     }
 
     func complete(tag: String) {
-        var tags = completeTags
-        tags.append(tag)
-        tags.append("")
-        textView.text = tags.joined(separator: ", ")
+        let text = textView.text as NSString
+        let lastCommaRange = text.range(of: ",", options: .backwards)
+        let partialTagLocation = lastCommaRange.location == NSNotFound ? 0 : NSMaxRange(lastCommaRange)
+        let partialTagRange = NSRange(location: partialTagLocation, length: text.length - partialTagLocation)
+
+        textView.selectedRange = partialTagRange
+        textView.insertText(partialTagLocation == 0 ? "\(tag), " : " \(tag), ")
         updateSuggestions()
     }
 
@@ -360,10 +363,9 @@ private extension ProductTagsViewController {
 extension ProductTagsViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         guard textView.markedTextRange == nil else {
-            // Don't try to normalize if we're still in multistage input
+            // Don't update suggestions while we're still in multistage input.
             return
         }
-        normalizeText()
         updateSuggestions()
     }
 
@@ -375,28 +377,16 @@ extension ProductTagsViewController: UITextViewDelegate {
             partialTag.isEmpty {
             // Don't allow a second comma if the last tag is blank
             return false
-        } else if
-            range.length == 1 && text.isEmpty, // Deleting last character
-            range.location > 0, // Not at the beginning
-            range.location + range.length == original.length, // At the end
-            original.substring(with: NSRange(location: range.location - 1, length: 1)) == "," { // Previous is a comma
-            // Delete the comma as well
-            textView.text = original.substring(to: range.location - 1) + original.substring(from: range.location + range.length)
-            textView.selectedRange = NSRange(location: range.location - 1, length: 0)
-            textViewDidChange(textView)
-            return false
         } else if range.length == 0, // Inserting
             text == ",", // a comma
             range.location == original.length { // at the end
             // Append a space
-            textView.text = original.replacingCharacters(in: range, with: ", ")
-            textViewDidChange(textView)
+            insertTagSeparator(in: textView)
             return false
         } else if text == "\n", // return
             range.location == original.length, // at the end
             !partialTag.isEmpty { // with some (partial) tag typed
-            textView.text = original.replacingCharacters(in: range, with: ", ")
-            textViewDidChange(textView)
+            insertTagSeparator(in: textView)
             return false
         } else if text == "\n" { // return anywhere else
                 return false
@@ -404,12 +394,10 @@ extension ProductTagsViewController: UITextViewDelegate {
         return true
     }
 
-    private func normalizeText() {
-        // Remove any space before a comma, and allow one space at most after.
-        let regexp = try! NSRegularExpression(pattern: "\\s*(,(\\s|(\\s(?=\\s)))?)\\s*", options: [])
-        let text = textView.text ?? ""
-        let range = NSRange(location: 0, length: (text as NSString).length)
-        textView.text = regexp.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: "$1")
+    private func insertTagSeparator(in textView: UITextView) {
+        DispatchQueue.main.async { [weak textView] in
+            textView?.insertText(", ")
+        }
     }
 
     /// Normalize tags for initial set up.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewControllerTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import UIKit
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+@Suite(.serialized)
+struct ProductTagsViewControllerTests {
+    @Test func test_paste_when_text_contains_tabs_then_undo_restores_empty_text() async throws {
+        // Given
+        let sut = ProductTagsViewController(product: .fake(), completion: { _ in })
+        let window = UIWindow()
+        window.rootViewController = sut
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        sut.loadViewIfNeeded()
+        let textView = try #require(sut.value(forKey: "textView") as? UITextView)
+        textView.text = ""
+        #expect(textView.becomeFirstResponder())
+        textView.undoManager?.removeAllActions()
+
+        let pastedText = "First tag\t\t,\t\tSecond tag"
+
+        // When
+        textView.paste(itemProviders: [NSItemProvider(object: pastedText as NSString)])
+        for _ in 0..<100 {
+            if textView.text.isNotEmpty {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        // Then
+        #expect(textView.text == pastedText)
+        let undoManager = try #require(textView.undoManager)
+        #expect(undoManager.canUndo)
+        undoManager.undo()
+        #expect(textView.text.isEmpty)
+    }
+
+    @Test func test_text_view_did_change_when_pasted_text_contains_tabs_then_preserves_text_and_selection() throws {
+        // Given
+        let sut = ProductTagsViewController(product: .fake(), completion: { _ in })
+        sut.loadViewIfNeeded()
+        let textView = try #require(sut.value(forKey: "textView") as? UITextView)
+        let pastedText = "First tag\t\t,\t\tSecond tag"
+        let selection = NSRange(location: (pastedText as NSString).length, length: 0)
+        textView.text = pastedText
+        textView.selectedRange = selection
+
+        // When
+        sut.textViewDidChange(textView)
+
+        // Then
+        #expect(textView.text == pastedText)
+        #expect(textView.selectedRange == selection)
+    }
+}


### PR DESCRIPTION
Closes: WOOMOB-2671

## Description
Pasting text containing extra spaces, or tabs, around commas, into Product Tags and then undoing could crash in TextKit with an out-of-bounds `NSMutableRLEArray` range.

`textViewDidChange` previously normalized the entire text view value after every edit. That replaced the backing text storage after UIKit had registered its undo range, leaving the undo manager with stale ranges. This change stops replacing the complete string while editing and routes programmatic autocomplete and separator edits through `UITextInput` so UIKit keeps its text storage and undo state in sync.

There is a visual change here: previously, the extra spaces would have been removed when typed or tags selected — now they're shown in the user input. Tag whitespace is still trimmed when tags are extracted for saving, so tabs and extra spaces are not submitted to the API.

## Test Steps
1. Open a product and edit its tags.
2. Paste text containing multiple spaces or tabs around a comma, for example `First tag   ,     Second tag`.
3. Undo the paste. (Three-finger swipe left.)
4. Confirm that the editor returns to its previous value without crashing.
5. Paste the text again, save the tags, and reopen the editor.
6. Confirm that the saved tags are displayed with a single space after the comma.

## Screenshots

### Before

https://github.com/user-attachments/assets/31f9e674-ac61-4240-b3ca-454e282948b4



### After

https://github.com/user-attachments/assets/9c109c31-5e3a-46e0-95c1-9252d9b00505



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
