### PR TITLE
[WOOMOB-3697] Fix "No navigation controller found to show login epilogue" crash on magic-link login

### DIFF
--- a/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -141,7 +141,14 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
         guard let navigationController else {
-            fatalError("No navigation controller found to show login epilogue")
+            // A dropped presentation can orphan this VC (a recoverable UIKit race, not programmer
+            // error), so report and skip the epilogue instead of crashing. `flow` tags the concrete
+            // login flow, since this method is shared across all of them.
+            WPAuthenticatorLogError("No navigation controller found to show login epilogue")
+            WordPressAuthenticator.track(.loginMagicLinkFailed,
+                                         properties: ["reason": "missing_navigation_controller",
+                                                      "flow": String(describing: type(of: self))])
+            return
         }
 
         authenticationDelegate.presentLoginEpilogue(in: navigationController,

--- a/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
@@ -10,6 +10,9 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     var shouldHandleError: Bool = false
 
     private(set) var presentSignupEpilogueCalled = false
+    private(set) var presentLoginEpilogueCalled = false
+    private(set) var trackedEvents: [WPAnalyticsStat] = []
+    private(set) var lastTrackedProperties: [AnyHashable: Any]?
     private(set) var socialUser: SocialUser?
 
     func createdWordPressComAccount(username: String, authToken: String) {
@@ -29,7 +32,7 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     }
 
     func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, source: SignInSource?, onDismiss: @escaping () -> Void) {
-        // no-op
+        presentLoginEpilogueCalled = true
     }
 
     func presentSignupEpilogue(
@@ -76,14 +79,15 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     }
 
     func track(event: WPAnalyticsStat) {
-        // no-op
+        trackedEvents.append(event)
     }
 
     func track(event: WPAnalyticsStat, properties: [AnyHashable: Any]) {
-        // no-op
+        trackedEvents.append(event)
+        lastTrackedProperties = properties
     }
 
     func track(event: WPAnalyticsStat, error: Error) {
-        // no-op
+        trackedEvents.append(event)
     }
 }

--- a/WooCommerce/WordPressAuthenticatorTests/NUX/NUXLinkAuthViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/NUX/NUXLinkAuthViewControllerTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import UIKit
+@testable import WordPressAuthenticator
+
+@MainActor
+struct NUXLinkAuthViewControllerTests {
+
+    @Test func test_showLoginEpilogue_when_navigationController_is_nil_then_skips_epilogue_and_reports_without_crashing() {
+        // Given a controller orphaned from its navigation stack (nav controller nil)
+        WordPressAuthenticator.initializeForTesting()
+        let spy = WordPressAuthenticatorDelegateSpy()
+        WordPressAuthenticator.shared.delegate = spy
+        let controller = NUXLinkAuthViewController()
+        let credentials = AuthenticatorCredentials(wpcom: WordPressComCredentials(authToken: "token",
+                                                                                  isJetpackLogin: false,
+                                                                                  multifactor: false,
+                                                                                  siteURL: "https://wordpress.com"))
+
+        // When showing the login epilogue on the orphaned controller
+        controller.showLoginEpilogue(for: credentials)
+
+        // Then it skips the epilogue instead of trapping — an orphaned epilogue is recoverable, not fatal
+        #expect(spy.presentLoginEpilogueCalled == false)
+        // And it reports the handled failure, tagged with the concrete flow, so the race stays visible after shipping
+        #expect(spy.trackedEvents.contains(.loginMagicLinkFailed))
+        #expect(spy.lastTrackedProperties?["reason"] as? String == "missing_navigation_controller")
+        #expect(spy.lastTrackedProperties?["flow"] as? String == "NUXLinkAuthViewController")
+    }
+}


### PR DESCRIPTION
Closes WOOMOB-3697

## Description

Completing a WordPress.com **magic-link login** could crash with a deliberate `fatalError("No navigation controller found to show login epilogue")`.

The magic-link handoff presents the login screen in a navigation controller, then shows the epilogue in it once account sync finishes. If that presentation is silently dropped mid-transition (dismissing presenter / app foregrounding — more likely on iOS 26), the nav controller deallocates while the login VC lives on through the sync completion, leaving its `navigationController` nil at epilogue time — a recoverable UIKit race, not programmer error.

`showLoginEpilogue` now skips the epilogue and reports a handled `login_magic_link_failed` (Tracks, tagged with the login `flow`) instead of trapping, so the app is no longer terminated (an authenticated user recovers into the store picker on the next launch). It's the shared crash site, so this covers both the QR magic-link path (most crashes, per Sentry) and the email path.

## Test Steps

This is a rare UIKit timing race, so it doesn't reproduce reliably by hand.

1. Happy path unchanged: log in with an email magic link, and with QR, both reach the store picker as before.




