### PR TITLE
[WOOMOB-3707] Fix crash on unparseable stats date during dashboard sync

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -139,6 +139,7 @@ public enum WooAnalyticsStat: String {
     case dashboardMainStatsWaitingTimeLoaded = "dashboard_main_stats_waiting_time_loaded"
     case dashboardTopPerformersWaitingTimeLoaded = "dashboard_top_performers_waiting_time_loaded"
     case dashboardStoreTimezoneDifferFromDevice = "dashboard_store_timezone_differ_from_device"
+    case dashboardStatsUnexpectedDateFormat = "stats_unexpected_format"
 
     // MARK: Dashboard stats custom range
     case dashboardStatsCustomRangeAddButtonTapped = "dashboard_stats_custom_range_add_button_tapped"

--- a/Modules/Sources/Yosemite/Model/Extensions/WCAnalyticsStatsInterval+Date.swift
+++ b/Modules/Sources/Yosemite/Model/Extensions/WCAnalyticsStatsInterval+Date.swift
@@ -1,21 +1,14 @@
 import Foundation
-import WooFoundation
 
 extension WCAnalyticsStatsInterval {
     /// Returns the interval start date by parsing the `dateStart` string.
-    public func dateStart(timeZone: TimeZone) -> Date {
-        guard let date = createDateFormatter(timeZone: timeZone).date(from: dateStart) else {
-            logErrorAndExit("Failed to parse date: \(dateStart)")
-        }
-        return date
+    public func dateStart(timeZone: TimeZone) -> Date? {
+        createDateFormatter(timeZone: timeZone).date(from: dateStart)
     }
 
     /// Returns the interval end date by parsing the `dateEnd` string.
-    public func dateEnd(timeZone: TimeZone) -> Date {
-        guard let date = createDateFormatter(timeZone: timeZone).date(from: dateEnd) else {
-            logErrorAndExit("Failed to parse date: \(dateEnd)")
-        }
-        return date
+    public func dateEnd(timeZone: TimeZone) -> Date? {
+        createDateFormatter(timeZone: timeZone).date(from: dateEnd)
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -9,7 +9,7 @@ final class OrderStatsV4Interval_DateTests: XCTestCase {
                                                             netRevenue: 0,
                                                             averageOrderValue: 0)
 
-    func testDateStartAndDateEnd() {
+    func testDateStartAndDateEnd() throws {
         let dateStringInSiteTimeZone = "2019-08-08 10:45:00"
         let interval = OrderStatsV4Interval(interval: "hour",
                                             dateStart: dateStringInSiteTimeZone,
@@ -19,7 +19,8 @@ final class OrderStatsV4Interval_DateTests: XCTestCase {
         // Note that iOS 26 has changed behaviour here, and excess seconds in the timezone break the calculation
         // This is 488 minutes, or 8 hours and 8 minutes
         let timeZone = TimeZone(secondsFromGMT: 29280)!
-        [interval.dateStart(timeZone: timeZone), interval.dateEnd(timeZone: timeZone)].forEach { date in
+        let dates = try [XCTUnwrap(interval.dateStart(timeZone: timeZone)), XCTUnwrap(interval.dateEnd(timeZone: timeZone))]
+        dates.forEach { date in
             let dateComponents = Calendar(identifier: .iso8601).dateComponents(in: timeZone, from: date)
             XCTAssertEqual(dateComponents.year, 2019)
             XCTAssertEqual(dateComponents.month, 8)
@@ -28,6 +29,38 @@ final class OrderStatsV4Interval_DateTests: XCTestCase {
             XCTAssertEqual(dateComponents.minute, 45)
             XCTAssertEqual(dateComponents.second, 0)
         }
+    }
+
+    // MARK: - Unparseable dates return nil instead of crashing
+
+    func test_dateStart_when_date_string_is_empty_then_returns_nil() throws {
+        // Given
+        let interval = OrderStatsV4Interval(interval: "hour",
+                                            dateStart: "",
+                                            dateEnd: "2019-08-08 10:45:00",
+                                            subtotals: mockIntervalSubtotals)
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+
+        // When
+        let dateStart = interval.dateStart(timeZone: timeZone)
+
+        // Then
+        XCTAssertNil(dateStart)
+    }
+
+    func test_dateEnd_when_date_string_is_malformed_then_returns_nil() throws {
+        // Given
+        let interval = OrderStatsV4Interval(interval: "hour",
+                                            dateStart: "2019-08-08 10:45:00",
+                                            dateEnd: "not-a-date",
+                                            subtotals: mockIntervalSubtotals)
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+
+        // When
+        let dateEnd = interval.dateEnd(timeZone: timeZone)
+
+        // Then
+        XCTAssertNil(dateEnd)
     }
 
     func test_date_start_and_date_end_parsed_when_daylight_saving_time_begins() throws {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.3
 -----
+- [*] Dashboard: Fixed a crash on the store performance card when a store returns stats with an invalid date. [https://github.com/woocommerce/woocommerce-ios/pull/17628]
 - [Internal] Send a persistent device id in remote feature flag requests so logins without a WordPress.com account are included in progressive rollouts. [https://github.com/woocommerce/woocommerce-ios/pull/17605]
 - [*] Payments: fixed successful in-person payments appearing to fail when the capture response is interrupted. [https://github.com/woocommerce/woocommerce-ios/pull/17593]
 - [Internal] Add `payment_method_type` and `currency` properties to receipt Tracks events for Android parity. [https://github.com/woocommerce/woocommerce-ios/pull/17548]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -1,4 +1,5 @@
 import Foundation
+import enum Yosemite.StatsGranularityV4
 import enum Yosemite.StatsTimeRangeV4
 import enum Yosemite.AnalyticsOrderDateType
 import enum Yosemite.DashboardRevenueStatsType
@@ -15,6 +16,7 @@ extension WooAnalyticsEvent {
             static let type = "type"
             static let option = "option"
             static let date = "date"
+            static let granularity = "granularity"
         }
 
         /// Shared `type` value for all stats card events. Mirrors the Android
@@ -36,11 +38,13 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardMainStatsLoaded, properties: [Keys.range: timeRange.analyticsValue])
         }
 
-        /// Tracked when a store returns a stats interval whose date can't be parsed, so it is dropped from
-        /// the Store Performance chart. Mirrors Android's `stats_unexpected_format`.
-        static func statsUnexpectedDateFormat(timeRange: StatsTimeRangeV4, dateStrings: [String]) -> WooAnalyticsEvent {
+        /// Tracked when a store returns a stats interval whose date can't be parsed, so it is dropped from the Store Performance chart.
+        static func statsUnexpectedDateFormat(timeRange: StatsTimeRangeV4,
+                                              granularity: StatsGranularityV4,
+                                              dateStrings: [String]) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardStatsUnexpectedDateFormat,
                               properties: [Keys.range: timeRange.analyticsValue,
+                                           Keys.granularity: granularity.rawValue,
                                            Keys.date: dateStrings.joined(separator: ", ")])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -14,6 +14,7 @@ extension WooAnalyticsEvent {
             static let siteConnectionType = "site_connection_type"
             static let type = "type"
             static let option = "option"
+            static let date = "date"
         }
 
         /// Shared `type` value for all stats card events. Mirrors the Android
@@ -33,6 +34,14 @@ extension WooAnalyticsEvent {
         /// - Parameter timeRange: the range of store stats (e.g. Today, This Week, This Month, This Year).
         static func dashboardMainStatsLoaded(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardMainStatsLoaded, properties: [Keys.range: timeRange.analyticsValue])
+        }
+
+        /// Tracked when a store returns a stats interval whose date can't be parsed, so it is dropped from
+        /// the Store Performance chart. Mirrors Android's `stats_unexpected_format`.
+        static func statsUnexpectedDateFormat(timeRange: StatsTimeRangeV4, dateStrings: [String]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsUnexpectedDateFormat,
+                              properties: [Keys.range: timeRange.analyticsValue,
+                                           Keys.date: dateStrings.joined(separator: ", ")])
         }
 
         /// Tracked when the date range on the store stats view changes.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
@@ -6,10 +6,12 @@ struct StatsIntervalDataParser {
     /// Returns the stats intervals, ordered by date.
     ///
     static func sortStatsIntervals<Stats: WCAnalyticsStats>(from stats: Stats?) -> [Stats.Interval] {
-        return stats?.intervals.sorted(by: { lhs, rhs -> Bool in
-            let siteTimezone = TimeZone.siteTimezone
-            return lhs.dateStart(timeZone: siteTimezone) < rhs.dateStart(timeZone: siteTimezone)
-        }) ?? []
+        let siteTimezone = TimeZone.siteTimezone
+        // Skip intervals whose date can't be parsed (bad server data) instead of crashing, then sort by date.
+        return (stats?.intervals ?? [])
+            .compactMap { interval in interval.dateStart(timeZone: siteTimezone).map { (interval: interval, date: $0) } }
+            .sorted { $0.date < $1.date }
+            .map { $0.interval }
     }
 
     /// Returns the requested stats total data values for every interval in the provided stats.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -536,12 +536,14 @@ private extension StorePerformanceViewModel {
 
     func createOrderStatsIntervalData(orderStatsIntervals: [OrderStatsV4Interval],
                                       revenueType: DashboardRevenueStatsType) -> [StoreStatsChartData] {
-            let intervalDates = orderStatsIntervals.map { $0.dateStart(timeZone: siteTimezone) }
-            let revenues = orderStatsIntervals.map { ($0.revenueValue(for: revenueType) as NSDecimalNumber).doubleValue }
-            return zip(intervalDates, revenues)
-                .map { x, y -> StoreStatsChartData in
-                    .init(date: x, revenue: y)
+            // Skip intervals with an unparseable start date (bad server data) rather than crashing.
+            return orderStatsIntervals.compactMap { interval -> StoreStatsChartData? in
+                guard let date = interval.dateStart(timeZone: siteTimezone) else {
+                    return nil
                 }
+                let revenue = (interval.revenueValue(for: revenueType) as NSDecimalNumber).doubleValue
+                return StoreStatsChartData(date: date, revenue: revenue)
+            }
         }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -147,6 +147,7 @@ final class StoreStatsPeriodViewModel {
     private let analytics: Analytics
 
     private var cancellables: Set<AnyCancellable> = []
+    private var reportedUnparseableDateStarts: Set<[String]> = []
 
     init(siteID: Int64,
          timeRange: StatsTimeRangeV4,
@@ -299,8 +300,7 @@ private extension StoreStatsPeriodViewModel {
         orderStatsData = (stats: orderStats, intervals: intervals)
     }
 
-    /// Reports the intervals dropped for an unparseable date, with the offending strings, once per
-    /// sync — not in `sortStatsIntervals`, which runs many times per render.
+    /// Reports each unique set of intervals dropped for an unparseable date once over the lifetime of the view model.
     func reportUnparseableIntervalsIfNeeded(in orderStats: OrderStatsV4?, keptCount: Int) {
         guard let orderStats, orderStats.intervals.count > keptCount else {
             return
@@ -309,13 +309,19 @@ private extension StoreStatsPeriodViewModel {
         let unparseableDateStarts = orderStats.intervals
             .filter { $0.dateStart(timeZone: .siteTimezone) == nil }
             .map(\.dateStart)
+            .sorted()
+        guard reportedUnparseableDateStarts.insert(unparseableDateStarts).inserted else {
+            return
+        }
         crashLogging.logMessage(
             "Dropped stats interval(s) with an unparseable date during dashboard sync",
             properties: ["dropped_interval_count": orderStats.intervals.count - keptCount,
                          "unparseable_date_starts": unparseableDateStarts],
             level: .error
         )
-        analytics.track(event: .Dashboard.statsUnexpectedDateFormat(timeRange: timeRange, dateStrings: unparseableDateStarts))
+        analytics.track(event: .Dashboard.statsUnexpectedDateFormat(timeRange: timeRange,
+                                                                     granularity: orderStats.granularity,
+                                                                     dateStrings: unparseableDateStarts))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -143,6 +143,8 @@ final class StoreStatsPeriodViewModel {
     private let currencyFormatter: CurrencyFormatter
     private let storageManager: StorageManagerType
     private let currencySettings: CurrencySettings
+    private let crashLogging: CrashLogger
+    private let analytics: Analytics
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -152,7 +154,9 @@ final class StoreStatsPeriodViewModel {
          currentDate: Date,
          currencyFormatter: CurrencyFormatter,
          currencySettings: CurrencySettings,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         crashLogging: CrashLogger = ServiceLocator.crashLogging,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.timeRange = timeRange
         self.siteTimezone = siteTimezone
@@ -160,6 +164,8 @@ final class StoreStatsPeriodViewModel {
         self.currencyFormatter = currencyFormatter
         self.currencySettings = currencySettings
         self.storageManager = storageManager
+        self.crashLogging = crashLogging
+        self.analytics = analytics
 
         // Make sure the ResultsControllers are ready to observe changes to the data even before the view loads
         configureResultsControllers()
@@ -267,14 +273,15 @@ private extension StoreStatsPeriodViewModel {
         /// Attempting to get only the last x items from site visit stats,
         /// with x being the number of intervals available from order stats.
         ///
-        if let orderStats = orderStatsResultsController.fetchedObjects.first,
-           !orderStats.intervals.isEmpty,
+        /// Use the parsed intervals (bad dates dropped) so the visit-stats index stays aligned with the chart.
+        let orderIntervalCount = orderStatsData.intervals.count
+        if orderIntervalCount > 0,
            let items = siteStats?.items,
-           items.count > orderStats.intervals.count {
+           items.count > orderIntervalCount {
             let sortedItems = items.sorted(by: { lhs, rhs -> Bool in
                 return lhs.period < rhs.period
             })
-            let matchingItems = Array(sortedItems.suffix(orderStats.intervals.count))
+            let matchingItems = Array(sortedItems.suffix(orderIntervalCount))
             self.siteStats = siteStats?.copy(items: matchingItems)
         } else {
             self.siteStats = siteStats
@@ -288,7 +295,27 @@ private extension StoreStatsPeriodViewModel {
     func updateOrderDataIfNeeded() {
         let orderStats = orderStatsResultsController.fetchedObjects.first
         let intervals = StatsIntervalDataParser.sortStatsIntervals(from: orderStats)
+        reportUnparseableIntervalsIfNeeded(in: orderStats, keptCount: intervals.count)
         orderStatsData = (stats: orderStats, intervals: intervals)
+    }
+
+    /// Reports the intervals dropped for an unparseable date, with the offending strings, once per
+    /// sync — not in `sortStatsIntervals`, which runs many times per render.
+    func reportUnparseableIntervalsIfNeeded(in orderStats: OrderStatsV4?, keptCount: Int) {
+        guard let orderStats, orderStats.intervals.count > keptCount else {
+            return
+        }
+        // Match the timezone the parser dropped with, so the reported strings line up.
+        let unparseableDateStarts = orderStats.intervals
+            .filter { $0.dateStart(timeZone: .siteTimezone) == nil }
+            .map(\.dateStart)
+        crashLogging.logMessage(
+            "Dropped stats interval(s) with an unparseable date during dashboard sync",
+            properties: ["dropped_interval_count": orderStats.intervals.count - keptCount,
+                         "unparseable_date_starts": unparseableDateStarts],
+            level: .error
+        )
+        analytics.track(event: .Dashboard.statsUnexpectedDateFormat(timeRange: timeRange, dateStrings: unparseableDateStarts))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsIntervalDataParserTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsIntervalDataParserTests.swift
@@ -75,4 +75,24 @@ final class StatsIntervalDataParserTests: XCTestCase {
         // Then
         XCTAssertEqual(averageOrderValueData, [20, 30])
     }
+
+    func test_getChartData_when_an_interval_has_an_empty_dateStart_then_it_is_dropped_and_does_not_crash() {
+        // Given
+        // One interval has an unparseable (empty) start date, mirroring the malformed server
+        // data that used to crash the app during dashboard sync.
+        let orderStats = OrderStatsV4.fake().copy(intervals: [
+            .fake().copy(dateStart: "",
+                         dateEnd: "2019-07-09 01:59:59",
+                         subtotals: .fake().copy(grossRevenue: 25)),
+            .fake().copy(dateStart: "2019-07-09 00:00:00",
+                         dateEnd: "2019-07-09 00:59:59",
+                         subtotals: .fake().copy(grossRevenue: 31))
+        ])
+
+        // When
+        let totalRevenueData = StatsIntervalDataParser.getChartData(for: .grossRevenue, from: orderStats)
+
+        // Then
+        XCTAssertEqual(totalRevenueData, [31])
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -181,7 +181,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         let orderStats = OrderStatsV4(siteID: siteID,
                                       granularity: timeRange.intervalGranularity,
                                       totals: .fake(),
-                                      intervals: [ .fake().copy(subtotals: .fake().copy(totalOrders: 3, grossRevenue: 62.7)) ])
+                                      intervals: [ .fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                                 subtotals: .fake().copy(totalOrders: 3, grossRevenue: 62.7)) ])
         insertOrderStats(orderStats, timeRange: timeRange)
 
         XCTAssertEqual(conversionStatsTextValues, ["-"])
@@ -207,7 +208,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         let orderStats = OrderStatsV4(siteID: siteID,
                                       granularity: timeRange.intervalGranularity,
                                       totals: .fake(),
-                                      intervals: [ .fake().copy(subtotals: .fake().copy(totalOrders: 3, grossRevenue: 62.7)) ])
+                                      intervals: [ .fake().copy(dateStart: "2022-01-03 00:00:00",
+                                                                 subtotals: .fake().copy(totalOrders: 3, grossRevenue: 62.7)) ])
         insertOrderStats(orderStats, timeRange: timeRange)
 
         XCTAssertEqual(conversionStatsTextValues, ["-"])
@@ -402,17 +404,125 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         // Then — each switch produces a fresh emission with the corresponding amount.
         XCTAssertEqual(revenueStatsTextValues, ["-", "$100.50", "$80.25", "$60.10"])
     }
+
+    // MARK: - Unparseable interval dates: reporting and alignment
+
+    func test_updateOrderData_when_an_interval_has_unparseable_date_then_reports_non_fatal_once_with_bad_date() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .thisMonth
+        let crashLogger = MockCrashLogger()
+        let viewModel = createViewModel(timeRange: timeRange, crashLogging: crashLogger)
+        observeStatsEmittedValues(viewModel: viewModel)
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake(),
+                                      intervals: [
+                                        .fake().copy(dateStart: "", subtotals: .fake()),
+                                        .fake().copy(dateStart: "2022-01-03 00:00:00", subtotals: .fake())
+                                      ])
+
+        // When
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(crashLogger.loggedMessages.count, 1)
+        let logged = crashLogger.loggedMessages.first
+        XCTAssertEqual(logged?.properties?["dropped_interval_count"] as? Int, 1)
+        XCTAssertEqual(logged?.properties?["unparseable_date_starts"] as? [String], [""])
+        XCTAssertEqual(logged?.level, .error)
+    }
+
+    func test_updateOrderData_when_all_interval_dates_parse_then_does_not_report() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .thisMonth
+        let crashLogger = MockCrashLogger()
+        let viewModel = createViewModel(timeRange: timeRange, crashLogging: crashLogger)
+        observeStatsEmittedValues(viewModel: viewModel)
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake(),
+                                      intervals: [ .fake().copy(dateStart: "2022-01-03 00:00:00", subtotals: .fake()) ])
+
+        // When
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertTrue(crashLogger.loggedMessages.isEmpty)
+    }
+
+    func test_updateOrderData_when_an_interval_has_unparseable_date_then_tracks_unexpected_format_event() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .thisMonth
+        let analyticsProvider = MockAnalyticsProvider()
+        let viewModel = createViewModel(timeRange: timeRange,
+                                        analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        observeStatsEmittedValues(viewModel: viewModel)
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake(),
+                                      intervals: [
+                                        .fake().copy(dateStart: "", subtotals: .fake()),
+                                        .fake().copy(dateStart: "2022-01-03 00:00:00", subtotals: .fake())
+                                      ])
+
+        // When
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        let eventIndices = analyticsProvider.receivedEvents.enumerated()
+            .filter { $0.element == "stats_unexpected_format" }
+            .map(\.offset)
+        XCTAssertEqual(eventIndices.count, 1)
+        let properties = eventIndices.first.map { analyticsProvider.receivedProperties[$0] }
+        XCTAssertEqual(properties?["date"] as? String, "")
+    }
+
+    func test_visitorStatsText_when_an_interval_has_unparseable_date_then_selected_visitor_count_stays_aligned() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .thisMonth
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        // Three visit-stat items, ascending by period.
+        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [
+            .fake().copy(period: "2022-01-01", visitors: 10),
+            .fake().copy(period: "2022-01-02", visitors: 20),
+            .fake().copy(period: "2022-01-03", visitors: 30)
+        ])
+        insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
+
+        // Three order intervals; the earliest has an unparseable (empty) date and is dropped, leaving two.
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake(),
+                                      intervals: [
+                                        .fake().copy(dateStart: "", subtotals: .fake()),
+                                        .fake().copy(dateStart: "2022-01-02 00:00:00", subtotals: .fake()),
+                                        .fake().copy(dateStart: "2022-01-03 00:00:00", subtotals: .fake())
+                                      ])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // When — select the last of the two surviving chart bars.
+        viewModel.selectedIntervalIndex = 1
+
+        // Then — visitor count is the last item (30), aligned to the filtered intervals (not the raw-count 20).
+        XCTAssertEqual(visitorStatsTextValues.last, "30")
+    }
 }
 
 private extension StoreStatsPeriodViewModelTests {
-    func createViewModel(timeRange: StatsTimeRangeV4) -> StoreStatsPeriodViewModel {
+    func createViewModel(timeRange: StatsTimeRangeV4,
+                         crashLogging: CrashLogger = MockCrashLogger(),
+                         analytics: Analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())) -> StoreStatsPeriodViewModel {
         StoreStatsPeriodViewModel(siteID: siteID,
                                   timeRange: timeRange,
                                   siteTimezone: defaultSiteTimezone,
                                   currentDate: defaultDate,
                                   currencyFormatter: currencyFormatter,
                                   currencySettings: currencySettings,
-                                  storageManager: storageManager)
+                                  storageManager: storageManager,
+                                  crashLogging: crashLogging,
+                                  analytics: analytics)
     }
 
     func observeStatsEmittedValues(viewModel: StoreStatsPeriodViewModel) {
@@ -471,5 +581,24 @@ private extension StoreStatsPeriodViewModelTests {
         storageSiteSummaryStats.period = timeRange.summaryStatsGranularity.rawValue
         storageSiteSummaryStats.update(with: readOnlySiteSummaryStats)
         storage.saveIfNeeded()
+    }
+}
+
+/// Records `logMessage` calls so tests can assert what was reported.
+private final class MockCrashLogger: CrashLogger {
+    private(set) var loggedMessages: [(message: String, properties: [String: Any]?, level: SeverityLevel)] = []
+
+    func logError(_ error: Error, userInfo: [String: Any]?, level: SeverityLevel) {}
+
+    func logMessage(_ message: String, properties: [String: Any]?, level: SeverityLevel) {
+        loggedMessages.append((message, properties, level))
+    }
+
+    func logMessageAndWait(_ message: String, properties: [String: Any]?, level: SeverityLevel) {
+        loggedMessages.append((message, properties, level))
+    }
+
+    func logFatalErrorAndExit(_ error: Error, userInfo: [String: Any]?) -> Never {
+        fatalError(error.localizedDescription)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -407,7 +407,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 
     // MARK: - Unparseable interval dates: reporting and alignment
 
-    func test_updateOrderData_when_an_interval_has_unparseable_date_then_reports_non_fatal_once_with_bad_date() {
+    func test_loadCachedContent_when_same_unparseable_date_is_processed_repeatedly_then_reports_non_fatal_once() {
         // Given
         let timeRange: StatsTimeRangeV4 = .thisMonth
         let crashLogger = MockCrashLogger()
@@ -423,6 +423,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 
         // When
         insertOrderStats(orderStats, timeRange: timeRange)
+        viewModel.loadCachedContent()
+        viewModel.loadCachedContent()
 
         // Then
         XCTAssertEqual(crashLogger.loggedMessages.count, 1)
@@ -450,7 +452,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertTrue(crashLogger.loggedMessages.isEmpty)
     }
 
-    func test_updateOrderData_when_an_interval_has_unparseable_date_then_tracks_unexpected_format_event() {
+    func test_loadCachedContent_when_same_unparseable_date_is_processed_repeatedly_then_tracks_unexpected_format_event_once() {
         // Given
         let timeRange: StatsTimeRangeV4 = .thisMonth
         let analyticsProvider = MockAnalyticsProvider()
@@ -467,6 +469,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 
         // When
         insertOrderStats(orderStats, timeRange: timeRange)
+        viewModel.loadCachedContent()
+        viewModel.loadCachedContent()
 
         // Then
         let eventIndices = analyticsProvider.receivedEvents.enumerated()
@@ -475,6 +479,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(eventIndices.count, 1)
         let properties = eventIndices.first.map { analyticsProvider.receivedProperties[$0] }
         XCTAssertEqual(properties?["date"] as? String, "")
+        XCTAssertEqual(properties?["granularity"] as? String, "day")
     }
 
     func test_visitorStatsText_when_an_interval_has_unparseable_date_then_selected_visitor_count_stays_aligned() {


### PR DESCRIPTION
Closes WOOMOB-3707

## Description

The dashboard **Store Performance / Store Stats** card crashed the app with a deliberate `fatalError` when a store returned a stats interval whose date string couldn't be parsed.

Date parsing is now non-fatal: `dateStart`/`dateEnd` return `Date?`, and callers skip the unparseable interval instead of crashing. When an interval is dropped, `StatsIntervalDataParser` reports a handled non-fatal so we keep visibility on how often stores emit bad dates.

## Cross-platform parity

Checked how woocommerce-android handles the same bad data.

- Matched: this PR now fires the same `stats_unexpected_format` Tracks event, alongside the Sentry non-fatal.
- Not matched (by design): we drop the interval where Android keeps it with a blank label. iOS's Store Performance chart plots on a continuous `Date` axis** (`LineMark`/`AreaMark` x = `item.date`, a date-stride axis, tap-selection by nearest time interval), whereas Android's chart is index/label-based.

## Test Steps

A real store can't reproduce this — WooCommerce core always formats interval dates server-side — so it's mocked: the script registers a WireMock override that returns a revenue-stats response whose first interval has an empty `date_start`. Nothing on disk changes — the override is runtime-only and disappears when the mock stops.

### One-click setup

Save the script below as `review-woomob-3707.sh` in the repo root, then run it (`./review-woomob-3707.sh`, or `--skip-build` to reuse your last build). It builds the app, starts the mock server, injects the override, and launches the app on a simulator — logged out and pointed at the mock.

<details><summary><code>review-woomob-3707.sh</code></summary>

```bash
#!/bin/bash
#
# One-click review setup for the dashboard stats crash (unparseable interval date).
# Builds the app, starts the WireMock mock, injects an override so the revenue-stats
# response has an interval with an empty `date_start`, and launches the app on a
# simulator pointed at the mock, logged out. Then you just log in and open My store.
#
# Usage:
#   ./review-woomob-3707.sh            # build + launch
#   ./review-woomob-3707.sh --skip-build
#
# Run from the repo root. Requires Java (brew install openjdk) for WireMock.
set -euo pipefail

SKIP_BUILD=0
[[ "${1:-}" == "--skip-build" ]] && SKIP_BUILD=1

WORKSPACE="WooCommerce.xcworkspace"
SCHEME="WooCommerce"
BUNDLE_ID="com.automattic.woocommerce"
MOCK_PORT=8282
STATS_MAPPING="Modules/Sources/APIMocks/Resources/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats_hour.json"

step() { printf '\n\033[1;34m▸ %s\033[0m\n' "$1"; }

# 1. Resolve a simulator (prefer a booted one, else boot an iPhone).
step "Resolving simulator"
UDID="$(xcrun simctl list devices booted | grep -oE '[0-9A-F-]{36}' | head -1 || true)"
if [[ -z "$UDID" ]]; then
  UDID="$(xcrun simctl list devices available | grep -oE 'iPhone [0-9][^(]*\(([0-9A-F-]{36})\)' | grep -oE '[0-9A-F-]{36}' | head -1)"
  echo "Booting $UDID"
  xcrun simctl boot "$UDID"
fi
open -a Simulator
echo "Using simulator: $UDID"

# 2. Start the WireMock mock server if not already up.
step "Starting WireMock mock server (:$MOCK_PORT)"
if curl -s "http://localhost:$MOCK_PORT/__admin/" >/dev/null 2>&1; then
  echo "Already running."
else
  command -v java >/dev/null || { echo "Java required (brew install openjdk)"; exit 1; }
  ./API-Mocks/scripts/start.sh "$MOCK_PORT" >/tmp/woomob3707-wiremock.log 2>&1 &
  for _ in $(seq 1 20); do curl -s "http://localhost:$MOCK_PORT/__admin/" >/dev/null 2>&1 && break; sleep 1; done
  echo "Started."
fi

# 3. Inject a high-priority override so the revenue-stats response has an interval
#    with an empty date_start (the malformed data the fix has to survive). It is
#    runtime-only — it disappears when the mock is stopped, and the committed
#    mappings on disk are never touched.
step "Injecting empty-date_start stats override"
/usr/bin/python3 - "$STATS_MAPPING" "$MOCK_PORT" <<'PY'
import json, sys, urllib.request
mapping_path, port = sys.argv[1], sys.argv[2]
doc = json.load(open(mapping_path))
body = doc["response"]["jsonBody"]
first = body["data"]["intervals"][0]
first["date_start"] = ""
first["date_start_gmt"] = ""
override = {
    "priority": 1,
    "request": {
        "method": "GET",
        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
        "queryParameters": {
            "json": {"equalTo": "true"},
            "path": {"matches": "/wc-analytics/reports/revenue/stats(.*)"},
        },
    },
    "response": {"status": 200, "jsonBody": body},
}
req = urllib.request.Request(
    f"http://localhost:{port}/__admin/mappings",
    data=json.dumps(override).encode(), method="POST",
    headers={"Content-Type": "application/json"})
urllib.request.urlopen(req).read()
print('  override registered (revenue stats -> first interval date_start = "")')
PY

# 4. Build (unless skipped) and locate the .app.
if [[ "$SKIP_BUILD" == "0" ]]; then
  step "Building $SCHEME (this can take a few minutes)"
  xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
    -destination "platform=iOS Simulator,id=$UDID" build >/tmp/woomob3707-build.log 2>&1 \
    || { echo "Build failed — see /tmp/woomob3707-build.log"; exit 1; }
fi
PRODUCTS_DIR="$(xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
  -destination "platform=iOS Simulator,id=$UDID" -showBuildSettings 2>/dev/null \
  | awk -F'= ' '/ BUILT_PRODUCTS_DIR =/{print $2; exit}')"
APP="$PRODUCTS_DIR/$SCHEME.app"
[[ -d "$APP" ]] || { echo "Built app not found at $APP — run without --skip-build first."; exit 1; }

# 5. Install + launch logged out, pointed at the mock.
step "Installing & launching against the mock (logged out)"
xcrun simctl install "$UDID" "$APP"
xcrun simctl terminate "$UDID" "$BUNDLE_ID" 2>/dev/null || true
xcrun simctl launch "$UDID" "$BUNDLE_ID" mocked-wpcom-api logout-at-launch >/dev/null

cat <<'STEPS'

✅ Ready. In the app:
   1. Log In → store address: yourwoosite.com → Continue
   2. Email t@wp.com → Continue → Password pw → Continue → 2FA 123456 → Continue
      → you land on "My store".
   → Expect (this PR): the Store Performance card renders; the interval with the
     empty date is dropped, no crash.
   → Without this fix: the app crashes (EXC_BREAKPOINT) during the dashboard
     sync, before My store finishes loading.

To stop the mock: ./API-Mocks/scripts/stop.sh 8282
STEPS
```

</details>

Then, in the app:

1. **Log In** → store address `yourwoosite.com` → **Continue**.
2. Email `t@wp.com` → **Continue** → password `pw` → **Continue** → 2FA `123456` → **Continue**. You land on **My store**.
3. Confirm the **Store Performance** card renders — the interval with the empty date is dropped, no crash. Without this fix the app instead crashes (`EXC_BREAKPOINT`) during the dashboard sync, before **My store** finishes loading.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


