### PR TITLE
Add IPP track events for card reader location fetching

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
@@ -206,3 +206,41 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - In-Person Payments Card Reader Location Events
+extension WooAnalyticsEvent {
+    /// Analytics events for the outcome of card reader location fetching.
+    ///
+    /// Tracked from the data layer (`CommonReaderConfigProvider`), where the location fetch
+    /// resolves and the failure reason is determined. Defined here (rather than in the app target's
+    /// `InPersonPayments` group) so that Yosemite can reach them.
+    public enum InPersonPaymentsLocation {
+        /// Event property keys.
+        private enum Key {
+            static let siteID = "site_id"
+            static let reason = "reason"
+        }
+
+        /// Reason the location fetch failed. Raw values are sent as the `reason` property.
+        public enum FailureReason: String {
+            case incompleteStoreAddress = "incomplete_store_address"
+            case invalidPostalCode = "invalid_postal_code"
+            case other
+        }
+
+        /// Tracked when the default reader location is fetched successfully.
+        public static func cardReaderLocationSuccess(siteID: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardReaderLocationSuccess,
+                              properties: [Key.siteID: "\(siteID)"])
+        }
+
+        /// Tracked when the default reader location fetch fails.
+        public static func cardReaderLocationFailure(siteID: Int64, reason: FailureReason) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardReaderLocationFailure,
+                              properties: [
+                                Key.siteID: "\(siteID)",
+                                Key.reason: reason.rawValue
+                              ])
+        }
+    }
+}

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -347,6 +347,9 @@ public enum WooAnalyticsStat: String {
     case cardReaderAutomaticDisconnect = "card_reader_automatic_disconnect"
     case cardReaderLocationPermissionPreAlertShown = "card_reader_location_permission_pre_alert_shown"
     case cardReaderLocationPermissionRequiredShown = "card_reader_location_permission_required_shown"
+    case cardReaderLocationSuccess = "card_reader_location_success"
+    case cardReaderLocationFailure = "card_reader_location_failure"
+    case cardReaderLocationMissingTapped = "card_reader_location_missing_tapped"
 
     // MARK: Card Reader Software Update Events
     //

--- a/Modules/Sources/Yosemite/Tools/CommonReaderConfigProvider.swift
+++ b/Modules/Sources/Yosemite/Tools/CommonReaderConfigProvider.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Hardware
 import Networking
+import protocol WooFoundation.Analytics
+import struct WooFoundationCore.WooAnalyticsEvent
 
 public protocol CardReaderRemoteConfigLoading {
     func setContext(siteID: Int64, remote: CardReaderCapableRemote)
@@ -13,10 +15,14 @@ public protocol CommonReaderConfigProviding: CardReaderRemoteConfigLoading, Card
 public final class CommonReaderConfigProvider: CommonReaderConfigProviding {
     var siteID: Int64?
     var readerConfigRemote: CardReaderCapableRemote?
+    private let analytics: Analytics?
 
-    public init(siteID: Int64? = nil, readerConfigRemote: CardReaderCapableRemote? = nil) {
+    public init(siteID: Int64? = nil,
+                readerConfigRemote: CardReaderCapableRemote? = nil,
+                analytics: Analytics? = nil) {
         self.siteID = siteID
         self.readerConfigRemote = readerConfigRemote
+        self.analytics = analytics
     }
 
     public func setContext(siteID: Int64, remote: CardReaderCapableRemote) {
@@ -53,18 +59,45 @@ public final class CommonReaderConfigProvider: CommonReaderConfigProviding {
             return
         }
 
+        let analytics = self.analytics
         readerConfigRemote?.loadDefaultReaderLocation(for: siteID) { result in
             switch result {
             case .success(let location):
                 let readerLocation = location.toReaderLocation(siteID: siteID)
+                analytics?.track(WooAnalyticsEvent.InPersonPaymentsLocation.cardReaderLocationSuccess(siteID: siteID))
                 completion(.success(readerLocation.id))
             case .failure(let error):
-                if let configError = CardReaderConfigError(error: error) {
+                let configError = CardReaderConfigError(error: error)
+                analytics?.track(WooAnalyticsEvent.InPersonPaymentsLocation
+                    .cardReaderLocationFailure(siteID: siteID, reason: configError.locationFailureReason))
+                if let configError {
                     completion(.failure(configError))
                 } else {
                     completion(.failure(error))
                 }
             }
+        }
+    }
+}
+
+private extension Analytics {
+    /// Convenience for tracking a strongly-typed `WooAnalyticsEvent` from the data layer,
+    /// where the app target's `track(event:)` convenience is not available.
+    func track(_ event: WooAnalyticsEvent) {
+        track(event.statName.rawValue, properties: event.properties, error: event.error)
+    }
+}
+
+private extension Optional where Wrapped == CardReaderConfigError {
+    /// Maps a resolved `CardReaderConfigError` (or its absence) to an analytics failure reason.
+    var locationFailureReason: WooAnalyticsEvent.InPersonPaymentsLocation.FailureReason {
+        switch self {
+        case .incompleteStoreAddress?:
+            return .incompleteStoreAddress
+        case .invalidPostalCode?:
+            return .invalidPostalCode
+        case .none:
+            return .other
         }
     }
 }

--- a/Modules/Tests/YosemiteTests/Tools/CommonReaderConfigProviderTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/CommonReaderConfigProviderTests.swift
@@ -132,6 +132,83 @@ struct CommonReaderConfigProviderTests {
         }
     }
 
+    @Test func fetchDefaultLocationID_when_fetch_succeeds_then_tracks_card_reader_location_success() async throws {
+        // Given
+        let analytics = MockAnalytics()
+        let mockRemote = MockCardReaderCapableRemote(resultForDefaultReaderLocation: .success(.fake()))
+        let sut = CommonReaderConfigProvider(siteID: 123, readerConfigRemote: mockRemote, analytics: analytics)
+
+        // When
+        _ = try await withCheckedThrowingContinuation { continuation in
+            sut.fetchDefaultLocationID { result in
+                continuation.resume(with: result)
+            }
+        }
+
+        // Then
+        let event = analytics.trackedEvents.first { $0.eventName == "card_reader_location_success" }
+        #expect(event != nil)
+        #expect(event?.properties?["site_id"] as? String == "123")
+    }
+
+    @Test func fetchDefaultLocationID_when_store_address_incomplete_then_tracks_failure_with_incomplete_store_address_reason() async throws {
+        // Given
+        let analytics = MockAnalytics()
+        let mockRemote = MockCardReaderCapableRemote(resultForDefaultReaderLocation: .failure(
+            DotcomError.unknown(code: "store_address_is_incomplete", message: "https://example.com", data: nil)))
+        let sut = CommonReaderConfigProvider(siteID: 123, readerConfigRemote: mockRemote, analytics: analytics)
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            sut.fetchDefaultLocationID { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        // Then
+        let event = analytics.trackedEvents.first { $0.eventName == "card_reader_location_failure" }
+        #expect(event?.properties?["reason"] as? String == "incomplete_store_address")
+        #expect(event?.properties?["site_id"] as? String == "123")
+    }
+
+    @Test func fetchDefaultLocationID_when_postal_code_invalid_then_tracks_failure_with_invalid_postal_code_reason() async throws {
+        // Given
+        let analytics = MockAnalytics()
+        let mockRemote = MockCardReaderCapableRemote(resultForDefaultReaderLocation: .failure(
+            DotcomError.unknown(code: "postal_code_invalid", message: "", data: nil)))
+        let sut = CommonReaderConfigProvider(siteID: 123, readerConfigRemote: mockRemote, analytics: analytics)
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            sut.fetchDefaultLocationID { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        // Then
+        let event = analytics.trackedEvents.first { $0.eventName == "card_reader_location_failure" }
+        #expect(event?.properties?["reason"] as? String == "invalid_postal_code")
+    }
+
+    @Test func fetchDefaultLocationID_when_fetch_fails_with_unrelated_error_then_tracks_failure_with_other_reason() async throws {
+        // Given
+        let analytics = MockAnalytics()
+        let mockRemote = MockCardReaderCapableRemote(resultForDefaultReaderLocation: .failure(
+            DotcomError.unknown(code: "some_unrelated_error", message: nil, data: nil)))
+        let sut = CommonReaderConfigProvider(siteID: 123, readerConfigRemote: mockRemote, analytics: analytics)
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            sut.fetchDefaultLocationID { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        // Then
+        let event = analytics.trackedEvents.first { $0.eventName == "card_reader_location_failure" }
+        #expect(event?.properties?["reason"] as? String == "other")
+    }
+
     @Test func resetContext_clears_siteID_and_remote() {
         let mockRemote = MockCardReaderCapableRemote(resultForDefaultReaderLocation: .success(.fake()))
         let sut = CommonReaderConfigProvider(siteID: 123, readerConfigRemote: mockRemote)

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -269,6 +269,9 @@ private extension TracksProvider {
             WooAnalyticsStat.cardReaderDisconnectTapped,
             WooAnalyticsStat.cardReaderLocationPermissionPreAlertShown,
             WooAnalyticsStat.cardReaderLocationPermissionRequiredShown,
+            WooAnalyticsStat.cardReaderLocationSuccess,
+            WooAnalyticsStat.cardReaderLocationFailure,
+            WooAnalyticsStat.cardReaderLocationMissingTapped,
 
             // Card Reader Software Update
             WooAnalyticsStat.cardReaderSoftwareUpdateTapped,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -2424,6 +2424,15 @@ extension WooAnalyticsEvent {
                                 Keys.gatewayID: safeGatewayID(for: gatewayID)
                               ])
         }
+
+        static func cardReaderLocationMissingTapped(gatewayID: String?,
+                                                    countryCode: CountryCode) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardReaderLocationMissingTapped,
+                              properties: [
+                                Keys.countryCode: countryCode.rawValue,
+                                Keys.gatewayID: safeGatewayID(for: gatewayID)
+                              ])
+        }
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -113,7 +113,7 @@ final class ServiceLocator {
     private static var _cardReader: CardReaderService = NoOpCardReaderService()
     #endif
 
-    private static var _cardReaderConfigProvider: CommonReaderConfigProviding = CommonReaderConfigProvider()
+    private static var _cardReaderConfigProvider: CommonReaderConfigProviding = CommonReaderConfigProvider(analytics: analytics)
 
     /// Support for printing receipts
     ///

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -168,6 +168,14 @@ final class CardReaderConnectionAnalyticsTracker {
         )
     }
 
+    /// Called when the user taps to fix a missing/incomplete store address from the connection error alert.
+    func cardReaderLocationMissingTapped() {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments.cardReaderLocationMissingTapped(
+            gatewayID: gatewayID,
+            countryCode: configuration.countryCode)
+        )
+    }
+
     enum ConnectionType: String {
         case automaticReconnection = "automatic_reconnection"
         case userInitiated = "user_initiated"

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -739,10 +739,12 @@ private extension CardReaderConnectionController {
         if let adminUrl {
             if isWPCOMStore() {
                 return { [weak self] in
+                    self?.analyticsTracker.cardReaderLocationMissingTapped()
                     self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)
                 }
             } else {
                 return { [weak self] in
+                    self?.analyticsTracker.cardReaderLocationMissingTapped()
                     UIApplication.shared.open(adminUrl)
                     self?.showIncompleteAddressErrorWithRefreshButton()
                 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
@@ -611,10 +611,12 @@ private extension TapToPayCardReaderConnectionController {
         if let adminUrl {
             if isWPCOMStore() {
                 return { [weak self] in
+                    self?.analyticsTracker.cardReaderLocationMissingTapped()
                     self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)
                 }
             } else {
                 return { [weak self] in
+                    self?.analyticsTracker.cardReaderLocationMissingTapped()
                     UIApplication.shared.open(adminUrl)
                     self?.showIncompleteAddressErrorWithRefreshButton()
                 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTrackerTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import Yosemite
+@testable import WooCommerce
+
+struct CardReaderConnectionAnalyticsTrackerTests {
+
+    @Test func cardReaderLocationMissingTapped_tracks_card_reader_location_missing_tapped_event() throws {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let sut = CardReaderConnectionAnalyticsTracker(
+            configuration: CardPresentPaymentsConfiguration(country: .US),
+            siteID: 123,
+            connectionType: .userInitiated,
+            stores: MockStoresManager(sessionManager: .testingInstance),
+            analytics: analytics)
+
+        // When
+        sut.cardReaderLocationMissingTapped()
+
+        // Then
+        let index = try #require(analyticsProvider.receivedEvents.firstIndex(of: "card_reader_location_missing_tapped"))
+        let properties = analyticsProvider.receivedProperties[index]
+        #expect(properties["country"] as? String == "US")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTrackerTests.swift
@@ -2,7 +2,7 @@ import Testing
 import Yosemite
 @testable import WooCommerce
 
-struct CardReaderConnectionAnalyticsTrackerTests {
+@MainActor struct CardReaderConnectionAnalyticsTrackerTests {
 
     @Test func cardReaderLocationMissingTapped_tracks_card_reader_location_missing_tapped_event() throws {
         // Given


### PR DESCRIPTION
Closes WOOMOB-3520

## Description
We track card-reader location permission events but never the outcome of the location fetch, this PR adds three IPP analytics events so we have visibility into whether the default reader-location fetch succeeds, fails (and why), and whether merchants act on the "incomplete store address" prompt.

```
- card_reader_location_success
- card_reader_location_failure, with a reason property (incomplete_store_address / invalid_postal_code / other)
- card_reader_location_missing_tapped
```

## Test Steps
Easier way to test this seems to be by forcing location: 

1. Add the following to `CommonReaderConfigProvider.fetchDefaultLocationID` line 63, after `let analytics = self.analytics`:

```swift
    public func fetchDefaultLocationID(completion: @escaping(Result<String, Error>) -> Void) {
        guard let siteID = self.siteID else {
            return
        }

        let analytics = self.analytics

        #if DEBUG
        let arguments = ProcessInfo.processInfo.arguments
        if let flagIndex = arguments.firstIndex(of: "-force-reader-location"),
           arguments.indices.contains(flagIndex + 1) {
            let forced = arguments[flagIndex + 1]
            DispatchQueue.main.async {
                switch forced {
                case "success":
                    analytics?.track(WooAnalyticsEvent.InPersonPaymentsLocation.cardReaderLocationSuccess(siteID: siteID))
                    completion(.success("tml_debug_forced"))
                case "invalid_postal_code":
                    analytics?.track(WooAnalyticsEvent.InPersonPaymentsLocation
                        .cardReaderLocationFailure(siteID: siteID, reason: .invalidPostalCode))
                    completion(.failure(CardReaderConfigError.invalidPostalCode))
                case "other":
                    analytics?.track(WooAnalyticsEvent.InPersonPaymentsLocation
                        .cardReaderLocationFailure(siteID: siteID, reason: .other))
                    completion(.failure(DotcomError.unknown(code: "debug_forced_other", message: nil, data: nil)))
                default: // "incomplete_address"
                    let adminURL = URL(string: "https://example.com/wp-admin/admin.php?page=wc-settings&tab=general")
                    analytics?.track(WooAnalyticsEvent.InPersonPaymentsLocation
                        .cardReaderLocationFailure(siteID: siteID, reason: .incompleteStoreAddress))
                    completion(.failure(CardReaderConfigError.incompleteStoreAddress(adminUrl: adminURL)))
                }
            }
            return
        }
        #endif
```
2. WooCommerce > Edit Scheme > Arguments passed on launch, enable `-simulate-stripe-card-reader`, and add any/some/all of the following:

```
-force-reader-location incomplete_address
-force-reader-location invalid_postal_code
-force-reader-location other
-force-reader-location success
```

<img width="985" height="538" alt="Screenshot 2026-07-22 at 11 27 24" src="https://github.com/user-attachments/assets/6338b345-2aac-40dd-a8e2-1deb85f78412" />

3. Run the app. Go to Menu > Payments > Manage card readers 
4. See the event details captured in console:

```
🔵 Tracked card_reader_location_failure, properties: [reason: incomplete_store_address, site_id: 215063064, horizontal_size_class: compact]
🔵 Tracked card_reader_location_missing_tapped, properties: [cached_woo_core_version: 10.5.3, is_wpcom_store: false, blog_id: 215063064, country: US, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, plugin_slug: woocommerce-stripe, is_jetpack_cp_connected: false, is_jetpack_installed: true, horizontal_size_class: compact, is_jetpack_connected: true, site_url: https://indiemelon.mystagingwebsite.com]
```

## Screenshots

<img width="148" height="320" alt="Simulator Screen Recording - iPhone 16 Pro Max - Logged wpcom a8c - 2026-07-22 at 11 19 14" src="https://github.com/user-attachments/assets/64f7ccbe-4eb1-458a-b0ac-7a4a8797f8fe" />
