### PR TITLE
[WOOMOB-43] Fix magic link login not navigating to the store dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.4
 -----
+- [*] Fixed magic link login not navigating to the store dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/17622]
 
 
 25.3

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -171,7 +171,8 @@ class AuthenticationManager: Authentication {
     func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) async -> Bool {
         if WordPressAuthenticator.shared.isWordPressAuthUrl(url) {
             return WordPressAuthenticator.shared.handleWordPressAuthUrl(url,
-                                                                        rootViewController: rootViewController)
+                                                                        rootViewController: rootViewController,
+                                                                        restoresSiteAddress: true)
         }
 
         if isQRLoginUrl(url),

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -306,8 +306,12 @@ private extension QRLoginCoordinator {
                 // `showLoginEpilogue` assertion. Dismiss the sheet first, then
                 // hand off from the now-stable root.
                 rootViewController.dismiss(animated: false) {
+                    // QR login shares the magic-link `.login` case but never saved a site address,
+                    // so it must not restore one (would leak a stale address from an abandoned
+                    // email magic-link request into this account — wrong-store error).
                     _ = WordPressAuthenticator.shared.handleWordPressAuthUrl(callbackURL,
-                                                                             rootViewController: rootViewController)
+                                                                             rootViewController: rootViewController,
+                                                                             restoresSiteAddress: false)
                 }
                 // Sign-in proceeds through WordPressAuthenticator from here —
                 // release the coordinator; the login UI is about to be replaced.

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -398,6 +398,10 @@ import WordPressUI
         case .login:
             flow = .login
             loginFields.meta.emailMagicLinkSource = .login
+            // Restore the entered store address so the epilogue navigates to that store.
+            if let siteAddress = MagicLinkSiteAddressStorage.shared.consume() {
+                loginFields.siteAddress = siteAddress
+            }
             Self.track(.loginMagicLinkOpened)
         default:
             WPAuthenticatorLogError("Magic link error: the flow should be either `signup` or `login`. We can't handle an unsupported flow.")

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -108,8 +108,8 @@ import WordPressUI
 
     /// Attempts to process the specified URL as a WordPress Authentication Link. Returns *true* on success.
     ///
-    @objc public func handleWordPressAuthUrl(_ url: URL, rootViewController: UIViewController, automatedTesting: Bool = false) -> Bool {
-        return WordPressAuthenticator.openAuthenticationURL(url, fromRootViewController: rootViewController, automatedTesting: automatedTesting)
+    @objc public func handleWordPressAuthUrl(_ url: URL, rootViewController: UIViewController, restoresSiteAddress: Bool, automatedTesting: Bool = false) -> Bool {
+        return WordPressAuthenticator.openAuthenticationURL(url, fromRootViewController: rootViewController, restoresSiteAddress: restoresSiteAddress, automatedTesting: automatedTesting)
     }
 
     // MARK: - Helpers for presenting the login flow
@@ -360,6 +360,7 @@ import WordPressUI
     @objc public class func openAuthenticationURL(
         _ url: URL,
         fromRootViewController rootViewController: UIViewController,
+        restoresSiteAddress: Bool,
         automatedTesting: Bool = false) -> Bool {
 
         guard let queryDictionary = url.query?.dictionaryFromQueryString() else {
@@ -398,8 +399,10 @@ import WordPressUI
         case .login:
             flow = .login
             loginFields.meta.emailMagicLinkSource = .login
-            // Restore the entered store address so the epilogue navigates to that store.
-            if let siteAddress = MagicLinkSiteAddressStorage.shared.consume() {
+            // Restore the entered store address only for the email magic-link flow. QR login shares
+            // this case (its callback carries no `flow`) but never saved an address, so it must not
+            // consume a stale one — hence the explicit opt-in rather than always consuming here.
+            if restoresSiteAddress, let siteAddress = MagicLinkSiteAddressStorage.shared.consume() {
                 loginFields.siteAddress = siteAddress
             }
             Self.track(.loginMagicLinkOpened)

--- a/WooCommerce/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
@@ -24,8 +24,7 @@ class NUXLinkAuthViewController: LoginViewController {
     }
 
     func syncAndContinue(authToken: String, flow: Flow, isJetpackConnect: Bool) {
-        let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackConnect, multifactor: false, siteURL: "https://wordpress.com")
-        let credentials = AuthenticatorCredentials(wpcom: wpcom)
+        let credentials = makeCredentials(authToken: authToken, isJetpackConnect: isJetpackConnect)
 
         syncWPComAndPresentEpilogue(credentials: credentials) {
             self.tracker.track(step: .success)
@@ -40,5 +39,12 @@ class NUXLinkAuthViewController: LoginViewController {
                 WordPressAuthenticator.track(.loginMagicLinkSucceeded)
             }
         }
+    }
+
+    /// Uses the entered store address so the epilogue navigates to it; falls back to wordpress.com.
+    func makeCredentials(authToken: String, isJetpackConnect: Bool) -> AuthenticatorCredentials {
+        let siteURL = loginFields.siteAddress.isEmpty ? "https://wordpress.com" : loginFields.siteAddress
+        let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackConnect, multifactor: false, siteURL: siteURL)
+        return AuthenticatorCredentials(wpcom: wpcom)
     }
 }

--- a/WooCommerce/WordPressAuthenticator/Services/MagicLinkSiteAddressStorage.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/MagicLinkSiteAddressStorage.swift
@@ -9,8 +9,8 @@ final class MagicLinkSiteAddressStorage {
     private let storageKey = "com.wordpress.authenticator.magicLinkSiteAddress"
     private let now: () -> Date
 
-    /// Magic links typically expire in ~10-15 minutes.
-    private let expirationInterval: TimeInterval = 15 * 60
+    /// Magic links expire in 60 minutes.
+    private let expirationInterval: TimeInterval = 60 * 60
 
     init(userDefaults: UserDefaults = .standard, now: @escaping () -> Date = { Date() }) {
         self.userDefaults = userDefaults

--- a/WooCommerce/WordPressAuthenticator/Services/MagicLinkSiteAddressStorage.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/MagicLinkSiteAddressStorage.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Persists the login store address in `UserDefaults` so it survives the magic-link
+/// cold launch (link opened from Mail) and can be restored on consume. Read-once.
+final class MagicLinkSiteAddressStorage {
+    static let shared = MagicLinkSiteAddressStorage()
+
+    private let userDefaults: UserDefaults
+    private let storageKey = "com.wordpress.authenticator.magicLinkSiteAddress"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    /// nil/empty clears the previous value (latest request wins).
+    func save(_ siteAddress: String?) {
+        guard let siteAddress, !siteAddress.isEmpty else {
+            clear()
+            return
+        }
+        userDefaults.set(siteAddress, forKey: storageKey)
+    }
+
+    /// Returns the stored address and clears it; nil if none.
+    func consume() -> String? {
+        defer { clear() }
+        return userDefaults.string(forKey: storageKey)
+    }
+
+    private func clear() {
+        userDefaults.removeObject(forKey: storageKey)
+    }
+}

--- a/WooCommerce/WordPressAuthenticator/Services/MagicLinkSiteAddressStorage.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/MagicLinkSiteAddressStorage.swift
@@ -7,9 +7,14 @@ final class MagicLinkSiteAddressStorage {
 
     private let userDefaults: UserDefaults
     private let storageKey = "com.wordpress.authenticator.magicLinkSiteAddress"
+    private let now: () -> Date
 
-    init(userDefaults: UserDefaults = .standard) {
+    /// Magic links typically expire in ~10-15 minutes.
+    private let expirationInterval: TimeInterval = 15 * 60
+
+    init(userDefaults: UserDefaults = .standard, now: @escaping () -> Date = { Date() }) {
         self.userDefaults = userDefaults
+        self.now = now
     }
 
     /// nil/empty clears the previous value (latest request wins).
@@ -18,16 +23,29 @@ final class MagicLinkSiteAddressStorage {
             clear()
             return
         }
-        userDefaults.set(siteAddress, forKey: storageKey)
+        let entry = StoredSiteAddress(siteAddress: siteAddress, timestamp: now())
+        userDefaults.set(try? JSONEncoder().encode(entry), forKey: storageKey)
     }
 
-    /// Returns the stored address and clears it; nil if none.
+    /// Returns the stored address and clears it; nil if none or expired.
     func consume() -> String? {
         defer { clear() }
-        return userDefaults.string(forKey: storageKey)
+        guard let data = userDefaults.data(forKey: storageKey),
+              let stored = try? JSONDecoder().decode(StoredSiteAddress.self, from: data),
+              now().timeIntervalSince(stored.timestamp) < expirationInterval else {
+            return nil
+        }
+        return stored.siteAddress
     }
 
     private func clear() {
         userDefaults.removeObject(forKey: storageKey)
+    }
+}
+
+private extension MagicLinkSiteAddressStorage {
+    struct StoredSiteAddress: Codable {
+        let siteAddress: String
+        let timestamp: Date
     }
 }

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -679,6 +679,7 @@ private extension GetStartedViewController {
         service.requestAuthenticationLink(for: email,
                                           jetpackLogin: loginFields.meta.jetpackLogin,
                                           success: { [weak self] in
+                                            MagicLinkSiteAddressStorage.shared.save(self?.loginFields.siteAddress)
                                             self?.didRequestAuthenticationLink()
                                             self?.configureViewLoading(false)
             }, failure: { [weak self] (error: Error) in

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -675,11 +675,14 @@ private extension GetStartedViewController {
         }
 
         configureViewLoading(true)
+        // Capture before the async request so the save doesn't depend on `self` surviving:
+        // if the screen deallocates first, `self?.loginFields.siteAddress` would be nil and clear it.
+        let siteAddress = loginFields.siteAddress
         let service = WordPressComAccountService()
         service.requestAuthenticationLink(for: email,
                                           jetpackLogin: loginFields.meta.jetpackLogin,
                                           success: { [weak self] in
-                                            MagicLinkSiteAddressStorage.shared.save(self?.loginFields.siteAddress)
+                                            MagicLinkSiteAddressStorage.shared.save(siteAddress)
                                             self?.didRequestAuthenticationLink()
                                             self?.configureViewLoading(false)
             }, failure: { [weak self] (error: Error) in

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequestViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequestViewController.swift
@@ -49,7 +49,9 @@ private extension MagicLinkRequestViewController {
             tracker.track(click: .requestMagicLink)
             configureSubmitButton(animating: true)
 
-            let result = await MagicLinkRequester().requestMagicLink(email: loginFields.username, jetpackLogin: loginFields.meta.jetpackLogin)
+            let result = await MagicLinkRequester().requestMagicLink(email: loginFields.username,
+                                                                     jetpackLogin: loginFields.meta.jetpackLogin,
+                                                                     siteAddress: loginFields.siteAddress)
 
             configureSubmitButton(animating: false)
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequester.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequester.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Encapsulates the async request for a magic link and email validation for use cases that send a magic link.
 struct MagicLinkRequester {
     /// Makes the call to request a magic authentication link be emailed to the user if possible.
-    func requestMagicLink(email: String, jetpackLogin: Bool) async -> Result<Void, Error> {
+    func requestMagicLink(email: String, jetpackLogin: Bool, siteAddress: String? = nil) async -> Result<Void, Error> {
         await withCheckedContinuation { continuation in
             guard email.isValidEmail() else {
                 return continuation.resume(returning: .failure(MagicLinkRequestError.invalidEmail))
@@ -13,6 +13,7 @@ struct MagicLinkRequester {
             service.requestAuthenticationLink(for: email,
                                               jetpackLogin: jetpackLogin,
                                               success: {
+                MagicLinkSiteAddressStorage.shared.save(siteAddress)
                 continuation.resume(returning: .success(()))
             }, failure: { error in
                 continuation.resume(returning: .failure(error))

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequester.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequester.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Encapsulates the async request for a magic link and email validation for use cases that send a magic link.
 struct MagicLinkRequester {
     /// Makes the call to request a magic authentication link be emailed to the user if possible.
-    func requestMagicLink(email: String, jetpackLogin: Bool, siteAddress: String? = nil) async -> Result<Void, Error> {
+    func requestMagicLink(email: String, jetpackLogin: Bool, siteAddress: String) async -> Result<Void, Error> {
         await withCheckedContinuation { continuation in
             guard email.isValidEmail() else {
                 return continuation.resume(returning: .failure(MagicLinkRequestError.invalidEmail))

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordCoordinator.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordCoordinator.swift
@@ -42,7 +42,9 @@ private extension PasswordCoordinator {
     /// Makes the call to request a magic authentication link be emailed to the user.
     func requestMagicLink() async -> Result<Void, Error> {
         loginFields.meta.emailMagicLinkSource = .login
-        return await MagicLinkRequester().requestMagicLink(email: loginFields.username, jetpackLogin: loginFields.meta.jetpackLogin)
+        return await MagicLinkRequester().requestMagicLink(email: loginFields.username,
+                                                           jetpackLogin: loginFields.meta.jetpackLogin,
+                                                           siteAddress: loginFields.siteAddress)
     }
 
     /// After a magic link is successfully sent, navigates the user to the requested screen.

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -277,7 +277,9 @@ private extension PasswordViewController {
         loginFields.meta.emailMagicLinkSource = .login
 
         updateLoadingUI(isRequestingMagicLink: true)
-        let result = await MagicLinkRequester().requestMagicLink(email: loginFields.username, jetpackLogin: loginFields.meta.jetpackLogin)
+        let result = await MagicLinkRequester().requestMagicLink(email: loginFields.username,
+                                                                 jetpackLogin: loginFields.meta.jetpackLogin,
+                                                                 siteAddress: loginFields.siteAddress)
         switch result {
         case .success:
             didRequestAuthenticationLink()

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -188,6 +188,7 @@ private extension VerifyEmailViewController {
         service.requestAuthenticationLink(for: email,
                                           jetpackLogin: loginFields.meta.jetpackLogin,
                                           success: { [weak self] in
+                                            MagicLinkSiteAddressStorage.shared.save(self?.loginFields.siteAddress)
                                             self?.didRequestAuthenticationLink()
                                             self?.configureViewLoading(false)
             }, failure: { [weak self] (error: Error) in

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -184,11 +184,14 @@ private extension VerifyEmailViewController {
         let email = loginFields.username
 
         configureViewLoading(true)
+        // Capture before the async request so the save doesn't depend on `self` surviving:
+        // if the screen deallocates first, `self?.loginFields.siteAddress` would be nil and clear it.
+        let siteAddress = loginFields.siteAddress
         let service = WordPressComAccountService()
         service.requestAuthenticationLink(for: email,
                                           jetpackLogin: loginFields.meta.jetpackLogin,
                                           success: { [weak self] in
-                                            MagicLinkSiteAddressStorage.shared.save(self?.loginFields.siteAddress)
+                                            MagicLinkSiteAddressStorage.shared.save(siteAddress)
                                             self?.didRequestAuthenticationLink()
                                             self?.configureViewLoading(false)
             }, failure: { [weak self] (error: Error) in

--- a/WooCommerce/WordPressAuthenticatorTests/Authenticator/MagicLinkSiteAddressRestoreTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Authenticator/MagicLinkSiteAddressRestoreTests.swift
@@ -4,8 +4,15 @@ import UIKit
 
 /// Tests that magic-link consumption restores the saved site address only when the caller opts in
 /// (email magic link), not for QR login which shares the same `.login` code path.
+///
+/// `openAuthenticationURL` reads the process-wide `MagicLinkSiteAddressStorage.shared`, so these can't
+/// use an ephemeral store. Serialize and clear around each test so state can't race or leak to disk.
 @MainActor
-struct MagicLinkSiteAddressRestoreTests {
+@Suite(.serialized)
+final class MagicLinkSiteAddressRestoreTests {
+
+    init() { _ = MagicLinkSiteAddressStorage.shared.consume() }
+    deinit { _ = MagicLinkSiteAddressStorage.shared.consume() }
 
     @Test func test_openAuthenticationURL_when_restoresSiteAddress_is_false_then_saved_address_is_not_consumed() {
         // Given a saved store address and a QR-login-style callback (no `flow`)

--- a/WooCommerce/WordPressAuthenticatorTests/Authenticator/MagicLinkSiteAddressRestoreTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Authenticator/MagicLinkSiteAddressRestoreTests.swift
@@ -1,0 +1,41 @@
+import Testing
+import UIKit
+@testable import WordPressAuthenticator
+
+/// Tests that magic-link consumption restores the saved site address only when the caller opts in
+/// (email magic link), not for QR login which shares the same `.login` code path.
+@MainActor
+struct MagicLinkSiteAddressRestoreTests {
+
+    @Test func test_openAuthenticationURL_when_restoresSiteAddress_is_false_then_saved_address_is_not_consumed() {
+        // Given a saved store address and a QR-login-style callback (no `flow`)
+        WordPressAuthenticator.initializeForTesting()
+        MagicLinkSiteAddressStorage.shared.save("https://qr-should-not-touch.com")
+        let url = URL(string: "woocommerce://magic-login?token=token")!
+
+        // When the URL is handled without restoring the site address (QR login opts out)
+        _ = WordPressAuthenticator.openAuthenticationURL(url,
+                                                         fromRootViewController: UIViewController(),
+                                                         restoresSiteAddress: false,
+                                                         automatedTesting: true)
+
+        // Then the saved address is left untouched so QR login can't inherit a stale one
+        #expect(MagicLinkSiteAddressStorage.shared.consume() == "https://qr-should-not-touch.com")
+    }
+
+    @Test func test_openAuthenticationURL_when_restoresSiteAddress_is_true_then_saved_address_is_consumed() {
+        // Given a saved store address and an email magic-link callback
+        WordPressAuthenticator.initializeForTesting()
+        MagicLinkSiteAddressStorage.shared.save("https://magic-link.com")
+        let url = URL(string: "woocommerce://magic-login?token=token&flow=login")!
+
+        // When the URL is handled with restore enabled (email magic link opts in)
+        _ = WordPressAuthenticator.openAuthenticationURL(url,
+                                                         fromRootViewController: UIViewController(),
+                                                         restoresSiteAddress: true,
+                                                         automatedTesting: true)
+
+        // Then the saved address was consumed (read-once) during the restore
+        #expect(MagicLinkSiteAddressStorage.shared.consume() == nil)
+    }
+}

--- a/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -118,6 +118,6 @@ class WordPressAuthenticatorTests: XCTestCase {
         let authenticator = WordpressAuthenticatorProvider.getWordpressAuthenticator()
         let url = URL(string: "https://wordpress.com/wp-login.php?token=1234567890%26action&magic-login&sr=1&signature=1234567890oienhdtsra&flow=signup")
 
-        XCTAssertTrue(authenticator.handleWordPressAuthUrl(url!, rootViewController: UIViewController(), automatedTesting: true))
+        XCTAssertTrue(authenticator.handleWordPressAuthUrl(url!, rootViewController: UIViewController(), restoresSiteAddress: false, automatedTesting: true))
     }
 }

--- a/WooCommerce/WordPressAuthenticatorTests/NUX/NUXLinkAuthViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/NUX/NUXLinkAuthViewControllerTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import UIKit
+@testable import WordPressAuthenticator
+
+/// Tests `NUXLinkAuthViewController` credential building after magic-link consumption.
+@MainActor
+struct NUXLinkAuthViewControllerTests {
+
+    @Test func test_makeCredentials_when_site_address_entered_then_siteURL_matches_entered_address() {
+        // Given a controller with the store address entered at the start of the login flow
+        WordPressAuthenticator.initializeForTesting()
+        let controller = NUXLinkAuthViewController()
+        controller.loginFields.siteAddress = "https://yourwoosite.com"
+
+        // When building the credentials used to sync the account after magic-link consumption
+        let credentials = controller.makeCredentials(authToken: "token", isJetpackConnect: false)
+
+        // Then the credential carries the entered address so the epilogue can match and route to that store
+        #expect(credentials.wpcom?.siteURL == "https://yourwoosite.com")
+    }
+
+    @Test func test_makeCredentials_when_no_site_address_then_siteURL_falls_back_to_wordpress_com() {
+        // Given a controller with no entered store address (generic entry)
+        WordPressAuthenticator.initializeForTesting()
+        let controller = NUXLinkAuthViewController()
+        controller.loginFields.siteAddress = ""
+
+        // When building the credentials
+        let credentials = controller.makeCredentials(authToken: "token", isJetpackConnect: false)
+
+        // Then it falls back to wordpress.com, preserving the pre-fix store-picker behavior for this case
+        #expect(credentials.wpcom?.siteURL == "https://wordpress.com")
+    }
+}

--- a/WooCommerce/WordPressAuthenticatorTests/Services/MagicLinkSiteAddressStorageTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Services/MagicLinkSiteAddressStorageTests.swift
@@ -50,6 +50,20 @@ struct MagicLinkSiteAddressStorageTests {
         #expect(storage.consume() == nil)
     }
 
+    @Test func test_consume_when_entry_older_than_ttl_then_returns_nil() {
+        // Given an address saved 16 minutes ago (TTL is 15)
+        let defaults = makeEphemeralDefaults()
+        let savedAt = Date()
+        MagicLinkSiteAddressStorage(userDefaults: defaults, now: { savedAt }).save("https://yourwoosite.com")
+
+        // When consuming after the magic link would have expired
+        let consumer = MagicLinkSiteAddressStorage(userDefaults: defaults, now: { savedAt.addingTimeInterval(16 * 60) })
+        let consumed = consumer.consume()
+
+        // Then the stale address is not restored into an unrelated later login
+        #expect(consumed == nil)
+    }
+
     @Test func test_save_when_value_is_empty_then_clears_previous_value() {
         // Given a persisted store address
         let storage = MagicLinkSiteAddressStorage(userDefaults: makeEphemeralDefaults())

--- a/WooCommerce/WordPressAuthenticatorTests/Services/MagicLinkSiteAddressStorageTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Services/MagicLinkSiteAddressStorageTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import WordPressAuthenticator
+
+/// Tests for `MagicLinkSiteAddressStorage`: save/read-once persistence of the login store address.
+struct MagicLinkSiteAddressStorageTests {
+
+    /// A fresh, isolated `UserDefaults` so tests don't pollute each other.
+    private func makeEphemeralDefaults() -> UserDefaults {
+        let suiteName = "MagicLinkSiteAddressStorageTests.\(UUID().uuidString)"
+        // Force-unwrap is safe: `suiteName` is never nil/empty nor the bundle id, the only cases that return nil.
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test func test_consume_when_address_saved_then_returns_saved_address() {
+        // Given a persisted store address
+        let storage = MagicLinkSiteAddressStorage(userDefaults: makeEphemeralDefaults())
+        storage.save("https://yourwoosite.com")
+
+        // When consuming it
+        let consumed = storage.consume()
+
+        // Then the round trip returns the entered address so the epilogue can match the store
+        #expect(consumed == "https://yourwoosite.com")
+    }
+
+    @Test func test_consume_when_called_twice_then_second_call_returns_nil() {
+        // Given a persisted store address
+        let storage = MagicLinkSiteAddressStorage(userDefaults: makeEphemeralDefaults())
+        storage.save("https://yourwoosite.com")
+
+        // When consuming it once
+        _ = storage.consume()
+
+        // Then it is read-once: a second consume finds nothing (prevents a later login reusing it)
+        #expect(storage.consume() == nil)
+    }
+
+    @Test func test_save_when_value_is_nil_then_clears_previous_value() {
+        // Given a persisted store address
+        let storage = MagicLinkSiteAddressStorage(userDefaults: makeEphemeralDefaults())
+        storage.save("https://yourwoosite.com")
+
+        // When a later request saves nil (latest request wins)
+        storage.save(nil)
+
+        // Then the previous value is cleared
+        #expect(storage.consume() == nil)
+    }
+
+    @Test func test_save_when_value_is_empty_then_clears_previous_value() {
+        // Given a persisted store address
+        let storage = MagicLinkSiteAddressStorage(userDefaults: makeEphemeralDefaults())
+        storage.save("https://yourwoosite.com")
+
+        // When a later generic-entry request saves an empty string
+        storage.save("")
+
+        // Then the previous value is cleared so it can't leak into the generic flow
+        #expect(storage.consume() == nil)
+    }
+}

--- a/WooCommerce/WordPressAuthenticatorTests/Services/MagicLinkSiteAddressStorageTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Services/MagicLinkSiteAddressStorageTests.swift
@@ -51,13 +51,13 @@ struct MagicLinkSiteAddressStorageTests {
     }
 
     @Test func test_consume_when_entry_older_than_ttl_then_returns_nil() {
-        // Given an address saved 16 minutes ago (TTL is 15)
+        // Given an address saved 61 minutes ago (TTL is 60)
         let defaults = makeEphemeralDefaults()
         let savedAt = Date()
         MagicLinkSiteAddressStorage(userDefaults: defaults, now: { savedAt }).save("https://yourwoosite.com")
 
         // When consuming after the magic link would have expired
-        let consumer = MagicLinkSiteAddressStorage(userDefaults: defaults, now: { savedAt.addingTimeInterval(16 * 60) })
+        let consumer = MagicLinkSiteAddressStorage(userDefaults: defaults, now: { savedAt.addingTimeInterval(61 * 60) })
         let consumed = consumer.consume()
 
         // Then the stale address is not restored into an unrelated later login


### PR DESCRIPTION
Closes WOOMOB-43

## Description

Logging in via a magic link landed on the store picker instead of the dashboard of the store entered at the start of login.

On consumption the entered address is lost: `openAuthenticationURL` rebuilds a fresh `LoginFields()` and `NUXLinkAuthViewController` hardcodes the credential `siteURL` to `https://wordpress.com`, so `ULAccountMatcher` finds no match and the epilogue shows the picker. It's inherited from the vendored WordPressAuthenticator (built for the WordPress app), so it never honoured the entered store in WooCommerce.

Fix: persist the entered address when the magic link is requested (a read-once, cold-launch-safe `UserDefaults` store) and restore it on consumption, so the epilogue matches the store and navigates to its dashboard — mirroring the password path. No entered address falls back to the existing store picker.

## Test Steps

You're gonna need a site that is Jetpack connected and WooCommerce isactivated not just installed.

1. Log out.
2. Tap Log In and enter the store address for that account.
3. Continue with WordPress.com and enter the account email.
4. Choose Log in with magic link.
5. Open the email and tap the link.
6. Navigates straight to that store's dashboard, not the store picker.

## Screenshots

| Before | After |
| --- | --- |
| <img height="622" alt="03-bug-store-picker" src="https://github.com/user-attachments/assets/07d6c40e-1761-4c48-a1e9-9b041fcd727d" /> | <img height="622" alt="04-fixed-dashboard" src="https://github.com/user-attachments/assets/cfce9d82-dbc8-418c-87d4-122127e36a1a" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
