### PR TITLE
Add transient currency-scoped product retrieval

### DIFF
--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -12,6 +12,12 @@ public protocol ProductVariationsRemoteProtocol {
                                   pageNumber: Int,
                                   pageSize: Int,
                                   completion: @escaping ([ProductVariation]?, Error?) -> Void)
+    func loadProductVariations(for siteID: Int64,
+                               productID: Int64,
+                               variationIDs: [Int64],
+                               pageNumber: Int,
+                               pageSize: Int,
+                               currency: String?) async throws -> [ProductVariation]
     func loadVariationsForPointOfSale(for siteID: Int64,
                                       parentProductID: Int64,
                                       pageNumber: Int) async throws -> PagedItems<POSProductVariation>
@@ -71,6 +77,23 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    public func loadProductVariations(for siteID: Int64,
+                                      productID: Int64,
+                                      variationIDs: [Int64] = [],
+                                      pageNumber: Int,
+                                      pageSize: Int,
+                                      currency: String? = nil) async throws -> [ProductVariation] {
+        let request = productVariationsRequest(for: siteID,
+                                               productID: productID,
+                                               variationIDs: variationIDs,
+                                               context: nil,
+                                               pageNumber: pageNumber,
+                                               pageSize: pageSize,
+                                               currency: currency)
+        let mapper = ProductVariationListMapper(siteID: siteID, productID: productID)
+        return try await enqueue(request, mapper: mapper)
+    }
+
     /// Retrieves all of the `ProductVariation`s available in POS.
     /// - Parameters:
     ///   - siteID: Site for which we'll fetch remote product variations.
@@ -113,7 +136,8 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                           context: String?,
                                           pageNumber: Int,
                                           pageSize: Int,
-                                          posProductsOnly: Bool = false) -> JetpackRequest {
+                                          posProductsOnly: Bool = false,
+                                          currency: String? = nil) -> JetpackRequest {
         let stringOfVariationIDs = variationIDs.map { String($0) }
             .joined(separator: ",")
         let stringOfRequiredFields = fields.joined(separator: ",")
@@ -127,7 +151,8 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
             ParameterKey.status: status?.rawValue,
             ParameterKey.orderBy: orderBy?.rawValue,
             ParameterKey.order: order?.rawValue,
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(posProductsOnly),
+            ParameterKey.currency: currency
         ]
             .compactMapValues { $0 }
 
@@ -357,6 +382,7 @@ public extension ProductVariationsRemote {
         static let orderBy: String    = "orderby"
         static let order: String      = "order"
         static let posProductsOnly: String = "pos_products_only"
+        static let currency = "currency"
     }
 
     enum OrderByField: String {

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -21,7 +21,8 @@ public protocol ProductsRemoteProtocol {
                          orderBy: ProductsRemote.OrderKey,
                          order: ProductsRemote.Order,
                          productIDs: [Int64],
-                         excludedProductIDs: [Int64]) async throws -> [Product]
+                         excludedProductIDs: [Int64],
+                         currency: String?) async throws -> [Product]
     func searchProducts(for siteID: Int64,
                         keyword: String,
                         searchFields: [ProductSearchField],
@@ -31,11 +32,13 @@ public protocol ProductsRemoteProtocol {
                         productStatus: ProductStatus?,
                         productType: ProductType?,
                         productCategory: ProductCategory?,
-                        excludedProductIDs: [Int64]) async throws -> [Product]
+                        excludedProductIDs: [Int64],
+                        currency: String?) async throws -> [Product]
     func searchProductsBySKU(for siteID: Int64,
                              keyword: String,
                              pageNumber: Int,
-                             pageSize: Int) async throws -> [Product]
+                             pageSize: Int,
+                             currency: String?) async throws -> [Product]
     func searchProductsByGlobalUniqueIdentifier(for siteID: Int64,
                              keyword: String,
                              pageNumber: Int,
@@ -194,7 +197,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                 orderBy: OrderKey = .name,
                                 order: Order = .ascending,
                                 productIDs: [Int64] = [],
-                                excludedProductIDs: [Int64] = []) async throws -> [Product] {
+                                excludedProductIDs: [Int64] = [],
+                                currency: String? = nil) async throws -> [Product] {
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
             .joined(separator: ",")
         let stringOfProductIDs: String = {
@@ -220,8 +224,10 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.perPage: String(pageSize),
             ParameterKey.contextKey: context ?? Default.context,
             ParameterKey.orderBy: orderBy.value,
-            ParameterKey.order: order.value
-        ].merging(filterParameters, uniquingKeysWith: { first, _ in first })
+            ParameterKey.order: order.value,
+            ParameterKey.currency: currency
+        ].compactMapValues { $0 }
+            .merging(filterParameters, uniquingKeysWith: { first, _ in first })
 
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
@@ -473,7 +479,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                productStatus: ProductStatus? = nil,
                                productType: ProductType? = nil,
                                productCategory: ProductCategory? = nil,
-                               excludedProductIDs: [Int64] = []) async throws -> [Product] {
+                               excludedProductIDs: [Int64] = [],
+                               currency: String? = nil) async throws -> [Product] {
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
             .joined(separator: ",")
 
@@ -491,7 +498,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.search: keyword,
             ParameterKey.searchFields: searchFields.map { $0.rawValue },
             ParameterKey.exclude: stringOfExcludedProductIDs,
-            ParameterKey.contextKey: Default.context
+            ParameterKey.contextKey: Default.context,
+            ParameterKey.currency: currency
         ].merging(filterParameters, uniquingKeysWith: { first, _ in first })
 
         let path = Path.products
@@ -510,14 +518,16 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func searchProductsBySKU(for siteID: Int64,
                                     keyword: String,
                                     pageNumber: Int,
-                                    pageSize: Int) async throws -> [Product] {
+                                    pageSize: Int,
+                                    currency: String? = nil) async throws -> [Product] {
         let parameters = [
             ParameterKey.sku: keyword,
             ParameterKey.partialSKUSearch: keyword,
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
-            ParameterKey.contextKey: Default.context
-        ]
+            ParameterKey.contextKey: Default.context,
+            ParameterKey.currency: currency
+        ].compactMapValues { $0 }
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ListMapper<Product>(siteID: siteID)
@@ -808,6 +818,7 @@ public extension ProductsRemote {
         static let extendedInfo = "extended_info"
         static let downloadable = "downloadable"
         static let posProductsOnly = "pos_products_only"
+        static let currency = "currency"
     }
 
     private enum ParameterValues {

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -492,7 +492,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.exclude: stringOfExcludedProductIDs
         ].filter({ $0.value.isEmpty == false })
 
-        let parameters: RequestParameterConvertibleDictionary = [
+        let parameters = ([
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.search: keyword,
@@ -500,7 +500,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.exclude: stringOfExcludedProductIDs,
             ParameterKey.contextKey: Default.context,
             ParameterKey.currency: currency
-        ].merging(filterParameters, uniquingKeysWith: { first, _ in first })
+        ] as OptionalRequestParameterConvertibleDictionary).compactMapValues { $0 }
+            .merging(filterParameters, uniquingKeysWith: { first, _ in first })
 
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)

--- a/Modules/Sources/Yosemite/Actions/ProductAction.swift
+++ b/Modules/Sources/Yosemite/Actions/ProductAction.swift
@@ -62,6 +62,36 @@ public enum ProductAction: Action {
                              shouldDeleteStoredProductsOnFirstPage: Bool = true,
                              onCompletion: (Result<Bool, Error>) -> Void)
 
+    /// Retrieves a currency-scoped page of products without writing the results to local storage.
+    ///
+    case retrieveProductsTransiently(siteID: Int64,
+                                     currency: String,
+                                     pageNumber: Int,
+                                     pageSize: Int = ProductsRemote.Default.pageSize,
+                                     stockStatus: ProductStockStatus?,
+                                     productStatus: ProductStatus?,
+                                     productType: ProductType?,
+                                     productCategory: ProductCategory?,
+                                     sortOrder: ProductsSortOrder,
+                                     productIDs: [Int64] = [],
+                                     excludedProductIDs: [Int64] = [],
+                                     onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
+
+    /// Searches for currency-scoped products without writing products or search results to local storage.
+    ///
+    case searchProductsTransiently(siteID: Int64,
+                                   currency: String,
+                                   keyword: String,
+                                   filter: ProductSearchFilter = .all,
+                                   pageNumber: Int,
+                                   pageSize: Int,
+                                   stockStatus: ProductStockStatus? = nil,
+                                   productStatus: ProductStatus? = nil,
+                                   productType: ProductType? = nil,
+                                   productCategory: ProductCategory? = nil,
+                                   excludedProductIDs: [Int64] = [],
+                                   onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
+
     /// Retrieves the specified Product.
     ///
     case retrieveProduct(siteID: Int64, productID: Int64, onCompletion: (Result<Product, Error>) -> Void)

--- a/Modules/Sources/Yosemite/Actions/ProductVariationAction.swift
+++ b/Modules/Sources/Yosemite/Actions/ProductVariationAction.swift
@@ -26,6 +26,16 @@ public enum ProductVariationAction: Action {
                                             pageSize: Int,
                                             onCompletion: (Result<Bool, Error>) -> Void)
 
+    /// Retrieves a currency-scoped page of variations without writing the results to local storage.
+    ///
+    case retrieveProductVariationsTransiently(siteID: Int64,
+                                              productID: Int64,
+                                              currency: String,
+                                              variationIDs: [Int64] = [],
+                                              pageNumber: Int,
+                                              pageSize: Int,
+                                              onCompletion: (Result<(variations: [ProductVariation], hasNextPage: Bool), Error>) -> Void)
+
     /// Retrieves the specified ProductVariation.
     ///
     case retrieveProductVariation(siteID: Int64, productID: Int64, variationID: Int64, onCompletion: (Result<ProductVariation, Error>) -> Void)

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -53,6 +53,20 @@ public class ProductStore: Store {
             retrieveProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .retrieveProducts(let siteID, let productIDs, let pageNumber, let pageSize, let onCompletion):
             retrieveProducts(siteID: siteID, productIDs: productIDs, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case let .retrieveProductsTransiently(siteID, currency, pageNumber, pageSize, stockStatus, productStatus, productType,
+                                              productCategory, sortOrder, productIDs, excludedProductIDs, onCompletion):
+            retrieveProductsTransiently(siteID: siteID,
+                                        currency: currency,
+                                        pageNumber: pageNumber,
+                                        pageSize: pageSize,
+                                        stockStatus: stockStatus,
+                                        productStatus: productStatus,
+                                        productType: productType,
+                                        productCategory: productCategory,
+                                        sortOrder: sortOrder,
+                                        productIDs: productIDs,
+                                        excludedProductIDs: excludedProductIDs,
+                                        onCompletion: onCompletion)
         case .retrieveFirstPurchasableItemMatchFromIdentifier(siteID: let siteID, identifier: let identifier, onCompletion: let onCompletion):
             retrieveFirstPurchasableItemMatchFromIdentifier(siteID: siteID, identifier: identifier, onCompletion: onCompletion)
         case let.searchProductsInCache(siteID, keyword, pageSize, onCompletion):
@@ -80,6 +94,20 @@ public class ProductStore: Store {
                            productCategory: productCategory,
                            excludedProductIDs: excludedProductIDs,
                            onCompletion: onCompletion)
+        case let .searchProductsTransiently(siteID, currency, keyword, filter, pageNumber, pageSize, stockStatus, productStatus,
+                                            productType, productCategory, excludedProductIDs, onCompletion):
+            searchProductsTransiently(siteID: siteID,
+                                      currency: currency,
+                                      keyword: keyword,
+                                      filter: filter,
+                                      pageNumber: pageNumber,
+                                      pageSize: pageSize,
+                                      stockStatus: stockStatus,
+                                      productStatus: productStatus,
+                                      productType: productType,
+                                      productCategory: productCategory,
+                                      excludedProductIDs: excludedProductIDs,
+                                      onCompletion: onCompletion)
         case .synchronizeProducts(let siteID,
                                   let pageNumber,
                                   let pageSize,
@@ -209,6 +237,82 @@ public class ProductStore: Store {
 //
 private extension ProductStore {
 
+    func retrieveProductsTransiently(siteID: Int64,
+                                     currency: String,
+                                     pageNumber: Int,
+                                     pageSize: Int,
+                                     stockStatus: ProductStockStatus?,
+                                     productStatus: ProductStatus?,
+                                     productType: ProductType?,
+                                     productCategory: ProductCategory?,
+                                     sortOrder: ProductsSortOrder,
+                                     productIDs: [Int64],
+                                     excludedProductIDs: [Int64],
+                                     onCompletion: @escaping (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let products = try await remote.loadAllProducts(for: siteID,
+                                                                context: nil,
+                                                                pageNumber: pageNumber,
+                                                                pageSize: pageSize,
+                                                                stockStatus: stockStatus,
+                                                                productStatus: productStatus,
+                                                                productType: productType,
+                                                                productCategory: productCategory,
+                                                                orderBy: sortOrder.remoteOrderKey,
+                                                                order: sortOrder.remoteOrder,
+                                                                productIDs: productIDs,
+                                                                excludedProductIDs: excludedProductIDs,
+                                                                currency: currency)
+                onCompletion(.success((products, products.count == pageSize)))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func searchProductsTransiently(siteID: Int64,
+                                   currency: String,
+                                   keyword: String,
+                                   filter: ProductSearchFilter,
+                                   pageNumber: Int,
+                                   pageSize: Int,
+                                   stockStatus: ProductStockStatus?,
+                                   productStatus: ProductStatus?,
+                                   productType: ProductType?,
+                                   productCategory: ProductCategory?,
+                                   excludedProductIDs: [Int64],
+                                   onCompletion: @escaping (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let products: [Product]
+                if filter == .sku {
+                    products = try await remote.searchProductsBySKU(for: siteID,
+                                                                    keyword: keyword,
+                                                                    pageNumber: pageNumber,
+                                                                    pageSize: pageSize,
+                                                                    currency: currency)
+                } else {
+                    let fields: [ProductSearchField] = filter == .name ? [.name] : []
+                    products = try await remote.searchProducts(for: siteID,
+                                                               keyword: keyword,
+                                                               searchFields: fields,
+                                                               pageNumber: pageNumber,
+                                                               pageSize: pageSize,
+                                                               stockStatus: stockStatus,
+                                                               productStatus: productStatus,
+                                                               productType: productType,
+                                                               productCategory: productCategory,
+                                                               excludedProductIDs: excludedProductIDs,
+                                                               currency: currency)
+                }
+                onCompletion(.success((products, products.count == pageSize)))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
     /// Deletes all of the Stored Products.
     ///
     func resetStoredProducts(onCompletion: @escaping () -> Void) {
@@ -244,7 +348,8 @@ private extension ProductStore {
                                             productStatus: productStatus,
                                             productType: productType,
                                             productCategory: productCategory,
-                                            excludedProductIDs: excludedProductIDs)
+                                            excludedProductIDs: excludedProductIDs,
+                                            currency: nil)
         }
         Task { @MainActor in
             do {
@@ -258,7 +363,8 @@ private extension ProductStore {
                     products = try await remote.searchProductsBySKU(for: siteID,
                                                                     keyword: keyword,
                                                                     pageNumber: pageNumber,
-                                                                    pageSize: pageSize)
+                                                                    pageSize: pageSize,
+                                                                    currency: nil)
                 }
                 await upsertSearchResultsInBackground(siteID: siteID, keyword: keyword, filter: filter, readOnlyProducts: products)
                 let hasNextPage = products.count == pageSize
@@ -311,7 +417,8 @@ private extension ProductStore {
                                                             orderBy: sortOrder.remoteOrderKey,
                                                             order: sortOrder.remoteOrder,
                                                             productIDs: productIDs,
-                                                            excludedProductIDs: excludedProductIDs)
+                                                            excludedProductIDs: excludedProductIDs,
+                                                            currency: nil)
 
             let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber && shouldDeleteStoredProductsOnFirstPage
             await upsertStoredProductsInBackground(readOnlyProducts: products,
@@ -1348,7 +1455,8 @@ private extension ProductStore {
         try await remote.searchProductsBySKU(for: siteID,
                                              keyword: keyword,
                                              pageNumber: Remote.Default.firstPageNumber,
-                                             pageSize: ProductsRemote.Default.pageSize)
+                                             pageSize: ProductsRemote.Default.pageSize,
+                                             currency: nil)
     }
 
     func searchProductsByGlobalUniqueIdentifier(for siteID: Int64, keyword: String) async throws -> [Product] {

--- a/Modules/Sources/Yosemite/Stores/ProductVariationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductVariationStore.swift
@@ -47,6 +47,14 @@ public final class ProductVariationStore: Store {
                                          onCompletion: onCompletion)
         case .retrieveProductVariation(let siteID, let productID, let variationID, let onCompletion):
             retrieveProductVariation(siteID: siteID, productID: productID, variationID: variationID, onCompletion: onCompletion)
+        case let .retrieveProductVariationsTransiently(siteID, productID, currency, variationIDs, pageNumber, pageSize, onCompletion):
+            retrieveProductVariationsTransiently(siteID: siteID,
+                                                 productID: productID,
+                                                 currency: currency,
+                                                 variationIDs: variationIDs,
+                                                 pageNumber: pageNumber,
+                                                 pageSize: pageSize,
+                                                 onCompletion: onCompletion)
         case .createProductVariation(let siteID, let productID, let newVariation, let onCompletion):
             createProductVariation(siteID: siteID, productID: productID, newVariation: newVariation, onCompletion: onCompletion)
         case .createProductVariations(let siteID, let productID, let productVariations, let onCompletion):
@@ -69,6 +77,28 @@ public final class ProductVariationStore: Store {
 // MARK: - Services!
 //
 private extension ProductVariationStore {
+
+    func retrieveProductVariationsTransiently(siteID: Int64,
+                                              productID: Int64,
+                                              currency: String,
+                                              variationIDs: [Int64],
+                                              pageNumber: Int,
+                                              pageSize: Int,
+                                              onCompletion: @escaping (Result<(variations: [ProductVariation], hasNextPage: Bool), Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let variations = try await remote.loadProductVariations(for: siteID,
+                                                                        productID: productID,
+                                                                        variationIDs: variationIDs,
+                                                                        pageNumber: pageNumber,
+                                                                        pageSize: pageSize,
+                                                                        currency: currency)
+                onCompletion(.success((variations, variations.count == pageSize)))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
 
     /// Synchronizes all the product reviews associated with a given Site ID (if any!).
     ///

--- a/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -26,6 +26,37 @@ final class ProductVariationsRemoteTests: XCTestCase {
 
     // MARK: - Load all product variations tests
 
+    func test_loadProductVariations_with_currency_includes_currency_param_in_network_request() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+
+        // When
+        _ = try await remote.loadProductVariations(for: sampleSiteID,
+                                                   productID: sampleProductID,
+                                                   pageNumber: 1,
+                                                   pageSize: 25,
+                                                   currency: "EUR")
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "EUR")
+    }
+
+    func test_loadProductVariations_without_currency_omits_currency_param_from_network_request() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+
+        // When
+        _ = try await remote.loadProductVariations(for: sampleSiteID,
+                                                   productID: sampleProductID,
+                                                   pageNumber: 1,
+                                                   pageSize: 25)
+
+        // Then
+        XCTAssertNil(try XCTUnwrap(network.queryParametersDictionary)["currency"])
+    }
+
     /// Verifies that loadAllProductVariations properly parses the `product-variations-load-all` sample response.
     ///
     func testLoadAllProductVariationsProperlyReturnsParsedData() {

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -669,6 +669,23 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "EUR")
     }
 
+    func test_searchProducts_without_currency_omits_currency_param_from_network_request() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        _ = try await remote.searchProducts(for: sampleSiteID,
+                                            keyword: "test",
+                                            searchFields: [],
+                                            pageNumber: 1,
+                                            pageSize: 25,
+                                            currency: nil)
+
+        // Then
+        XCTAssertNil(try XCTUnwrap(network.queryParametersDictionary)["currency"])
+    }
+
     // MARK: - Search Products by SKU
 
     func test_searchProductsBySKU_with_currency_includes_currency_param_in_network_request() async throws {

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -424,6 +424,18 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertEqual(products.count, 10)
     }
 
+    func test_loadAllProducts_with_currency_includes_currency_param_in_network_request() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+
+        // When
+        _ = try await remote.loadAllProducts(for: sampleSiteID, currency: "EUR")
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "EUR")
+    }
+
     /// Verifies that loadAllProducts with `excludedProductIDs` makes a network request with the corresponding parameter.
     ///
     func test_loadAllProducts_with_excluded_ids_includes_an_exclude_param_in_network_request() async throws {
@@ -640,7 +652,40 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
     }
 
+    func test_searchProducts_with_currency_includes_currency_param_in_network_request() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        _ = try await remote.searchProducts(for: sampleSiteID,
+                                            keyword: "test",
+                                            searchFields: [],
+                                            pageNumber: 1,
+                                            pageSize: 25,
+                                            currency: "EUR")
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "EUR")
+    }
+
     // MARK: - Search Products by SKU
+
+    func test_searchProductsBySKU_with_currency_includes_currency_param_in_network_request() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        _ = try await remote.searchProductsBySKU(for: sampleSiteID,
+                                                 keyword: "SKU",
+                                                 pageNumber: 1,
+                                                 pageSize: 25,
+                                                 currency: "GBP")
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "GBP")
+    }
 
     func test_searchProductsBySKU_properly_returns_parsed_products() async throws {
         // Given

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -90,6 +90,15 @@ final class MockProductVariationsRemote {
 // MARK: - ProductVariationsRemoteProtocol conformance
 
 extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
+    func loadProductVariations(for siteID: Int64,
+                               productID: Int64,
+                               variationIDs: [Int64],
+                               pageNumber: Int,
+                               pageSize: Int,
+                               currency: String?) async throws -> [ProductVariation] {
+        []
+    }
+
     func loadAllProductVariations(for siteID: Int64,
                                   productID: Int64,
                                   variationIDs: [Int64],

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -290,7 +290,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                          orderBy: ProductsRemote.OrderKey,
                          order: ProductsRemote.Order,
                          productIDs: [Int64],
-                         excludedProductIDs: [Int64]) async throws -> [Product] {
+                         excludedProductIDs: [Int64],
+                         currency: String?) async throws -> [Product] {
         synchronizeProductsTriggered = true
         synchronizeProductsWithStockStatus = stockStatus
         synchronizeProductsWithProductStatus = productStatus
@@ -322,7 +323,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                         productStatus: ProductStatus?,
                         productType: ProductType?,
                         productCategory: ProductCategory?,
-                        excludedProductIDs: [Int64]) async throws -> [Product] {
+                        excludedProductIDs: [Int64],
+                        currency: String?) async throws -> [Product] {
         searchProductTriggered = true
         searchProductWithStockStatus = stockStatus
         searchProductWithProductType = productType
@@ -342,7 +344,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     func searchProductsBySKU(for siteID: Int64,
                              keyword: String,
                              pageNumber: Int,
-                             pageSize: Int) async throws -> [Product] {
+                             pageSize: Int,
+                             currency: String?) async throws -> [Product] {
         guard let result = searchProductsBySKUResultsBySKU[keyword] else {
             XCTFail("\(String(describing: self)) Could not find result for SKU \(keyword)")
             throw NetworkError.notFound()

--- a/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
@@ -332,6 +332,57 @@ final class ProductStoreTests: XCTestCase {
 
     // MARK: - ProductAction.synchronizeProducts
 
+    func test_retrieveProductsTransiently_returns_currency_scoped_products_without_persisting_them() throws {
+        // Given
+        let expectation = expectation(description: #function)
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+
+        // When
+        let action = ProductAction.retrieveProductsTransiently(siteID: sampleSiteID,
+                                                               currency: "EUR",
+                                                               pageNumber: 1,
+                                                               pageSize: 25,
+                                                               stockStatus: nil,
+                                                               productStatus: nil,
+                                                               productType: nil,
+                                                               productCategory: nil,
+                                                               sortOrder: .nameAscending) { result in
+            XCTAssertEqual(try? result.get().products.count, 10)
+            expectation.fulfill()
+        }
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "EUR")
+    }
+
+    func test_searchProductsTransiently_returns_currency_scoped_products_without_persisting_products_or_search_results() throws {
+        // Given
+        let expectation = expectation(description: #function)
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        let action = ProductAction.searchProductsTransiently(siteID: sampleSiteID,
+                                                             currency: "GBP",
+                                                             keyword: "photo",
+                                                             pageNumber: 1,
+                                                             pageSize: 25) { result in
+            XCTAssertFalse((try? result.get().products.isEmpty) ?? true)
+            expectation.fulfill()
+        }
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductSearchResults.self), 0)
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "GBP")
+    }
+
     /// Verifies that ProductAction.synchronizeProducts effectively persists any retrieved products.
     ///
     func testRetrieveProductsEffectivelyPersistsRetrievedProducts() {

--- a/Modules/Tests/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -49,6 +49,29 @@ final class ProductVariationStoreTests: XCTestCase {
 
     // MARK: - ProductVariationAction.synchronizeProductVariations
 
+    func test_retrieveProductVariationsTransiently_returns_currency_scoped_variations_without_persisting_them() throws {
+        // Given
+        let expectation = expectation(description: #function)
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+
+        // When
+        let action = ProductVariationAction.retrieveProductVariationsTransiently(siteID: sampleSiteID,
+                                                                                 productID: sampleProductID,
+                                                                                 currency: "EUR",
+                                                                                 pageNumber: 1,
+                                                                                 pageSize: 25) { result in
+            XCTAssertEqual(try? result.get().variations.count, 8)
+            expectation.fulfill()
+        }
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "EUR")
+    }
+
     /// Verifies that `ProductVariationAction.synchronizeProductVariations` effectively persists any retrieved product variations.
     ///
     func testRetrieveProductVariationsEffectivelyPersisted() {


### PR DESCRIPTION
Part of: WOOMOB-3628

## Description

Adds transient product, product-search, and variation retrieval actions for WOOMOB-3628.

These allow us to request product details with a different currency than the store's default, for editing an order, without overwriting the persisted product details.

## Test Steps

Not hooked up to any UI until #17619 is merged, so just a CI check is enough. Best tested on the final PR.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
