### PR TITLE
[WOOMOB-3556] Fix new order notification text truncation and dark mode color

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [Internal] Add `payment_method_type` and `currency` properties to receipt Tracks events for Android parity. [https://github.com/woocommerce/woocommerce-ios/pull/17548]
 - [*] Fixed products failing to load when a plugin returns null for a product's categories, tags, images, or other list fields. [https://github.com/woocommerce/woocommerce-ios/pull/17545]
 - [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17599]
+- [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17601]
 - [*] Fixed a crash when undoing pasted product tags containing tabs or extra whitespace. [https://github.com/woocommerce/woocommerce-ios/pull/17592]
 - [*] Point of Sale: once the local catalog has fully synced, POS opens instantly without waiting on network checks and also works offline. [https://github.com/woocommerce/woocommerce-ios/pull/17498]
 - [*] Order Creation: fixed custom amount fields losing entered values and keyboard focus after rotating an iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17550]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.4
 -----
+- [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17601]
 
 
 25.3
@@ -11,8 +12,6 @@
 - [*] Payments: fixed successful in-person payments appearing to fail when the capture response is interrupted. [https://github.com/woocommerce/woocommerce-ios/pull/17593]
 - [Internal] Add `payment_method_type` and `currency` properties to receipt Tracks events for Android parity. [https://github.com/woocommerce/woocommerce-ios/pull/17548]
 - [*] Fixed products failing to load when a plugin returns null for a product's categories, tags, images, or other list fields. [https://github.com/woocommerce/woocommerce-ios/pull/17545]
-- [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17599]
-- [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17601]
 - [*] Fixed a crash when undoing pasted product tags containing tabs or extra whitespace. [https://github.com/woocommerce/woocommerce-ios/pull/17592]
 - [*] Point of Sale: once the local catalog has fully synced, POS opens instantly without waiting on network checks and also works offline. [https://github.com/woocommerce/woocommerce-ios/pull/17498]
 - [*] Order Creation: fixed custom amount fields losing entered values and keyboard focus after rotating an iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17550]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Payments: fixed successful in-person payments appearing to fail when the capture response is interrupted. [https://github.com/woocommerce/woocommerce-ios/pull/17593]
 - [Internal] Add `payment_method_type` and `currency` properties to receipt Tracks events for Android parity. [https://github.com/woocommerce/woocommerce-ios/pull/17548]
 - [*] Fixed products failing to load when a plugin returns null for a product's categories, tags, images, or other list fields. [https://github.com/woocommerce/woocommerce-ios/pull/17545]
+- [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17599]
 - [*] Fixed a crash when undoing pasted product tags containing tabs or extra whitespace. [https://github.com/woocommerce/woocommerce-ios/pull/17592]
 - [*] Point of Sale: once the local catalog has fully synced, POS opens instantly without waiting on network checks and also works offline. [https://github.com/woocommerce/woocommerce-ios/pull/17498]
 - [*] Order Creation: fixed custom amount fields losing entered values and keyboard focus after rotating an iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17550]

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -156,6 +156,10 @@ private extension NoticeView {
         actionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = Metrics.actionButtonContentInsets
+        // On the iOS 26 SDK a configured button draws its own inset, rounded background, which turns the
+        // action area into a floating pill. Clear it so the flush view backgroundColor fills the full frame,
+        // keeping the original two-tone split (only the notice's outer corners are rounded by its container mask).
+        configuration.background = .clear()
         actionButton.configuration = configuration
         actionButton.backgroundColor = Appearance.actionBackgroundColor
     }

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -122,7 +122,13 @@ private extension NoticeView {
 
         contentStackView.addArrangedSubview(labelStackView)
 
+        // Let the label block fill the width and the button keep its intrinsic size. On the iOS 26 SDK the .fill
+        // stack otherwise splits them ~50/50 and truncates the title; content-hugging doesn't fix a nested stack.
+        let labelStackFillWidth = labelStackView.widthAnchor.constraint(greaterThanOrEqualToConstant: UIView.layoutFittingExpandedSize.width)
+        labelStackFillWidth.priority = .required - 1
+
         NSLayoutConstraint.activate([
+            labelStackFillWidth,
             labelStackView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
             labelStackView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor)
         ])
@@ -229,7 +235,7 @@ private extension NoticeView {
 
     enum Appearance {
         static let actionBackgroundColor = UIColor.systemColor(.secondarySystemGroupedBackground)
-        static let actionColor: UIColor = .primaryButtonBackground
+        static let actionColor: UIColor = .accent
         static let shadowColor: UIColor = .black
         static let shadowOpacity: Float = 0.2
         static let shadowRadius: CGFloat = 8.0


### PR DESCRIPTION
Closes WOOMOB-3556

## Description

The in-app foreground notice shown for a new-order push (a `Notice` with a **View** action) truncated its title on iPhone, rendered **View** in a muted colour in dark mode, and drew **View** as a floating rounded pill instead of the flush action area. All three only surface when the app is built with the iOS 26 SDK — it's SDK-gated, not tied to the device's iOS version, which is why they reproduced on iOS 18.

- **Truncation** — `NoticeView`'s horizontal `.fill` stack `[label, action button]` left both at the default content-hugging priority. Under the iOS 26 SDK the stack breaks that tie by stretching the button to ~half the notice, leaving the title no room ("You have 1 new ord…"). The label block now gets a greedy fill width so it takes the available space while the button keeps its intrinsic size.
- **Colour** — **View** used `.primaryButtonBackground`, a non-adaptive purple with no dark variant, so in dark mode it stayed darker than every other accent. Switched to the adaptive `.accent` (no-op in light mode).
- **Rounded corners / floating pill** — on the iOS 26 SDK a button with a `UIButton.Configuration` draws its own inset, rounded background, turning the flush action area into a floating rounded pill. Resolved by clearing the configuration background (`.background = .clear()`) so the button's flush `backgroundColor` fills the frame, restoring the original two-tone split (iOS 18 was already correct).

## Test Steps

1. On an iPhone, log into a store and stay on a main tab (e.g. My Store) with notifications enabled.
2. Trigger a new-order push while the app is foregrounded (place an order on the store).
3. Confirm the in-app notice shows the full title (not truncated) with **View** hugging the right edge.
4. Switch to dark mode and repeat — confirm **View** matches the app's other purple accents, not a darker/muted purple.

## Screenshots

| Case | Before | After |
| --- | --- | --- |
| iPhone · iOS 26 · light | <img width="1179" height="2556" alt="before-iphone-26-light" src="https://github.com/user-attachments/assets/b12ad75d-f5bf-4d9a-8aef-36eead7867a7" /> | <img width="1179" height="2556" alt="after-iphone-26-light" src="https://github.com/user-attachments/assets/dfa0a530-2658-4fcd-b7f9-b2231d6de293" /> |
| iPhone · iOS 26 · dark | <img width="1179" height="2556" alt="before-iphone-26-dark" src="https://github.com/user-attachments/assets/8f9dd743-ce6b-47ed-8a03-403f9aa3ebf1" /> | <img width="1179" height="2556" alt="after-iphone-26-dark" src="https://github.com/user-attachments/assets/97db4c19-8168-4669-8823-4540774de5ba" /> |
| iPhone · iOS 18 · light | <img width="1179" height="2556" alt="before-iphone-18-light" src="https://github.com/user-attachments/assets/3a647019-ec6c-48b3-85af-ed5b31d9a015" /> | <img width="1179" height="2556" alt="after-iphone-18-light" src="https://github.com/user-attachments/assets/f807c82f-9a5b-44ea-a1b1-b4951ad76478" /> |
| iPhone · iOS 18 · dark | <img width="1179" height="2556" alt="before-iphone-18-dark" src="https://github.com/user-attachments/assets/3b939ab5-ac60-4a00-8d5b-9eb1167cb135" /> | <img width="1179" height="2556" alt="after-iphone-18-dark" src="https://github.com/user-attachments/assets/8954f5a6-2cb8-46c3-9c57-cb85a1669b20" /> |
| iPad · iOS 26 | <img width="1668" height="2420" alt="before-ipad-26" src="https://github.com/user-attachments/assets/a548906f-b3fc-4758-86a0-74553133bd1f" /> | <img width="1668" height="2420" alt="after-ipad-26" src="https://github.com/user-attachments/assets/b502795b-8aa3-471a-a01c-243b32e6c094" /> |
| iPad · iOS 18 | <img width="1668" height="2420" alt="before-ipad-18" src="https://github.com/user-attachments/assets/d856217b-dd1d-4b47-92db-4e5b5ed0dd17" /> | <img width="1668" height="2420" alt="after-ipad-18" src="https://github.com/user-attachments/assets/a63e2bd3-5ba3-464e-9af4-cd484512a7c3" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

