### PR TITLE
Add currency mode to product selectors

### DIFF
--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -32,12 +32,14 @@ public protocol ProductsRemoteProtocol {
                         productStatus: ProductStatus?,
                         productType: ProductType?,
                         productCategory: ProductCategory?,
+                        productIDs: [Int64],
                         excludedProductIDs: [Int64],
                         currency: String?) async throws -> [Product]
     func searchProductsBySKU(for siteID: Int64,
                              keyword: String,
                              pageNumber: Int,
                              pageSize: Int,
+                             productIDs: [Int64],
                              currency: String?) async throws -> [Product]
     func searchProductsByGlobalUniqueIdentifier(for siteID: Int64,
                              keyword: String,
@@ -479,8 +481,10 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                productStatus: ProductStatus? = nil,
                                productType: ProductType? = nil,
                                productCategory: ProductCategory? = nil,
+                               productIDs: [Int64] = [],
                                excludedProductIDs: [Int64] = [],
                                currency: String? = nil) async throws -> [Product] {
+        let stringOfProductIDs = productIDs.map(String.init).joined(separator: ",")
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
             .joined(separator: ",")
 
@@ -489,6 +493,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.productStatus: productStatus?.rawValue ?? "",
             ParameterKey.productType: productType?.rawValue ?? "",
             ParameterKey.category: filterProductCategoryParemeterValue(from: productCategory),
+            ParameterKey.include: stringOfProductIDs,
             ParameterKey.exclude: stringOfExcludedProductIDs
         ].filter({ $0.value.isEmpty == false })
 
@@ -520,15 +525,19 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                     keyword: String,
                                     pageNumber: Int,
                                     pageSize: Int,
+                                    productIDs: [Int64] = [],
                                     currency: String? = nil) async throws -> [Product] {
+        let stringOfProductIDs = productIDs.map(String.init).joined(separator: ",")
         let parameters = [
             ParameterKey.sku: keyword,
             ParameterKey.partialSKUSearch: keyword,
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.contextKey: Default.context,
+            ParameterKey.include: stringOfProductIDs,
             ParameterKey.currency: currency
         ].compactMapValues { $0 }
+            .filter { key, value in key != ParameterKey.include || value.isNotEmpty }
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ListMapper<Product>(siteID: siteID)

--- a/Modules/Sources/Yosemite/Actions/ProductAction.swift
+++ b/Modules/Sources/Yosemite/Actions/ProductAction.swift
@@ -89,6 +89,7 @@ public enum ProductAction: Action {
                                    productStatus: ProductStatus? = nil,
                                    productType: ProductType? = nil,
                                    productCategory: ProductCategory? = nil,
+                                   productIDs: [Int64] = [],
                                    excludedProductIDs: [Int64] = [],
                                    onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
 

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -95,7 +95,7 @@ public class ProductStore: Store {
                            excludedProductIDs: excludedProductIDs,
                            onCompletion: onCompletion)
         case let .searchProductsTransiently(siteID, currency, keyword, filter, pageNumber, pageSize, stockStatus, productStatus,
-                                            productType, productCategory, excludedProductIDs, onCompletion):
+                                            productType, productCategory, productIDs, excludedProductIDs, onCompletion):
             searchProductsTransiently(siteID: siteID,
                                       currency: currency,
                                       keyword: keyword,
@@ -106,6 +106,7 @@ public class ProductStore: Store {
                                       productStatus: productStatus,
                                       productType: productType,
                                       productCategory: productCategory,
+                                      productIDs: productIDs,
                                       excludedProductIDs: excludedProductIDs,
                                       onCompletion: onCompletion)
         case .synchronizeProducts(let siteID,
@@ -281,6 +282,7 @@ private extension ProductStore {
                                    productStatus: ProductStatus?,
                                    productType: ProductType?,
                                    productCategory: ProductCategory?,
+                                   productIDs: [Int64],
                                    excludedProductIDs: [Int64],
                                    onCompletion: @escaping (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void) {
         Task { @MainActor in
@@ -291,6 +293,7 @@ private extension ProductStore {
                                                                     keyword: keyword,
                                                                     pageNumber: pageNumber,
                                                                     pageSize: pageSize,
+                                                                    productIDs: productIDs,
                                                                     currency: currency)
                 } else {
                     let fields: [ProductSearchField] = filter == .name ? [.name] : []
@@ -303,6 +306,7 @@ private extension ProductStore {
                                                                productStatus: productStatus,
                                                                productType: productType,
                                                                productCategory: productCategory,
+                                                               productIDs: productIDs,
                                                                excludedProductIDs: excludedProductIDs,
                                                                currency: currency)
                 }
@@ -348,6 +352,7 @@ private extension ProductStore {
                                             productStatus: productStatus,
                                             productType: productType,
                                             productCategory: productCategory,
+                                            productIDs: [],
                                             excludedProductIDs: excludedProductIDs,
                                             currency: nil)
         }
@@ -364,6 +369,7 @@ private extension ProductStore {
                                                                     keyword: keyword,
                                                                     pageNumber: pageNumber,
                                                                     pageSize: pageSize,
+                                                                    productIDs: [],
                                                                     currency: nil)
                 }
                 await upsertSearchResultsInBackground(siteID: siteID, keyword: keyword, filter: filter, readOnlyProducts: products)
@@ -1456,6 +1462,7 @@ private extension ProductStore {
                                              keyword: keyword,
                                              pageNumber: Remote.Default.firstPageNumber,
                                              pageSize: ProductsRemote.Default.pageSize,
+                                             productIDs: [],
                                              currency: nil)
     }
 

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -686,6 +686,23 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertNil(try XCTUnwrap(network.queryParametersDictionary)["currency"])
     }
 
+    func test_searchProducts_with_productIDs_includes_include_param_in_network_request() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        _ = try await remote.searchProducts(for: sampleSiteID,
+                                            keyword: "test",
+                                            searchFields: [],
+                                            pageNumber: 1,
+                                            pageSize: 25,
+                                            productIDs: [12, 34])
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["include"] as? String, "12,34")
+    }
+
     // MARK: - Search Products by SKU
 
     func test_searchProductsBySKU_with_currency_includes_currency_param_in_network_request() async throws {
@@ -702,6 +719,22 @@ final class ProductsRemoteTests: XCTestCase {
 
         // Then
         XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "GBP")
+    }
+
+    func test_searchProductsBySKU_with_productIDs_includes_include_param_in_network_request() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        _ = try await remote.searchProductsBySKU(for: sampleSiteID,
+                                                 keyword: "SKU",
+                                                 pageNumber: 1,
+                                                 pageSize: 25,
+                                                 productIDs: [12, 34])
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["include"] as? String, "12,34")
     }
 
     func test_searchProductsBySKU_properly_returns_parsed_products() async throws {

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -323,6 +323,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                         productStatus: ProductStatus?,
                         productType: ProductType?,
                         productCategory: ProductCategory?,
+                        productIDs: [Int64],
                         excludedProductIDs: [Int64],
                         currency: String?) async throws -> [Product] {
         searchProductTriggered = true
@@ -345,6 +346,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                              keyword: String,
                              pageNumber: Int,
                              pageSize: Int,
+                             productIDs: [Int64],
                              currency: String?) async throws -> [Product] {
         guard let result = searchProductsBySKUResultsBySKU[keyword] else {
             XCTFail("\(String(describing: self)) Could not find result for SKU \(keyword)")

--- a/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
@@ -370,7 +370,8 @@ final class ProductStoreTests: XCTestCase {
                                                              currency: "GBP",
                                                              keyword: "photo",
                                                              pageNumber: 1,
-                                                             pageSize: 25) { result in
+                                                             pageSize: 25,
+                                                             productIDs: [12, 34]) { result in
             XCTAssertFalse((try? result.get().products.isEmpty) ?? true)
             expectation.fulfill()
         }
@@ -381,6 +382,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductSearchResults.self), 0)
         XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["currency"] as? String, "GBP")
+        XCTAssertEqual(try XCTUnwrap(network.queryParametersDictionary)["include"] as? String, "12,34")
     }
 
     /// Verifies that ProductAction.synchronizeProducts effectively persists any retrieved products.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -8,6 +8,7 @@ import Combine
 ///
 final class ProductRowViewModel: ObservableObject, Identifiable {
     private let currencyFormatter: CurrencyFormatter
+    private let currency: String?
 
     /// Unique ID for the view model.
     ///
@@ -118,7 +119,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         guard let price else {
             return nil
         }
-        return currencyFormatter.formatAmount(price)
+        return currencyFormatter.formatAmount(price, with: currency)
     }
 
     /// Formatted price label based on a product's price and quantity. Accounting for discounts, if any.
@@ -132,12 +133,14 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             return "-"
         }
         let productSubtotal = quantity * priceDecimal
-        let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal)
-
-        guard let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal),
-              productDiscount > 0,
-              let discountLabelComponent = currencyFormatter.formatAmount(productDiscount) else {
+        let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal, with: currency)
+        guard productDiscount > 0,
+              let discountLabelComponent = currencyFormatter.formatAmount(productDiscount, with: currency) else {
             return priceLabelComponent
+        }
+
+        guard let priceLabelComponent else {
+            return nil
         }
 
         return priceLabelComponent + " - " + discountLabelComponent
@@ -261,6 +264,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          pricedIndividually: Bool = true,
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         currency: String? = nil,
          analytics: Analytics = ServiceLocator.analytics,
          configure: (() -> Void)? = nil) {
         self.id = id ?? Int64(UUID().uuidString.hashValue)
@@ -279,6 +283,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.pricedIndividually = pricedIndividually
         self.isConfigurable = isConfigurable
         self.currencyFormatter = currencyFormatter
+        self.currency = currency
         self.analytics = analytics
         self.numberOfVariations = numberOfVariations
         self.variationDisplayMode = variationDisplayMode
@@ -296,6 +301,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      selectedState: ProductRow.SelectedState = .notSelected,
                      pricedIndividually: Bool = true,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                     currency: String? = nil,
                      analytics: Analytics = ServiceLocator.analytics,
                      featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
                      configure: (() -> Void)? = nil) {
@@ -366,6 +372,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   pricedIndividually: pricedIndividually,
                   isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
+                  currency: currency,
                   analytics: analytics,
                   configure: configure)
     }
@@ -382,6 +389,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      selectedState: ProductRow.SelectedState = .notSelected,
                      pricedIndividually: Bool = true,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                     currency: String? = nil,
                      analytics: Analytics = ServiceLocator.analytics) {
         let imageURL: URL?
         if let encodedImageURLString = productVariation.image?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
@@ -411,6 +419,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   pricedIndividually: pricedIndividually,
                   isConfigurable: false,
                   currencyFormatter: currencyFormatter,
+                  currency: currency,
                   analytics: analytics)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -51,6 +51,9 @@ enum ProductSelectorSource {
 ///
 final class ProductSelectorViewModel: ObservableObject {
     private let siteID: Int64
+    private let currency: String?
+    private let pageFirstIndex: Int
+    private var transientProducts: [Product] = []
 
     /// Storage to fetch product list
     ///
@@ -242,6 +245,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     init(siteID: Int64,
          source: ProductSelectorSource,
+         currency: String? = nil,
          selectedItemIDs: [Int64] = [],
          purchasableItemsOnly: Bool = false,
          shouldDeleteStoredProductsOnFirstPage: Bool = true,
@@ -267,6 +271,8 @@ final class ProductSelectorViewModel: ObservableObject {
          onConfigureProductRow: ((_ product: Product) -> Void)? = nil) {
         self.siteID = siteID
         self.source = source
+        self.currency = currency
+        self.pageFirstIndex = pageFirstIndex
         self.storageManager = storageManager
         self.stores = stores
         self.analytics = analytics
@@ -413,8 +419,11 @@ final class ProductSelectorViewModel: ObservableObject {
         let selectedItems = selectedItemsIDs.filter { variableProduct.variations.contains($0) }
         return ProductVariationSelectorViewModel(siteID: siteID,
                                                  product: variableProduct,
+                                                 currency: currency,
                                                  selectedProductVariationIDs: selectedItems,
                                                  orderSyncState: orderSyncState,
+                                                 storageManager: storageManager,
+                                                 stores: stores,
                                                  onVariationSelectionStateChanged: { [weak self] productVariation, product, selected in
             guard let self else { return }
             onVariationSelectionStateChanged?(productVariation, product, selected)
@@ -525,6 +534,11 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
     /// Sync all products from remote.
     ///
     private func syncProducts(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: SyncCompletion?) {
+        if let currency {
+            syncProductsTransiently(currency: currency, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+            return
+        }
+
         let action = ProductAction.synchronizeProducts(siteID: siteID,
                                                        pageNumber: pageNumber,
                                                        pageSize: pageSize,
@@ -556,6 +570,15 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
     /// Sync products matching a given keyword.
     ///
     private func searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: SyncCompletion?) {
+        if let currency {
+            searchProductsTransiently(currency: currency,
+                                      keyword: keyword,
+                                      pageNumber: pageNumber,
+                                      pageSize: pageSize,
+                                      onCompletion: onCompletion)
+            return
+        }
+
         searchProductsInCacheIfPossible(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize)
 
         let action = ProductAction.searchProducts(siteID: siteID,
@@ -590,6 +613,73 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
 
         stores.dispatch(action)
         tracker.trackSearchTriggered()
+    }
+
+    private func syncProductsTransiently(currency: String, pageNumber: Int, pageSize: Int, onCompletion: SyncCompletion?) {
+        let productIDs = filtersSubject.value.favoriteProduct != nil ? favoriteProductIDs : []
+        let action = ProductAction.retrieveProductsTransiently(siteID: siteID,
+                                                               currency: currency,
+                                                               pageNumber: pageNumber,
+                                                               pageSize: pageSize,
+                                                               stockStatus: filtersSubject.value.stockStatus,
+                                                               productStatus: filtersSubject.value.productStatus,
+                                                               productType: filtersSubject.value.promotableProductType?.productType,
+                                                               productCategory: filtersSubject.value.productCategory,
+                                                               sortOrder: .nameAscending,
+                                                               productIDs: productIDs) { [weak self] result in
+            guard let self else { return }
+            self.handleTransientResult(result, pageNumber: pageNumber, onCompletion: onCompletion)
+        }
+        stores.dispatch(action)
+    }
+
+    private func searchProductsTransiently(currency: String,
+                                           keyword: String,
+                                           pageNumber: Int,
+                                           pageSize: Int,
+                                           onCompletion: SyncCompletion?) {
+        let action = ProductAction.searchProductsTransiently(siteID: siteID,
+                                                             currency: currency,
+                                                             keyword: keyword,
+                                                             filter: productSearchFilter,
+                                                             pageNumber: pageNumber,
+                                                             pageSize: pageSize,
+                                                             stockStatus: filtersSubject.value.stockStatus,
+                                                             productStatus: filtersSubject.value.productStatus,
+                                                             productType: filtersSubject.value.promotableProductType?.productType,
+                                                             productCategory: filtersSubject.value.productCategory) { [weak self] result in
+            guard let self, keyword == self.searchTerm else { return }
+            switch result {
+            case .success:
+                self.tracker.trackSearchSuccessIfNecessary()
+            case .failure(let error):
+                self.tracker.trackSearchFailureIfNecessary(with: error)
+            }
+            self.handleTransientResult(result, pageNumber: pageNumber, onCompletion: onCompletion)
+        }
+        stores.dispatch(action)
+        tracker.trackSearchTriggered()
+    }
+
+    private func handleTransientResult(_ result: Result<(products: [Product], hasNextPage: Bool), Error>,
+                                       pageNumber: Int,
+                                       onCompletion: SyncCompletion?) {
+        switch result {
+        case let .success((products, hasNextPage)):
+            let products = purchasableItemsOnly ? products.filter(\.purchasable) : products
+            if pageNumber == pageFirstIndex {
+                transientProducts = products
+            } else {
+                let existingIDs = Set(transientProducts.map(\.productID))
+                transientProducts += products.filter { !existingIDs.contains($0.productID) }
+            }
+            reloadData()
+            transitionToResultsUpdatedState()
+            onCompletion?(.success(hasNextPage))
+        case let .failure(error):
+            transitionToResultsUpdatedState()
+            onCompletion?(.failure(error))
+        }
     }
 
     private func searchProductsInCacheIfPossible(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int) {
@@ -680,6 +770,12 @@ private extension ProductSelectorViewModel {
     /// Reloads the data from the storage and composes sections and selections.
     ///
     func reloadData() {
+        if currency != nil {
+            createSectionsAddingTopProductsIfRequired(from: transientProducts)
+            observeSelections()
+            return
+        }
+
             do {
                 try productsResultsController.performFetch()
                 var loadedProducts: [Product] = []
@@ -745,6 +841,12 @@ private extension ProductSelectorViewModel {
     }
 
     func updatePredicate(searchTerm: String, filters: FilterProductListViewModel.Filters, productSearchFilter: ProductSearchFilter) async {
+        guard currency == nil else {
+            transientProducts = []
+            reloadData()
+            return
+        }
+
         let productIDs: [Int64]? = await {
             guard filters.favoriteProduct != nil else {
                 return nil
@@ -881,9 +983,23 @@ private extension ProductSelectorViewModel {
 
             return ProductRowViewModel(product: product,
                                        selectedState: selectedState,
+                                       currencyFormatter: currencyFormatter,
                                        featureFlagService: featureFlagService,
                                        configure: configure)
         }
+    }
+
+    var currencyFormatter: CurrencyFormatter {
+        let siteSettings = ServiceLocator.currencySettings
+        guard let currency, let currencyCode = CurrencyCode(rawValue: currency) else {
+            return CurrencyFormatter(currencySettings: siteSettings)
+        }
+        let settings = CurrencySettings(currencyCode: currencyCode,
+                                        currencyPosition: siteSettings.currencyPosition,
+                                        thousandSeparator: siteSettings.groupingSeparator,
+                                        decimalSeparator: siteSettings.decimalSeparator,
+                                        numberOfDecimals: siteSettings.fractionDigits)
+        return CurrencyFormatter(currencySettings: settings)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -616,7 +616,13 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
     }
 
     private func syncProductsTransiently(currency: String, pageNumber: Int, pageSize: Int, onCompletion: SyncCompletion?) {
-        let productIDs = filtersSubject.value.favoriteProduct != nil ? favoriteProductIDs : []
+        let favoritesFilterIsActive = filtersSubject.value.favoriteProduct != nil
+        guard !favoritesFilterIsActive || favoriteProductIDs.isNotEmpty else {
+            handleTransientResult(.success((products: [], hasNextPage: false)), pageNumber: pageNumber, onCompletion: onCompletion)
+            return
+        }
+
+        let productIDs = favoritesFilterIsActive ? favoriteProductIDs : []
         let action = ProductAction.retrieveProductsTransiently(siteID: siteID,
                                                                currency: currency,
                                                                pageNumber: pageNumber,
@@ -628,6 +634,12 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
                                                                sortOrder: .nameAscending,
                                                                productIDs: productIDs) { [weak self] result in
             guard let self else { return }
+            if case let .failure(error) = result {
+                productNotice = NoticeFactory.productSyncNotice { [weak self] in
+                    self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
+                }
+                DDLogError("⛔️ Error retrieving transient products during order creation: \(error)")
+            }
             self.handleTransientResult(result, pageNumber: pageNumber, onCompletion: onCompletion)
         }
         stores.dispatch(action)
@@ -638,6 +650,13 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
                                            pageNumber: Int,
                                            pageSize: Int,
                                            onCompletion: SyncCompletion?) {
+        let favoritesFilterIsActive = filtersSubject.value.favoriteProduct != nil
+        guard !favoritesFilterIsActive || favoriteProductIDs.isNotEmpty else {
+            handleTransientResult(.success((products: [], hasNextPage: false)), pageNumber: pageNumber, onCompletion: onCompletion)
+            return
+        }
+
+        let productIDs = favoritesFilterIsActive ? favoriteProductIDs : []
         let action = ProductAction.searchProductsTransiently(siteID: siteID,
                                                              currency: currency,
                                                              keyword: keyword,
@@ -647,13 +666,23 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
                                                              stockStatus: filtersSubject.value.stockStatus,
                                                              productStatus: filtersSubject.value.productStatus,
                                                              productType: filtersSubject.value.promotableProductType?.productType,
-                                                             productCategory: filtersSubject.value.productCategory) { [weak self] result in
+                                                             productCategory: filtersSubject.value.productCategory,
+                                                             productIDs: productIDs) { [weak self] result in
             guard let self, keyword == self.searchTerm else { return }
             switch result {
             case .success:
                 self.tracker.trackSearchSuccessIfNecessary()
             case .failure(let error):
                 self.tracker.trackSearchFailureIfNecessary(with: error)
+                self.productNotice = NoticeFactory.productSearchNotice { [weak self] in
+                    guard let self else { return }
+                    self.searchProducts(siteID: self.siteID,
+                                        keyword: keyword,
+                                        pageNumber: pageNumber,
+                                        pageSize: pageSize,
+                                        onCompletion: nil)
+                }
+                DDLogError("⛔️ Error searching transient products during order creation: \(error)")
             }
             self.handleTransientResult(result, pageNumber: pageNumber, onCompletion: onCompletion)
         }
@@ -983,23 +1012,10 @@ private extension ProductSelectorViewModel {
 
             return ProductRowViewModel(product: product,
                                        selectedState: selectedState,
-                                       currencyFormatter: currencyFormatter,
+                                       currency: currency,
                                        featureFlagService: featureFlagService,
                                        configure: configure)
         }
-    }
-
-    var currencyFormatter: CurrencyFormatter {
-        let siteSettings = ServiceLocator.currencySettings
-        guard let currency, let currencyCode = CurrencyCode(rawValue: currency) else {
-            return CurrencyFormatter(currencySettings: siteSettings)
-        }
-        let settings = CurrencySettings(currencyCode: currencyCode,
-                                        currencyPosition: siteSettings.currencyPosition,
-                                        thousandSeparator: siteSettings.groupingSeparator,
-                                        decimalSeparator: siteSettings.decimalSeparator,
-                                        numberOfDecimals: siteSettings.fractionDigits)
-        return CurrencyFormatter(currencySettings: settings)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -79,9 +79,9 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     @Published private(set) var syncStatus: SyncStatus?
 
-    /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
+    /// Keeps track of synchronized pages and whether the API reports another page.
     ///
-    private let syncingCoordinator = SyncingCoordinator()
+    private let paginationTracker = PaginationTracker()
 
     /// Tracks if the infinite scroll indicator should be displayed
     ///
@@ -154,7 +154,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.onSelectionsCleared = onSelectionsCleared
 
-        configureSyncingCoordinator()
+        configurePaginationTracker()
         configureProductVariationsResultsController()
         configureFirstPageLoad()
         bindSelectionDisabledState()
@@ -209,7 +209,12 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         if currency != nil {
             parentProduct = self.parentProduct
         } else {
-            try? productResultsController.performFetch()
+            do {
+                try productResultsController.performFetch()
+            } catch {
+                DDLogError("⛔️ Error fetching the parent product while selecting a variation: \(error)")
+                return
+            }
             parentProduct = productResultsController.fetchedObjects.first
         }
 
@@ -240,11 +245,11 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     }
 }
 
-// MARK: - SyncingCoordinatorDelegate & Sync Methods
-extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
+// MARK: - PaginationTrackerDelegate & Sync Methods
+extension ProductVariationSelectorViewModel: PaginationTrackerDelegate {
     /// Sync product variations from remote.
     ///
-    func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)?) {
+    func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: SyncCompletion?) {
         transitionToSyncingState()
         if let currency {
             let action = ProductVariationAction.retrieveProductVariationsTransiently(siteID: siteID,
@@ -257,21 +262,26 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
                 switch result {
                 case let .success((variations, hasNextPage)):
                     let variations = variations.filter(\.purchasable)
-                    if pageNumber == 1 {
+                    if pageNumber == PaginationTracker.Defaults.pageFirstIndex {
                         productVariations = variations
                     } else {
                         let existingIDs = Set(productVariations.map(\.productVariationID))
                         productVariations += variations.filter { !existingIDs.contains($0.productVariationID) }
                     }
                     transitionToResultsUpdatedState()
-                    onCompletion?(hasNextPage)
+                    onCompletion?(.success(hasNextPage))
+                    if variations.isEmpty && hasNextPage {
+                        DispatchQueue.main.async { [weak self] in
+                            self?.syncNextPage()
+                        }
+                    }
                 case let .failure(error):
                     notice = NoticeFactory.productVariationSyncNotice { [weak self] in
                         self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
                     }
                     transitionToResultsUpdatedState()
                     DDLogError("⛔️ Error retrieving transient product variations: \(error)")
-                    onCompletion?(false)
+                    onCompletion?(.failure(error))
                 }
             }
             stores.dispatch(action)
@@ -296,7 +306,7 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
             }
 
             self.transitionToResultsUpdatedState()
-            onCompletion?(result.isSuccess)
+            onCompletion?(result)
         }
         stores.dispatch(action)
     }
@@ -304,14 +314,13 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
     /// Sync first page of product variations from remote if needed.
     ///
     func syncFirstPage() {
-        syncingCoordinator.synchronizeFirstPage()
+        paginationTracker.syncFirstPage()
     }
 
     /// Sync next page of product variations from remote.
     ///
     func syncNextPage() {
-        let lastIndex = currency == nil ? productVariationsResultsController.numberOfObjects - 1 : productVariations.count - 1
-        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: lastIndex)
+        paginationTracker.ensureNextPageIsSynced()
     }
 }
 
@@ -361,10 +370,10 @@ private extension ProductVariationSelectorViewModel {
         }
     }
 
-    /// Setup: Syncing Coordinator
+    /// Setup: Pagination tracker
     ///
-    func configureSyncingCoordinator() {
-        syncingCoordinator.delegate = self
+    func configurePaginationTracker() {
+        paginationTracker.delegate = self
     }
 
     /// Performs initial sync on first page load
@@ -398,22 +407,9 @@ private extension ProductVariationSelectorViewModel {
                                            isSubscriptionProduct: self.isSubscriptionProduct,
                                            displayMode: .stock,
                                            selectedState: selectedState,
-                                           currencyFormatter: self.currencyFormatter)
+                                           currency: self.currency)
             }
         }.assign(to: &$productVariationRows)
-    }
-
-    var currencyFormatter: CurrencyFormatter {
-        let siteSettings = ServiceLocator.currencySettings
-        guard let currency, let currencyCode = CurrencyCode(rawValue: currency) else {
-            return CurrencyFormatter(currencySettings: siteSettings)
-        }
-        let settings = CurrencySettings(currencyCode: currencyCode,
-                                        currencyPosition: siteSettings.currencyPosition,
-                                        thousandSeparator: siteSettings.groupingSeparator,
-                                        decimalSeparator: siteSettings.decimalSeparator,
-                                        numberOfDecimals: siteSettings.fractionDigits)
-        return CurrencyFormatter(currencySettings: settings)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -8,6 +8,8 @@ import WooFoundation
 ///
 final class ProductVariationSelectorViewModel: ObservableObject {
     private let siteID: Int64
+    private let currency: String?
+    private let parentProduct: Product?
 
     /// Storage to fetch product variation list
     ///
@@ -128,6 +130,8 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          productName: String,
          productAttributes: [ProductAttribute],
          isSubscriptionProduct: Bool = false,
+         currency: String? = nil,
+         parentProduct: Product? = nil,
          allowedProductVariationIDs: [Int64] = [],
          selectedProductVariationIDs: [Int64] = [],
          orderSyncState: Published<OrderSyncState>.Publisher? = nil,
@@ -136,6 +140,8 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          onVariationSelectionStateChanged: ((ProductVariation, Product, Bool) -> Void)? = nil,
          onSelectionsCleared: (() -> Void)? = nil) {
         self.siteID = siteID
+        self.currency = currency
+        self.parentProduct = parentProduct
         self.productID = productID
         self.productName = productName
         self.productAttributes = productAttributes
@@ -156,6 +162,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     convenience init(siteID: Int64,
                      product: Product,
+                     currency: String? = nil,
                      allowedProductVariationIDs: [Int64] = [],
                      selectedProductVariationIDs: [Int64] = [],
                      orderSyncState: Published<OrderSyncState>.Publisher? = nil,
@@ -168,6 +175,8 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   productName: product.name,
                   productAttributes: product.attributesForVariations,
                   isSubscriptionProduct: product.productType.isSubscription,
+                  currency: currency,
+                  parentProduct: product,
                   allowedProductVariationIDs: allowedProductVariationIDs,
                   selectedProductVariationIDs: selectedProductVariationIDs,
                   orderSyncState: orderSyncState,
@@ -196,9 +205,15 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     func changeSelectionStateForVariation(with variationID: Int64, selected: Bool) {
         // Fetch parent product
         // Needed because the parent product contains the product name & attributes.
-        try? productResultsController.performFetch()
+        let parentProduct: Product?
+        if currency != nil {
+            parentProduct = self.parentProduct
+        } else {
+            try? productResultsController.performFetch()
+            parentProduct = productResultsController.fetchedObjects.first
+        }
 
-        guard let parentProduct = productResultsController.fetchedObjects.first,
+        guard let parentProduct,
               let selectedVariation = productVariations.first(where: { $0.productVariationID == variationID }) else {
             return
         }
@@ -231,6 +246,38 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
     ///
     func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)?) {
         transitionToSyncingState()
+        if let currency {
+            let action = ProductVariationAction.retrieveProductVariationsTransiently(siteID: siteID,
+                                                                                    productID: productID,
+                                                                                    currency: currency,
+                                                                                    variationIDs: allowedProductVariationIDs,
+                                                                                    pageNumber: pageNumber,
+                                                                                    pageSize: pageSize) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success((variations, hasNextPage)):
+                    let variations = variations.filter(\.purchasable)
+                    if pageNumber == 1 {
+                        productVariations = variations
+                    } else {
+                        let existingIDs = Set(productVariations.map(\.productVariationID))
+                        productVariations += variations.filter { !existingIDs.contains($0.productVariationID) }
+                    }
+                    transitionToResultsUpdatedState()
+                    onCompletion?(hasNextPage)
+                case let .failure(error):
+                    notice = NoticeFactory.productVariationSyncNotice { [weak self] in
+                        self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
+                    }
+                    transitionToResultsUpdatedState()
+                    DDLogError("⛔️ Error retrieving transient product variations: \(error)")
+                    onCompletion?(false)
+                }
+            }
+            stores.dispatch(action)
+            return
+        }
+
         let action = ProductVariationAction.synchronizeProductVariationsSubset(siteID: siteID,
                                                                                productID: productID,
                                                                                variationIDs: allowedProductVariationIDs,
@@ -263,7 +310,7 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
     /// Sync next page of product variations from remote.
     ///
     func syncNextPage() {
-        let lastIndex = productVariationsResultsController.numberOfObjects - 1
+        let lastIndex = currency == nil ? productVariationsResultsController.numberOfObjects - 1 : productVariations.count - 1
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: lastIndex)
     }
 }
@@ -292,6 +339,12 @@ private extension ProductVariationSelectorViewModel {
     /// Performs initial fetch from storage and updates sync status accordingly.
     ///
     func configureProductVariationsResultsController() {
+        guard currency == nil else {
+            observeSelections()
+            transitionToResultsUpdatedState()
+            return
+        }
+
         updateProductVariationsResultsController()
         transitionToResultsUpdatedState()
     }
@@ -344,9 +397,23 @@ private extension ProductVariationSelectorViewModel {
                                            name: ProductVariationFormatter().generateName(for: variation, from: self.productAttributes),
                                            isSubscriptionProduct: self.isSubscriptionProduct,
                                            displayMode: .stock,
-                                           selectedState: selectedState)
+                                           selectedState: selectedState,
+                                           currencyFormatter: self.currencyFormatter)
             }
         }.assign(to: &$productVariationRows)
+    }
+
+    var currencyFormatter: CurrencyFormatter {
+        let siteSettings = ServiceLocator.currencySettings
+        guard let currency, let currencyCode = CurrencyCode(rawValue: currency) else {
+            return CurrencyFormatter(currencySettings: siteSettings)
+        }
+        let settings = CurrencySettings(currencyCode: currencyCode,
+                                        currencyPosition: siteSettings.currencyPosition,
+                                        thousandSeparator: siteSettings.groupingSeparator,
+                                        decimalSeparator: siteSettings.decimalSeparator,
+                                        numberOfDecimals: siteSettings.fractionDigits)
+        return CurrencyFormatter(currencySettings: settings)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -130,6 +130,22 @@ final class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
+    func test_price_labels_when_currency_is_provided_then_use_provided_currency() {
+        // Given
+        let product = Product.fake().copy(price: "10")
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ProductRowViewModel(product: product,
+                                            productDiscount: 1,
+                                            currencyFormatter: currencyFormatter,
+                                            currency: "GBP")
+
+        // Then
+        XCTAssertEqual(viewModel.priceLabel, "£10.00")
+        XCTAssertEqual(viewModel.priceAndDiscountsLabel, "£10.00 - £1.00")
+    }
+
     func test_priceAndDiscountsLabel_when_price_is_non_numeric_then_returns_dash() {
         // Given
         let price = "not-a-number"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -35,6 +35,69 @@ final class ProductSelectorViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_sync_when_currency_is_configured_then_retrieves_and_paginates_products_in_memory_with_order_currency() {
+        // Given
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 99, name: "Cached USD product", purchasable: true))
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 source: .orderForm(flow: .creation),
+                                                 currency: "GBP",
+                                                 storageManager: storageManager,
+                                                 stores: stores)
+        let firstPage = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "First", price: "10", purchasable: true)
+        let secondPage = Product.fake().copy(siteID: sampleSiteID, productID: 2, name: "Second", price: "20", purchasable: true)
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .retrieveProductsTransiently(_, currency, pageNumber, _, _, _, _, _, _, _, _, onCompletion):
+                XCTAssertEqual(currency, "GBP")
+                onCompletion(.success((pageNumber == 1 ? [firstPage] : [secondPage], pageNumber == 1)))
+            default:
+                XCTFail("Currency mode dispatched a persistent product action")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 1, onCompletion: nil)
+        viewModel.sync(pageNumber: 2, pageSize: 1, onCompletion: nil)
+
+        // Then
+        XCTAssertEqual(viewModel.productRows.map(\.productOrVariationID), [1, 2])
+        XCTAssertEqual(viewModel.productRows.first?.priceLabel, "£10.00")
+        XCTAssertFalse(viewModel.productRows.contains { $0.productOrVariationID == 99 })
+    }
+
+    func test_sync_when_currency_and_search_term_are_configured_then_searches_and_paginates_in_memory_without_cached_search() {
+        // Given
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 source: .orderForm(flow: .creation),
+                                                 currency: "EUR",
+                                                 storageManager: storageManager,
+                                                 stores: stores)
+        viewModel.searchTerm = "shirt"
+        var searchedPages: [Int] = []
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .searchProductsTransiently(_, currency, keyword, _, pageNumber, _, _, _, _, _, _, onCompletion):
+                searchedPages.append(pageNumber)
+                XCTAssertEqual(currency, "EUR")
+                XCTAssertEqual(keyword, "shirt")
+                let product = Product.fake().copy(siteID: self.sampleSiteID, productID: Int64(pageNumber), purchasable: true)
+                onCompletion(.success(([product], pageNumber == 1)))
+            default:
+                XCTFail("Currency search dispatched a cached or persistent product action")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 1, onCompletion: nil)
+        viewModel.sync(pageNumber: 2, pageSize: 1, onCompletion: nil)
+
+        // Then
+        XCTAssertEqual(searchedPages, [1, 2])
+        XCTAssertEqual(viewModel.productRows.map(\.productOrVariationID), [1, 2])
+    }
+
     func test_view_model_is_initialized_with_default_values() {
         // Given
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, source: .orderForm(flow: .creation))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -78,7 +78,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .searchProductsTransiently(_, currency, keyword, _, pageNumber, _, _, _, _, _, _, onCompletion):
+            case let .searchProductsTransiently(_, currency, keyword, _, pageNumber, _, _, _, _, _, _, _, onCompletion):
                 searchedPages.append(pageNumber)
                 XCTAssertEqual(currency, "EUR")
                 XCTAssertEqual(keyword, "shirt")
@@ -96,6 +96,53 @@ final class ProductSelectorViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(searchedPages, [1, 2])
         XCTAssertEqual(viewModel.productRows.map(\.productOrVariationID), [1, 2])
+    }
+
+    func test_sync_when_transient_product_retrieval_fails_then_shows_sync_notice() {
+        // Given
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 source: .orderForm(flow: .creation),
+                                                 currency: "GBP",
+                                                 storageManager: storageManager,
+                                                 stores: stores)
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .retrieveProductsTransiently(_, _, _, _, _, _, _, _, _, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: nil)
+
+        // Then
+        XCTAssertEqual(viewModel.notice, ProductSelectorViewModel.NoticeFactory.productSyncNotice(retryAction: {}))
+    }
+
+    func test_sync_when_transient_product_search_fails_then_shows_search_notice() {
+        // Given
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 source: .orderForm(flow: .creation),
+                                                 currency: "GBP",
+                                                 storageManager: storageManager,
+                                                 stores: stores)
+        viewModel.searchTerm = "shirt"
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .searchProductsTransiently(_, _, _, _, _, _, _, _, _, _, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: nil)
+
+        // Then
+        XCTAssertEqual(viewModel.notice, ProductSelectorViewModel.NoticeFactory.productSearchNotice(retryAction: {}))
     }
 
     func test_view_model_is_initialized_with_default_values() {
@@ -1732,6 +1779,72 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.favoriteProductIDs, sampleProductIDs)
+    }
+
+    func test_sync_when_currency_and_empty_favorites_filter_are_configured_then_returns_empty_without_request() {
+        // Given
+        let favoriteProductsUseCase = MockFavoriteProductsUseCase()
+        favoriteProductsUseCase.favoriteProductIDsValue = []
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 source: .orderForm(flow: .creation),
+                                                 currency: "GBP",
+                                                 storageManager: storageManager,
+                                                 stores: stores,
+                                                 favoriteProductsUseCase: favoriteProductsUseCase)
+        viewModel.updateFilters(.init(stockStatus: nil,
+                                      productStatus: nil,
+                                      promotableProductType: nil,
+                                      productCategory: nil,
+                                      favoriteProduct: FavoriteProductsFilter(),
+                                      numberOfActiveFilters: 1))
+        var dispatchedAction = false
+        stores.whenReceivingAction(ofType: ProductAction.self) { _ in
+            dispatchedAction = true
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: nil)
+
+        // Then
+        XCTAssertFalse(dispatchedAction)
+        XCTAssertTrue(viewModel.productRows.isEmpty)
+        XCTAssertEqual(viewModel.syncStatus, .empty)
+    }
+
+    func test_sync_when_currency_search_and_favorites_filter_are_configured_then_forwards_favorite_productIDs() async {
+        // Given
+        let favoriteProductsUseCase = MockFavoriteProductsUseCase()
+        favoriteProductsUseCase.favoriteProductIDsValue = [23, 89, 432]
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 source: .orderForm(flow: .creation),
+                                                 currency: "GBP",
+                                                 storageManager: storageManager,
+                                                 stores: stores,
+                                                 favoriteProductsUseCase: favoriteProductsUseCase)
+        await viewModel.loadFavoriteProductIDs()
+        viewModel.updateFilters(.init(stockStatus: nil,
+                                      productStatus: nil,
+                                      promotableProductType: nil,
+                                      productCategory: nil,
+                                      favoriteProduct: FavoriteProductsFilter(),
+                                      numberOfActiveFilters: 1))
+        viewModel.searchTerm = "shirt"
+        var requestedProductIDs: [Int64] = []
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .searchProductsTransiently(_, _, _, _, _, _, _, _, _, _, productIDs, _, onCompletion):
+                requestedProductIDs = productIDs
+                onCompletion(.success((products: [], hasNextPage: false)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: nil)
+
+        // Then
+        XCTAssertEqual(requestedProductIDs, favoriteProductsUseCase.favoriteProductIDsValue)
     }
 
     // MARK: - Resetting filters

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -56,6 +56,68 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.productVariationRows.contains { $0.productOrVariationID == 99 })
     }
 
+    func test_syncNextPage_when_transient_page_is_partially_filtered_then_retrieves_next_page() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)
+        let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID,
+                                                          product: product,
+                                                          currency: "GBP",
+                                                          storageManager: storageManager,
+                                                          stores: stores)
+        var retrievedPages: [Int] = []
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .retrieveProductVariationsTransiently(_, _, _, _, pageNumber, pageSize, onCompletion):
+                retrievedPages.append(pageNumber)
+                let variations = (0..<pageSize).map { index in
+                    self.sampleProductVariation.copy(productVariationID: Int64(pageNumber * pageSize + index),
+                                                     purchasable: index != 0)
+                }
+                onCompletion(.success((variations, pageNumber == 1)))
+            default:
+                XCTFail("Currency mode dispatched a persistent variation action")
+            }
+        }
+
+        // When
+        viewModel.syncFirstPage()
+        viewModel.syncNextPage()
+
+        // Then
+        XCTAssertEqual(retrievedPages, [1, 2])
+    }
+
+    func test_sync_when_transient_page_has_no_purchasable_variations_then_automatically_retrieves_next_page() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)
+        let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID,
+                                                          product: product,
+                                                          currency: "GBP",
+                                                          storageManager: storageManager,
+                                                          stores: stores)
+        var retrievedPages: [Int] = []
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .retrieveProductVariationsTransiently(_, _, _, _, pageNumber, _, onCompletion):
+                retrievedPages.append(pageNumber)
+                let variation = self.sampleProductVariation.copy(productVariationID: Int64(pageNumber),
+                                                                 purchasable: pageNumber > 1)
+                onCompletion(.success(([variation], pageNumber == 1)))
+            default:
+                XCTFail("Currency mode dispatched a persistent variation action")
+            }
+        }
+
+        // When
+        viewModel.syncFirstPage()
+
+        // Then
+        waitUntil {
+            retrievedPages == [1, 2]
+        }
+        XCTAssertEqual(viewModel.productVariationRows.map(\.productOrVariationID), [2])
+    }
+
     func test_view_model_adds_product_variation_rows_with_expected_values() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -25,6 +25,37 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_sync_when_currency_is_configured_then_retrieves_and_paginates_variations_in_memory_with_order_currency() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)
+        insert(sampleProductVariation.copy(productVariationID: 99, price: "99"))
+        let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID,
+                                                          product: product,
+                                                          currency: "GBP",
+                                                          storageManager: storageManager,
+                                                          stores: stores)
+        stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .retrieveProductVariationsTransiently(_, productID, currency, _, pageNumber, _, onCompletion):
+                XCTAssertEqual(productID, self.sampleProductID)
+                XCTAssertEqual(currency, "GBP")
+                let variation = self.sampleProductVariation.copy(productVariationID: Int64(pageNumber), price: "\(pageNumber * 10)")
+                onCompletion(.success(([variation], pageNumber == 1)))
+            default:
+                XCTFail("Currency mode dispatched a persistent variation action")
+            }
+        }
+
+        // When
+        viewModel.sync(pageNumber: 1, pageSize: 1, onCompletion: nil)
+        viewModel.sync(pageNumber: 2, pageSize: 1, onCompletion: nil)
+
+        // Then
+        XCTAssertEqual(viewModel.productVariationRows.map(\.productOrVariationID), [1, 2])
+        XCTAssertEqual(viewModel.productVariationRows.first?.priceLabel, "£10.00")
+        XCTAssertFalse(viewModel.productVariationRows.contains { $0.productOrVariationID == 99 })
+    }
+
     func test_view_model_adds_product_variation_rows_with_expected_values() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID,


### PR DESCRIPTION
Part of: WOOMOB-3628

This PR is stacked on #17614 and should be reviewed after it.

## Description

Adds an optional currency mode to the product and variation selectors.

Currency mode uses the transient actions from #17614, keeps paginated list and search results in memory, bypasses Core Data and local cached search, and formats rows using the requested order currency. The ordinary selector path remains unchanged when currency is `nil`.

## Test Steps

CI passing should be enough – manual testing will be better on #17619

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
