### PR TITLE
Prevent offline banner updates during navigation transitions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.3
 -----
+- [Internal] Prevent offline banner updates from overlapping navigation transitions. [https://github.com/woocommerce/woocommerce-ios/pull/17611]
 - [Internal] Send a persistent device id in remote feature flag requests so logins without a WordPress.com account are included in progressive rollouts. [https://github.com/woocommerce/woocommerce-ios/pull/17605]
 - [*] Payments: fixed successful in-person payments appearing to fail when the capture response is interrupted. [https://github.com/woocommerce/woocommerce-ios/pull/17593]
 - [Internal] Add `payment_method_type` and `currency` properties to receipt Tracks events for Android parity. [https://github.com/woocommerce/woocommerce-ios/pull/17548]

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -54,7 +54,7 @@ extension WooNavigationController {
 /// Make sure to implement the method in ALL subclasses of `WooNavigationController`,
 /// otherwise it will break the interactive pop gesture.
 ///
-private class WooNavigationControllerDelegate: NSObject, UINavigationControllerDelegate {
+final class WooNavigationControllerDelegate: NSObject, UINavigationControllerDelegate {
 
     private let connectivityObserver: ConnectivityObserver
     private weak var currentController: UIViewController?
@@ -116,9 +116,41 @@ private extension WooNavigationControllerDelegate {
         connectivityObserver.statusPublisher
             .sink { [weak self] status in
                 guard let self, let currentController = self.currentController else { return }
-                self.configureOfflineBanner(for: currentController, status: status)
+                self.configureOfflineBannerWhenNavigationIsStable(for: currentController, status: status)
             }
             .store(in: &subscriptions)
+    }
+
+    /// Connectivity can change while a navigation transition is updating content overlay insets.
+    /// Updating the safe area at the same time can cause UIKit to recursively lay out the navigation hierarchy.
+    func configureOfflineBannerWhenNavigationIsStable(for viewController: UIViewController, status: ConnectivityStatus) {
+        guard isVisibleTopViewController(viewController) else {
+            return
+        }
+
+        guard let transitionCoordinator = viewController.navigationController?.transitionCoordinator else {
+            return configureOfflineBanner(for: viewController, status: status)
+        }
+
+        let scheduledAlongsideTransition = transitionCoordinator.animate(alongsideTransition: nil) { [weak self, weak viewController] _ in
+            guard let self, let viewController, self.isVisibleTopViewController(viewController) else {
+                return
+            }
+            self.configureOfflineBanner(for: viewController, status: status)
+        }
+
+        if !scheduledAlongsideTransition {
+            configureOfflineBanner(for: viewController, status: status)
+        }
+    }
+
+    func isVisibleTopViewController(_ viewController: UIViewController) -> Bool {
+        guard viewController.viewIfLoaded?.window != nil,
+              let navigationController = viewController.navigationController else {
+            return false
+        }
+
+        return navigationController.topViewController === viewController
     }
 
     /// Shows or hides offline banner based on the input connectivity status and

--- a/WooCommerce/WooCommerceTests/System/WooNavigationControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooNavigationControllerTests.swift
@@ -1,0 +1,84 @@
+import Testing
+import UIKit
+import WooFoundation
+@testable import WooCommerce
+
+@MainActor
+@Suite(.serialized)
+struct WooNavigationControllerTests {
+
+    @Test func test_connectivity_change_when_current_controller_is_visible_and_top_then_updates_offline_banner() {
+        // Given
+        let connectivityObserver = MockConnectivityObserver()
+        let sut = WooNavigationControllerDelegate(connectivityObserver: connectivityObserver)
+        let viewController = OfflineBannerViewController()
+        let navigationController = StableNavigationController(rootViewController: viewController)
+        let window = makeVisibleWindow(rootViewController: navigationController)
+        sut.navigationController(navigationController, didShow: viewController, animated: false)
+
+        // When
+        connectivityObserver.setStatus(.notReachable)
+
+        // Then
+        #expect(viewController.view.subviews.contains { $0 is OfflineBannerView })
+        #expect(viewController.additionalSafeAreaInsets.bottom == OfflineBannerView.height)
+        _ = window
+    }
+
+    @Test func test_connectivity_change_when_current_controller_is_no_longer_top_then_does_not_update_offline_banner() {
+        // Given
+        let connectivityObserver = MockConnectivityObserver()
+        let sut = WooNavigationControllerDelegate(connectivityObserver: connectivityObserver)
+        let viewController = OfflineBannerViewController()
+        let navigationController = StableNavigationController(rootViewController: viewController)
+        let window = makeVisibleWindow(rootViewController: navigationController)
+        sut.navigationController(navigationController, didShow: viewController, animated: false)
+        navigationController.pushViewController(UIViewController(), animated: false)
+
+        // When
+        connectivityObserver.setStatus(.notReachable)
+
+        // Then
+        #expect(viewController.view.subviews.contains { $0 is OfflineBannerView } == false)
+        #expect(viewController.additionalSafeAreaInsets == .zero)
+        _ = window
+    }
+
+    @Test func test_connectivity_change_when_current_controller_is_not_visible_then_does_not_update_offline_banner() {
+        // Given
+        let connectivityObserver = MockConnectivityObserver()
+        let sut = WooNavigationControllerDelegate(connectivityObserver: connectivityObserver)
+        let viewController = OfflineBannerViewController()
+        let navigationController = StableNavigationController(rootViewController: viewController)
+        sut.navigationController(navigationController, didShow: viewController, animated: false)
+
+        // When
+        connectivityObserver.setStatus(.notReachable)
+
+        // Then
+        #expect(viewController.view.subviews.contains { $0 is OfflineBannerView } == false)
+        #expect(viewController.additionalSafeAreaInsets == .zero)
+    }
+}
+
+private extension WooNavigationControllerTests {
+    func makeVisibleWindow(rootViewController: UIViewController) -> UIWindow {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = rootViewController
+        window.makeKeyAndVisible()
+        rootViewController.view.layoutIfNeeded()
+        return window
+    }
+}
+
+private final class OfflineBannerViewController: UIViewController {
+    override var shouldShowOfflineBanner: Bool {
+        true
+    }
+}
+
+private final class StableNavigationController: WooNavigationController {
+    override var transitionCoordinator: UIViewControllerTransitionCoordinator? {
+        nil
+    }
+}


### PR DESCRIPTION
Closes: WOOMOB-3694

## Description
A connectivity change can update the offline banner while a navigation transition is also updating UIKit content-overlay insets. On iOS 26, that overlap may trigger incorrect layout, and crash.

This PR defers banner updates until the transition completes, then confirms the expected controller is visible and topmost before changing its safe-area inset.

## Test Steps
I couldn't repro this.

Check that the offline banner shows and hides as expected

Optionally navigate rapidly between Order list/detail screens while toggling network connectivity, and confirm the offline banner retains its existing appearance and placement.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.