### PR TITLE
[WOOMOB-3693] Fix stuck Log In button after entering a wrong email

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -114,12 +114,14 @@ class AuthenticationManager: Authentication {
                 self.analytics.track(.loginPrologueContinueTapped)
                 return false
             }
-            // A coordinator is already driving the QR-login flow — e.g. a rapid
-            // second tap while the availability check from the first tap was
-            // still in flight. Don't build a second one; it would orphan the
-            // first along with its navigation stack.
-            guard self.qrLoginCoordinator == nil else {
-                return true
+            // Reuse a coordinator only while its QR screens are still live (e.g.
+            // a rapid second tap); release a stale one an error-screen restart
+            // left behind, or its tap is swallowed forever.
+            if let existingCoordinator = self.qrLoginCoordinator {
+                guard existingCoordinator.isNavigationStackShowingQRFlow == false else {
+                    return true
+                }
+                self.qrLoginCoordinator = nil
             }
             // Track the click while the active flow is still `prologue`;
             // the QR coordinator's `start()` switches it to `login_qr`.

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -59,6 +59,8 @@ final class QRLoginCoordinator {
     /// stack once it has delivered a payload. (WOOMOB-3136)
     private weak var scannerViewController: UIViewController?
 
+    private weak var rootViewController: UIViewController?
+
     init(mode: Mode = .camera,
          navigationController: UINavigationController,
          parser: QRLoginPayloadParser = QRLoginPayloadParser(),
@@ -101,11 +103,12 @@ final class QRLoginCoordinator {
         handleScanned(payload: payload)
     }
 
-    /// Whether any of this flow's own screens are still on the navigation stack.
+    /// Whether this flow's own screens are still on the navigation stack.
     var isNavigationStackShowingQRFlow: Bool {
-        [prologueViewController, scannerViewController]
-            .compactMap { $0 }
-            .contains { navigationController.viewControllers.contains($0) }
+        guard let rootViewController else {
+            return false
+        }
+        return navigationController.viewControllers.contains(rootViewController)
     }
 }
 
@@ -472,6 +475,9 @@ private extension QRLoginCoordinator {
                 title: Localization.help,
                 primaryAction: UIAction { [weak self] _ in self?.showHelp() }
             )
+        }
+        if rootViewController == nil {
+            rootViewController = hosting
         }
         navigationController.pushViewController(hosting, animated: true)
         return hosting

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -100,6 +100,13 @@ final class QRLoginCoordinator {
     func presentDeepLink(payload: QRLoginPayload) {
         handleScanned(payload: payload)
     }
+
+    /// Whether any of this flow's own screens are still on the navigation stack.
+    var isNavigationStackShowingQRFlow: Bool {
+        [prologueViewController, scannerViewController]
+            .compactMap { $0 }
+            .contains { navigationController.viewControllers.contains($0) }
+    }
 }
 
 // MARK: - Prologue + scanner


### PR DESCRIPTION
Closes WOOMOB-3693

## Description

Manual copy of #17613 onto `trunk`. 

## Test Steps

1. Fresh install / Log out of the app
2. Reach the screen to provide site address
3. Input a woo site
4. Provide a non-existing email address
5. Tap continue
6. On the next screen tap "Log in with an other account"
7. Tap "Log in"
8. QR login screen is shown

## Screenshots

| Before | After |
| --- | --- |
| <img width="256" height="554" alt="Before" src="https://github.com/user-attachments/assets/971de704-da66-4694-bd50-c6d78e1c70ba" /> | <img width="256" height="554" alt="After" src="https://github.com/user-attachments/assets/ee3cf901-5275-44f5-b6b9-1e7b08da62a1" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
