### PR TITLE
[WOOMOB-3697] Fix "No navigation controller found to show login epilogue" crash on magic-link login

### DIFF
--- a/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -141,7 +141,12 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
         guard let navigationController else {
-            fatalError("No navigation controller found to show login epilogue")
+            // A dropped magic-link presentation can orphan this view controller, so a nil nav here
+            // is a recoverable UIKit race, not programmer error. Skip the epilogue instead of
+            // crashing — the account is authenticated and the store picker shows on relaunch.
+            WPAuthenticatorLogError("No navigation controller found to show login epilogue")
+            WordPressAuthenticator.track(.loginMagicLinkFailed)
+            return
         }
 
         authenticationDelegate.presentLoginEpilogue(in: navigationController,

--- a/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
@@ -10,6 +10,7 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     var shouldHandleError: Bool = false
 
     private(set) var presentSignupEpilogueCalled = false
+    private(set) var presentLoginEpilogueCalled = false
     private(set) var socialUser: SocialUser?
 
     func createdWordPressComAccount(username: String, authToken: String) {
@@ -29,7 +30,7 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     }
 
     func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, source: SignInSource?, onDismiss: @escaping () -> Void) {
-        // no-op
+        presentLoginEpilogueCalled = true
     }
 
     func presentSignupEpilogue(

--- a/WooCommerce/WordPressAuthenticatorTests/NUX/NUXLinkAuthViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/NUX/NUXLinkAuthViewControllerTests.swift
@@ -1,0 +1,25 @@
+import Testing
+import UIKit
+@testable import WordPressAuthenticator
+
+@MainActor
+struct NUXLinkAuthViewControllerTests {
+
+    @Test func test_showLoginEpilogue_when_navigationController_is_nil_then_does_not_crash_and_skips_epilogue() {
+        // Given a controller orphaned from its navigation stack (nav controller nil)
+        WordPressAuthenticator.initializeForTesting()
+        let spy = WordPressAuthenticatorDelegateSpy()
+        WordPressAuthenticator.shared.delegate = spy
+        let controller = NUXLinkAuthViewController()
+        let credentials = AuthenticatorCredentials(wpcom: WordPressComCredentials(authToken: "token",
+                                                                                  isJetpackLogin: false,
+                                                                                  multifactor: false,
+                                                                                  siteURL: "https://wordpress.com"))
+
+        // When showing the login epilogue on the orphaned controller
+        controller.showLoginEpilogue(for: credentials)
+
+        // Then it skips the epilogue instead of trapping — an orphaned epilogue is recoverable, not fatal
+        #expect(spy.presentLoginEpilogueCalled == false)
+    }
+}


### PR DESCRIPTION
Closes WOOMOB-3697

## Description

Completing a WordPress.com **magic-link login** could crash the app with a deliberate `fatalError("No navigation controller found to show login epilogue")`.

The magic-link handoff presents the login screen inside a navigation controller and then, once the account sync finishes, shows the login epilogue by presenting it in that navigation controller. If the presentation is silently dropped mid-transition (the presenter is dismissing / the app is foregrounding — more likely on iOS 26), the navigation controller deallocates while the login view controller lives on through the sync completion. It is then orphaned, so its `navigationController` is nil when the epilogue runs. Crashing on that is wrong — it is a recoverable UIKit race, not programmer error.

`showLoginEpilogue` now skips the epilogue and reports a handled `login_magic_link_failed` (Tracks) instead of trapping when the navigation controller is nil. The account is already authenticated, so the store picker shows on the next launch rather than the session being destroyed.

Most of these crashes come through the QR-login magic-link path (per the Sentry logs); the email magic-link path hits the same code. The fix is at the shared crash site so it covers both.

Targeted at `release/25.3` as a beta fix.

## Considered and deferred

- The sibling `showSignupEpilogue` has the identical bare `fatalError()`. Left as-is — it is unreachable in WooCommerce (`shouldPresentSignupEpilogue` is always false). Noted for a possible follow-up.
- A fuller fix would decouple the post-login re-root from the login screen's navigation controller so the epilogue can't be lost this way. Out of scope for a beta crash fix.

## Test Steps

This is a rare UIKit timing race, so it doesn't reproduce reliably by hand. Validation is the regression test plus, optionally, a forced repro.

1. Run `NUXLinkAuthViewControllerTests` (WordPressAuthenticator scheme). `test_showLoginEpilogue_when_navigationController_is_nil_then_does_not_crash_and_skips_epilogue` passes: with a nil navigation controller, the epilogue is skipped instead of trapping.
2. Happy path unchanged: log in with an email magic link, and with QR — both reach the store picker / dashboard as before.
3. Optional — force the crash path. Temporarily add this DEBUG hook in `openAuthenticationURL` (`WordPressAuthenticator.swift`), right after the nav controller is created (**do not commit it**):
   ```swift
   #if DEBUG
   if ProcessInfo.processInfo.arguments.contains("simulate-magic-link-presentation-failure") {
       loginVC.syncAndContinue(authToken: authToken, flow: flow, isJetpackConnect: url.isJetpackConnect)
       return true
   }
   #endif
   ```
   Then, logged out, launch with `simulate-magic-link-presentation-failure` and run:
   `xcrun simctl openurl <UDID> "woocommerce://magic-login?token=anything&flow=login"`
   - Before this PR: crash, app ejected to SpringBoard (`LoginViewController.swift:144`).
   - After: app stays alive, `login_magic_link_failed` tracked, no crash.
