### PR TITLE
Test translation context suggestions for iOS strings

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -9,11 +9,11 @@ unless respond_to?(:translation_context_checker)
   gem_dir = Dir.mktmpdir('i18n-context-generator-gems')
   installed = Bundler.with_unbundled_env do
     system(
-      'gem', 'install', 'i18n-context-generator', '--version', '0.5.0',
+      'gem', 'install', 'i18n-context-generator', '--version', '0.5.1',
       '--no-document', '--install-dir', gem_dir
     )
   end
-  raise 'Could not install i18n-context-generator 0.5.0' unless installed
+  raise 'Could not install i18n-context-generator 0.5.1' unless installed
 
   Dir.glob(File.join(gem_dir, 'gems', '*', 'lib')).each { |path| $LOAD_PATH.unshift(path) }
   require 'i18n_context_generator'

--- a/Dangerfile
+++ b/Dangerfile
@@ -15,7 +15,12 @@ unless respond_to?(:translation_context_checker)
   end
   raise 'Could not install i18n-context-generator 0.5.2' unless installed
 
-  Dir.glob(File.join(gem_dir, 'gems', '*', 'lib')).each { |path| $LOAD_PATH.unshift(path) }
+  Dir.glob(File.join(gem_dir, 'specifications', '*.gemspec')).each do |path|
+    specification = Gem::Specification.load(path)
+    specification.require_paths.each do |require_path|
+      $LOAD_PATH.unshift(File.join(specification.full_gem_path, require_path))
+    end
+  end
   require 'i18n_context_generator'
 
   Dir.mktmpdir('dangermattic-translation-context') do |plugin_dir|

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,6 +2,33 @@
 
 github.dismiss_out_of_range_messages
 
+unless respond_to?(:translation_context_checker)
+  require 'bundler'
+  require 'tmpdir'
+
+  gem_dir = Dir.mktmpdir('i18n-context-generator-gems')
+  installed = Bundler.with_unbundled_env do
+    system(
+      'gem', 'install', 'i18n-context-generator', '--version', '0.5.0',
+      '--no-document', '--install-dir', gem_dir
+    )
+  end
+  raise 'Could not install i18n-context-generator 0.5.0' unless installed
+
+  Dir.glob(File.join(gem_dir, 'gems', '*', 'lib')).each { |path| $LOAD_PATH.unshift(path) }
+  require 'i18n_context_generator'
+
+  Dir.mktmpdir('dangermattic-translation-context') do |plugin_dir|
+    cloned = system(
+      'git', 'clone', '--quiet', '--depth', '1', '--branch', 'iangmaia/add-translation-context-plugin',
+      'https://github.com/Automattic/dangermattic.git', plugin_dir
+    )
+    raise 'Could not load Dangermattic translation context plugin' unless cloned
+
+    danger.import_plugin(File.join(plugin_dir, 'lib/dangermattic/plugins/translation_context_checker.rb'))
+  end
+end
+
 translation_context_checker.check_context_suggestions(
   discovery_mode: :translations,
   source_paths: ['WooCommerce/Classes/'],

--- a/Dangerfile
+++ b/Dangerfile
@@ -9,11 +9,11 @@ unless respond_to?(:translation_context_checker)
   gem_dir = Dir.mktmpdir('i18n-context-generator-gems')
   installed = Bundler.with_unbundled_env do
     system(
-      'gem', 'install', 'i18n-context-generator', '--version', '0.5.1',
+      'gem', 'install', 'i18n-context-generator', '--version', '0.5.2',
       '--no-document', '--install-dir', gem_dir
     )
   end
-  raise 'Could not install i18n-context-generator 0.5.1' unless installed
+  raise 'Could not install i18n-context-generator 0.5.2' unless installed
 
   Dir.glob(File.join(gem_dir, 'gems', '*', 'lib')).each { |path| $LOAD_PATH.unshift(path) }
   require 'i18n_context_generator'
@@ -29,11 +29,10 @@ unless respond_to?(:translation_context_checker)
   end
 end
 
-translation_context_checker.check_context_suggestions(
-  discovery_mode: :translations,
+translation_context_checker.check_resource_changes(
   source_paths: ['WooCommerce/Classes/'],
-  translation_paths: 'WooCommerce/Resources/en.lproj/Localizable.strings',
-  inline_mode: :translation_suggestion,
+  resource_paths: 'WooCommerce/Resources/en.lproj/Localizable.strings',
+  inline_mode: :resource_suggestion,
   report_type: :warning
 )
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -34,7 +34,6 @@ translation_context_checker.check_context_suggestions(
   source_paths: ['WooCommerce/Classes/'],
   translation_paths: 'WooCommerce/Resources/en.lproj/Localizable.strings',
   inline_mode: :translation_suggestion,
-  summary: true,
   report_type: :warning
 )
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,6 +2,15 @@
 
 github.dismiss_out_of_range_messages
 
+translation_context_checker.check_context_suggestions(
+  discovery_mode: :translations,
+  source_paths: ['WooCommerce/Classes/'],
+  translation_paths: 'WooCommerce/Resources/en.lproj/Localizable.strings',
+  inline_mode: :translation_suggestion,
+  summary: true,
+  report_type: :warning
+)
+
 # `files: []` forces rubocop to scan all files, not just the ones modified in the PR
 rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'danger-dangermattic', '~> 1.4'
+gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic.git', branch: 'iangmaia/add-translation-context-plugin'
 gem 'dotenv'
 gem 'fastlane', '~> 2.237'
 gem 'fastlane-plugin-firebase_app_distribution', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/Automattic/dangermattic.git
-  revision: 21a63ef9531f011aff31a07c46128eff4b080570
+  revision: 59227cd8538059fba81fb1cd72f8bc12addbba48
   branch: iangmaia/add-translation-context-plugin
   specs:
-    danger-dangermattic (1.4.0)
+    danger-dangermattic (1.4.1)
       danger (~> 9.6)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)
-      i18n-context-generator (~> 0.5)
+      i18n-context-generator (~> 0.5.2)
       rubocop (~> 1.63)
 
 GEM
@@ -258,7 +258,7 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
-    i18n-context-generator (0.5.1)
+    i18n-context-generator (0.5.2)
       concurrent-ruby (~> 1.2)
       csv (~> 3.3)
       dotstrings (~> 0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/Automattic/dangermattic.git
+  revision: 21a63ef9531f011aff31a07c46128eff4b080570
+  branch: iangmaia/add-translation-context-plugin
+  specs:
+    danger-dangermattic (1.4.0)
+      danger (~> 9.6)
+      danger-plugin-api (~> 1.0)
+      danger-rubocop (~> 0.13)
+      i18n-context-generator (~> 0.5)
+      rubocop (~> 1.63)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -43,6 +55,7 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
+    concurrent-ruby (1.3.8)
     cork (0.3.0)
       colored2 (~> 3.1)
     csv (3.3.5)
@@ -60,11 +73,6 @@ GEM
       octokit (>= 4.0)
       pstore (~> 0.1)
       terminal-table (>= 1, < 5)
-    danger-dangermattic (1.4.0)
-      danger (~> 9.5, >= 9.5.3)
-      danger-plugin-api (~> 1.0)
-      danger-rubocop (~> 0.13)
-      rubocop (~> 1.63)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
     danger-rubocop (0.13.0)
@@ -76,6 +84,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
+    dotstrings (0.6.0)
     emoji_regex (3.2.3)
     erubi (1.13.1)
     excon (1.5.0)
@@ -249,6 +258,14 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
+    i18n-context-generator (0.5.0)
+      concurrent-ruby (~> 1.2)
+      csv (~> 3.3)
+      dotstrings (~> 0.6)
+      oj (~> 3.16)
+      rexml (~> 3.2)
+      thor (~> 1.5)
+      tty-progressbar (~> 0.18)
     java-properties (0.3.0)
     jmespath (1.6.2)
     json (2.20.0)
@@ -279,6 +296,9 @@ GEM
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    oj (3.17.4)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
     open4 (1.3.4)
     openssl (4.0.2)
     options (2.3.2)
@@ -346,12 +366,19 @@ GEM
       CFPropertyList
       naturally
     singleton (0.3.0)
+    strings-ansi (0.2.0)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     text (1.3.1)
+    thor (1.5.0)
     trailblazer-option (0.1.2)
     tty-cursor (0.7.1)
+    tty-progressbar (0.18.3)
+      strings-ansi (~> 0.2)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      unicode-display_width (>= 1.6, < 3.0)
     tty-screen (0.8.2)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
@@ -379,7 +406,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger-dangermattic (~> 1.4)
+  danger-dangermattic!
   dotenv
   fastlane (~> 2.237)
   fastlane-plugin-firebase_app_distribution (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
-    i18n-context-generator (0.5.0)
+    i18n-context-generator (0.5.1)
       concurrent-ruby (~> 1.2)
       csv (~> 3.3)
       dotstrings (~> 0.6)

--- a/WooCommerce/Classes/ViewRelated/TranslationContextPluginTest.swift
+++ b/WooCommerce/Classes/ViewRelated/TranslationContextPluginTest.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Test-only localized strings for exercising translation-context suggestions.
+enum TranslationContextPluginTest {
+    static let saveOrderButtonTitle = NSLocalizedString(
+        "translation.context.test.order.saveButtonTitle",
+        value: "Save",
+        comment: "Button title"
+    )
+
+    static let processingOrderStatus = NSLocalizedString(
+        "translation.context.test.order.processingStatus",
+        value: "Processing",
+        comment: ""
+    )
+
+    static let orderNotePlaceholder = NSLocalizedString(
+        "translation.context.test.order.notePlaceholder",
+        value: "Add a note",
+        comment: ""
+    )
+}

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -16988,3 +16988,10 @@ If your translation of that term also happens to contains a hyphen, please be su
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Collect Payment";
 
+/* Button title */
+"translation.context.test.order.saveButtonTitle" = "Save";
+
+"translation.context.test.order.processingStatus" = "Processing";
+
+"translation.context.test.order.notePlaceholder" = "Add a note";
+


### PR DESCRIPTION
## Description

This is a do-not-merge integration test for the `translation_context_checker` from https://github.com/Automattic/dangermattic/pull/112. It pins that branch, adds three deliberately under-described legacy `Localizable.strings` entries with Swift usages, and requests inline translation suggestions.

The fixtures represent the Save button in an order editor, the status shown while that order is processing, and the placeholder for adding an internal order note. This description is intentionally self-contained because pull request title and description context is enabled by default.

## Test Steps

1. Wait for the Danger PR check to complete.
2. Confirm the shared Danger environment bootstraps `i18n-context-generator` 0.5.1 and loads the complete plugin from the Dangermattic branch.
3. Confirm it suggests translator comments inline on all three changed `.strings` entries without duplicating them in the PR summary.
4. Confirm the suggestions reflect the order-editor meanings described above.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
