### PR TITLE
[WOOMOB-3587] Protect unsaved edits during product duplication

### DIFF
--- a/WooCommerce/Classes/Routing/ProductDetail/Coordinator/ProductDetailNativeCoordinator.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/Coordinator/ProductDetailNativeCoordinator.swift
@@ -10,7 +10,7 @@ class ProductDetailNativeCoordinator {
         presentationStyle: ProductDetailNavigator.Presentation,
         isReadOnly: Bool,
         onDelete: (() -> Void)? = nil,
-        onDuplicate: ((Product) -> Void)? = nil) -> UIViewController {
+        onDuplicate: @escaping ProductDuplicateNavigationHandler) -> UIViewController {
             return ProductDetailsFactory.productDetails(product: product,
                                                         presentationStyle: presentationStyle.asProductFormPresentationStyle,
                                                         forceReadOnly: isReadOnly,

--- a/WooCommerce/Classes/Routing/ProductDetail/ProductDetailNavigator.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/ProductDetailNavigator.swift
@@ -54,14 +54,34 @@ final class ProductDetailNavigator {
             }
         } else {
             let coordinator = coordinatorFactory.nativeCoordinator()
+            let duplicateNavigation: ProductDuplicateNavigationHandler = { [self] sourceViewController, duplicatedProduct in
+                if let onDuplicate {
+                    onDuplicate(duplicatedProduct)
+                } else {
+                    replaceDestination(sourceViewController: sourceViewController, with: duplicatedProduct)
+                }
+            }
             viewController = coordinator.viewController(product: product,
                                                         presentationStyle: presentationStyle,
                                                         isReadOnly: isReadOnly,
                                                         onDelete: onDelete,
-                                                        onDuplicate: onDuplicate)
+                                                        onDuplicate: duplicateNavigation)
         }
 
         return viewController
+    }
+
+    /// Replaces a native product editor with another product detail so Back cannot reveal the source editor's draft.
+    func replaceDestination(sourceViewController: UIViewController, with duplicatedProduct: Product) {
+        guard let navigationController = sourceViewController.navigationController,
+              let sourceIndex = navigationController.viewControllers.firstIndex(where: { $0 === sourceViewController }) else {
+            return
+        }
+
+        let destination = makeDestination(product: duplicatedProduct, isReadOnly: false)
+        var viewControllers = navigationController.viewControllers
+        viewControllers[sourceIndex] = destination
+        navigationController.setViewControllers(viewControllers, animated: true)
     }
 
     private func shouldOpenInWeb(product: Product) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -41,6 +41,7 @@ final class AddProductCoordinator: Coordinator {
     private let analytics: Analytics
     private let navigateToProductForm: ((UIViewController) -> Void)?
     private let onDeleteCompletion: () -> Void
+    private let onDuplicateCompletion: ((Product) -> Void)?
 
     /// ResultController to to track the current product count.
     ///
@@ -77,7 +78,8 @@ final class AddProductCoordinator: Coordinator {
          analytics: Analytics = ServiceLocator.analytics,
          isFirstProduct: Bool,
          navigateToProductForm: ((UIViewController) -> Void)? = nil,
-         onDeleteCompletion: @escaping () -> Void = {}) {
+         onDeleteCompletion: @escaping () -> Void = {},
+         onDuplicateCompletion: ((Product) -> Void)? = nil) {
         self.siteID = siteID
         self.source = source
         switch sourceView {
@@ -100,6 +102,7 @@ final class AddProductCoordinator: Coordinator {
         self.isFirstProduct = isFirstProduct
         self.navigateToProductForm = navigateToProductForm
         self.onDeleteCompletion = onDeleteCompletion
+        self.onDuplicateCompletion = onDuplicateCompletion
     }
 
     func start() {
@@ -270,13 +273,22 @@ private extension AddProductCoordinator {
                                                  showShareProductButton: viewModel.canShareProduct())
             }
         }
+        let onDuplicateCompletion = self.onDuplicateCompletion
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        isAIContent: isAIContent,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack,
-                                                       onDeleteCompletion: onDeleteCompletion)
+                                                       onDeleteCompletion: onDeleteCompletion,
+                                                       onDuplicateCompletion: { sourceViewController, duplicatedProduct in
+            if let onDuplicateCompletion {
+                onDuplicateCompletion(duplicatedProduct)
+            } else {
+                ProductDetailNavigator.shared.replaceDestination(sourceViewController: sourceViewController,
+                                                                 with: duplicatedProduct)
+            }
+        })
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         if let navigateToProductForm {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -84,6 +84,24 @@ extension ProductFormViewController {
         present(alertController, animated: true)
     }
 
+    /// Product duplication confirmation alert shown when the form has unsaved changes.
+    func presentProductDuplicationConfirmationAlert(completion: @escaping (_ isConfirmed: Bool) -> Void) {
+        let alertController = UIAlertController(title: Localization.Alert.productDuplicationConfirmationTitle,
+                                                message: Localization.Alert.productDuplicationConfirmationMessage,
+                                                preferredStyle: .alert)
+        let cancel = UIAlertAction(title: Localization.Alert.productDuplicationConfirmationCancelButton,
+                                   style: .cancel) { _ in
+            completion(false)
+        }
+        let confirm = UIAlertAction(title: Localization.Alert.productDuplicationConfirmationConfirmButton,
+                                    style: .destructive) { _ in
+            completion(true)
+        }
+        alertController.addAction(cancel)
+        alertController.addAction(confirm)
+        present(alertController, animated: true)
+    }
+
     /// Variation Deletion Confirmation alert
     ///
     func presentVariationConfirmationDeleteAlert(completion: @escaping (_ isConfirmed: Bool) -> ()) {
@@ -178,6 +196,28 @@ private enum Localization {
             NSLocalizedString("Cancel", comment: "Cancel button on the alert when the user is cancelling the action on moving a product to the trash")
         static let productDeleteConfirmationConfirmButton =
             NSLocalizedString("Move to Trash", comment: "Confirmation button on the alert when the user is moving a product to the trash")
+
+        // Product duplication
+        static let productDuplicationConfirmationTitle = NSLocalizedString(
+            "productFormViewController.productDuplicationConfirmation.title",
+            value: "Discard changes and duplicate?",
+            comment: "Title of the confirmation alert shown before duplicating a product with unsaved changes."
+        )
+        static let productDuplicationConfirmationMessage = NSLocalizedString(
+            "productFormViewController.productDuplicationConfirmation.message",
+            value: "Your unsaved changes will be lost. The duplicate will use the last saved version.",
+            comment: "Message explaining that product duplication uses the last saved version instead of unsaved changes."
+        )
+        static let productDuplicationConfirmationCancelButton = NSLocalizedString(
+            "productFormViewController.productDuplicationConfirmation.cancel",
+            value: "Cancel",
+            comment: "Button that cancels product duplication and keeps unsaved changes."
+        )
+        static let productDuplicationConfirmationConfirmButton = NSLocalizedString(
+            "productFormViewController.productDuplicationConfirmation.confirm",
+            value: "Discard & duplicate",
+            comment: "Destructive button that confirms duplication using the last saved product version."
+        )
 
         // Variation deletion
         static let variationDeleteConfirmationTitle = NSLocalizedString("Remove variation",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -409,7 +409,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         if viewModel.canDuplicateProduct() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.duplicate) { [weak self] _ in
                 ServiceLocator.analytics.track(.productDetailDuplicateButtonTapped)
-                self?.duplicateProduct()
+                self?.handleProductDuplication()
             }
         }
 
@@ -1179,9 +1179,10 @@ private extension ProductFormViewController {
         self.shareProductCoordinator = shareProductCoordinator
     }
 
-    func duplicateProduct() {
+    private func duplicateProduct(from snapshot: ProductDuplicationSnapshot<ProductModel>,
+                                  discardingChangesOnSuccess: Bool) {
         showSavingProgress(.duplicate)
-        viewModel.duplicateProduct(onCompletion: { [weak self] result in
+        viewModel.duplicateProduct(from: snapshot, onCompletion: { [weak self] result in
             switch result {
             case .failure(let error):
                 DDLogError("⛔️ Error duplicating Product: \(error)")
@@ -1191,6 +1192,10 @@ private extension ProductFormViewController {
                     self?.displayError(error: error, title: Localization.duplicateProductError)
                 }
             case .success(let duplicatedProduct):
+                if discardingChangesOnSuccess {
+                    self?.viewModel.discardChanges(afterSuccessfulDuplicationFrom: snapshot)
+                }
+
                 // Dismisses the in-progress UI, then either hands the duplicate to the presenter to open (matching
                 // Android) or, when no handler is provided, confirms the copy in place (the legacy behavior).
                 self?.navigationController?.dismiss(animated: true) {
@@ -2201,6 +2206,29 @@ private extension ProductFormViewController {
         }
         let viewController = QuantityRulesViewController(viewModel: quantityRulesViewModel)
         show(viewController, sender: self)
+    }
+}
+
+// MARK: Product duplication
+
+extension ProductFormViewController {
+    /// Handles the initial duplication intent and captures the persisted source before presenting confirmation UI.
+    func handleProductDuplication() {
+        guard let snapshot = viewModel.productDuplicationSnapshot() else {
+            return
+        }
+
+        guard viewModel.hasUnsavedChanges() else {
+            duplicateProduct(from: snapshot, discardingChangesOnSuccess: false)
+            return
+        }
+
+        presentProductDuplicationConfirmationAlert { [weak self] isConfirmed in
+            guard isConfirmed else {
+                return
+            }
+            self?.duplicateProduct(from: snapshot, discardingChangesOnSuccess: true)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -7,6 +7,8 @@ import Yosemite
 import SwiftUI
 import protocol Storage.StorageManagerType
 
+typealias ProductDuplicateNavigationHandler = (_ sourceViewController: UIViewController, _ duplicatedProduct: Product) -> Void
+
 /// The entry UI for adding/editing a Product.
 final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: UIViewController, UITableViewDelegate {
     typealias ProductModel = ViewModel.ProductModel
@@ -94,9 +96,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     private let onDeleteCompletion: () -> Void
 
-    /// Called with the newly created duplicate after a successful product duplication, letting the presenter decide
-    /// how to open it. When `nil`, the form falls back to confirming the copy in place (the legacy behavior).
-    private let onDuplicateCompletion: ((Product) -> Void)?
+    /// Opens the newly created duplicate after successful product duplication, replacing this source editor.
+    private let onDuplicateCompletion: ProductDuplicateNavigationHandler
 
     private let userDefaults: UserDefaults
 
@@ -110,7 +111,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          userDefaults: UserDefaults = .standard,
          onDeleteCompletion: @escaping () -> Void = {},
-         onDuplicateCompletion: ((Product) -> Void)? = nil) {
+         onDuplicateCompletion: @escaping ProductDuplicateNavigationHandler) {
         self.viewModel = viewModel
         self.isAIContent = isAIContent
         self.eventLogger = eventLogger
@@ -1179,8 +1180,7 @@ private extension ProductFormViewController {
         self.shareProductCoordinator = shareProductCoordinator
     }
 
-    private func duplicateProduct(from snapshot: ProductDuplicationSnapshot<ProductModel>,
-                                  discardingChangesOnSuccess: Bool) {
+    private func duplicateProduct(from snapshot: ProductDuplicationSnapshot<ProductModel>) {
         showSavingProgress(.duplicate)
         viewModel.duplicateProduct(from: snapshot, onCompletion: { [weak self] result in
             switch result {
@@ -1192,25 +1192,18 @@ private extension ProductFormViewController {
                     self?.displayError(error: error, title: Localization.duplicateProductError)
                 }
             case .success(let duplicatedProduct):
-                if discardingChangesOnSuccess {
-                    self?.viewModel.discardChanges(afterSuccessfulDuplicationFrom: snapshot)
-                }
-
-                // Dismisses the in-progress UI, then either hands the duplicate to the presenter to open (matching
-                // Android) or, when no handler is provided, confirms the copy in place (the legacy behavior).
+                // Dismisses the in-progress UI, then hands the duplicate to the navigation owner to replace this editor.
                 self?.navigationController?.dismiss(animated: true) {
                     guard let self else {
                         return
                     }
-                    if let onDuplicateCompletion = self.onDuplicateCompletion,
-                       let product = (duplicatedProduct as? EditableProductModel)?.product {
-                        onDuplicateCompletion(product)
-                        ServiceLocator.noticePresenter.enqueue(
-                            notice: .init(title: ProductSavedAlertType.copied.alertTitle)
-                        )
-                    } else {
-                        self.presentProductConfirmationSaveAlert(type: .copied)
+                    guard let product = (duplicatedProduct as? EditableProductModel)?.product else {
+                        return
                     }
+                    self.onDuplicateCompletion(self, product)
+                    ServiceLocator.noticePresenter.enqueue(
+                        notice: .init(title: ProductSavedAlertType.copied.alertTitle)
+                    )
                 }
             }
         })
@@ -2219,7 +2212,7 @@ extension ProductFormViewController {
         }
 
         guard viewModel.hasUnsavedChanges() else {
-            duplicateProduct(from: snapshot, discardingChangesOnSuccess: false)
+            duplicateProduct(from: snapshot)
             return
         }
 
@@ -2227,7 +2220,7 @@ extension ProductFormViewController {
             guard isConfirmed else {
                 return
             }
-            self?.duplicateProduct(from: snapshot, discardingChangesOnSuccess: true)
+            self?.duplicateProduct(from: snapshot)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -2211,7 +2211,7 @@ extension ProductFormViewController {
             return
         }
 
-        guard viewModel.hasUnsavedChanges() else {
+        if !viewModel.hasUnsavedChanges() {
             duplicateProduct(from: snapshot)
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -348,7 +348,7 @@ extension ProductFormViewModel {
     }
 
     func canDuplicateProduct() -> Bool {
-        formType == .edit
+        formType == .edit && originalProduct.product.existsRemotely
     }
 }
 
@@ -647,10 +647,21 @@ extension ProductFormViewModel {
         }
     }
 
-    func duplicateProduct(onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void) {
+    func productDuplicationSnapshot() -> ProductDuplicationSnapshot<ProductModel>? {
+        guard canDuplicateProduct() else {
+            return nil
+        }
+        return ProductDuplicationSnapshot(product: originalProduct, password: originalPassword)
+    }
 
-        remoteActionUseCase.duplicateProduct(originalProduct: product,
-                                             password: password) { [weak self] result in
+    func duplicateProduct(from snapshot: ProductDuplicationSnapshot<ProductModel>,
+                          onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void) {
+        guard formType == .edit, snapshot.product.product.existsRemotely else {
+            return
+        }
+
+        remoteActionUseCase.duplicateProduct(originalProduct: snapshot.product,
+                                             password: snapshot.password) { [weak self] result in
             guard let self else { return }
             switch result {
             case .failure(let error):
@@ -662,6 +673,17 @@ extension ProductFormViewModel {
                 onCompletion(.success(data.product))
             }
         }
+    }
+
+    func discardChanges(afterSuccessfulDuplicationFrom snapshot: ProductDuplicationSnapshot<ProductModel>) {
+        guard formType == .edit, snapshot.product.product.existsRemotely else {
+            return
+        }
+
+        originalProduct = snapshot.product
+        originalPassword = snapshot.password
+        productImageActionHandler.resetProductImages(to: snapshot.product)
+        isUpdateEnabledSubject.send(hasUnsavedChanges())
     }
 
     func deleteProductRemotely(onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -675,17 +675,6 @@ extension ProductFormViewModel {
         }
     }
 
-    func discardChanges(afterSuccessfulDuplicationFrom snapshot: ProductDuplicationSnapshot<ProductModel>) {
-        guard formType == .edit, snapshot.product.product.existsRemotely else {
-            return
-        }
-
-        originalProduct = snapshot.product
-        originalPassword = snapshot.password
-        productImageActionHandler.resetProductImages(to: snapshot.product)
-        isUpdateEnabledSubject.send(hasUnsavedChanges())
-    }
-
     func deleteProductRemotely(onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void) {
 
         remoteActionUseCase.deleteProduct(product: product) { result in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -26,6 +26,12 @@ enum SaveMessageType {
     case duplicate
 }
 
+/// An immutable persisted source captured for a product duplication attempt.
+struct ProductDuplicationSnapshot<ProductModel> {
+    let product: ProductModel
+    let password: String?
+}
+
 
 /// A view model for `ProductFormViewController` to add/edit a generic product model (e.g. `Product` or `ProductVariation`).
 ///
@@ -173,7 +179,15 @@ protocol ProductFormViewModelProtocol {
 
     func deleteProductRemotely(onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void)
 
-    func duplicateProduct(onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void)
+    /// Captures the persisted source for a duplication attempt, or returns `nil` when duplication is unavailable.
+    func productDuplicationSnapshot() -> ProductDuplicationSnapshot<ProductModel>?
+
+    /// Duplicates the exact persisted source captured when the merchant initiated duplication.
+    func duplicateProduct(from snapshot: ProductDuplicationSnapshot<ProductModel>,
+                          onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void)
+
+    /// Discards the live form state after a confirmed duplication has completed successfully.
+    func discardChanges(afterSuccessfulDuplicationFrom snapshot: ProductDuplicationSnapshot<ProductModel>)
 
     // Reset action
 
@@ -200,6 +214,14 @@ protocol ProductFormViewModelProtocol {
 extension ProductFormViewModelProtocol {
     /// No-op by default. Conformers backed by a remotely-editable product override this to re-fetch.
     func refreshProduct() {}
+
+    /// Convenience for non-UI callers that do not need to retain a snapshot across confirmation UI.
+    func duplicateProduct(onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void) {
+        guard let snapshot = productDuplicationSnapshot() else {
+            return
+        }
+        duplicateProduct(from: snapshot, onCompletion: onCompletion)
+    }
 
     func shouldShowMoreOptionsMenu() -> Bool {
         canSaveAsDraft() || canEditProductSettings() || canViewProductInStore() || canShareProduct() || canDeleteProduct() || canFavoriteProduct()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -186,9 +186,6 @@ protocol ProductFormViewModelProtocol {
     func duplicateProduct(from snapshot: ProductDuplicationSnapshot<ProductModel>,
                           onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void)
 
-    /// Discards the live form state after a confirmed duplication has completed successfully.
-    func discardChanges(afterSuccessfulDuplicationFrom snapshot: ProductDuplicationSnapshot<ProductModel>)
-
     // Reset action
 
     func resetPassword(_ password: String?)
@@ -214,14 +211,6 @@ protocol ProductFormViewModelProtocol {
 extension ProductFormViewModelProtocol {
     /// No-op by default. Conformers backed by a remotely-editable product override this to re-fetch.
     func refreshProduct() {}
-
-    /// Convenience for non-UI callers that do not need to retain a snapshot across confirmation UI.
-    func duplicateProduct(onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void) {
-        guard let snapshot = productDuplicationSnapshot() else {
-            return
-        }
-        duplicateProduct(from: snapshot, onCompletion: onCompletion)
-    }
 
     func shouldShowMoreOptionsMenu() -> Bool {
         canSaveAsDraft() || canEditProductSettings() || canViewProductInStore() || canShareProduct() || canDeleteProduct() || canFavoriteProduct()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -435,10 +435,6 @@ extension ProductVariationFormViewModel {
         // no-op
     }
 
-    func discardChanges(afterSuccessfulDuplicationFrom snapshot: ProductDuplicationSnapshot<EditableProductVariationModel>) {
-        // no-op
-    }
-
     func deleteProductRemotely(onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void) {
         let deleteAction = ProductVariationAction.deleteProductVariation(productVariation: productVariation.productVariation) { [weak self] result in
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -426,7 +426,16 @@ extension ProductVariationFormViewModel {
         storesManager.dispatch(updateAction)
     }
 
-    func duplicateProduct(onCompletion: @escaping (Result<EditableProductVariationModel, ProductUpdateError>) -> Void) {
+    func productDuplicationSnapshot() -> ProductDuplicationSnapshot<EditableProductVariationModel>? {
+        nil
+    }
+
+    func duplicateProduct(from snapshot: ProductDuplicationSnapshot<EditableProductVariationModel>,
+                          onCompletion: @escaping (Result<EditableProductVariationModel, ProductUpdateError>) -> Void) {
+        // no-op
+    }
+
+    func discardChanges(afterSuccessfulDuplicationFrom snapshot: ProductDuplicationSnapshot<EditableProductVariationModel>) {
         // no-op
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
@@ -229,7 +229,10 @@ private extension ProductLoaderViewController {
     func presentProductDetails(for product: Product) {
         let viewController = ProductDetailNavigator.shared.makeDestination(product: product,
                                                                            presentationStyle: .contained(in: { [weak self] in self }),
-                                                                           isReadOnly: forceReadOnly)
+                                                                           isReadOnly: forceReadOnly,
+                                                                           onDuplicate: { [weak self] duplicatedProduct in
+            self?.state = .productLoaded(product: duplicatedProduct)
+        })
         attachProductDetailsChildViewController(viewController)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -17,7 +17,7 @@ struct ProductDetailsFactory {
                                forceReadOnly: Bool,
                                productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
                                onDeleteCompletion: @escaping () -> Void = {},
-                               onDuplicateCompletion: ((Product) -> Void)? = nil) -> UIViewController {
+                               onDuplicateCompletion: @escaping ProductDuplicateNavigationHandler) -> UIViewController {
         let vc = productDetails(product: product,
                                 presentationStyle: presentationStyle,
                                 currencySettings: currencySettings,
@@ -36,7 +36,7 @@ private extension ProductDetailsFactory {
                                isEditProductsEnabled: Bool,
                                productImageUploader: ProductImageUploaderProtocol,
                                onDeleteCompletion: @escaping () -> Void,
-                               onDuplicateCompletion: ((Product) -> Void)? = nil) -> UIViewController {
+                               onDuplicateCompletion: @escaping ProductDuplicateNavigationHandler) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
         let productImageActionHandler = productImageUploader

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -56,7 +56,8 @@ private extension ProductVariationDetailsFactory {
         vc = ProductFormViewController(viewModel: viewModel,
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
-                                       presentationStyle: presentationStyle)
+                                       presentationStyle: presentationStyle,
+                                       onDuplicateCompletion: { _, _ in })
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -187,6 +187,8 @@ private extension ProductsSplitViewCoordinator {
             self?.showSecondaryView(contentType: .productForm(product: nil), viewController: viewController, replacesNavigationStack: true)
         }, onDeleteCompletion: { [weak self] in
             self?.onSecondaryProductFormDeletion()
+        }, onDuplicateCompletion: { [weak self] duplicatedProduct in
+            self?.showProductForm(product: duplicatedProduct)
         })
         addProductCoordinator.onProductCreated = { [weak self] product in
             guard let self, let lastContentType = contentTypes.last, lastContentType == .productForm(product: nil) else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -566,7 +566,8 @@ private extension ProductVariationsViewController {
                                                        eventLogger: ProductVariationFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
-                                                       presentationStyle: .navigationStack)
+                                                       presentationStyle: .navigationStack,
+                                                       onDuplicateCompletion: { _, _ in })
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductDetailCoordinator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductDetailCoordinator.swift
@@ -9,11 +9,15 @@ class MockProductDetailWebCoordinator: ProductDetailWebCoordinator {
 }
 
 class MockProductDetailNativeCoordinator: ProductDetailNativeCoordinator {
+    let viewControllerInstance = UIViewController()
+    private(set) var onDuplicate: ProductDuplicateNavigationHandler?
+
     override func viewController(product: Product,
                         presentationStyle: ProductDetailNavigator.Presentation,
                         isReadOnly: Bool,
                         onDelete: (() -> Void)?,
-                        onDuplicate: ((Product) -> Void)?) -> UIViewController {
-        UIViewController()
+                        onDuplicate: @escaping ProductDuplicateNavigationHandler) -> UIViewController {
+        self.onDuplicate = onDuplicate
+        return viewControllerInstance
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductDetailCoordinatorFactory.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductDetailCoordinatorFactory.swift
@@ -4,6 +4,7 @@ import Yosemite
 class MockProductDetailCoordinatorFactory: ProductDetailCoordinatorFactoryProtocol {
     private(set) var createdWebCoordiantor = false
     private(set) var createdNativeCoordiantor = false
+    private(set) var nativeCoordinators: [MockProductDetailNativeCoordinator] = []
 
     func webCoordinator(site: Site?) -> ProductDetailWebCoordinator {
         createdWebCoordiantor = true
@@ -12,6 +13,8 @@ class MockProductDetailCoordinatorFactory: ProductDetailCoordinatorFactoryProtoc
 
     func nativeCoordinator() -> ProductDetailNativeCoordinator {
         createdNativeCoordiantor = true
-        return MockProductDetailNativeCoordinator()
+        let coordinator = MockProductDetailNativeCoordinator()
+        nativeCoordinators.append(coordinator)
+        return coordinator
     }
 }

--- a/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductDetailNavigatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductDetailNavigatorTests.swift
@@ -1,5 +1,6 @@
 @testable import WooCommerce
 import Testing
+import UIKit
 import Yosemite
 
 @MainActor
@@ -58,5 +59,75 @@ final class ProductDetailNavigatorTests {
         // Then
         #expect(coordinatorFactory.createdWebCoordiantor)
         #expect(!coordinatorFactory.createdNativeCoordiantor)
+    }
+
+    @Test
+    func test_duplicate_navigation_without_owner_callback_replaces_source_in_navigation_stack() async throws {
+        // Given
+        let coordinatorFactory = MockProductDetailCoordinatorFactory()
+        let navigator = ProductDetailNavigator(coordinatorFactory: coordinatorFactory)
+        let source = navigator.makeDestination(product: Self.aNonBookingProduct, isReadOnly: false)
+        let sourceCoordinator = try #require(coordinatorFactory.nativeCoordinators.first)
+        let previous = UIViewController()
+        let navigationController = UINavigationController()
+        navigationController.viewControllers = [previous, source]
+        let initialViewControllers = navigationController.viewControllers
+        let sourceIndex = try #require(initialViewControllers.firstIndex { $0 === source })
+        let previousIndex = try #require(initialViewControllers.firstIndex { $0 === previous })
+        let duplicate = Self.aNonBookingProduct.copy(productID: 456)
+
+        // When
+        sourceCoordinator.onDuplicate?(source, duplicate)
+        try await waitUntil { navigationController.viewControllers.contains { $0 === source } == false }
+
+        // Then
+        #expect(navigationController.viewControllers.count == initialViewControllers.count)
+        #expect(navigationController.viewControllers[previousIndex] === previous)
+        #expect(navigationController.viewControllers[sourceIndex] !== source)
+        #expect(source.navigationController == nil)
+        #expect(coordinatorFactory.nativeCoordinators.count == 2)
+
+        // And the replacement carries the same default replacement behavior.
+        let firstDuplicateDestination = navigationController.viewControllers[sourceIndex]
+        let firstDuplicateCoordinator = coordinatorFactory.nativeCoordinators[1]
+        firstDuplicateCoordinator.onDuplicate?(firstDuplicateDestination, duplicate.copy(productID: 789))
+        try await waitUntil { navigationController.viewControllers.contains { $0 === firstDuplicateDestination } == false }
+        #expect(navigationController.viewControllers.count == initialViewControllers.count)
+        #expect(navigationController.viewControllers[sourceIndex] !== firstDuplicateDestination)
+        #expect(firstDuplicateDestination.navigationController == nil)
+        #expect(coordinatorFactory.nativeCoordinators.count == 3)
+    }
+
+    @Test
+    func test_duplicate_navigation_with_owner_callback_executes_owner_once_without_default_push_or_replace() throws {
+        // Given
+        let coordinatorFactory = MockProductDetailCoordinatorFactory()
+        let navigator = ProductDetailNavigator(coordinatorFactory: coordinatorFactory)
+        var navigatedProducts: [Product] = []
+        let source = navigator.makeDestination(product: Self.aNonBookingProduct,
+                                               isReadOnly: false,
+                                               onDuplicate: { navigatedProducts.append($0) })
+        let sourceCoordinator = try #require(coordinatorFactory.nativeCoordinators.first)
+        let navigationController = UINavigationController(rootViewController: source)
+        let duplicate = Self.aNonBookingProduct.copy(productID: 456)
+
+        // When
+        sourceCoordinator.onDuplicate?(source, duplicate)
+
+        // Then
+        #expect(navigatedProducts == [duplicate])
+        #expect(navigationController.viewControllers.count == 1)
+        #expect(navigationController.viewControllers.first === source)
+        #expect(coordinatorFactory.nativeCoordinators.count == 1)
+    }
+
+    private func waitUntil(_ condition: @escaping @MainActor () -> Bool) async throws {
+        for _ in 0..<100 {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(condition())
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+DuplicationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+DuplicationTests.swift
@@ -73,7 +73,7 @@ struct ProductFormViewController_DuplicationTests {
         #expect(context.duplicateResultAnalyticsEvents.isEmpty)
     }
 
-    @Test func test_duplicate_when_confirmed_and_successful_then_uses_intent_snapshot_and_discards_draft() async throws {
+    @Test func test_duplicate_when_confirmed_and_successful_then_navigates_once_without_resetting_source_draft() async throws {
         // Given
         let context = TestContext()
         defer { context.cleanUp() }
@@ -81,9 +81,18 @@ struct ProductFormViewController_DuplicationTests {
         let draftImage = ProductImage.fake().copy(imageID: 2)
         let product = Product.fake().copy(productID: 123, name: "Saved product", images: [savedImage], variations: [11])
         let stores = MockStoresManager(sessionManager: .testingInstance)
+        var navigationCount = 0
+        var navigatedSource: UIViewController?
+        var navigatedProduct: Product?
+        let navigateToDuplicate: ProductDuplicateNavigationHandler = { source, duplicate in
+            navigationCount += 1
+            navigatedSource = source
+            navigatedProduct = duplicate
+        }
         let (productForm, viewModel, imageActionHandler) = createProductForm(product: product,
                                                                             stores: stores,
-                                                                            password: "saved-password")
+                                                                            password: "saved-password",
+                                                                            onDuplicateCompletion: navigateToDuplicate)
         viewModel.updateName("Unsaved product")
         viewModel.updateImages([draftImage])
         viewModel.updateProductSettings(ProductSettings(from: viewModel.productModel.product, password: "unsaved-password"))
@@ -111,17 +120,23 @@ struct ProductFormViewController_DuplicationTests {
         viewModel.updateProductVariations(from: product.copy(productID: 999, variations: [99]))
         #expect(viewModel.productModel.name == "Unsaved product")
         #expect(viewModel.productModel.productID == 999)
+        let expectedDraft = viewModel.productModel
+        let expectedBaseline = viewModel.originalProductModel
 
         // And duplication is confirmed
         alert.tapButton(atIndex: 1)
+        try await waitUntil { navigationCount == 1 }
 
-        // Then the captured source is duplicated and the live draft is discarded only after success.
+        // Then the captured source is duplicated and navigation owns leaving the unmodified source draft.
         #expect(duplicatedSourceID == 123)
-        #expect(viewModel.productModel == EditableProductModel(product: product))
-        #expect(viewModel.originalProductModel == EditableProductModel(product: product))
-        #expect(viewModel.password == "saved-password")
-        try await waitUntil { imageActionHandler.productImageStatuses.images == [savedImage] }
-        #expect(viewModel.hasUnsavedChanges() == false)
+        #expect(navigationCount == 1)
+        #expect(navigatedSource === productForm)
+        #expect(navigatedProduct == product.copy(productID: 456, name: "Saved product Copy"))
+        #expect(viewModel.productModel == expectedDraft)
+        #expect(viewModel.originalProductModel == expectedBaseline)
+        #expect(viewModel.password == "unsaved-password")
+        #expect(imageActionHandler.productImageStatuses.images == [draftImage])
+        #expect(viewModel.hasUnsavedChanges())
         #expect(context.duplicateResultAnalyticsEvents == [WooAnalyticsStat.duplicateProductSuccess.rawValue])
     }
 
@@ -185,9 +200,9 @@ struct ProductFormViewController_DuplicationTests {
 private extension ProductFormViewController_DuplicationTests {
     func createProductForm(product: Product,
                            stores: StoresManager,
-                           password: String? = nil) -> (ProductFormViewController<ProductFormViewModel>,
-                                                         ProductFormViewModel,
-                                                         ProductImageActionHandler) {
+                           password: String? = nil,
+                           onDuplicateCompletion: @escaping ProductDuplicateNavigationHandler = { _, _ in })
+    -> (ProductFormViewController<ProductFormViewModel>, ProductFormViewModel, ProductImageActionHandler) {
         let model = EditableProductModel(product: product)
         let imageActionHandler = ProductImageActionHandler(siteID: product.siteID,
                                                            productID: .product(id: product.productID),
@@ -201,7 +216,8 @@ private extension ProductFormViewController_DuplicationTests {
         let productForm = ProductFormViewController(viewModel: viewModel,
                                                     eventLogger: ProductFormEventLogger(),
                                                     productImageActionHandler: imageActionHandler,
-                                                    presentationStyle: .navigationStack)
+                                                    presentationStyle: .navigationStack,
+                                                    onDuplicateCompletion: onDuplicateCompletion)
         return (productForm, viewModel, imageActionHandler)
     }
 
@@ -236,7 +252,7 @@ private final class TestContext {
     }
 
     func present(_ viewController: UIViewController) {
-        window.rootViewController = viewController
+        window.rootViewController = UINavigationController(rootViewController: viewController)
         viewController.loadViewIfNeeded()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+DuplicationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+DuplicationTests.swift
@@ -1,0 +1,262 @@
+import Testing
+import UIKit
+import Yosemite
+import protocol WooFoundation.Analytics
+
+@testable import WooCommerce
+
+@MainActor
+@Suite(.serialized)
+struct ProductFormViewController_DuplicationTests {
+    @Test func test_duplicate_when_saved_product_is_unchanged_then_starts_immediately() {
+        // Given
+        let context = TestContext()
+        defer { context.cleanUp() }
+        let product = Product.fake().copy(productID: 123, name: "Saved product")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let (productForm, _, _) = createProductForm(product: product, stores: stores)
+        var duplicationStarted = false
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case .duplicateProduct = action {
+                duplicationStarted = true
+            }
+        }
+
+        // When
+        productForm.handleProductDuplication()
+
+        // Then
+        #expect(duplicationStarted)
+        #expect(productForm.presentedViewController == nil)
+    }
+
+    @Test func test_duplicate_when_product_is_edited_then_shows_confirmation_and_cancel_retains_draft() async throws {
+        // Given
+        let context = TestContext()
+        defer { context.cleanUp() }
+        let savedImage = ProductImage.fake().copy(imageID: 1)
+        let draftImage = ProductImage.fake().copy(imageID: 2)
+        let product = Product.fake().copy(productID: 123, name: "Saved product", images: [savedImage])
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let (productForm, viewModel, imageActionHandler) = createProductForm(product: product,
+                                                                            stores: stores,
+                                                                            password: "saved-password")
+        viewModel.updateName("Unsaved product")
+        viewModel.updateImages([draftImage])
+        viewModel.updateProductSettings(ProductSettings(from: viewModel.productModel.product, password: "unsaved-password"))
+        imageActionHandler.updateProductImageStatusesAfterReordering(product.copy(images: [draftImage]).imageStatuses)
+        try await waitUntil { imageActionHandler.productImageStatuses.images == [draftImage] }
+        context.present(productForm)
+
+        // When
+        productForm.handleProductDuplication()
+
+        // Then
+        let alert = try #require(productForm.presentedViewController as? UIAlertController)
+        #expect(alert.title == "Discard changes and duplicate?")
+        #expect(alert.message == "Your unsaved changes will be lost. The duplicate will use the last saved version.")
+        #expect(alert.actions.map(\.title) == ["Cancel", "Discard & duplicate"])
+        #expect(alert.actions.map(\.style) == [.cancel, .destructive])
+        #expect(stores.receivedActions.containsProductDuplication == false)
+        #expect(context.duplicateResultAnalyticsEvents.isEmpty)
+
+        // When cancelling
+        alert.tapButton(atIndex: 0)
+
+        // Then the exact live draft is retained and no result action is sent.
+        #expect(viewModel.productModel.name == "Unsaved product")
+        #expect(viewModel.productModel.images == [draftImage])
+        #expect(viewModel.password == "unsaved-password")
+        #expect(imageActionHandler.productImageStatuses.images == [draftImage])
+        #expect(viewModel.hasUnsavedChanges())
+        #expect(stores.receivedActions.containsProductDuplication == false)
+        #expect(context.duplicateResultAnalyticsEvents.isEmpty)
+    }
+
+    @Test func test_duplicate_when_confirmed_and_successful_then_uses_intent_snapshot_and_discards_draft() async throws {
+        // Given
+        let context = TestContext()
+        defer { context.cleanUp() }
+        let savedImage = ProductImage.fake().copy(imageID: 1)
+        let draftImage = ProductImage.fake().copy(imageID: 2)
+        let product = Product.fake().copy(productID: 123, name: "Saved product", images: [savedImage], variations: [11])
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let (productForm, viewModel, imageActionHandler) = createProductForm(product: product,
+                                                                            stores: stores,
+                                                                            password: "saved-password")
+        viewModel.updateName("Unsaved product")
+        viewModel.updateImages([draftImage])
+        viewModel.updateProductSettings(ProductSettings(from: viewModel.productModel.product, password: "unsaved-password"))
+        imageActionHandler.updateProductImageStatusesAfterReordering(product.copy(images: [draftImage]).imageStatuses)
+        try await waitUntil { imageActionHandler.productImageStatuses.images == [draftImage] }
+        var duplicatedSourceID: Int64?
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .duplicateProduct(_, productID, onCompletion):
+                duplicatedSourceID = productID
+                onCompletion(.success(456))
+            case let .retrieveProduct(_, _, onCompletion):
+                onCompletion(.success(product.copy(productID: 456, name: "Saved product Copy")))
+            default:
+                break
+            }
+        }
+        context.present(productForm)
+
+        // When the initial intent captures product ID 123
+        productForm.handleProductDuplication()
+        let alert = try #require(productForm.presentedViewController as? UIAlertController)
+
+        // And the persisted baseline changes while the alert is visible
+        viewModel.updateProductVariations(from: product.copy(productID: 999, variations: [99]))
+        #expect(viewModel.productModel.name == "Unsaved product")
+        #expect(viewModel.productModel.productID == 999)
+
+        // And duplication is confirmed
+        alert.tapButton(atIndex: 1)
+
+        // Then the captured source is duplicated and the live draft is discarded only after success.
+        #expect(duplicatedSourceID == 123)
+        #expect(viewModel.productModel == EditableProductModel(product: product))
+        #expect(viewModel.originalProductModel == EditableProductModel(product: product))
+        #expect(viewModel.password == "saved-password")
+        try await waitUntil { imageActionHandler.productImageStatuses.images == [savedImage] }
+        #expect(viewModel.hasUnsavedChanges() == false)
+        #expect(context.duplicateResultAnalyticsEvents == [WooAnalyticsStat.duplicateProductSuccess.rawValue])
+    }
+
+    @Test func test_duplicate_when_confirmed_and_failed_then_retains_live_draft() async throws {
+        // Given
+        let context = TestContext()
+        defer { context.cleanUp() }
+        let savedImage = ProductImage.fake().copy(imageID: 1)
+        let draftImage = ProductImage.fake().copy(imageID: 2)
+        let product = Product.fake().copy(productID: 123, name: "Saved product", images: [savedImage])
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let (productForm, viewModel, imageActionHandler) = createProductForm(product: product,
+                                                                            stores: stores,
+                                                                            password: "saved-password")
+        viewModel.updateName("Unsaved product")
+        viewModel.updateImages([draftImage])
+        viewModel.updateProductSettings(ProductSettings(from: viewModel.productModel.product, password: "unsaved-password"))
+        imageActionHandler.updateProductImageStatusesAfterReordering(product.copy(images: [draftImage]).imageStatuses)
+        try await waitUntil { imageActionHandler.productImageStatuses.images == [draftImage] }
+        let error = NSError(domain: "ProductDuplicate", code: 500)
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .duplicateProduct(_, _, onCompletion) = action {
+                onCompletion(.failure(.unknown(error: AnyError(error))))
+            }
+        }
+        context.present(productForm)
+
+        // When
+        productForm.handleProductDuplication()
+        let alert = try #require(productForm.presentedViewController as? UIAlertController)
+        alert.tapButton(atIndex: 1)
+
+        // Then
+        #expect(viewModel.productModel.name == "Unsaved product")
+        #expect(viewModel.productModel.images == [draftImage])
+        #expect(viewModel.password == "unsaved-password")
+        #expect(imageActionHandler.productImageStatuses.images == [draftImage])
+        #expect(viewModel.hasUnsavedChanges())
+        #expect(context.duplicateResultAnalyticsEvents == [WooAnalyticsStat.duplicateProductFailed.rawValue])
+    }
+
+    @Test func test_duplicate_when_edit_product_has_productID_zero_then_no_ops_before_progress_or_request() {
+        // Given
+        let context = TestContext()
+        defer { context.cleanUp() }
+        let product = Product.fake().copy(productID: 0)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let (productForm, _, _) = createProductForm(product: product, stores: stores)
+
+        // When
+        productForm.handleProductDuplication()
+
+        // Then
+        #expect(productForm.presentedViewController == nil)
+        #expect(stores.receivedActions.containsProductDuplication == false)
+        #expect(context.duplicateResultAnalyticsEvents.isEmpty)
+    }
+}
+
+@MainActor
+private extension ProductFormViewController_DuplicationTests {
+    func createProductForm(product: Product,
+                           stores: StoresManager,
+                           password: String? = nil) -> (ProductFormViewController<ProductFormViewModel>,
+                                                         ProductFormViewModel,
+                                                         ProductImageActionHandler) {
+        let model = EditableProductModel(product: product)
+        let imageActionHandler = ProductImageActionHandler(siteID: product.siteID,
+                                                           productID: .product(id: product.productID),
+                                                           imageStatuses: product.imageStatuses,
+                                                           stores: stores)
+        let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
+                                             productImageActionHandler: imageActionHandler,
+                                             stores: stores)
+        viewModel.resetPassword(password)
+        let productForm = ProductFormViewController(viewModel: viewModel,
+                                                    eventLogger: ProductFormEventLogger(),
+                                                    productImageActionHandler: imageActionHandler,
+                                                    presentationStyle: .navigationStack)
+        return (productForm, viewModel, imageActionHandler)
+    }
+
+    func waitUntil(_ condition: @escaping @MainActor () -> Bool) async throws {
+        for _ in 0..<100 {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(condition())
+    }
+}
+
+@MainActor
+private final class TestContext {
+    private let originalAnalytics: Analytics
+    let analyticsProvider = MockAnalyticsProvider()
+    let window = UIWindow(frame: UIScreen.main.bounds)
+
+    init() {
+        originalAnalytics = ServiceLocator.analytics
+        ServiceLocator.setAnalytics(WooAnalytics(analyticsProvider: analyticsProvider))
+        window.makeKeyAndVisible()
+    }
+
+    var duplicateResultAnalyticsEvents: [String] {
+        analyticsProvider.receivedEvents.filter {
+            $0 == WooAnalyticsStat.duplicateProductSuccess.rawValue ||
+                $0 == WooAnalyticsStat.duplicateProductFailed.rawValue
+        }
+    }
+
+    func present(_ viewController: UIViewController) {
+        window.rootViewController = viewController
+        viewController.loadViewIfNeeded()
+    }
+
+    func cleanUp() {
+        window.resignKey()
+        window.rootViewController = nil
+        ServiceLocator.setAnalytics(originalAnalytics)
+    }
+}
+
+private extension Array where Element == Action {
+    var containsProductDuplication: Bool {
+        contains { action in
+            guard let productAction = action as? ProductAction else {
+                return false
+            }
+            if case .duplicateProduct = productAction {
+                return true
+            }
+            return false
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
@@ -31,7 +31,8 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
                                                     eventLogger: ProductFormEventLogger(),
                                                     productImageActionHandler: actionHandler,
                                                     presentationStyle: .navigationStack,
-                                                    productImageUploader: productImageUploader)
+                                                    productImageUploader: productImageUploader,
+                                                    onDuplicateCompletion: { _, _ in })
         productForm.viewDidLoad()
 
         // Then
@@ -50,7 +51,8 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
                                                     eventLogger: ProductFormEventLogger(),
                                                     productImageActionHandler: actionHandler,
                                                     presentationStyle: .navigationStack,
-                                                    productImageUploader: productImageUploader)
+                                                    productImageUploader: productImageUploader,
+                                                    onDuplicateCompletion: { _, _ in })
         let rootViewController = UIViewController()
         window.rootViewController = rootViewController
 
@@ -78,7 +80,8 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
                                                     eventLogger: ProductFormEventLogger(),
                                                     productImageActionHandler: actionHandler,
                                                     presentationStyle: .navigationStack,
-                                                    productImageUploader: productImageUploader)
+                                                    productImageUploader: productImageUploader,
+                                                    onDuplicateCompletion: { _, _ in })
         let rootNavigationController = MockNavigationController(rootViewController: .init())
         window.rootViewController = rootNavigationController
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -301,6 +301,106 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         XCTAssertEqual(viewModel.originalProductModel, EditableProductModel(product: originalProduct))
         XCTAssertFalse(viewModel.hasUnsavedChanges())
     }
+
+    func test_duplicateProduct_uses_captured_saved_aggregate_and_password_in_compatibility_fallback() throws {
+        // Given
+        let savedPassword = "saved-password"
+        let savedProduct = Product.fake().copy(productID: 123,
+                                               name: "Saved product",
+                                               slug: "saved-product",
+                                               permalink: "https://example.com/saved-product",
+                                               statusKey: ProductStatus.published.rawValue,
+                                               sku: "saved-sku",
+                                               variations: [11, 12],
+                                               password: savedPassword)
+        let viewModel = createViewModel(product: savedProduct, formType: .edit)
+        viewModel.resetPassword(savedPassword)
+        viewModel.updateName("Unsaved product")
+        viewModel.updateProductSettings(ProductSettings(from: viewModel.productModel.product, password: "unsaved-password"))
+        let snapshot = try XCTUnwrap(viewModel.productDuplicationSnapshot())
+
+        // Change the persisted baseline after the initial intent. The captured source must remain unchanged.
+        viewModel.updateProductVariations(from: savedProduct.copy(variations: [99]))
+        viewModel.resetPassword("later-password")
+
+        var productSentToFallback: Product?
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .duplicateProduct(siteID, productID, onCompletion):
+                XCTAssertEqual(siteID, savedProduct.siteID)
+                XCTAssertEqual(productID, savedProduct.productID)
+                onCompletion(.failure(.endpointUnavailable))
+            case let .addProduct(product, _):
+                productSentToFallback = product
+            default:
+                break
+            }
+        }
+
+        // When
+        viewModel.duplicateProduct(from: snapshot) { _ in
+            XCTFail("The fallback request is intentionally left pending")
+        }
+
+        // Then
+        let expectedFallbackProduct = savedProduct.copy(productID: 0,
+                                                        name: "Saved product Copy",
+                                                        slug: "",
+                                                        permalink: "",
+                                                        statusKey: ProductStatus.draft.rawValue,
+                                                        sku: .some(nil),
+                                                        password: savedPassword)
+        XCTAssertEqual(productSentToFallback, expectedFallbackProduct)
+        XCTAssertEqual(viewModel.productModel.name, "Unsaved product")
+    }
+
+    func test_duplicateProduct_failure_retains_live_product_and_password_draft() {
+        // Given
+        let savedProduct = Product.fake().copy(productID: 123, name: "Saved product")
+        let viewModel = createViewModel(product: savedProduct, formType: .edit)
+        viewModel.resetPassword("saved-password")
+        viewModel.updateName("Unsaved product")
+        viewModel.updateProductSettings(ProductSettings(from: viewModel.productModel.product, password: "unsaved-password"))
+        let expectedDraft = viewModel.productModel
+        let error = NSError(domain: "ProductDuplicate", code: 500)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .duplicateProduct(_, _, onCompletion) = action {
+                onCompletion(.failure(.unknown(error: AnyError(error))))
+            }
+        }
+
+        // When
+        var result: Result<EditableProductModel, ProductUpdateError>?
+        viewModel.duplicateProduct { result = $0 }
+
+        // Then
+        XCTAssertEqual(result, .failure(.unknown(error: AnyError(error))))
+        XCTAssertEqual(viewModel.productModel, expectedDraft)
+        XCTAssertEqual(viewModel.password, "unsaved-password")
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func test_duplicateProduct_for_edit_form_product_with_productID_zero_no_ops() {
+        // Given
+        let product = Product.fake().copy(productID: 0)
+        let viewModel = createViewModel(product: product, formType: .edit)
+        var completionCalled = false
+
+        // When
+        viewModel.duplicateProduct { _ in completionCalled = true }
+
+        // Then
+        XCTAssertFalse(completionCalled)
+        XCTAssertFalse(storesManager.receivedActions.contains { action in
+            guard let productAction = action as? ProductAction else {
+                return false
+            }
+            if case .duplicateProduct = productAction {
+                return true
+            }
+            return false
+        })
+    }
 }
 
 private extension ProductFormViewModel_SaveTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -273,6 +273,7 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
                                                   statusKey: ProductStatus.published.rawValue)
         let productImagesUploader = MockProductImageUploader()
         let viewModel = createViewModel(product: originalProduct, formType: .edit, productImagesUploader: productImagesUploader)
+        let snapshot = try XCTUnwrap(viewModel.productDuplicationSnapshot())
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .duplicateProduct(_, _, onCompletion):
@@ -288,7 +289,7 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         // When
         var duplicatedProduct: EditableProductModel?
         waitForExpectation { expectation in
-            viewModel.duplicateProduct { result in
+            viewModel.duplicateProduct(from: snapshot) { result in
                 duplicatedProduct = try? result.get()
                 expectation.fulfill()
             }
@@ -354,40 +355,15 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.name, "Unsaved product")
     }
 
-    func test_duplicateProduct_failure_retains_live_product_and_password_draft() {
-        // Given
-        let savedProduct = Product.fake().copy(productID: 123, name: "Saved product")
-        let viewModel = createViewModel(product: savedProduct, formType: .edit)
-        viewModel.resetPassword("saved-password")
-        viewModel.updateName("Unsaved product")
-        viewModel.updateProductSettings(ProductSettings(from: viewModel.productModel.product, password: "unsaved-password"))
-        let expectedDraft = viewModel.productModel
-        let error = NSError(domain: "ProductDuplicate", code: 500)
-        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
-            if case let .duplicateProduct(_, _, onCompletion) = action {
-                onCompletion(.failure(.unknown(error: AnyError(error))))
-            }
-        }
-
-        // When
-        var result: Result<EditableProductModel, ProductUpdateError>?
-        viewModel.duplicateProduct { result = $0 }
-
-        // Then
-        XCTAssertEqual(result, .failure(.unknown(error: AnyError(error))))
-        XCTAssertEqual(viewModel.productModel, expectedDraft)
-        XCTAssertEqual(viewModel.password, "unsaved-password")
-        XCTAssertTrue(viewModel.hasUnsavedChanges())
-    }
-
     func test_duplicateProduct_for_edit_form_product_with_productID_zero_no_ops() {
         // Given
         let product = Product.fake().copy(productID: 0)
         let viewModel = createViewModel(product: product, formType: .edit)
+        let snapshot = ProductDuplicationSnapshot(product: viewModel.originalProductModel, password: nil)
         var completionCalled = false
 
         // When
-        viewModel.duplicateProduct { _ in completionCalled = true }
+        viewModel.duplicateProduct(from: snapshot) { _ in completionCalled = true }
 
         // Then
         XCTAssertFalse(completionCalled)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -356,7 +356,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_edit_product_form_with_non_published_status_can_duplicate_product() {
         // Arrange
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.pending.rawValue)
+        let product = Product.fake().copy(productID: 123, name: "Test", statusKey: ProductStatus.pending.rawValue)
         let viewModel = createViewModel(product: product, formType: .edit)
 
         // Action
@@ -368,7 +368,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_edit_product_form_with_published_status_can_duplicate_product() {
         // Arrange
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
+        let product = Product.fake().copy(productID: 123, name: "Test", statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product, formType: .edit)
 
         // Action
@@ -376,6 +376,18 @@ final class ProductFormViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertTrue(canDuplicateProduct)
+    }
+
+    func test_edit_product_form_with_productID_zero_cannot_duplicate_product() {
+        // Given
+        let product = Product.fake().copy(productID: 0, statusKey: ProductStatus.published.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let canDuplicateProduct = viewModel.canDuplicateProduct()
+
+        // Then
+        XCTAssertFalse(canDuplicateProduct)
     }
 
     func test_update_variations_updates_original_product_while_maintaining_pending_changes() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductDetailsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductDetailsFactoryTests.swift
@@ -13,7 +13,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         let viewController = ProductDetailsFactory.productDetails(product: product,
                                                                   presentationStyle: .navigationStack,
-                                                                  forceReadOnly: false)
+                                                                  forceReadOnly: false,
+                                                                  onDuplicateCompletion: { _, _ in })
 
         // Assert
         XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
@@ -28,7 +29,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         let viewController = ProductDetailsFactory.productDetails(product: product,
                                                                   presentationStyle: .navigationStack,
-                                                                  forceReadOnly: false)
+                                                                  forceReadOnly: false,
+                                                                  onDuplicateCompletion: { _, _ in })
 
         // Assert
         XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
@@ -43,7 +45,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         let viewController = ProductDetailsFactory.productDetails(product: product,
                                                                   presentationStyle: .navigationStack,
-                                                                  forceReadOnly: false)
+                                                                  forceReadOnly: false,
+                                                                  onDuplicateCompletion: { _, _ in })
         // Assert
         XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
     }
@@ -57,7 +60,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         let viewController = ProductDetailsFactory.productDetails(product: product,
                                                                   presentationStyle: .navigationStack,
-                                                                  forceReadOnly: false)
+                                                                  forceReadOnly: false,
+                                                                  onDuplicateCompletion: { _, _ in })
 
         // Assert
         XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
@@ -72,7 +76,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         let viewController = ProductDetailsFactory.productDetails(product: product,
                                                                   presentationStyle: .navigationStack,
-                                                                  forceReadOnly: false)
+                                                                  forceReadOnly: false,
+                                                                  onDuplicateCompletion: { _, _ in })
         // Assert
         XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
     }
@@ -84,7 +89,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         let viewController = ProductDetailsFactory.productDetails(product: product,
                                                                   presentationStyle: .navigationStack,
-                                                                  forceReadOnly: true)
+                                                                  forceReadOnly: true,
+                                                                  onDuplicateCompletion: { _, _ in })
         // Assert
         XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductDuplicationEntryPathNavigationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductDuplicationEntryPathNavigationTests.swift
@@ -1,0 +1,133 @@
+import Testing
+import UIKit
+import Yosemite
+
+@testable import WooCommerce
+
+@MainActor
+extension ProductFormViewController_DuplicationTests {
+    @Test
+    func test_product_loader_duplication_replaces_contained_source_editor() async throws {
+        // Given
+        let sourceProduct = Product.fake().copy(productID: 123, name: "Source")
+        let duplicate = sourceProduct.copy(productID: 456, name: "Source Copy")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        configureDuplication(stores: stores, sourceProduct: sourceProduct, duplicate: duplicate)
+        let context = NavigationTestContext(stores: stores)
+        defer { context.cleanUp() }
+        let loader = ProductLoaderViewController(model: .product(productID: sourceProduct.productID),
+                                                 siteID: sourceProduct.siteID,
+                                                 forceReadOnly: false)
+        context.present(UINavigationController(rootViewController: loader))
+        loader.loadViewIfNeeded()
+        let source = try await productFormChild(in: loader)
+
+        // When
+        source.handleProductDuplication()
+        try await waitUntil {
+            loader.children.contains { $0 is ProductFormViewController<ProductFormViewModel> && $0 !== source }
+        }
+
+        // Then
+        let destination = try await productFormChild(in: loader)
+        #expect(destination !== source)
+        #expect(loader.children.count == 1)
+        #expect(source.parent == nil)
+        #expect(destination.parent === loader)
+    }
+
+    @Test
+    func test_add_product_form_after_first_save_replaces_source_editor() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let context = NavigationTestContext(stores: stores)
+        defer { context.cleanUp() }
+        let previous = UIViewController()
+        let navigationController = UINavigationController(rootViewController: previous)
+        context.present(navigationController)
+        let coordinator = AddProductCoordinator(siteID: 123,
+                                                source: .productDescriptionAIAnnouncementModal,
+                                                sourceView: nil,
+                                                sourceNavigationController: navigationController,
+                                                isFirstProduct: false)
+        coordinator.start()
+        let source = try #require(navigationController.topViewController as? ProductFormViewController<ProductFormViewModel>)
+        let viewModel = try #require(productViewModel(in: source))
+        let savedProduct = viewModel.productModel.product.copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let duplicate = savedProduct.copy(productID: 456, name: "Source Copy")
+        configureDuplication(stores: stores, sourceProduct: savedProduct, duplicate: duplicate)
+        viewModel.updateProductVariations(from: savedProduct)
+
+        // When
+        source.handleProductDuplication()
+        try await waitUntil { navigationController.topViewController !== source }
+
+        // Then
+        #expect(navigationController.viewControllers.count == 2)
+        #expect(navigationController.viewControllers[0] === previous)
+        #expect(navigationController.viewControllers[1] !== source)
+        #expect(source.navigationController == nil)
+    }
+}
+
+@MainActor
+private extension ProductFormViewController_DuplicationTests {
+    func configureDuplication(stores: MockStoresManager, sourceProduct: Product, duplicate: Product) {
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .duplicateProduct(_, productID, onCompletion) where productID == sourceProduct.productID:
+                onCompletion(.success(duplicate.productID))
+            case let .retrieveProduct(_, productID, onCompletion) where productID == sourceProduct.productID:
+                onCompletion(.success(sourceProduct))
+            case let .retrieveProduct(_, productID, onCompletion) where productID == duplicate.productID:
+                onCompletion(.success(duplicate))
+            default:
+                break
+            }
+        }
+    }
+
+    func productFormChild(in loader: ProductLoaderViewController) async throws -> ProductFormViewController<ProductFormViewModel> {
+        try await waitUntil {
+            loader.children.contains { $0 is ProductFormViewController<ProductFormViewModel> }
+        }
+        return try #require(loader.children.compactMap { $0 as? ProductFormViewController<ProductFormViewModel> }.first)
+    }
+
+    func productViewModel(in productForm: ProductFormViewController<ProductFormViewModel>) -> ProductFormViewModel? {
+        Mirror(reflecting: productForm).children.first { $0.label == "viewModel" }?.value as? ProductFormViewModel
+    }
+
+    func waitUntil(_ condition: @escaping @MainActor () -> Bool) async throws {
+        for _ in 0..<100 {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(condition())
+    }
+}
+
+@MainActor
+private final class NavigationTestContext {
+    private let originalStores: StoresManager
+    private let window = UIWindow(frame: UIScreen.main.bounds)
+
+    init(stores: StoresManager) {
+        originalStores = ServiceLocator.stores
+        ServiceLocator.setStores(stores)
+        window.makeKeyAndVisible()
+    }
+
+    func present(_ viewController: UIViewController) {
+        window.rootViewController = viewController
+        viewController.loadViewIfNeeded()
+    }
+
+    func cleanUp() {
+        window.resignKey()
+        window.rootViewController = nil
+        ServiceLocator.setStores(originalStores)
+    }
+}


### PR DESCRIPTION
WOOMOB-3587

## Description
This follow-up was prompted by [the unsaved-product duplication issue Jorge identified during review of Android PR #16262](https://github.com/woocommerce/woocommerce-android/pull/16262#pullrequestreview-4752784096). It builds on the iOS [core/backend duplication endpoint migration in PR #17553](https://github.com/woocommerce/woocommerce-ios/pull/17553).

The backend duplicate endpoint always duplicates the persisted, last-saved product—never the mutable iOS editor draft. iOS captures the last-saved product and password when the merchant first chooses Duplicate, and that same immutable snapshot feeds both the core endpoint and its compatibility fallback.

When the editor is dirty, Duplicate shows the native destructive confirmation with the exact copy “Discard changes and duplicate?”, “Your unsaved changes will be lost. The duplicate will use the last saved version.”, “Cancel”, and “Discard & duplicate”. New or never-saved products do not expose Duplicate, and defensive guards fail closed before progress or networking if duplication is invoked directly.

### Navigation and editor behavior

- On success, iOS opens the returned canonical duplicate to match Android and make the confirmation copy truthful.
- The source editor is replaced or detached across every editable native navigation owner: split view; normal navigation-stack product details, including legacy Products and AI Assistant; ProductLoader; and Add Product after its first save.
- Back returns to the prior screen, not the discarded source draft.
- There is no manual draft reset; navigation lifetime removes the source editor.
- The opened duplicate retains the handler for repeated duplication.
- Cancel or failure keeps the source editor and its unsaved draft intact, preserving the existing error UX and analytics. Navigation occurs only on success.

## Test Steps
1. **Saved, unchanged product**
   - Open an existing saved product without editing it.
   - Choose **Duplicate**.
   - Verify duplication starts immediately without a discard confirmation and the copied product replaces the source editor.
2. **Dirty product — Cancel**
   - Open a saved product and make an unsaved change, such as changing its name.
   - Choose **Duplicate**.
   - Verify the exact title, message, **Cancel**, and **Discard & duplicate** actions described above.
   - Tap **Cancel** and verify the unsaved draft remains unchanged and no duplication result occurs.
3. **Dirty product — Confirm and Back**
   - With an unsaved change present, choose **Duplicate**, then tap **Discard & duplicate**.
   - Verify the duplicate opens using the last-saved values, not the unsaved draft.
   - Tap **Back** and verify it returns to the prior Products screen rather than the source editor.
   - Reopen the duplicate’s action menu and verify **Duplicate** remains available.
4. **Duplication failure retention**
   - In an environment where the duplication request fails, edit a saved product and confirm duplication.
   - Verify the existing duplication error UX appears and the unsaved source draft remains intact.
5. **New Product visibility**
   - Open the New Product form before its first save.
   - Verify **Duplicate** is not shown and that invoking duplication through a direct/internal path performs no progress or network request.

## Screenshots
<img width="360" alt="image" src="https://github.com/user-attachments/assets/d29f2f3f-e67f-4414-a222-2bb88050d7a7" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

