### PR TITLE
[WOOMOB-3556] Fix new order notification text truncation and dark mode color

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.3
 -----
+- [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17599]
 - [*] Fixed a crash when undoing pasted product tags containing tabs or extra whitespace. [https://github.com/woocommerce/woocommerce-ios/pull/17592]
 - [*] Point of Sale: once the local catalog has fully synced, POS opens instantly without waiting on network checks and also works offline. [https://github.com/woocommerce/woocommerce-ios/pull/17498]
 - [*] Order Creation: fixed custom amount fields losing entered values and keyboard focus after rotating an iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17550]

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -122,7 +122,13 @@ private extension NoticeView {
 
         contentStackView.addArrangedSubview(labelStackView)
 
+        // Let the label block fill the width and the button keep its intrinsic size. On the iOS 26 SDK the .fill
+        // stack otherwise splits them ~50/50 and truncates the title; content-hugging doesn't fix a nested stack.
+        let labelStackFillWidth = labelStackView.widthAnchor.constraint(greaterThanOrEqualToConstant: UIView.layoutFittingExpandedSize.width)
+        labelStackFillWidth.priority = .required - 1
+
         NSLayoutConstraint.activate([
+            labelStackFillWidth,
             labelStackView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
             labelStackView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor)
         ])
@@ -229,7 +235,7 @@ private extension NoticeView {
 
     enum Appearance {
         static let actionBackgroundColor = UIColor.systemColor(.secondarySystemGroupedBackground)
-        static let actionColor: UIColor = .primaryButtonBackground
+        static let actionColor: UIColor = .accent
         static let shadowColor: UIColor = .black
         static let shadowOpacity: Float = 0.2
         static let shadowRadius: CGFloat = 8.0


### PR DESCRIPTION
Closes WOOMOB-3556

## Description

The in-app foreground notice shown for a new-order push (a `Notice` with a **View** action) truncated its title on iPhone and rendered **View** in a muted colour in dark mode. Both only surface when the app is built with the iOS 26 SDK — it's SDK-gated, not tied to the device's iOS version, which is why it reproduced on iOS 18.

- **Truncation** — `NoticeView`'s horizontal `.fill` stack `[label, action button]` left both at the default content-hugging priority. Under the iOS 26 SDK the stack breaks that tie by stretching the button to ~half the notice, leaving the title no room ("You have 1 new ord…"). The label block now gets a greedy fill width so it takes the available space while the button keeps its intrinsic size.
- **Colour** — **View** used `.primaryButtonBackground`, a non-adaptive purple with no dark variant, so in dark mode it stayed darker than every other accent. Switched to the adaptive `.accent` (no-op in light mode).

Affects any compact-width iPhone on iOS 18–26; iPad is unaffected (the notice isn't title-truncated there).

**Out of scope:** while validating on iPad I noticed the notice renders full-width instead of the intended centered ~50%-width toast — `DefaultNoticePresenter`'s regular-size-class width cap isn't activating (likely since #16182). That's a separate pre-existing issue, not touched here.

## Test Steps

1. On an iPhone, log into a store and stay on a main tab (e.g. My Store) with notifications enabled.
2. Trigger a new-order push while the app is foregrounded (place an order on the store).
3. Confirm the in-app notice shows the full title (not truncated) with **View** hugging the right edge.
4. Switch to dark mode and repeat — confirm **View** matches the app's other purple accents, not a darker/muted purple.

## Screenshots

| Case | Before | After |
| --- | --- | --- |
| iPhone · iOS 26 · light | <!-- before-iphone-26-light.png --> | <!-- after-iphone-26-light.png --> |
| iPhone · iOS 26 · dark | <!-- before-iphone-26-dark.png --> | <!-- after-iphone-26-dark.png --> |
| iPhone · iOS 18 · light | <!-- before-iphone-18-light.png --> | <!-- after-iphone-18-light.png --> |
| iPhone · iOS 18 · dark | <!-- before-iphone-18-dark.png --> | <!-- after-iphone-18-dark.png --> |
| iPad · iOS 26 | <!-- before-ipad-26.png --> | <!-- after-ipad-26.png --> |
| iPad · iOS 18 | <!-- before-ipad-18.png --> | <!-- after-ipad-18.png --> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
