### PR TITLE
Fix order details crash on rotation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 25.4
 -----
 - [*] Login: Fixed stores failing to load when hosting blocks one of the WordPress REST API URL formats. [https://github.com/woocommerce/woocommerce-ios/pull/17602]
+- [*] Orders: Fixed a crash when rotating order details on large iPhones running iOS 27. [https://github.com/woocommerce/woocommerce-ios/pull/17620]
 
 25.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,12 +4,8 @@
 -----
 - [*] Login: Fixed stores failing to load when hosting blocks one of the WordPress REST API URL formats. [https://github.com/woocommerce/woocommerce-ios/pull/17602]
 - [*] Orders: Fixed a crash when rotating order details on large iPhones running iOS 27. [https://github.com/woocommerce/woocommerce-ios/pull/17620]
-
-25.4
------
 - [*] Fixed the in-app new order notification showing a cut-off title and a wrong-coloured "View" button in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/17601]
 - [*] Products: Fixed bulk Regular Price update failing for variable products whose variations share a duplicate SKU or GTIN. [https://github.com/woocommerce/woocommerce-ios/pull/17556]
-
 
 25.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -8,6 +8,8 @@ final class OrdersSplitViewWrapperController: UIViewController, UsesCompactLayou
 
     private lazy var ordersSplitViewController = WooSplitViewController(columnForCollapsingHandler: handleCollapsingSplitView)
     private lazy var ordersViewController = OrdersRootViewController(siteID: siteID, switchDetailsHandler: handleSwitchingDetails)
+    // Keep one navigation bar owner while the split view moves between compact and expanded layouts.
+    private let secondaryNavigationController = WooNavigationController()
 
     init(siteID: Int64) {
         self.siteID = siteID
@@ -49,14 +51,12 @@ final class OrdersSplitViewWrapperController: UIViewController, UsesCompactLayou
                 return
             }
             let loaderViewController = OrderLoaderViewController(orderID: orderID, siteID: Int64(siteID), note: note)
-            let loaderNavigationController = WooNavigationController(rootViewController: loaderViewController)
-            return showSecondaryView(loaderNavigationController)
+            return showSecondaryView(loaderViewController)
         }
     }
 
     private func orderLoaderAlreadyShownInSecondaryView(for orderID: Int64) -> Bool {
-        guard let navigationController = ordersSplitViewController.viewController(for: .secondary) as? WooNavigationController,
-              let loaderController = navigationController.topViewController as? OrderLoaderViewController else {
+        guard let loaderController = secondaryNavigationController.topViewController as? OrderLoaderViewController else {
             return false
         }
         return loaderController.orderID == orderID
@@ -77,13 +77,11 @@ private extension OrdersSplitViewWrapperController {
         let config = EmptyStateViewController.Config.simpleImageWithDescription(image: .shoppingBagsImage,
                                                                                details: Localization.emptyOrderDetails)
         emptyStateViewController.configure(config)
-        let navigationController = WooNavigationController(rootViewController: emptyStateViewController)
-        showSecondaryView(navigationController)
+        showSecondaryView(emptyStateViewController)
     }
 
     func isShowingEmptyView() -> Bool {
-        (ordersSplitViewController.viewController(for: .secondary) as? UINavigationController)?
-            .viewControllers.contains(where: { $0 is EmptyStateViewController }) == true
+        secondaryNavigationController.viewControllers.contains(where: { $0 is EmptyStateViewController })
     }
 
     func showSecondaryView(_ viewController: UIViewController, onCompletion: (() -> Void)? = nil) {
@@ -91,7 +89,7 @@ private extension OrdersSplitViewWrapperController {
         // - white debugging noticed that ordersViewController.navigationController had multiple orders in the view controllers list
         ordersViewController.navigationController?.popToRootViewController(animated: false)
 
-        ordersSplitViewController.setViewController(viewController, for: .secondary)
+        secondaryNavigationController.setViewControllers([viewController], animated: false)
         ordersSplitViewController.show(.secondary)
         completeAfterShowingSecondary(onCompletion)
     }
@@ -148,13 +146,11 @@ private extension OrdersSplitViewWrapperController {
         // The up and down arrows are enabled when there is more than one item in `viewModels`.
         guard
             let viewModel = viewModels[safe: currentIndex],
-            let secondaryNavigationController = ordersSplitViewController.viewController(for: .secondary) as? UINavigationController,
             let existingOrderDetailsViewController = secondaryNavigationController.topViewController as? OrderDetailsViewController,
             existingOrderDetailsViewController.isQuickOrderNavigationSupported() == orderDetailsViewController.isQuickOrderNavigationSupported()
         else {
             // When showing an order without quick navigation, it simply sets the order details to the secondary view.
-            let orderDetailsNavigationController = WooNavigationController(rootViewController: orderDetailsViewController)
-            showSecondaryView(orderDetailsNavigationController) {
+            showSecondaryView(orderDetailsViewController) {
                 onCompletion?(true)
             }
             return
@@ -181,12 +177,12 @@ private extension OrdersSplitViewWrapperController {
         ordersNavigationController.viewControllers = [ordersViewController]
         ordersSplitViewController.setViewController(ordersNavigationController, for: .primary)
 
+        ordersSplitViewController.setViewController(secondaryNavigationController, for: .secondary)
         showEmptyView()
     }
 
-    func handleCollapsingSplitView(splitViewController: UISplitViewController) -> UISplitViewController.Column {
-        if let navigationController = splitViewController.viewController(for: .secondary) as? UINavigationController,
-           navigationController.viewControllers.contains(where: { $0 is OrderDetailsViewController }) {
+    func handleCollapsingSplitView(splitViewController _: UISplitViewController) -> UISplitViewController.Column {
+        if secondaryNavigationController.viewControllers.contains(where: { $0 is OrderDetailsViewController }) {
             return .secondary
         }
         return .primary

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersSplitViewWrapperControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersSplitViewWrapperControllerTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import UIKit
+@testable import WooCommerce
+
+@MainActor
+struct OrdersSplitViewWrapperControllerTests {
+    @Test func presenting_order_loader_reuses_secondary_navigation_controller() throws {
+        // Given
+        let viewController = OrdersSplitViewWrapperController(siteID: 123)
+        viewController.loadViewIfNeeded()
+        let splitViewController = try #require(viewController.children.first as? UISplitViewController)
+        let initialNavigationController = try #require(
+            splitViewController.viewController(for: .secondary) as? UINavigationController
+        )
+
+        // When
+        viewController.presentDetails(for: 456, siteID: 123)
+
+        // Then
+        let updatedNavigationController = try #require(
+            splitViewController.viewController(for: .secondary) as? UINavigationController
+        )
+        #expect(updatedNavigationController === initialNavigationController)
+        #expect(updatedNavigationController.topViewController is OrderLoaderViewController)
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-3698

## Description
Fixes `WOOCOMMERCE-IOS-1QH4`, an iOS 27-only crash when order details rotate between compact and expanded split-view layouts. Orders now keeps one secondary navigation controller and replaces its stack, avoiding navigation-item ownership moving between navigation bars.

## Test Steps
I wasn't able to reproduce this as my iOS 27 device isn't big enough for split view, so it's a speculative fix and steps.

1. On a large iPhone, open an order.
2. Rotate repeatedly between portrait and landscape.
3. Confirm order details remain visible without a crash.

Also check on iPad, especially with resizing

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.