### PR TITLE
[WOOMOB-2398] Scroll to top on second tab re-selection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 25.4
 -----
-- [*] Tapping an already-selected tab now returns it to the top of that tab. [https://github.com/woocommerce/woocommerce-ios/pull/17624]
+- [*] Tapping an already-selected tab now returns it to its root screen. [https://github.com/woocommerce/woocommerce-ios/pull/17624]
 
 
 25.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.4
 -----
+- [*] Tapping an already-selected tab now returns it to the top of that tab. [https://github.com/woocommerce/woocommerce-ios/pull/17624]
 
 
 25.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.4
 -----
 - [*] Tapping an already-selected tab now returns it to its root screen. [https://github.com/woocommerce/woocommerce-ios/pull/17624]
+- [*] Tapping an already-selected tab a second time now scrolls its content back to the top. [https://github.com/woocommerce/woocommerce-ios/pull/17627]
 
 
 25.3

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -6,32 +6,14 @@ import UIKit
 //
 extension UINavigationController {
 
-    /// Whenever there's a single viewController onscreen, this method will set the "Top" UIScrollView's
-    /// Content Offset to zero.
-    ///
-    func scrollContentToTop(animated: Bool) {
-        guard viewControllers.count == 1,
-            let scrollView = visibleViewController?.view?.subviews.first as? UIScrollView
-            else {
+    /// Pops to root, respecting the unsaved-changes guard on every screen being popped (like tapping Back through them).
+    func popToRootRespectingUnsavedChanges(animated: Bool) {
+        for viewController in viewControllers.dropFirst().reversed() {
+            guard viewController.shouldPopOnBackButton() else {
                 return
-        }
-
-        scrollView.setContentOffset(.zero, animated: animated)
-    }
-
-    /// Two-stage tab re-selection: pop to root, or scroll to top when already at root.
-    func popToRootOrScrollToTop(animated: Bool) {
-        if viewControllers.count > 1 {
-            // Every screen being popped must permit it (unsaved-changes guard), like tapping Back through them.
-            for viewController in viewControllers.dropFirst().reversed() {
-                guard viewController.shouldPopOnBackButton() else {
-                    return
-                }
             }
-            popToRootViewController(animated: animated)
-        } else {
-            scrollContentToTop(animated: animated)
         }
+        popToRootViewController(animated: animated)
     }
 
     /// Completion block for popToRootViewController

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -19,6 +19,15 @@ extension UINavigationController {
         scrollView.setContentOffset(.zero, animated: animated)
     }
 
+    /// Two-stage tab re-selection: pop to root, or scroll to top when already at root.
+    func popToRootOrScrollToTop(animated: Bool) {
+        if viewControllers.count > 1 {
+            popToRootViewController(animated: animated)
+        } else {
+            scrollContentToTop(animated: animated)
+        }
+    }
+
     /// Completion block for popToRootViewController
     /// UINavigationController API doesn't offer any options for this.
     /// However by using the CoreAnimation framework it's possible to add a completion block to the underlying animation

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -19,16 +19,20 @@ extension UINavigationController {
         scrollView.setContentOffset(.zero, animated: animated)
     }
 
+    /// Pops to root only if every screen being popped permits it (unsaved-changes guard), like tapping Back through them.
+    func popToRootRespectingUnsavedChanges(animated: Bool) {
+        for viewController in viewControllers.dropFirst().reversed() {
+            guard viewController.shouldPopOnBackButton() else {
+                return
+            }
+        }
+        popToRootViewController(animated: animated)
+    }
+
     /// Two-stage tab re-selection: pop to root, or scroll to top when already at root.
     func popToRootOrScrollToTop(animated: Bool) {
         if viewControllers.count > 1 {
-            // Every screen being popped must permit it (unsaved-changes guard), like tapping Back through them.
-            for viewController in viewControllers.dropFirst().reversed() {
-                guard viewController.shouldPopOnBackButton() else {
-                    return
-                }
-            }
-            popToRootViewController(animated: animated)
+            popToRootRespectingUnsavedChanges(animated: animated)
         } else {
             scrollContentToTop(animated: animated)
         }

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -22,9 +22,11 @@ extension UINavigationController {
     /// Two-stage tab re-selection: pop to root, or scroll to top when already at root.
     func popToRootOrScrollToTop(animated: Bool) {
         if viewControllers.count > 1 {
-            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
-            guard topViewController?.shouldPopOnBackButton() ?? true else {
-                return
+            // Every screen being popped must permit it (unsaved-changes guard), like tapping Back through them.
+            for viewController in viewControllers.dropFirst().reversed() {
+                guard viewController.shouldPopOnBackButton() else {
+                    return
+                }
             }
             popToRootViewController(animated: animated)
         } else {

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -22,6 +22,10 @@ extension UINavigationController {
     /// Two-stage tab re-selection: pop to root, or scroll to top when already at root.
     func popToRootOrScrollToTop(animated: Bool) {
         if viewControllers.count > 1 {
+            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
+            guard topViewController?.shouldPopOnBackButton() ?? true else {
+                return
+            }
             popToRootViewController(animated: animated)
         } else {
             scrollContentToTop(animated: animated)

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -6,14 +6,32 @@ import UIKit
 //
 extension UINavigationController {
 
-    /// Pops to root, respecting the unsaved-changes guard on every screen being popped (like tapping Back through them).
-    func popToRootRespectingUnsavedChanges(animated: Bool) {
-        for viewController in viewControllers.dropFirst().reversed() {
-            guard viewController.shouldPopOnBackButton() else {
+    /// Whenever there's a single viewController onscreen, this method will set the "Top" UIScrollView's
+    /// Content Offset to zero.
+    ///
+    func scrollContentToTop(animated: Bool) {
+        guard viewControllers.count == 1,
+            let scrollView = visibleViewController?.view?.subviews.first as? UIScrollView
+            else {
                 return
-            }
         }
-        popToRootViewController(animated: animated)
+
+        scrollView.setContentOffset(.zero, animated: animated)
+    }
+
+    /// Two-stage tab re-selection: pop to root, or scroll to top when already at root.
+    func popToRootOrScrollToTop(animated: Bool) {
+        if viewControllers.count > 1 {
+            // Every screen being popped must permit it (unsaved-changes guard), like tapping Back through them.
+            for viewController in viewControllers.dropFirst().reversed() {
+                guard viewController.shouldPopOnBackButton() else {
+                    return
+                }
+            }
+            popToRootViewController(animated: animated)
+        } else {
+            scrollContentToTop(animated: animated)
+        }
     }
 
     /// Completion block for popToRootViewController

--- a/WooCommerce/Classes/System/WooTabContainerController.swift
+++ b/WooCommerce/Classes/System/WooTabContainerController.swift
@@ -11,6 +11,11 @@ protocol TabReselectionHandling {
     func handleTabReselection()
 }
 
+/// Adopted by list roots that can scroll their content to the top on the second tab re-selection.
+protocol ReselectionScrollable {
+    func scrollToTopOnReselection(animated: Bool)
+}
+
 /// Container for a Woo tab, shown as the root view controller of one of the tabs.
 /// Provided as an alternative to `WooTabNavigationController`, for root controllers which should not be in a nav view
 /// For example, a Split View, which will not work correctly on iPhone when wrapped in a navigation view.

--- a/WooCommerce/Classes/System/WooTabContainerController.swift
+++ b/WooCommerce/Classes/System/WooTabContainerController.swift
@@ -6,6 +6,11 @@ enum NarrowWindowLayout {
 
 protocol UsesCompactLayoutInNarrowWindow: AnyObject {}
 
+/// Adopted by tab root content controllers that need custom handling when their tab is re-selected.
+protocol TabReselectionHandling {
+    func handleTabReselection()
+}
+
 /// Container for a Woo tab, shown as the root view controller of one of the tabs.
 /// Provided as an alternative to `WooTabNavigationController`, for root controllers which should not be in a nav view
 /// For example, a Split View, which will not work correctly on iPhone when wrapped in a navigation view.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -22,6 +22,7 @@ struct DashboardView: View {
     @State private var troubleshootURL: URL?
     @State private var storePlanState: StorePlanSyncState = .loading
     @State private var connectivityStatus: ConnectivityStatus = .notReachable
+    @State private var scrollPosition = ScrollPosition()
 
     /// Set externally in the hosting controller.
     var onboardingTaskTapped: ((Site, StoreOnboardingTask) -> Void)?
@@ -92,32 +93,26 @@ struct DashboardView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            ScrollViewReader { scrollProxy in
-                ScrollView {
-                    VStack(spacing: Layout.padding) {
-                        // Anchor for scroll-to-top on tab re-selection.
-                        Color.clear
-                            .frame(height: 0)
-                            .id(Layout.topAnchorID)
+            ScrollView {
+                VStack(spacing: Layout.padding) {
+                    // Store title
+                    Text(currentSite?.name ?? Localization.title)
+                        .subheadlineStyle()
+                        .padding(Layout.sectionHeadingPadding)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .renderedIf(verticalSizeClass == .regular)
 
-                        // Store title
-                        Text(currentSite?.name ?? Localization.title)
-                            .subheadlineStyle()
-                            .padding(Layout.sectionHeadingPadding)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .renderedIf(verticalSizeClass == .regular)
+                    // Feature announcement if any.
+                    featureAnnouncementCard
 
-                        // Feature announcement if any.
-                        featureAnnouncementCard
-
-                        dashboardCards(availableWidth: proxy.size.width)
-                    }
-                    .padding(.bottom, Layout.padding)
+                    dashboardCards(availableWidth: proxy.size.width)
                 }
-                .onChange(of: viewModel.scrollToTopTrigger) { _, _ in
-                    withAnimation {
-                        scrollProxy.scrollTo(Layout.topAnchorID, anchor: .top)
-                    }
+                .padding(.bottom, Layout.padding)
+            }
+            .scrollPosition($scrollPosition)
+            .onChange(of: viewModel.scrollToTopTrigger) { _, _ in
+                withAnimation {
+                    scrollPosition.scrollTo(edge: .top)
                 }
             }
         }
@@ -478,7 +473,6 @@ private extension DashboardView {
     enum Layout {
         static let padding: CGFloat = 16
         static let elementPadding: CGFloat = 24
-        static let topAnchorID = "dashboard.topAnchor"
         static let sectionHeadingPadding = EdgeInsets(top: 0, leading: 20, bottom: 8, trailing: 24)
         static let imagePadding: CGFloat = 40
         static let textPadding: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -92,21 +92,33 @@ struct DashboardView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            ScrollView {
-                VStack(spacing: Layout.padding) {
-                    // Store title
-                    Text(currentSite?.name ?? Localization.title)
-                        .subheadlineStyle()
-                        .padding(Layout.sectionHeadingPadding)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .renderedIf(verticalSizeClass == .regular)
+            ScrollViewReader { scrollProxy in
+                ScrollView {
+                    VStack(spacing: Layout.padding) {
+                        // Anchor for scroll-to-top on tab re-selection.
+                        Color.clear
+                            .frame(height: 0)
+                            .id(Layout.topAnchorID)
 
-                    // Feature announcement if any.
-                    featureAnnouncementCard
+                        // Store title
+                        Text(currentSite?.name ?? Localization.title)
+                            .subheadlineStyle()
+                            .padding(Layout.sectionHeadingPadding)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .renderedIf(verticalSizeClass == .regular)
 
-                    dashboardCards(availableWidth: proxy.size.width)
+                        // Feature announcement if any.
+                        featureAnnouncementCard
+
+                        dashboardCards(availableWidth: proxy.size.width)
+                    }
+                    .padding(.bottom, Layout.padding)
                 }
-                .padding(.bottom, Layout.padding)
+                .onChange(of: viewModel.scrollToTopTrigger) { _, _ in
+                    withAnimation {
+                        scrollProxy.scrollTo(Layout.topAnchorID, anchor: .top)
+                    }
+                }
             }
         }
         .background(Color(.listBackground))
@@ -466,6 +478,7 @@ private extension DashboardView {
     enum Layout {
         static let padding: CGFloat = 16
         static let elementPadding: CGFloat = 24
+        static let topAnchorID = "dashboard.topAnchor"
         static let sectionHeadingPadding = EdgeInsets(top: 0, leading: 20, bottom: 8, trailing: 24)
         static let imagePadding: CGFloat = 40
         static let textPadding: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -85,11 +85,7 @@ extension DashboardViewHostingController: TabReselectionHandling {
             return
         }
         if navigationController.viewControllers.count > 1 {
-            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
-            guard navigationController.topViewController?.shouldPopOnBackButton() ?? true else {
-                return
-            }
-            navigationController.popToRootViewController(animated: true)
+            navigationController.popToRootRespectingUnsavedChanges(animated: true)
         } else {
             viewModel.scrollToTop()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -78,6 +78,24 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
     }
 }
 
+extension DashboardViewHostingController: TabReselectionHandling {
+    /// Pops the dashboard nav stack to root, or scrolls the SwiftUI dashboard to the top when already at root.
+    func handleTabReselection() {
+        guard let navigationController else {
+            return
+        }
+        if navigationController.viewControllers.count > 1 {
+            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
+            guard navigationController.topViewController?.shouldPopOnBackButton() ?? true else {
+                return
+            }
+            navigationController.popToRootViewController(animated: true)
+        } else {
+            viewModel.scrollToTop()
+        }
+    }
+}
+
 // MARK: Private helpers
 private extension DashboardViewHostingController {
     func configureTabBarItem() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -99,6 +99,13 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var isReloadingAllData = false
 
+    /// Toggled to signal the dashboard scroll view should scroll to the top on tab re-selection.
+    @Published var scrollToTopTrigger = false
+
+    func scrollToTop() {
+        scrollToTopTrigger.toggle()
+    }
+
     let siteID: Int64
     let stores: StoresManager
     private let featureFlagService: FeatureFlagService

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -59,7 +59,22 @@ struct HubMenu: View {
 private extension HubMenu {
 
     var menuList: some View {
+        ScrollViewReader { proxy in
+            list
+                .onChange(of: viewModel.scrollToTopTrigger) { _, _ in
+                    withAnimation {
+                        proxy.scrollTo(Constants.topAnchorID, anchor: .top)
+                    }
+                }
+        }
+    }
+
+    var list: some View {
         List {
+            // Anchor for scroll-to-top on tab re-selection.
+            EmptyView()
+                .id(Constants.topAnchorID)
+
             // Store Section
             Section {
                 Button {
@@ -352,6 +367,7 @@ private extension HubMenu {
         static let iconSize: CGFloat = 20
         static let dotBadgePadding = EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 2)
         static let dotBadgeSize: CGFloat = 6
+        static let topAnchorID = "hubMenu.topAnchor"
 
         /// Spacing for the badge view in the avatar row.
         ///

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -71,11 +71,7 @@ private extension HubMenu {
 
     var list: some View {
         List {
-            // Anchor for scroll-to-top on tab re-selection.
-            EmptyView()
-                .id(Constants.topAnchorID)
-
-            // Store Section
+            // Store Section — also the anchor for scroll-to-top on tab re-selection.
             Section {
                 Button {
                     ServiceLocator.analytics.track(.hubMenuSwitchStoreTapped)
@@ -94,6 +90,7 @@ private extension HubMenu {
                 }
                 .disabled(!viewModel.switchStoreEnabled)
             }
+            .id(Constants.topAnchorID)
 
             // Settings Section
             Section(Localization.settings) {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -146,9 +146,13 @@ extension HubMenuViewController: DeepLinkNavigator {
 }
 
 extension HubMenuViewController: TabReselectionHandling {
-    /// The menu uses a SwiftUI `NavigationStack` the UIKit nav controller can't pop, so reset it here.
+    /// The menu owns a SwiftUI `NavigationStack` and `List` the UIKit nav controller can't reach: pop, else scroll to top.
     func handleTabReselection() {
-        viewModel.popToRoot()
+        if !viewModel.navigationPath.isEmpty {
+            viewModel.popToRoot()
+        } else {
+            viewModel.scrollToTop()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -145,6 +145,13 @@ extension HubMenuViewController: DeepLinkNavigator {
     }
 }
 
+extension HubMenuViewController: TabReselectionHandling {
+    /// The menu uses a SwiftUI `NavigationStack` the UIKit nav controller can't pop, so reset it here.
+    func handleTabReselection() {
+        viewModel.popToRoot()
+    }
+}
+
 private extension HubMenuViewController {
     func configureTabBarItem() {
         tabBarItem.title = Localization.tabTitle

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -203,6 +203,10 @@ final class HubMenuViewModel: ObservableObject {
         navigationPath.append(destination)
     }
 
+    func popToRoot() {
+        navigationPath = .init()
+    }
+
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {
         navigateToDestination(.reviewDetails(parcel: parcel))
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -207,6 +207,13 @@ final class HubMenuViewModel: ObservableObject {
         navigationPath = .init()
     }
 
+    /// Toggled to signal the menu list should scroll to the top on tab re-selection.
+    @Published var scrollToTopTrigger = false
+
+    func scrollToTop() {
+        scrollToTopTrigger.toggle()
+    }
+
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {
         navigateToDestination(.reviewDetails(parcel: parcel))
     }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -470,9 +470,9 @@ extension MainTabBarController: UIViewControllerTransitioningDelegate {
 }
 
 
-// MARK: - Static navigation helpers
+// MARK: - Tab re-selection
 //
-private extension MainTabBarController {
+extension MainTabBarController {
 
     /// Returns the re-selected tab's content to its root, via a `TabReselectionHandling` wrapper or a nav-controller pop.
     func handleTabReselection() {
@@ -489,6 +489,11 @@ private extension MainTabBarController {
         }
         // else (e.g. Bookings SwiftUI root): intentionally no-op.
     }
+}
+
+// MARK: - Static navigation helpers
+//
+private extension MainTabBarController {
 
     /// Tracks "Tab Selected" Events.
     ///

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -483,7 +483,7 @@ extension MainTabBarController {
         if let handler = content as? TabReselectionHandling {
             handler.handleTabReselection()
         } else if let navController = content as? UINavigationController {
-            navController.popToRootRespectingUnsavedChanges(animated: true)
+            navController.popToRootOrScrollToTop(animated: true)
             // Hub Menu's root owns a SwiftUI stack the UIKit pop can't reach, so let it reset itself too.
             (navController.viewControllers.first as? TabReselectionHandling)?.handleTabReselection()
         }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -474,20 +474,20 @@ extension MainTabBarController: UIViewControllerTransitioningDelegate {
 //
 extension MainTabBarController {
 
-    /// Returns the re-selected tab's content to its root, via a `TabReselectionHandling` wrapper or a nav-controller pop.
+    /// Returns the re-selected tab to its root: pops the UIKit navigation stack and lets the root content reset its own navigation.
     func handleTabReselection() {
         guard let selectedViewController else {
             return
         }
         let content = (selectedViewController as? TabContainerController)?.wrappedController ?? selectedViewController
-        if let handler = content as? TabReselectionHandling {
-            handler.handleTabReselection()
-        } else if let navController = content as? UINavigationController {
-            navController.popToRootOrScrollToTop(animated: true)
-            // Hub Menu's root owns a SwiftUI stack the UIKit pop can't reach, so let it reset itself too.
-            (navController.viewControllers.first as? TabReselectionHandling)?.handleTabReselection()
-        }
-        // else (e.g. Bookings SwiftUI root): intentionally no-op.
+        let navigationController = content as? UINavigationController
+
+        // Pop the UIKit navigation stack to root (My Store, Hub Menu); a no-op for non-navigation roots.
+        navigationController?.popToRootOrScrollToTop(animated: true)
+
+        // Let the root content reset navigation the UIKit pop can't reach — a split-view wrapper's column or a SwiftUI stack.
+        let rootContent = navigationController?.viewControllers.first ?? content
+        (rootContent as? TabReselectionHandling)?.handleTabReselection()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -483,7 +483,7 @@ extension MainTabBarController {
         if let handler = content as? TabReselectionHandling {
             handler.handleTabReselection()
         } else if let navController = content as? UINavigationController {
-            navController.popToRootOrScrollToTop(animated: true)
+            navController.popToRootRespectingUnsavedChanges(animated: true)
             // Hub Menu's root owns a SwiftUI stack the UIKit pop can't reach, so let it reset itself too.
             (navController.viewControllers.first as? TabReselectionHandling)?.handleTabReselection()
         }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -474,20 +474,23 @@ extension MainTabBarController: UIViewControllerTransitioningDelegate {
 //
 extension MainTabBarController {
 
-    /// Returns the re-selected tab to its root: pops the UIKit navigation stack and lets the root content reset its own navigation.
+    /// Returns the re-selected tab's content to its root and, when already at root, scrolls it to the top.
     func handleTabReselection() {
         guard let selectedViewController else {
             return
         }
         let content = (selectedViewController as? TabContainerController)?.wrappedController ?? selectedViewController
-        let navigationController = content as? UINavigationController
-
-        // Pop the UIKit navigation stack to root (My Store, Hub Menu); a no-op for non-navigation roots.
-        navigationController?.popToRootOrScrollToTop(animated: true)
-
-        // Let the root content reset navigation the UIKit pop can't reach — a split-view wrapper's column or a SwiftUI stack.
-        let rootContent = navigationController?.viewControllers.first ?? content
-        (rootContent as? TabReselectionHandling)?.handleTabReselection()
+        if let handler = content as? TabReselectionHandling {
+            // A conformer fully owns its two-stage pop-or-scroll behaviour.
+            handler.handleTabReselection()
+        } else if let navController = content as? UINavigationController {
+            if let handler = navController.viewControllers.first as? TabReselectionHandling {
+                handler.handleTabReselection()
+            } else {
+                navController.popToRootOrScrollToTop(animated: true)
+            }
+        }
+        // else (e.g. Bookings SwiftUI root): intentionally no-op.
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -313,7 +313,7 @@ final class MainTabBarController: UITabBarController {
         // Did we reselect the already-selected tab?
         if currentlySelectedTab == userSelectedTab {
             trackTabReselected(tab: userSelectedTab)
-            scrollContentToTop()
+            handleTabReselection()
         } else {
             trackTabSelected(newTab: userSelectedTab)
         }
@@ -474,14 +474,20 @@ extension MainTabBarController: UIViewControllerTransitioningDelegate {
 //
 private extension MainTabBarController {
 
-    /// *When applicable* this method will scroll the visible content to top.
-    ///
-    func scrollContentToTop() {
-        guard let navController = selectedViewController as? UINavigationController else {
+    /// Returns the re-selected tab's content to its root, via a `TabReselectionHandling` wrapper or a nav-controller pop.
+    func handleTabReselection() {
+        guard let selectedViewController else {
             return
         }
-
-        navController.scrollContentToTop(animated: true)
+        let content = (selectedViewController as? TabContainerController)?.wrappedController ?? selectedViewController
+        if let handler = content as? TabReselectionHandling {
+            handler.handleTabReselection()
+        } else if let navController = content as? UINavigationController {
+            navController.popToRootOrScrollToTop(animated: true)
+            // Hub Menu's root owns a SwiftUI stack the UIKit pop can't reach, so let it reset itself too.
+            (navController.viewControllers.first as? TabReselectionHandling)?.handleTabReselection()
+        }
+        // else (e.g. Bookings SwiftUI root): intentionally no-op.
     }
 
     /// Tracks "Tab Selected" Events.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -669,6 +669,17 @@ private extension OrdersRootViewController {
     }
 }
 
+// MARK: - ReselectionScrollable
+extension OrdersRootViewController: ReselectionScrollable {
+    /// Scrolls the order list to the top, honouring the content inset applied by the Liquid Glass header overlay.
+    func scrollToTopOnReselection(animated: Bool) {
+        guard let tableView = ordersViewController.tableView else {
+            return
+        }
+        tableView.setContentOffset(CGPoint(x: 0, y: -tableView.adjustedContentInset.top), animated: animated)
+    }
+}
+
 // MARK: - Constants
 private extension OrdersRootViewController {
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -213,12 +213,20 @@ private extension OrdersSplitViewWrapperController {
 }
 
 extension OrdersSplitViewWrapperController: TabReselectionHandling {
-    /// Returns the orders list (primary column) to its root when the Orders tab is re-selected.
+    /// Pops the orders list (primary column) to its root, or scrolls it to the top when already at root.
     func handleTabReselection() {
         guard let primaryNavigationController = ordersSplitViewController.viewController(for: .primary) as? UINavigationController else {
             return
         }
-        primaryNavigationController.popToRootOrScrollToTop(animated: true)
+        if primaryNavigationController.viewControllers.count > 1 {
+            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
+            guard primaryNavigationController.topViewController?.shouldPopOnBackButton() ?? true else {
+                return
+            }
+            primaryNavigationController.popToRootViewController(animated: true)
+        } else {
+            (primaryNavigationController.topViewController as? ReselectionScrollable)?.scrollToTopOnReselection(animated: true)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -218,7 +218,7 @@ extension OrdersSplitViewWrapperController: TabReselectionHandling {
         guard let primaryNavigationController = ordersSplitViewController.viewController(for: .primary) as? UINavigationController else {
             return
         }
-        primaryNavigationController.popToRootRespectingUnsavedChanges(animated: true)
+        primaryNavigationController.popToRootOrScrollToTop(animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -219,11 +219,7 @@ extension OrdersSplitViewWrapperController: TabReselectionHandling {
             return
         }
         if primaryNavigationController.viewControllers.count > 1 {
-            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
-            guard primaryNavigationController.topViewController?.shouldPopOnBackButton() ?? true else {
-                return
-            }
-            primaryNavigationController.popToRootViewController(animated: true)
+            primaryNavigationController.popToRootRespectingUnsavedChanges(animated: true)
         } else {
             (primaryNavigationController.topViewController as? ReselectionScrollable)?.scrollToTopOnReselection(animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -218,7 +218,7 @@ extension OrdersSplitViewWrapperController: TabReselectionHandling {
         guard let primaryNavigationController = ordersSplitViewController.viewController(for: .primary) as? UINavigationController else {
             return
         }
-        primaryNavigationController.popToRootOrScrollToTop(animated: true)
+        primaryNavigationController.popToRootRespectingUnsavedChanges(animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -212,6 +212,16 @@ private extension OrdersSplitViewWrapperController {
     }
 }
 
+extension OrdersSplitViewWrapperController: TabReselectionHandling {
+    /// Returns the orders list (primary column) to its root when the Orders tab is re-selected.
+    func handleTabReselection() {
+        guard let primaryNavigationController = ordersSplitViewController.viewController(for: .primary) as? UINavigationController else {
+            return
+        }
+        primaryNavigationController.popToRootOrScrollToTop(animated: true)
+    }
+}
+
 extension OrdersSplitViewWrapperController: DeepLinkNavigator {
     func navigate(to destination: any DeepLinkDestinationProtocol) {
         guard let ordersDestination = destination as? OrdersDestination else {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -83,7 +83,7 @@ extension ProductsSplitViewWrapperController: TabReselectionHandling {
         guard let primaryNavigationController = productsSplitViewController.viewController(for: .primary) as? UINavigationController else {
             return
         }
-        primaryNavigationController.popToRootOrScrollToTop(animated: true)
+        primaryNavigationController.popToRootRespectingUnsavedChanges(animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -83,7 +83,7 @@ extension ProductsSplitViewWrapperController: TabReselectionHandling {
         guard let primaryNavigationController = productsSplitViewController.viewController(for: .primary) as? UINavigationController else {
             return
         }
-        primaryNavigationController.popToRootRespectingUnsavedChanges(animated: true)
+        primaryNavigationController.popToRootOrScrollToTop(animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -77,6 +77,16 @@ private extension ProductsSplitViewWrapperController {
     }
 }
 
+extension ProductsSplitViewWrapperController: TabReselectionHandling {
+    /// Returns the products list (primary column) to its root on re-selection. Leaves an active search intact.
+    func handleTabReselection() {
+        guard let primaryNavigationController = productsSplitViewController.viewController(for: .primary) as? UINavigationController else {
+            return
+        }
+        primaryNavigationController.popToRootOrScrollToTop(animated: true)
+    }
+}
+
 extension ProductsSplitViewWrapperController {
     private enum Localization {
         static let tabTitle = NSLocalizedString("productsTab.tabTitle",

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -84,11 +84,7 @@ extension ProductsSplitViewWrapperController: TabReselectionHandling {
             return
         }
         if primaryNavigationController.viewControllers.count > 1 {
-            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
-            guard primaryNavigationController.topViewController?.shouldPopOnBackButton() ?? true else {
-                return
-            }
-            primaryNavigationController.popToRootViewController(animated: true)
+            primaryNavigationController.popToRootRespectingUnsavedChanges(animated: true)
         } else {
             (primaryNavigationController.topViewController as? ReselectionScrollable)?.scrollToTopOnReselection(animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -78,12 +78,20 @@ private extension ProductsSplitViewWrapperController {
 }
 
 extension ProductsSplitViewWrapperController: TabReselectionHandling {
-    /// Returns the products list (primary column) to its root on re-selection. Leaves an active search intact.
+    /// Pops the products list (primary column) to its root, or scrolls it to the top when already at root.
     func handleTabReselection() {
         guard let primaryNavigationController = productsSplitViewController.viewController(for: .primary) as? UINavigationController else {
             return
         }
-        primaryNavigationController.popToRootOrScrollToTop(animated: true)
+        if primaryNavigationController.viewControllers.count > 1 {
+            // Respect the unsaved-changes guard, like the Back button, so a programmatic pop can't silently discard edits.
+            guard primaryNavigationController.topViewController?.shouldPopOnBackButton() ?? true else {
+                return
+            }
+            primaryNavigationController.popToRootViewController(animated: true)
+        } else {
+            (primaryNavigationController.topViewController as? ReselectionScrollable)?.scrollToTopOnReselection(animated: true)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1811,6 +1811,14 @@ private extension ProductsViewController {
     }
 }
 
+// MARK: - ReselectionScrollable
+extension ProductsViewController: ReselectionScrollable {
+    /// Scrolls the product list to the top when the tab is re-selected while already at root.
+    func scrollToTopOnReselection(animated: Bool) {
+        tableView.setContentOffset(CGPoint(x: 0, y: -tableView.adjustedContentInset.top), animated: animated)
+    }
+}
+
 // MARK: - Nested Types
 //
 private extension ProductsViewController {

--- a/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
@@ -6,7 +6,7 @@ import UIKit
 struct UINavigationControllerWooTests {
 
     @Test
-    func popToRootRespectingUnsavedChanges_when_stack_has_multiple_view_controllers_then_pops_to_root() {
+    func popToRootOrScrollToTop_when_stack_has_multiple_view_controllers_then_pops_to_root() {
         // Given a navigation stack that has been pushed beyond its root (e.g. after tapping into a detail).
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
@@ -15,7 +15,7 @@ struct UINavigationControllerWooTests {
         #expect(navigationController.viewControllers.count == 3)
 
         // When re-selecting the tab asks the stack to pop to root.
-        navigationController.popToRootRespectingUnsavedChanges(animated: false)
+        navigationController.popToRootOrScrollToTop(animated: false)
 
         // Then only the root remains, so re-selecting the tab returns it to its root screen.
         #expect(navigationController.viewControllers.count == 1)
@@ -23,22 +23,22 @@ struct UINavigationControllerWooTests {
     }
 
     @Test
-    func popToRootRespectingUnsavedChanges_when_stack_is_already_at_root_then_stays_at_root() {
+    func popToRootOrScrollToTop_when_stack_is_already_at_root_then_stays_at_root() {
         // Given a navigation stack that is already showing its root screen.
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
         #expect(navigationController.viewControllers.count == 1)
 
-        // When re-selecting the tab asks the already-at-root stack to pop.
-        navigationController.popToRootRespectingUnsavedChanges(animated: false)
+        // When re-selecting the tab asks the stack to pop to root (scroll-to-top branch).
+        navigationController.popToRootOrScrollToTop(animated: false)
 
-        // Then it is a harmless no-op: the root is preserved and never popped below a single view controller.
+        // Then the root is preserved and never popped below a single view controller.
         #expect(navigationController.viewControllers.count == 1)
         #expect(navigationController.viewControllers.first === root)
     }
 
     @Test
-    func popToRootRespectingUnsavedChanges_when_a_screen_refuses_to_pop_then_does_not_pop() {
+    func popToRootOrScrollToTop_when_a_screen_refuses_to_pop_then_does_not_pop() {
         // Given a stack whose top screen has unsaved changes and refuses to pop.
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
@@ -46,14 +46,14 @@ struct UINavigationControllerWooTests {
         #expect(navigationController.viewControllers.count == 2)
 
         // When re-selecting the tab asks the stack to pop to root.
-        navigationController.popToRootRespectingUnsavedChanges(animated: false)
+        navigationController.popToRootOrScrollToTop(animated: false)
 
         // Then the stack is unchanged, so the unsaved edits are not discarded.
         #expect(navigationController.viewControllers.count == 2)
     }
 
     @Test
-    func popToRootRespectingUnsavedChanges_when_an_intermediate_screen_refuses_to_pop_then_does_not_pop() {
+    func popToRootOrScrollToTop_when_an_intermediate_screen_refuses_to_pop_then_does_not_pop() {
         // Given a dirty intermediate screen sitting below a clean top screen that would pop.
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
@@ -62,7 +62,7 @@ struct UINavigationControllerWooTests {
         #expect(navigationController.viewControllers.count == 3)
 
         // When re-selecting the tab asks the stack to pop to root.
-        navigationController.popToRootRespectingUnsavedChanges(animated: false)
+        navigationController.popToRootOrScrollToTop(animated: false)
 
         // Then the stack is unchanged, so the clean top can't let the dirty screen below be discarded.
         #expect(navigationController.viewControllers.count == 3)

--- a/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import UIKit
+@testable import WooCommerce
+
+@MainActor
+struct UINavigationControllerWooTests {
+
+    @Test
+    func popToRootOrScrollToTop_when_stack_has_multiple_view_controllers_then_pops_to_root() {
+        // Given a navigation stack that has been pushed beyond its root (e.g. after tapping into a detail).
+        let root = UIViewController()
+        let navigationController = UINavigationController(rootViewController: root)
+        navigationController.pushViewController(UIViewController(), animated: false)
+        navigationController.pushViewController(UIViewController(), animated: false)
+        #expect(navigationController.viewControllers.count == 3)
+
+        // When re-selecting the tab asks the stack to pop to root.
+        navigationController.popToRootOrScrollToTop(animated: false)
+
+        // Then only the root remains, so re-selecting the tab returns it to its root screen.
+        #expect(navigationController.viewControllers.count == 1)
+        #expect(navigationController.viewControllers.first === root)
+    }
+
+    @Test
+    func popToRootOrScrollToTop_when_stack_is_already_at_root_then_stays_at_root() {
+        // Given a navigation stack that is already showing its root screen.
+        let root = UIViewController()
+        let navigationController = UINavigationController(rootViewController: root)
+        #expect(navigationController.viewControllers.count == 1)
+
+        // When re-selecting the tab asks the stack to pop to root (scroll-to-top branch).
+        navigationController.popToRootOrScrollToTop(animated: false)
+
+        // Then the root is preserved and never popped below a single view controller.
+        #expect(navigationController.viewControllers.count == 1)
+        #expect(navigationController.viewControllers.first === root)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
@@ -6,7 +6,7 @@ import UIKit
 struct UINavigationControllerWooTests {
 
     @Test
-    func popToRootOrScrollToTop_when_stack_has_multiple_view_controllers_then_pops_to_root() {
+    func popToRootRespectingUnsavedChanges_when_stack_has_multiple_view_controllers_then_pops_to_root() {
         // Given a navigation stack that has been pushed beyond its root (e.g. after tapping into a detail).
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
@@ -15,7 +15,7 @@ struct UINavigationControllerWooTests {
         #expect(navigationController.viewControllers.count == 3)
 
         // When re-selecting the tab asks the stack to pop to root.
-        navigationController.popToRootOrScrollToTop(animated: false)
+        navigationController.popToRootRespectingUnsavedChanges(animated: false)
 
         // Then only the root remains, so re-selecting the tab returns it to its root screen.
         #expect(navigationController.viewControllers.count == 1)
@@ -23,22 +23,22 @@ struct UINavigationControllerWooTests {
     }
 
     @Test
-    func popToRootOrScrollToTop_when_stack_is_already_at_root_then_stays_at_root() {
+    func popToRootRespectingUnsavedChanges_when_stack_is_already_at_root_then_stays_at_root() {
         // Given a navigation stack that is already showing its root screen.
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
         #expect(navigationController.viewControllers.count == 1)
 
-        // When re-selecting the tab asks the stack to pop to root (scroll-to-top branch).
-        navigationController.popToRootOrScrollToTop(animated: false)
+        // When re-selecting the tab asks the already-at-root stack to pop.
+        navigationController.popToRootRespectingUnsavedChanges(animated: false)
 
-        // Then the root is preserved and never popped below a single view controller.
+        // Then it is a harmless no-op: the root is preserved and never popped below a single view controller.
         #expect(navigationController.viewControllers.count == 1)
         #expect(navigationController.viewControllers.first === root)
     }
 
     @Test
-    func popToRootOrScrollToTop_when_a_screen_refuses_to_pop_then_does_not_pop() {
+    func popToRootRespectingUnsavedChanges_when_a_screen_refuses_to_pop_then_does_not_pop() {
         // Given a stack whose top screen has unsaved changes and refuses to pop.
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
@@ -46,14 +46,14 @@ struct UINavigationControllerWooTests {
         #expect(navigationController.viewControllers.count == 2)
 
         // When re-selecting the tab asks the stack to pop to root.
-        navigationController.popToRootOrScrollToTop(animated: false)
+        navigationController.popToRootRespectingUnsavedChanges(animated: false)
 
         // Then the stack is unchanged, so the unsaved edits are not discarded.
         #expect(navigationController.viewControllers.count == 2)
     }
 
     @Test
-    func popToRootOrScrollToTop_when_an_intermediate_screen_refuses_to_pop_then_does_not_pop() {
+    func popToRootRespectingUnsavedChanges_when_an_intermediate_screen_refuses_to_pop_then_does_not_pop() {
         // Given a dirty intermediate screen sitting below a clean top screen that would pop.
         let root = UIViewController()
         let navigationController = UINavigationController(rootViewController: root)
@@ -62,7 +62,7 @@ struct UINavigationControllerWooTests {
         #expect(navigationController.viewControllers.count == 3)
 
         // When re-selecting the tab asks the stack to pop to root.
-        navigationController.popToRootOrScrollToTop(animated: false)
+        navigationController.popToRootRespectingUnsavedChanges(animated: false)
 
         // Then the stack is unchanged, so the clean top can't let the dirty screen below be discarded.
         #expect(navigationController.viewControllers.count == 3)

--- a/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
@@ -36,4 +36,42 @@ struct UINavigationControllerWooTests {
         #expect(navigationController.viewControllers.count == 1)
         #expect(navigationController.viewControllers.first === root)
     }
+
+    @Test
+    func popToRootOrScrollToTop_when_a_screen_refuses_to_pop_then_does_not_pop() {
+        // Given a stack whose top screen has unsaved changes and refuses to pop.
+        let root = UIViewController()
+        let navigationController = UINavigationController(rootViewController: root)
+        navigationController.pushViewController(NonPoppableViewController(), animated: false)
+        #expect(navigationController.viewControllers.count == 2)
+
+        // When re-selecting the tab asks the stack to pop to root.
+        navigationController.popToRootOrScrollToTop(animated: false)
+
+        // Then the stack is unchanged, so the unsaved edits are not discarded.
+        #expect(navigationController.viewControllers.count == 2)
+    }
+
+    @Test
+    func popToRootOrScrollToTop_when_an_intermediate_screen_refuses_to_pop_then_does_not_pop() {
+        // Given a dirty intermediate screen sitting below a clean top screen that would pop.
+        let root = UIViewController()
+        let navigationController = UINavigationController(rootViewController: root)
+        navigationController.pushViewController(NonPoppableViewController(), animated: false)
+        navigationController.pushViewController(UIViewController(), animated: false)
+        #expect(navigationController.viewControllers.count == 3)
+
+        // When re-selecting the tab asks the stack to pop to root.
+        navigationController.popToRootOrScrollToTop(animated: false)
+
+        // Then the stack is unchanged, so the clean top can't let the dirty screen below be discarded.
+        #expect(navigationController.viewControllers.count == 3)
+    }
+}
+
+/// Refuses to pop, mimicking a screen with unsaved changes.
+private final class NonPoppableViewController: UIViewController {
+    override func shouldPopOnBackButton() -> Bool {
+        false
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -142,6 +142,22 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_scrollToTop_flips_scrollToTopTrigger() {
+        // Given
+        // The trigger is a signal for the SwiftUI scroll view to scroll to top on tab re-selection, so a change must be observable.
+        let viewModel = DashboardViewModel(siteID: 0,
+                                           stores: stores,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+        let before = viewModel.scrollToTopTrigger
+
+        // When
+        viewModel.scrollToTop()
+
+        // Then
+        XCTAssertNotEqual(viewModel.scrollToTopTrigger, before)
+    }
+
+    @MainActor
     func test_view_model_syncs_just_in_time_messages() async {
         // Given
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -632,6 +632,37 @@ final class HubMenuViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_popToRoot_when_navigationPath_is_non_empty_then_resets_to_root() {
+        // Given a Menu tab that has navigated into a deep stack (non-empty NavigationStack path).
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        viewModel.navigationPath = NavigationPath(["testPath1", "testPath2"])
+        XCTAssertEqual(viewModel.navigationPath.count, 2)
+
+        // When re-selecting the tab triggers a pop to root.
+        viewModel.popToRoot()
+
+        // Then the stack returns to root so the tab shows its root screen again.
+        XCTAssertTrue(viewModel.navigationPath.isEmpty)
+        XCTAssertEqual(viewModel.navigationPath.count, 0)
+    }
+
+    @MainActor
+    func test_popToRoot_after_navigateToDestination_then_resets_to_root() {
+        // Given a Menu tab pushed to a destination (the realistic single-level navigation path).
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        viewModel.navigateToDestination(.settings)
+        XCTAssertEqual(viewModel.navigationPath.count, 1)
+
+        // When re-selecting the tab triggers a pop to root.
+        viewModel.popToRoot()
+
+        // Then the pushed destination is dismissed, returning the tab to root.
+        XCTAssertTrue(viewModel.navigationPath.isEmpty)
+    }
+
+    @MainActor
     func test_navigateToDestination_without_destination_leaves_navigationPath_intact() {
         // Given
         let navigationPath = NavigationPath(["testPath1", "testPath2"])

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -9,6 +9,20 @@ final class HubMenuViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 606
 
     @MainActor
+    func test_scrollToTop_flips_scrollToTopTrigger() {
+        // Given
+        // The trigger is a signal for the SwiftUI list to scroll to top on tab re-selection, so a change must be observable.
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        let before = viewModel.scrollToTopTrigger
+
+        // When
+        viewModel.scrollToTop()
+
+        // Then
+        XCTAssertNotEqual(viewModel.scrollToTopTrigger, before)
+    }
+
+    @MainActor
     func test_viewDidAppear_then_posts_notification() {
         // Given
         let viewModel = HubMenuViewModel(siteID: sampleSiteID, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -712,6 +712,53 @@ final class MainTabBarControllerTests: XCTestCase {
             isBookingsTabVisible: true
         ), isAnInstanceOf: BookingsTabViewHostingController.self)
     }
+
+    // MARK: - Tab re-selection
+
+    func test_handleTabReselection_when_tab_is_container_wrapped_reselection_handler_then_forwards_to_handler() throws {
+        // Given
+        let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)
+        let reselectionHandler = SpyReselectionController()
+        let containerController = TabContainerController()
+        containerController.wrappedController = reselectionHandler
+        tabBarController.viewControllers = [containerController]
+        tabBarController.selectedViewController = containerController
+
+        // When
+        tabBarController.handleTabReselection()
+
+        // Then
+        // The dispatch must unwrap the container and forward to its wrapped `TabReselectionHandling` content.
+        XCTAssertEqual(reselectionHandler.handledCount, 1)
+    }
+
+    func test_handleTabReselection_when_tab_is_navigation_controller_then_pops_to_root() throws {
+        // Given
+        let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        navigationController.pushViewController(UIViewController(), animated: false)
+        tabBarController.viewControllers = [navigationController]
+        tabBarController.selectedViewController = navigationController
+        window.rootViewController = tabBarController
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+
+        // When
+        tabBarController.handleTabReselection()
+
+        // Then
+        // The dispatch must pop the selected tab's navigation stack back to its root.
+        waitUntil {
+            navigationController.viewControllers.count == 1
+        }
+    }
+}
+
+private final class SpyReselectionController: UIViewController, TabReselectionHandling {
+    private(set) var handledCount = 0
+
+    func handleTabReselection() {
+        handledCount += 1
+    }
 }
 
 extension MainTabBarController {

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -732,6 +732,26 @@ final class MainTabBarControllerTests: XCTestCase {
         XCTAssertEqual(reselectionHandler.handledCount, 1)
     }
 
+    func test_handleTabReselection_when_navigation_root_is_reselection_handler_then_forwards_and_does_not_also_pop() throws {
+        // Given
+        // A conformer owns its full pop-or-scroll behaviour, so the tab bar must not double-dispatch by also popping the stack.
+        let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)
+        let reselectionHandler = SpyReselectionController()
+        let navigationController = UINavigationController(rootViewController: reselectionHandler)
+        navigationController.pushViewController(UIViewController(), animated: false)
+        tabBarController.viewControllers = [navigationController]
+        tabBarController.selectedViewController = navigationController
+        window.rootViewController = tabBarController
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+
+        // When
+        tabBarController.handleTabReselection()
+
+        // Then
+        XCTAssertEqual(reselectionHandler.handledCount, 1)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+    }
+
     func test_handleTabReselection_when_tab_is_navigation_controller_then_pops_to_root() throws {
         // Given
         let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)


### PR DESCRIPTION
Part of WOOMOB-2398 · stacked on #17624

## Description

Follow-up to #17624 (pop to root on tab re-selection) that adds the second stage from the issue: tapping an already-selected tab again — when it's already at its root — scrolls that tab's content back to the top.

Previously only pop-to-root worked; the scroll-to-top no-op'd on every tab because the roots are SwiftUI-hosted (My Store, Menu) or split-view lists (Orders, Products) that the old scroll heuristic couldn't reach. Each root now owns its two-stage behaviour: the Orders/Products list controllers scroll their table view, and the My Store and Menu SwiftUI roots scroll via a `ScrollViewReader` driven by a published trigger. The reselection dispatch in `MainTabBarController` is also collapsed to a single contract — a root conformer fully owns its pop-or-scroll — removing the earlier pop-and-also-forward double dispatch.

**Stacked on #17624** — this branch is based on that PR, so the diff below includes its commits until it merges to trunk. Only the "Scroll to top on tab re-selection…" commit is new here.

## Test Steps

1. Log into a store.
2. On any tab (My Store, Orders, Products, Menu), open a detail if you like, then scroll the content down.
3. Tap the same tab again — the first tap returns to the tab's root (if a detail was open), and a further tap scrolls the content back to the top.

## Screenshots

| Before | After |
| --- | --- |
| <!-- recording: second re-tap does nothing --> | <!-- recording: second re-tap scrolls the content to top --> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
