### PR TITLE
Cap rmagick below 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@
 source 'https://rubygems.org'
 
 group :screenshots, optional: true do
-  gem 'rmagick', '~> 4.1'
+  # Capped below 7: the wpmreleasetoolkit PromoScreenshots helper still targets
+  # rmagick 5.x and breaks on 7. See AINFRA-2482.
+  gem 'rmagick', '>= 4.1', '< 7'
 end
 
 gem 'danger-dangermattic', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,7 @@ DEPENDENCIES
   fastlane-plugin-wpmreleasetoolkit (~> 14.11)
   openssl (~> 4.0)
   rake (~> 13.4)
-  rmagick (~> 4.1)
+  rmagick (>= 4.1, < 7)
   rubocop (~> 1.88)
   rubocop-rake (~> 0.6)
   xcode-install


### PR DESCRIPTION
To avoid PR noise like https://github.com/woocommerce/woocommerce-ios/pull/17626.

See follow up https://linear.app/a8c/issue/AINFRA-2482