### PR TITLE
[WOOMOB-3693] Fix stuck Log In button after entering a wrong email

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -114,12 +114,14 @@ class AuthenticationManager: Authentication {
                 self.analytics.track(.loginPrologueContinueTapped)
                 return false
             }
-            // A coordinator is already driving the QR-login flow — e.g. a rapid
-            // second tap while the availability check from the first tap was
-            // still in flight. Don't build a second one; it would orphan the
-            // first along with its navigation stack.
-            guard self.qrLoginCoordinator == nil else {
-                return true
+            // Reuse a coordinator only while its QR screens are still live (e.g.
+            // a rapid second tap); release a stale one an error-screen restart
+            // left behind, or its tap is swallowed forever.
+            if let existingCoordinator = self.qrLoginCoordinator {
+                guard existingCoordinator.isNavigationStackShowingQRFlow == false else {
+                    return true
+                }
+                self.qrLoginCoordinator = nil
             }
             // Track the click while the active flow is still `prologue`;
             // the QR coordinator's `start()` switches it to `login_qr`.

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -59,6 +59,8 @@ final class QRLoginCoordinator {
     /// stack once it has delivered a payload. (WOOMOB-3136)
     private weak var scannerViewController: UIViewController?
 
+    private weak var rootViewController: UIViewController?
+
     init(mode: Mode = .camera,
          navigationController: UINavigationController,
          parser: QRLoginPayloadParser = QRLoginPayloadParser(),
@@ -101,11 +103,12 @@ final class QRLoginCoordinator {
         handleScanned(payload: payload)
     }
 
-    /// Whether any of this flow's own screens are still on the navigation stack.
+    /// Whether this flow's own screens are still on the navigation stack.
     var isNavigationStackShowingQRFlow: Bool {
-        [prologueViewController, scannerViewController]
-            .compactMap { $0 }
-            .contains { navigationController.viewControllers.contains($0) }
+        guard let rootViewController else {
+            return false
+        }
+        return navigationController.viewControllers.contains(rootViewController)
     }
 }
 
@@ -468,6 +471,9 @@ private extension QRLoginCoordinator {
                 title: Localization.help,
                 primaryAction: UIAction { [weak self] _ in self?.showHelp() }
             )
+        }
+        if rootViewController == nil {
+            rootViewController = hosting
         }
         navigationController.pushViewController(hosting, animated: true)
         return hosting

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -100,6 +100,13 @@ final class QRLoginCoordinator {
     func presentDeepLink(payload: QRLoginPayload) {
         handleScanned(payload: payload)
     }
+
+    /// Whether any of this flow's own screens are still on the navigation stack.
+    var isNavigationStackShowingQRFlow: Bool {
+        [prologueViewController, scannerViewController]
+            .compactMap { $0 }
+            .contains { navigationController.viewControllers.contains($0) }
+    }
 }
 
 // MARK: - Prologue + scanner


### PR DESCRIPTION
Closes WOOMOB-3693

## Description

In the login flow, entering a non-existing email and choosing "Log in with another account" left the **Log In** button dead — tapping it gave visual feedback but never navigated, and the app had to be force-closed to recover. This regressed in 25.2 when QR login became the default Log In route (#17508)

The cause is a leaked `QRLoginCoordinator`. When an error-screen restart runs `NavigateToRoot` it pops the QR-login screens but never releases the coordinator. The prologue Log In guard (`guard qrLoginCoordinator == nil`) then swallowed every subsequent tap forever.

The guard now reuses a coordinator only while its QR screens are still on the navigation stack — the rapid double-tap case it was protecting — and releases a stale one left behind by an error restart so a fresh flow starts. A new `isNavigationStackShowingQRFlow` property on the coordinator reports whether its screens are still live.

## Test Steps

1. Fresh install / Log out of the app
2. Reach the screen to provide site address
3. Input a woo site
4. Provide a non-existing email address
5. Tap continue
6. On the next scree tap "Log in with an other account"
7. Tap "Log in"
8. QR login screen is shown


## Screenshots

| Before | After |
| --- | --- |
| <img width="256" height="554" alt="ScreenRecording_07-24-2026 12-44-39_1" src="https://github.com/user-attachments/assets/971de704-da66-4694-bd50-c6d78e1c70ba" /> | <img width="256" height="554" alt="ScreenRecording_07-24-2026 15-48-50_1" src="https://github.com/user-attachments/assets/ee3cf901-5275-44f5-b6b9-1e7b08da62a1" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.