### PR TITLE
[WOOMOB-3658] Send a persistent device id in remote feature flag requests

### DIFF
--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -9,10 +9,18 @@ public protocol FeatureFlagRemoteProtocol {
 /// Feature Flags: Remote Endpoints
 ///
 public class FeatureFlagRemote: Remote, FeatureFlagRemoteProtocol {
+    private let userDefaults: UserDefaults
+
+    public init(network: Network, userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        super.init(network: network)
+    }
+
     public func loadAllFeatureFlags() async throws -> [RemoteFeatureFlag: Bool] {
         let parameters: [String: String] = [
             ParameterKeys.platform: "ios",
             ParameterKeys.marketingVersion: Bundle.main.marketingVersion,
+            ParameterKeys.deviceID: deviceID,
         ]
 
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: Paths.lookup, parameters: parameters)
@@ -23,6 +31,16 @@ public class FeatureFlagRemote: Remote, FeatureFlagRemoteProtocol {
             }
             return (featureFlag, value)
         })
+    }
+
+    /// Stable per-install identifier sent as `device_id` for rollout bucketing.
+    private var deviceID: String {
+        if let storedID = userDefaults.string(forKey: UserDefaultsKeys.deviceID) {
+            return storedID
+        }
+        let newID = UUID().uuidString
+        userDefaults.set(newID, forKey: UserDefaultsKeys.deviceID)
+        return newID
     }
 }
 
@@ -91,5 +109,10 @@ private extension FeatureFlagRemote {
     enum ParameterKeys {
         static let platform = "platform"
         static let marketingVersion = "marketing_version"
+        static let deviceID = "device_id"
+    }
+
+    enum UserDefaultsKeys {
+        static let deviceID = "FeatureFlagDeviceID"
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
@@ -60,6 +60,39 @@ final class FeatureFlagRemoteTests: XCTestCase {
         })
     }
 
+    @MainActor
+    func test_loadAllFeatureFlags_when_no_device_id_is_stored_then_sends_a_generated_device_id_and_persists_it() async throws {
+        // Given
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: "FeatureFlagRemoteTests.\(UUID().uuidString)"))
+        let remote = FeatureFlagRemote(network: network, userDefaults: userDefaults)
+        network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "feature-flags-load-all")
+
+        // When
+        _ = try await remote.loadAllFeatureFlags()
+
+        // Then
+        let queryParameters = try XCTUnwrap(network.queryParametersDictionary)
+        let sentDeviceID = try XCTUnwrap(queryParameters["device_id"] as? String)
+        XCTAssertFalse(sentDeviceID.isEmpty)
+        XCTAssertEqual(userDefaults.string(forKey: "FeatureFlagDeviceID"), sentDeviceID)
+    }
+
+    @MainActor
+    func test_loadAllFeatureFlags_when_a_device_id_is_stored_then_sends_the_stored_device_id() async throws {
+        // Given
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: "FeatureFlagRemoteTests.\(UUID().uuidString)"))
+        userDefaults.set("stored-device-id", forKey: "FeatureFlagDeviceID")
+        let remote = FeatureFlagRemote(network: network, userDefaults: userDefaults)
+        network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "feature-flags-load-all")
+
+        // When
+        _ = try await remote.loadAllFeatureFlags()
+
+        // Then
+        let queryParameters = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertEqual(queryParameters["device_id"] as? String, "stored-device-id")
+    }
+
     // MARK: - RemoteFeatureFlag rawValue mapping
 
     func test_rawValue_when_woo_mobile_ai_assistant_then_maps_to_wooAIAssistant_case() {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.3
 -----
+- [Internal] Send a persistent device id in remote feature flag requests so logins without a WordPress.com account are included in progressive rollouts. [https://github.com/woocommerce/woocommerce-ios/pull/17605]
 - [*] Payments: fixed successful in-person payments appearing to fail when the capture response is interrupted. [https://github.com/woocommerce/woocommerce-ios/pull/17593]
 - [Internal] Add `payment_method_type` and `currency` properties to receipt Tracks events for Android parity. [https://github.com/woocommerce/woocommerce-ios/pull/17548]
 - [*] Fixed products failing to load when a plugin returns null for a product's categories, tags, images, or other list fields. [https://github.com/woocommerce/woocommerce-ios/pull/17545]


### PR DESCRIPTION
## Description

Fixes WOOMOB-3658

The app does not send a `device_id` when it fetches remote feature flags. The endpoint expects a device id for the percentage rollout to work, so logins without a WordPress.com account are not spread across the rollout percentages. Logins with a WordPress.com account are unaffected.

This sends a persistent anonymous UUID instead, generated once and stored in `UserDefaults`, matching what the [WordPress iOS app](https://github.com/wordpress-mobile/WordPress-iOS/blob/57bed95278c682ed2857fd76c4f28f66aec4ed23/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift#L17-L28) does. The Android counterpart is https://github.com/woocommerce/woocommerce-android/pull/16300.

Before, on trunk:

```
FeatureFlagsRequest: https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags?marketing_version=25.2&platform=ios
```

After, on this branch:

```
FeatureFlagsRequest: https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags?device_id=7A0E5DE6-****-****-****-********07F1&marketing_version=25.2&platform=ios
```

## Test Steps

Apply this patch to log the request:

```diff
--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -24,6 +24,9 @@ public class FeatureFlagRemote: Remote, FeatureFlagRemoteProtocol {
         ]
 
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: Paths.lookup, parameters: parameters)
+        if let url = try? request.asURLRequest().url {
+            print("FeatureFlagsRequest: \(url.absoluteString)")
+        }
         let valuesByFeatureFlagString: [String: Bool] = try await enqueue(request)
         return Dictionary(uniqueKeysWithValues: valuesByFeatureFlagString.compactMap { key, value in
             guard let featureFlag = RemoteFeatureFlag(rawValue: key) else {
```

1. Build and install the app.
2. Log in with site credentials.
3. Filter the Xcode console by `FeatureFlagsRequest` and confirm `device_id` carries a UUID.
4. Relaunch the app.
5. Confirm the same UUID is sent.

## Screenshots

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.