### PR TITLE
[WOOMOB-3343] Add Divider component to the Store Design System

### DIFF
--- a/Modules/Sources/StoreDesignSystem/Components/Divider/StoreDivider.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Divider/StoreDivider.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+public struct StoreDivider: View {
+    // Draw the line at one physical pixel (1 / displayScale) so it stays crisp and uniform;
+    // a fixed 0.5pt is 1.5px on @3x and rasterizes unevenly between adjacent dividers.
+    @Environment(\.displayScale) private var displayScale
+
+    private let variant: StoreDividerVariant
+
+    public init(variant: StoreDividerVariant = .full) {
+        self.variant = variant
+    }
+
+    public var body: some View {
+        Rectangle()
+            .fill(Color.storeStateLayerOnSurfaceOpacity16)
+            .frame(height: 1 / displayScale)
+            .padding(.horizontal, variant.horizontalInset)
+            .accessibilityHidden(true)
+    }
+}

--- a/Modules/Sources/StoreDesignSystem/Components/Divider/StoreDividerVariant.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Divider/StoreDividerVariant.swift
@@ -1,0 +1,17 @@
+import CoreGraphics
+
+/// The inset treatment of a ``StoreDivider``.
+///
+/// - Note: A closed type holding the horizontal inset per variant. `full` spans edge to edge;
+///   `inset` aligns the line with inset content.
+public struct StoreDividerVariant {
+    let horizontalInset: CGFloat
+
+    private init(horizontalInset: CGFloat) {
+        self.horizontalInset = horizontalInset
+    }
+
+    public static let full = StoreDividerVariant(horizontalInset: StorePadding.p0)
+
+    public static let inset = StoreDividerVariant(horizontalInset: StorePadding.p7)
+}

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
@@ -33,6 +33,7 @@ private struct ComponentsView: View {
             NavigationLink("Badge") { BadgeComponentView() }
             NavigationLink("Button") { ButtonComponentView() }
             NavigationLink("Checkbox") { CheckboxComponentView() }
+            NavigationLink("Divider") { DividerComponentView() }
             NavigationLink("NoticeBanner") { NoticeBannerComponentView() }
             NavigationLink("RadioButton") { RadioButtonComponentView() }
             NavigationLink("Segmented Control") { SegmentedControlComponentView() }

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DividerComponentView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DividerComponentView.swift
@@ -1,0 +1,56 @@
+#if DEBUG || ALPHA
+import SwiftUI
+import StoreDesignSystem
+
+struct DividerComponentView: View {
+    private enum Variant: String, CaseIterable, Identifiable {
+        case full = "Full"
+        case inset = "Inset"
+
+        var id: Self { self }
+
+        var value: StoreDividerVariant {
+            switch self {
+            case .full: .full
+            case .inset: .inset
+            }
+        }
+    }
+
+    @State private var variant: Variant = .full
+
+    private let rowCount = 4
+
+    var body: some View {
+        ComponentDemoScaffold(title: "Divider", previewHeight: 280) {
+            Picker("Variant", selection: $variant) {
+                ForEach(Variant.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+        } preview: {
+            VStack(spacing: 0) {
+                ForEach(1...rowCount, id: \.self) { index in
+                    row("Cell \(index)")
+                    if index < rowCount {
+                        StoreDivider(variant: variant.value)
+                    }
+                }
+            }
+        }
+    }
+
+    private func row(_ title: String) -> some View {
+        Text(title)
+            .storeTextStyle(.bodyMedium)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(StorePadding.p7)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DividerComponentView()
+    }
+}
+#endif


### PR DESCRIPTION
Closes WOOMOB-3343

## Description

Adds `StoreDivider` to the divider in the new Design System

**The API:**
```swift
StoreDivider()                 // .full — edge-to-edge
StoreDivider(variant: .inset)  // 24pt leading/trailing inset, aligns with inset content
```

- **Variants** — `.full` (edge-to-edge) and `.inset` (24pt leading/trailing inset). Horizontal only.
- **Styling** — a hairline in the `storeStateLayerOnSurfaceOpacity16` on-surface overlay, so it reads correctly on any surface in light + dark. Design tokens only.
- **Demo** — added to the in-app Design System screen (Components -> Divider) with a variant picker over four cells.

## Test Steps

1. Install app
2. **Settings -> Debug -> Design System -> Components -> Divider**.
3. Switch the **Variant** picker between **Full** and **Inset** — Full spans edge-to-edge; Inset insets 24pt and aligns with the cell content.
4. Switch the system appearance to dark and confirm the hairline stays visible on the surface.

## Screenshots

| Light | Dark |
| --- | --- |
| <img width="1179" height="2556" alt="divider-demo-light" src="https://github.com/user-attachments/assets/90e4ca61-bf64-4845-9a83-0b33f6732170" /> | <img width="1179" height="2556" alt="divider-demo-dark" src="https://github.com/user-attachments/assets/fe8a263a-6db3-4cfe-8192-70ea94894ddb" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
