### PR TITLE
[WOOMOB-3646] Display order statuses using the store's language

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.4
 -----
+- [*] Order statuses now display in the store's language across the order list, search, filters, and the dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/17595]
 
 
 25.3

--- a/WooCommerce/Classes/Extensions/OrderStatus+DisplayName.swift
+++ b/WooCommerce/Classes/Extensions/OrderStatus+DisplayName.swift
@@ -1,0 +1,10 @@
+import Yosemite
+
+extension Collection where Element == OrderStatus {
+    /// Returns the server-provided display name for the given status (follows the store's
+    /// wp-admin language), falling back to the app's localized name when no match is found.
+    func displayName(for status: OrderStatusEnum) -> String {
+        let slug = status.rawValue
+        return first { $0.slug == slug }?.name ?? status.localizedName
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
@@ -124,9 +124,11 @@ private extension LastOrderDashboardRow {
 struct LastOrderDashboardRowViewModel {
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
     let order: Order
+    private let siteStatuses: [OrderStatus]
 
-    init(order: Order) {
+    init(order: Order, siteStatuses: [OrderStatus] = []) {
         self.order = order
+        self.siteStatuses = siteStatuses
     }
 
     var rowData: LastOrderDashboardRow.RowData {
@@ -163,7 +165,7 @@ struct LastOrderDashboardRowViewModel {
     }
 
     var statusDescription: String {
-        order.status.description
+        siteStatuses.displayName(for: order.status)
     }
 
     /// The value will only include the year if the `createdDate` is not from the current year.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCard.swift
@@ -60,7 +60,7 @@ struct LastOrdersDashboardCard: View {
 private extension LastOrdersDashboardCard {
     var emptyView: some View {
         VStack(spacing: 0) {
-            LastOrdersDashboardEmptyView(orderStatus: viewModel.selectedOrderStatus)
+            LastOrdersDashboardEmptyView(statusName: viewModel.selectedOrderStatusDisplayName)
                 .frame(maxWidth: .infinity)
 
             Divider()
@@ -124,7 +124,7 @@ private extension LastOrdersDashboardCard {
                             await viewModel.updateOrderStatus(status)
                         }
                     } label: {
-                        SelectableItemRow(title: status.description, selected: status.status == viewModel.selectedOrderStatus)
+                        SelectableItemRow(title: viewModel.title(for: status), selected: status.status == viewModel.selectedOrderStatus)
                     }
                 }
             } label: {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -75,13 +75,6 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
         var id: String {
             status?.rawValue ?? "any"
         }
-
-        var description: String {
-            guard let status else {
-                return Localization.anyStatusCase
-            }
-            return status.description
-        }
     }
     // Set externally to trigger callback upon hiding the Inbox card.
     var onDismiss: (() -> Void)?
@@ -96,7 +89,22 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
         guard let selectedOrderStatus else {
             return Localization.anyStatusCase
         }
-        return selectedOrderStatus.description
+        return siteStatuses.displayName(for: selectedOrderStatus)
+    }
+
+    /// Display name for the currently selected status, used by the empty state. Nil when no status is selected.
+    ///
+    var selectedOrderStatusDisplayName: String? {
+        selectedOrderStatus.map { siteStatuses.displayName(for: $0) }
+    }
+
+    /// Resolves the display name for a status selector menu row, preferring the server-provided name.
+    ///
+    func title(for row: OrderStatusRow) -> String {
+        guard let status = row.status else {
+            return Localization.anyStatusCase
+        }
+        return siteStatuses.displayName(for: status)
     }
 
     private let siteID: Int64
@@ -110,6 +118,11 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
 
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
+
+    /// The current list of order statuses for the site, used to resolve server-provided display names.
+    /// Cached and refreshed via the results controller's change handlers to avoid re-mapping on every access.
+    ///
+    private var siteStatuses: [OrderStatus] = []
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -137,8 +150,9 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
         do {
             async let orders = loadLast3Orders(for: selectedOrderStatus)
             try? await loadOrderStatuses()
+            let siteStatuses = statusResultsController.fetchedObjects
             rows = try await orders
-                .map { LastOrderDashboardRowViewModel(order: $0) }
+                .map { LastOrderDashboardRowViewModel(order: $0, siteStatuses: siteStatuses) }
             analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .lastOrders))
         } catch {
             syncingError = error
@@ -229,10 +243,8 @@ private extension LastOrdersDashboardCardViewModel {
     }
 
     func updateStatuses() {
-        let remoteStatuses = statusResultsController.fetchedObjects
-            .map { OrderStatusEnum(rawValue: $0.slug) }
-            .map { OrderStatusRow($0) }
-        allStatuses = [.any] + remoteStatuses
+        siteStatuses = statusResultsController.fetchedObjects
+        allStatuses = [.any] + siteStatuses.map { OrderStatusRow($0.status) }
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardEmptyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardEmptyView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
-import enum Yosemite.OrderStatusEnum
 
 /// Shown when the site doesn't have any orders for the given order status.
 /// Contains a placeholder image and text.
 ///
 struct LastOrdersDashboardEmptyView: View {
-    let orderStatus: OrderStatusEnum?
+    /// Server-provided display name of the selected status, or `nil` when no status is selected.
+    let statusName: String?
 
     var body: some View {
         VStack(alignment: .center, spacing: Layout.defaultSpacing) {
@@ -20,10 +20,10 @@ struct LastOrdersDashboardEmptyView: View {
 
 private extension LastOrdersDashboardEmptyView {
     var message: String {
-        guard let orderStatus else {
+        guard let statusName else {
             return Localization.noOrders
         }
-        return String.localizedStringWithFormat(Localization.noOrdersWithStatus, orderStatus.description.lowercased())
+        return String.localizedStringWithFormat(Localization.noOrdersWithStatus, statusName.lowercased())
     }
 
     enum Localization {
@@ -46,6 +46,6 @@ private extension LastOrdersDashboardEmptyView {
 
 struct LastOrdersDashboardEmptyView_Previews: PreviewProvider {
     static var previews: some View {
-        LastOrdersDashboardEmptyView(orderStatus: .pending)
+        LastOrdersDashboardEmptyView(statusName: "Pending payment")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -8,10 +8,12 @@ import WooFoundationCore
 struct OrderListCellViewModel {
     private let order: Order
     private let currencyFormatter: CurrencyFormatter
+    private let siteStatuses: [OrderStatus]
 
-    init(order: Order, currencySettings: CurrencySettings) {
+    init(order: Order, currencySettings: CurrencySettings, siteStatuses: [OrderStatus] = []) {
         self.order = order
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.siteStatuses = siteStatuses
     }
 
     /// For example, #560 Pamela Nguyen
@@ -63,7 +65,7 @@ struct OrderListCellViewModel {
     /// Textual representation of the status.
     ///
     var statusString: String {
-        order.status.localizedName
+        siteStatuses.displayName(for: order.status)
     }
 
     /// Sales channel

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -28,7 +28,7 @@ struct SummaryTableViewCellViewModel {
         salesChannel = order.salesChannel?.description
 
         let orderStatus = status?.status ?? order.status
-        let statusTitle = status?.name ?? order.status.rawValue
+        let statusTitle = status?.name ?? order.status.localizedName
         presentation = OrderStatusPresentation(
             style: orderStatus,
             title: statusTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -185,15 +185,6 @@ private extension OrderStatusFilterViewController {
             }
         }
 
-        var description: String? {
-            switch self {
-            case .custom(let status):
-                return status.name ?? status.slug
-            default:
-                return status?.description
-            }
-        }
-
         var type: UITableViewCell.Type {
             BasicTableViewCell.self
         }
@@ -220,7 +211,7 @@ private extension OrderStatusFilterViewController {
             cell.textLabel?.text = Localization.anyStatusCase
             cell.accessoryType = selected.isEmpty ? .checkmark : .none
         default:
-            cell.textLabel?.text = row.description
+            cell.textLabel?.text = row.status.map { allowedStatuses.displayName(for: $0) }
             if selected.contains(where: { $0 == row.status }) {
                 cell.accessoryType = .checkmark
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -315,6 +315,22 @@ private extension OrderListViewController {
             }
         }.store(in: &cancellables)
 
+        /// Reconfigure visible cells when the stored order statuses change, so status labels
+        /// pick up the latest server-provided names (e.g. after the first sync completes).
+        viewModel.statusesDidChange
+            .sink { [weak self] in
+                guard let self, let dataSource = self.dataSource else {
+                    return
+                }
+                var snapshot = dataSource.snapshot()
+                guard snapshot.itemIdentifiers.isEmpty == false else {
+                    return
+                }
+                snapshot.reconfigureItems(snapshot.itemIdentifiers)
+                dataSource.apply(snapshot, animatingDifferences: false)
+            }
+            .store(in: &cancellables)
+
         /// Update the top banner when needed
         viewModel.$topBanner
             .sink { [weak self] topBannerType in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -24,6 +24,16 @@ final class OrderListViewModel {
     ///
     private var foregroundNotificationsSubscription: AnyCancellable?
 
+    /// Emits when the stored order statuses change, so visible cells can be refreshed.
+    ///
+    private let statusesDidChangeSubject = PassthroughSubject<Void, Never>()
+
+    /// Publisher that fires when the stored order statuses change.
+    ///
+    var statusesDidChange: AnyPublisher<Void, Never> {
+        statusesDidChangeSubject.eraseToAnyPublisher()
+    }
+
     /// The block called if self requests a resynchronization of the first page. The
     /// resynchronization should only be done if the view is visible.
     ///
@@ -261,6 +271,13 @@ private extension OrderListViewModel {
     /// Setup: Status Results Controller
     ///
     func setupStatusResultsController() {
+        statusResultsController.onDidChangeContent = { [weak self] in
+            self?.statusesDidChangeSubject.send()
+        }
+        statusResultsController.onDidResetContent = { [weak self] in
+            self?.statusesDidChangeSubject.send()
+        }
+
         do {
             try statusResultsController.performFetch()
         } catch {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -298,7 +298,8 @@ extension OrderListViewModel {
         }
 
         return OrderListCellViewModel(order: order,
-                                      currencySettings: ServiceLocator.currencySettings)
+                                      currencySettings: ServiceLocator.currencySettings,
+                                      siteStatuses: currentSiteStatuses)
     }
 
     /// Creates an `OrderDetailsViewModel` for the `Order` pointed to by `objectID`.

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import UIKit
 import Yosemite
@@ -23,6 +24,14 @@ final class OrderSearchUICommand: SearchUICommand {
 
     var resynchronizeModels: (() -> Void) = {}
 
+    /// Emits when the stored order statuses change, so the search results table can be reloaded.
+    ///
+    private let reloadUISubject = PassthroughSubject<Void, Never>()
+
+    var reloadUIRequests: AnyPublisher<Void, Never> {
+        reloadUISubject.eraseToAnyPublisher()
+    }
+
     private let siteID: Int64
     private let storageManager: StorageManagerType
     private let analytics: Analytics
@@ -36,6 +45,12 @@ final class OrderSearchUICommand: SearchUICommand {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
         let resultsController = ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        resultsController.onDidChangeContent = { [weak self] in
+            self?.reloadUISubject.send()
+        }
+        resultsController.onDidResetContent = { [weak self] in
+            self?.reloadUISubject.send()
+        }
         do {
             try resultsController.performFetch()
         } catch {

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -30,6 +30,20 @@ final class OrderSearchUICommand: SearchUICommand {
 
     private let onSelectSearchResult: ((Order, UIViewController) -> Void)
 
+    /// Used for looking up the `OrderStatus` to show in the search result cells.
+    ///
+    private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let descriptor = NSSortDescriptor(key: "slug", ascending: true)
+        let resultsController = ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        do {
+            try resultsController.performFetch()
+        } catch {
+            DDLogError("⛔️ OrderSearchUICommand: Unable to fetch Order Statuses: \(error)")
+        }
+        return resultsController
+    }()
+
     init(siteID: Int64,
          onSelectSearchResult: @escaping ((Order, UIViewController) -> Void),
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -67,7 +81,8 @@ final class OrderSearchUICommand: SearchUICommand {
 
     func createCellViewModel(model: Order) -> OrderListCellViewModel {
         return OrderListCellViewModel(order: model,
-                                      currencySettings: ServiceLocator.currencySettings)
+                                      currencySettings: ServiceLocator.currencySettings,
+                                      siteStatuses: statusResultsController.fetchedObjects)
     }
 
     /// Synchronizes the Orders matching a given Keyword

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -182,6 +182,72 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_title_when_known_status_is_stored_then_returns_server_name() {
+        // Given
+        insertOrderStatuses([OrderStatus(name: "Server Processing", siteID: sampleSiteID, slug: "processing", total: 0)])
+        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+
+        // When
+        let title = viewModel.title(for: .processing)
+
+        // Then — the stored server name is preferred over the app-localized name
+        XCTAssertEqual(title, "Server Processing")
+    }
+
+    @MainActor
+    func test_title_when_status_not_stored_then_falls_back_to_localizedName() {
+        // Given — no statuses stored, so nothing matches `.processing`
+        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+
+        // When
+        let title = viewModel.title(for: .processing)
+
+        // Then
+        XCTAssertEqual(title, OrderStatusEnum.processing.localizedName)
+    }
+
+    @MainActor
+    func test_title_when_any_row_then_returns_localized_any_case() {
+        // Given
+        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+
+        // When
+        let title = viewModel.title(for: .any)
+
+        // Then
+        XCTAssertEqual(title, "Any")
+    }
+
+    func test_LastOrderDashboardRowViewModel_statusDescription_when_matching_site_status_then_uses_server_name() {
+        // Given
+        let order = Order.fake().copy(siteID: sampleSiteID, status: .processing)
+        let siteStatuses = [OrderStatus(name: "Server Processing", siteID: sampleSiteID, slug: "processing", total: 0)]
+
+        // When
+        let rowViewModel = LastOrderDashboardRowViewModel(order: order, siteStatuses: siteStatuses)
+
+        // Then
+        XCTAssertEqual(rowViewModel.statusDescription, "Server Processing")
+    }
+
+    func test_LastOrderDashboardRowViewModel_statusDescription_when_no_matching_site_status_then_falls_back_to_localizedName() {
+        // Given
+        let order = Order.fake().copy(siteID: sampleSiteID, status: .processing)
+
+        // When — no site statuses provided
+        let rowViewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        XCTAssertEqual(rowViewModel.statusDescription, OrderStatusEnum.processing.localizedName)
+    }
+
+    @MainActor
     func test_fetch_orders_request_asks_to_skip_saving_orders() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -34,16 +34,30 @@ final class OrderListCellViewModelTests: XCTestCase {
         XCTAssertTrue(formatted.contains(expectedYearString))
     }
 
-    func test_status_from_order_is_used() {
+    func test_statusString_when_no_matching_site_status_then_falls_back_to_localizedName() {
         // Given
         let order = MockOrders().sampleOrder()
 
-        // When
+        // When — no site statuses provided, so nothing matches the order's status
         let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.status, order.status)
         XCTAssertEqual(viewModel.statusString, order.status.localizedName)
+    }
+
+    func test_statusString_when_matching_site_status_exists_then_uses_server_name() {
+        // Given
+        let order = MockOrders().sampleOrder()
+        let siteStatuses = [OrderStatus(name: "Server Name", siteID: order.siteID, slug: order.status.rawValue, total: 0)]
+
+        // When
+        let viewModel = OrderListCellViewModel(order: order,
+                                               currencySettings: ServiceLocator.currencySettings,
+                                               siteStatuses: siteStatuses)
+
+        // Then — the server-provided name is preferred over the app-localized name
+        XCTAssertEqual(viewModel.statusString, "Server Name")
     }
 
     func test_OrderListCell_accessoryView_uses_chevron_with_tertiaryLabel_tint_as_disclosure_indicator() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -172,6 +172,27 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(snapshot.numberOfItems(inSection: sectionID), expectedOrders.future.count)
     }
 
+    // MARK: - Order Statuses
+
+    func test_statusesDidChange_emits_when_the_stored_order_statuses_change() {
+        // Given
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, filters: nil)
+        viewModel.activate()
+
+        let expectation = expectation(description: "statusesDidChange emits when the stored order statuses change")
+        viewModel.statusesDidChange
+            .sink {
+                expectation.fulfill()
+            }
+            .store(in: &subscriptions)
+
+        // When
+        insertOrderStatus(status: .processing)
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
     // MARK: - App Activation
 
     func test_it_requests_a_resynchronization_when_the_app_is_activated() {
@@ -422,6 +443,16 @@ private extension OrderListViewModelTests {
 
     func orderStatus(with status: OrderStatusEnum) -> Yosemite.OrderStatus {
         OrderStatus(name: nil, siteID: siteID, slug: status.rawValue, total: 0)
+    }
+
+    @discardableResult
+    func insertOrderStatus(status: OrderStatusEnum) -> StorageOrderStatus {
+        let storageOrderStatus = storage.insertNewObject(ofType: StorageOrderStatus.self)
+        storageOrderStatus.siteID = siteID
+        storageOrderStatus.slug = status.rawValue
+        storageOrderStatus.name = status.rawValue
+        storage.saveIfNeeded()
+        return storageOrderStatus
     }
 
     func insertOrder(id orderID: Int64,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderStatusDisplayNameTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderStatusDisplayNameTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import Yosemite
+@testable import WooCommerce
+
+/// Unit tests for `Collection where Element == OrderStatus`'s `displayName(for:)` helper.
+///
+/// Order status labels must prefer the server-provided `name` (which follows the store's
+/// wp-admin language) over the app's own localized strings.
+struct OrderStatusDisplayNameTests {
+
+    @Test func test_displayName_when_matching_status_has_server_name_then_returns_server_name() {
+        // Given
+        let siteStatuses = [OrderStatus(name: "En cours", siteID: 1, slug: "processing", total: 0)]
+
+        // When
+        let result = siteStatuses.displayName(for: .processing)
+
+        // Then — server name preferred over the app-localized "Processing"
+        #expect(result == "En cours")
+    }
+
+    @Test func test_displayName_when_no_matching_status_then_falls_back_to_localizedName() {
+        // Given — a status list that does not contain `.completed`
+        let siteStatuses = [OrderStatus(name: "En cours", siteID: 1, slug: "processing", total: 0)]
+
+        // When
+        let result = siteStatuses.displayName(for: .completed)
+
+        // Then
+        #expect(result == OrderStatusEnum.completed.localizedName)
+    }
+
+    @Test func test_displayName_when_matching_status_has_nil_name_then_falls_back_to_localizedName() {
+        // Given — a matching status whose server name is nil
+        let siteStatuses = [OrderStatus(name: nil, siteID: 1, slug: "processing", total: 0)]
+
+        // When
+        let result = siteStatuses.displayName(for: .processing)
+
+        // Then
+        #expect(result == OrderStatusEnum.processing.localizedName)
+    }
+
+    @Test func test_displayName_when_matching_custom_status_then_returns_server_name() {
+        // Given — a custom status whose server name differs from its slug
+        let siteStatuses = [OrderStatus(name: "Awaiting Shipment", siteID: 1, slug: "awaiting-shipment", total: 0)]
+
+        // When
+        let result = siteStatuses.displayName(for: .custom("awaiting-shipment"))
+
+        // Then
+        #expect(result == "Awaiting Shipment")
+    }
+
+    @Test func test_displayName_when_unmatched_custom_status_then_falls_back_to_slug() {
+        // Given — no matching status; for `.custom`, localizedName is the raw slug,
+        // so the fallback preserves today's `name ?? slug` behavior for custom statuses.
+        let siteStatuses: [OrderStatus] = []
+
+        // When
+        let result = siteStatuses.displayName(for: .custom("awaiting-shipment"))
+
+        // Then
+        #expect(result == "awaiting-shipment")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -62,6 +62,20 @@ final class OrderSearchUICommandTests: XCTestCase {
         XCTAssertEqual(cellViewModel.status, .onHold, "Expected createCellViewModel to return on hold status")
     }
 
+    func test_createCellViewModel_when_site_status_stored_then_statusString_uses_server_name() {
+        // Given
+        let mockOrder = MockOrders().makeOrder(status: .onHold)
+        // Server name differs from the slug, so we can tell them apart.
+        storageManager.insertOrderStatus(name: "Server On Hold", slug: OrderStatusEnum.onHold.rawValue)
+        storageManager.viewStorage.saveIfNeeded()
+
+        // When
+        let cellViewModel = systemUnderTest.createCellViewModel(model: mockOrder)
+
+        // Then — the stored server name is preferred over the app-localized name
+        XCTAssertEqual(cellViewModel.statusString, "Server On Hold")
+    }
+
     func test_SanitizeKeyword_removing_leading_pound_symbol() {
         // When
         let sanitizedKeywordWithHash = systemUnderTest.sanitizeKeyword("#123")
@@ -139,13 +153,20 @@ final class OrderSearchUICommandTests: XCTestCase {
 private final class MockOrderStatusesStoresManager: MockStorageManager {
     fileprivate static let siteID: Int64 = 12345
 
-    /// Inserts an order status
+    /// Inserts an order status whose name and slug are identical.
     ///
     @discardableResult
     func insertOrderStatus(name: String) -> StorageOrderStatus {
+        insertOrderStatus(name: name, slug: name)
+    }
+
+    /// Inserts an order status with independent name and slug so the two can be exercised separately.
+    ///
+    @discardableResult
+    func insertOrderStatus(name: String, slug: String) -> StorageOrderStatus {
         let orderStatus = viewStorage.insertNewObject(ofType: StorageOrderStatus.self)
         orderStatus.name = name
-        orderStatus.slug = name
+        orderStatus.slug = slug
         orderStatus.siteID = MockOrderStatusesStoresManager.siteID
         viewStorage.saveIfNeeded()
         return orderStatus

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 import Yosemite
 import YosemiteTestHelpers
@@ -11,6 +12,7 @@ final class OrderSearchUICommandTests: XCTestCase {
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
     private var systemUnderTest: OrderSearchUICommand!
+    private var cancellables: Set<AnyCancellable> = []
 
     override func setUp() {
         super.setUp()
@@ -21,6 +23,7 @@ final class OrderSearchUICommandTests: XCTestCase {
     }
 
     override func tearDown() {
+        cancellables.removeAll()
         storageManager = nil
         analyticsProvider = nil
         analytics = nil
@@ -74,6 +77,26 @@ final class OrderSearchUICommandTests: XCTestCase {
 
         // Then — the stored server name is preferred over the app-localized name
         XCTAssertEqual(cellViewModel.statusString, "Server On Hold")
+    }
+
+    func test_reloadUIRequests_emits_when_stored_order_statuses_change() {
+        // Given
+        // Access the results controller (via a cell view model) so its change observation is wired up.
+        _ = systemUnderTest.createCellViewModel(model: MockOrders().makeOrder(status: .onHold))
+
+        let expectation = expectation(description: "reloadUIRequests emits when the stored order statuses change")
+        systemUnderTest.reloadUIRequests
+            .sink {
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        // When
+        storageManager.insertOrderStatus(name: "Server On Hold", slug: OrderStatusEnum.onHold.rawValue)
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
     func test_SanitizeKeyword_removing_leading_pound_symbol() {


### PR DESCRIPTION
Closes WOOMOB-3646

## Description

Order status labels across the app used the app's own hardcoded localized strings (`OrderStatusEnum.localizedName`). This PR aligns them with the order detail screen — and with Android — by preferring the server-provided `name` from `reports/orders/totals`, which follows the store's language (**Settings → General → Site Language**). Known and custom statuses now render in the store's language across the order list, order search, order status filter, and the last-orders dashboard card.

A shared `Collection<OrderStatus>.displayName(for:)` helper resolves the name by matching on the status slug, falling back to the app's localized name when no matching status is found. Visible cells on the order list and search refresh in place when the stored statuses sync or change.

Not included: the Filters screen's single-select summary row still uses the localized name (it's driven by a generic filter type and would need broader plumbing) — the visible filter option rows are covered.

## Test Steps

1. Use a store whose **Settings → General → Site Language** is set to a non-English locale (e.g. Spanish), with orders in a few statuses. You can also use [this](https://mc.a8c.com/secret-store/?secret_id=14740) prepared one.
2. Run the app in English and open the **Orders** tab — status badges show the store-language names (e.g. "Procesando", "Completado").
3. Tap **Filter → Order Status** — the status options are in the store language.
4. **Search** for an order — the result's status badge is in the store language.
5. On **My Store**, the **Most recent orders** card badges and status menu are in the store language.
6. Confirm order **detail** is unchanged (it already showed the store-language name).

## Screenshots

| Case | Before | After |
| --- | --- | --- |
| Order list | <img width="1206" height="2622" alt="before-order-list" src="https://github.com/user-attachments/assets/ffce9463-9805-4948-9584-012749405208" /> | <img width="1179" height="2556" alt="after-order-list" src="https://github.com/user-attachments/assets/0b872036-a303-4c5b-90b5-e6278119cd63" /> |
| Order filter | <img width="1206" height="2622" alt="before-order-filter" src="https://github.com/user-attachments/assets/9f6092b2-ac89-413f-9d0c-df324ccb26d6" /> | <img width="1179" height="2556" alt="after-order-filter" src="https://github.com/user-attachments/assets/cd34a886-8a36-4c8c-9f95-733b55f76d89" /> |
| Order search | <img width="1206" height="2622" alt="before-order-search" src="https://github.com/user-attachments/assets/091b75a9-477e-4d9a-b8a8-e7b7d3b45724" /> | <img width="1179" height="2556" alt="after-order-search" src="https://github.com/user-attachments/assets/a4e3ee56-2b94-4622-b260-9d48c653c064" /> |
| Dashboard card | <img width="1206" height="2622" alt="before-dashboard-card" src="https://github.com/user-attachments/assets/fdfbc1e9-5fea-4a04-bfc1-035dbcb7607b" /> | <img width="1179" height="2556" alt="after-dashboard-card" src="https://github.com/user-attachments/assets/36199d35-0659-4950-8dd3-2977a637171e" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
