### PR TITLE
Clarify IPP country-not-supported wording during onboarding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripeViewModel.swift
@@ -20,7 +20,8 @@ struct InPersonPaymentsCountryNotSupportedStripeViewModel {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "We don’t support In‑Person Payments with Stripe in %1$@",
+        "inPersonPayments.countryNotSupportedStripe.title",
+        value: "We don’t support card In‑Person Payments with Stripe in %1$@",
         comment: """
                  Title for the error screen when In-Person Payments is not supported in a specific country
                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
@@ -29,7 +30,8 @@ private enum Localization {
     )
 
     static let titleUnknownCountry = NSLocalizedString(
-        "We don’t support In‑Person Payments with Stripe in your country",
+        "inPersonPayments.countryNotSupportedStripe.titleUnknownCountry",
+        value: "We don’t support card In‑Person Payments with Stripe in your country",
         comment: """
                  Title for the error screen when In-Person Payments is not supported because we don't know the name of the country
                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedViewModel.swift
@@ -20,7 +20,8 @@ struct InPersonPaymentsCountryNotSupportedViewModel {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "We don’t support In‑Person Payments in %1$@",
+        "inPersonPayments.countryNotSupported.title",
+        value: "We don’t support card In‑Person Payments in %1$@",
         comment: """
                  Title for the error screen when In-Person Payments is not supported in a specific country
                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
@@ -29,7 +30,8 @@ private enum Localization {
     )
 
     static let titleUnknownCountry = NSLocalizedString(
-        "We don’t support In‑Person Payments in your country",
+        "inPersonPayments.countryNotSupported.titleUnknownCountry",
+        value: "We don’t support card In‑Person Payments in your country",
         comment: """
                  Title for the error screen when In-Person Payments is not supported because we don't know the name of the country.
                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedViewModelsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedViewModelsTests.swift
@@ -13,6 +13,7 @@ struct InPersonPaymentsCountryNotSupportedViewModelsTests {
         let expectedCountryName = try #require(Locale.current.localizedString(forRegionCode: "ES"))
 
         // Then
+        #expect(sut.title.contains("card In‑Person Payments"))
         #expect(sut.title.contains(expectedCountryName))
     }
 
@@ -21,6 +22,7 @@ struct InPersonPaymentsCountryNotSupportedViewModelsTests {
         let sut = InPersonPaymentsCountryNotSupportedViewModel(countryCode: .unknown, analyticReason: "")
 
         // Then
+        #expect(sut.title.contains("card In‑Person Payments"))
         #expect(sut.title.contains("your country"))
         #expect(!sut.title.contains("%1$@"))
     }
@@ -31,6 +33,7 @@ struct InPersonPaymentsCountryNotSupportedViewModelsTests {
         let expectedCountryName = try #require(Locale.current.localizedString(forRegionCode: "ES"))
 
         // Then
+        #expect(sut.title.contains("card In‑Person Payments"))
         #expect(sut.title.contains(expectedCountryName))
         #expect(sut.title.contains("Stripe"))
     }
@@ -40,6 +43,7 @@ struct InPersonPaymentsCountryNotSupportedViewModelsTests {
         let sut = InPersonPaymentsCountryNotSupportedStripeViewModel(countryCode: .unknown, analyticReason: "")
 
         // Then
+        #expect(sut.title.contains("card In‑Person Payments"))
         #expect(sut.title.contains("your country"))
         #expect(!sut.title.contains("%1$@"))
     }


### PR DESCRIPTION
## Description
Closes WOOMOB-3529

This PR clarifies the IPP country-not-supported onboarding titles to say “card In-Person Payments” instead of “In-Person Payments”, as well as the country if is known. This makes it clearer that only card-based in-person payments are unsupported in the selected country. Merchants can still accept in-person cash payments via Cash on Delivery, as noted in the existing screen.

## Test Steps (optional)
This seems to be more of an edge case as when it was initially reported, since `countryNotSupported` no longer returns this view as it's mostly guarded away, only `countryNotSupportedStripe` seems to be reachable. In this case requires: 
1. Reachable when the country is supported for IPP generally/WooPayments
2. But not supported for Stripe
3. And the store has only Stripe as the active/selected gateway.

It looks that only `PR`, `CA`, and `AU` would fit this case. I've attached a -high quality- gif that shows the difference between Stripe being installed but disabled vs enabled for a CA store.

## Screenshots

| Header | Header |
|--------|--------|
| <img width="400" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-07-24 at 11 30 58" src="https://github.com/user-attachments/assets/9003fe23-7e8a-4725-b634-7b65c6257bc0" /> | <img width="400"  alt="Simulator Screen Recording - iPhone 16 Pro Max - Logged wpcom a8c - 2026-07-24 at 11 30 48" src="https://github.com/user-attachments/assets/49d751d3-6d8a-426a-be00-029f06af7ca2" /> | 

