### PR TITLE
POS: add `cached_woo_core_version` to local catalog sync coordinator events

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
@@ -73,6 +73,7 @@ extension WooAnalyticsEvent {
             static let responseContentType = "response_content_type"
             static let reason = "reason"
             static let wooCommerceVersion = "woocommerce_version"
+            static let cachedWooCoreVersion = "cached_woo_core_version"
         }
 
         // MARK: - Initial Launch & Loading Screen Events
@@ -163,13 +164,15 @@ extension WooAnalyticsEvent {
             lastGenerationState: String? = nil,
             failureStage: String? = nil,
             httpStatusCode: Int? = nil,
-            responseContentType: String? = nil
+            responseContentType: String? = nil,
+            cachedWooCoreVersion: String? = nil
         ) -> WooAnalyticsEvent {
             let errorType = errorClassifier(error)
             var properties: [String: WooAnalyticsEventPropertyType] = [
                 Key.syncType: syncType,
                 Key.syncStrategy: syncStrategy,
-                Key.errorType: errorType
+                Key.errorType: errorType,
+                Key.cachedWooCoreVersion: cachedWooCoreVersion ?? "unknown"
             ]
             if let pollAttempts {
                 properties[Key.pollAttempts] = "\(pollAttempts)"

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
@@ -117,12 +117,16 @@ extension WooAnalyticsEvent {
 
         // MARK: - Core Sync Events
 
-        public static func syncStarted(syncType: String, syncStrategy: String, connectionType: String) -> WooAnalyticsEvent {
+        public static func syncStarted(syncType: String,
+                                       syncStrategy: String,
+                                       connectionType: String,
+                                       cachedWooCoreVersion: String? = nil) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSaleLocalCatalogSyncStarted,
                               properties: [
                                 Key.syncType: syncType,
                                 Key.syncStrategy: syncStrategy,
-                                Key.connectionType: connectionType
+                                Key.connectionType: connectionType,
+                                Key.cachedWooCoreVersion: cachedWooCoreVersion ?? "unknown"
                               ])
         }
 
@@ -135,7 +139,8 @@ extension WooAnalyticsEvent {
             totalVariations: Int,
             syncDurationMs: Int,
             generationDurationMs: Int? = nil,
-            pollAttempts: Int? = nil
+            pollAttempts: Int? = nil,
+            cachedWooCoreVersion: String? = nil
         ) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [
                 Key.syncType: syncType,
@@ -144,7 +149,8 @@ extension WooAnalyticsEvent {
                 Key.variationsSynced: "\(variationsSynced)",
                 Key.totalProducts: "\(totalProducts)",
                 Key.totalVariations: "\(totalVariations)",
-                Key.syncDurationMs: "\(syncDurationMs)"
+                Key.syncDurationMs: "\(syncDurationMs)",
+                Key.cachedWooCoreVersion: cachedWooCoreVersion ?? "unknown"
             ]
             if let generationDurationMs {
                 properties[Key.generationDurationMs] = "\(generationDurationMs)"
@@ -192,11 +198,15 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .pointOfSaleLocalCatalogSyncFailed, properties: properties, error: error)
         }
 
-        public static func syncSkipped(reason: String, syncType: String, syncStrategy: String) -> WooAnalyticsEvent {
+        public static func syncSkipped(reason: String,
+                                       syncType: String,
+                                       syncStrategy: String,
+                                       cachedWooCoreVersion: String? = nil) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSaleLocalCatalogSyncSkipped,
                               properties: [Key.reason: reason,
                                            Key.syncType: syncType,
-                                           Key.syncStrategy: syncStrategy])
+                                           Key.syncStrategy: syncStrategy,
+                                           Key.cachedWooCoreVersion: cachedWooCoreVersion ?? "unknown"])
         }
 
         // MARK: - Host-Blocked Catalog File Events

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -239,7 +239,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 syncType: POSCatalogSyncType.full.rawValue,
                 syncStrategy: syncStrategy.rawValue,
                 error: POSCatalogSyncError.requestCancelled,
-                errorClassifier: POSCatalogSyncErrorClassifier.classify
+                errorClassifier: POSCatalogSyncErrorClassifier.classify,
+                cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)
             ))
             throw POSCatalogSyncError.requestCancelled
         } catch {
@@ -261,7 +262,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 lastGenerationState: lastGenerationState,
                 failureStage: catalogFileMetadata.failureStage,
                 httpStatusCode: catalogFileMetadata.httpStatusCode,
-                responseContentType: catalogFileMetadata.responseContentType
+                responseContentType: catalogFileMetadata.responseContentType,
+                cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)
             ))
             throw error
         }
@@ -291,9 +293,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                                                      isBackgroundSync: isBackgroundSync) {
             DDLogInfo("⚠️ POSCatalogSyncCoordinator: Catalog file is blocked by host for site \(siteID); " +
                       "skipping automatic file sync wait and falling back to paginated full sync")
-            let wooCommerceVersion = await pluginsService?.loadPluginInStorage(siteID: siteID,
-                                                                               plugin: .wooCommerce,
-                                                                               isActive: true)?.version
+            let wooCommerceVersion = await cachedWooCoreVersion(for: siteID)
             trackAnalytics(WooAnalyticsEvent.LocalCatalog.blockedFellBackToRemote(wooCommerceVersion: wooCommerceVersion))
             return try await fullSyncService.startPaginatedFullSync(for: siteID, allowCellular: allowCellular)
         }
@@ -313,9 +313,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             }
             return catalog
         } catch where error.isPOSCatalogFileBlockedError {
-            let wooCommerceVersion = await pluginsService?.loadPluginInStorage(siteID: siteID,
-                                                                               plugin: .wooCommerce,
-                                                                               isActive: true)?.version
+            let wooCommerceVersion = await cachedWooCoreVersion(for: siteID)
             let isRetryWhileBlocked = sitesWithBlockedCatalogFile.contains(siteID)
             sitesWithBlockedCatalogFile.insert(siteID)
             siteSettings.setPOSCatalogFileBlockedByHostAt(siteID: siteID, date: Date())
@@ -335,7 +333,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 errorClassifier: POSCatalogSyncErrorClassifier.classify,
                 failureStage: catalogFileMetadata.failureStage,
                 httpStatusCode: catalogFileMetadata.httpStatusCode,
-                responseContentType: catalogFileMetadata.responseContentType
+                responseContentType: catalogFileMetadata.responseContentType,
+                cachedWooCoreVersion: wooCommerceVersion
             ))
             trackAnalytics(WooAnalyticsEvent.LocalCatalog.blockedFellBackToRemote(wooCommerceVersion: wooCommerceVersion))
 
@@ -524,7 +523,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 syncType: POSCatalogSyncType.incremental.rawValue,
                 syncStrategy: syncStrategy.rawValue,
                 error: POSCatalogSyncError.requestCancelled,
-                errorClassifier: POSCatalogSyncErrorClassifier.classify
+                errorClassifier: POSCatalogSyncErrorClassifier.classify,
+                cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)
             ))
             throw POSCatalogSyncError.requestCancelled
         } catch {
@@ -534,7 +534,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 syncType: POSCatalogSyncType.incremental.rawValue,
                 syncStrategy: syncStrategy.rawValue,
                 error: error,
-                errorClassifier: POSCatalogSyncErrorClassifier.classify
+                errorClassifier: POSCatalogSyncErrorClassifier.classify,
+                cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)
             ))
             throw error
         }
@@ -676,6 +677,11 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
 
     nonisolated private func trackAnalytics(_ event: WooAnalyticsEvent) {
         analytics?.track(event.statName.rawValue, properties: event.properties, error: event.error)
+    }
+
+    /// The store's cached WooCommerce version, read from local plugin storage.
+    private func cachedWooCoreVersion(for siteID: Int64) async -> String? {
+        await pluginsService?.loadPluginInStorage(siteID: siteID, plugin: .wooCommerce, isActive: true)?.version
     }
 
     /// Extracts polling metadata from enriched `POSCatalogSyncError` cases for analytics.

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -171,7 +171,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             let reason = await getSyncSkipReason(for: siteID, maxAge: maxAge)
             trackAnalytics(WooAnalyticsEvent.LocalCatalog.syncSkipped(reason: reason,
                                                                       syncType: POSCatalogSyncType.full.rawValue,
-                                                                      syncStrategy: syncStrategy.rawValue))
+                                                                      syncStrategy: syncStrategy.rawValue,
+                                                                      cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)))
             throw POSCatalogSyncError.shouldNotSync
         }
 
@@ -188,7 +189,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         let connectionType = getConnectionType()
         trackAnalytics(WooAnalyticsEvent.LocalCatalog.syncStarted(syncType: POSCatalogSyncType.full.rawValue,
                                                                   syncStrategy: syncStrategy.rawValue,
-                                                                  connectionType: connectionType))
+                                                                  connectionType: connectionType,
+                                                                  cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)))
 
         let allowCellular = isFirstSync || siteSettings.getPOSLocalCatalogCellularDataAllowed(siteID: siteID)
         DDLogInfo("🔄 POSCatalogSyncCoordinator starting full sync for site \(siteID)")
@@ -226,7 +228,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 totalVariations: totalVariations,
                 syncDurationMs: syncDurationMs,
                 generationDurationMs: syncedCatalog.syncMetadata?.generationDurationMs,
-                pollAttempts: syncedCatalog.syncMetadata?.pollAttempts
+                pollAttempts: syncedCatalog.syncMetadata?.pollAttempts,
+                cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)
             ))
         } catch AFError.explicitlyCancelled, is CancellationError {
             if isFirstSync {
@@ -453,7 +456,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             let reason = await getIncrementalSyncSkipReason(for: siteID, maxAge: maxAge)
             trackAnalytics(WooAnalyticsEvent.LocalCatalog.syncSkipped(reason: reason,
                                                                       syncType: POSCatalogSyncType.incremental.rawValue,
-                                                                      syncStrategy: syncStrategy.rawValue))
+                                                                      syncStrategy: syncStrategy.rawValue,
+                                                                      cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)))
             return
         }
 
@@ -483,7 +487,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         let connectionType = getConnectionType()
         trackAnalytics(WooAnalyticsEvent.LocalCatalog.syncStarted(syncType: POSCatalogSyncType.incremental.rawValue,
                                                                   syncStrategy: syncStrategy.rawValue,
-                                                                  connectionType: connectionType))
+                                                                  connectionType: connectionType,
+                                                                  cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)))
 
         let syncStartTime = Date()
 
@@ -515,7 +520,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 variationsSynced: syncedCatalog.variations.count,
                 totalProducts: totalProducts,
                 totalVariations: totalVariations,
-                syncDurationMs: syncDurationMs
+                syncDurationMs: syncDurationMs,
+                cachedWooCoreVersion: await cachedWooCoreVersion(for: siteID)
             ))
         } catch AFError.explicitlyCancelled, is CancellationError {
             // Track sync failed analytics

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -1522,6 +1522,107 @@ extension POSCatalogSyncCoordinatorTests {
         #expect(syncFailed?.properties?["cached_woo_core_version"] as? String == "10.8.1")
     }
 
+    @Test func performFullSyncIfApplicable_tracks_cached_woo_core_version_on_started_and_completed() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics,
+            pluginsService: makePluginsService(wooCommerceVersion: "10.8.1")
+        )
+
+        // When
+        try await sut.performFullSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncStarted = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_started" }
+        #expect(syncStarted?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+        let syncCompleted = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_completed" }
+        #expect(syncCompleted?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+    }
+
+    @Test func performFullSyncIfApplicable_without_stored_plugin_tracks_unknown_on_started_and_completed() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics
+        )
+
+        // When
+        try await sut.performFullSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncStarted = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_started" }
+        #expect(syncStarted?.properties?["cached_woo_core_version"] as? String == "unknown")
+        let syncCompleted = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_completed" }
+        #expect(syncCompleted?.properties?["cached_woo_core_version"] as? String == "unknown")
+    }
+
+    @Test func performFullSyncIfApplicable_when_skipped_tracks_cached_woo_core_version() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics,
+            pluginsService: makePluginsService(wooCommerceVersion: "10.8.1")
+        )
+        // A recent sync exists, so the full sync is skipped
+        try createSiteInDatabase(siteID: sampleSiteID, lastFullSyncDate: Date())
+
+        // When
+        try? await sut.performFullSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncSkipped = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_skipped" }
+        #expect(syncSkipped?.properties?["sync_type"] as? String == "full")
+        #expect(syncSkipped?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+    }
+
+    @Test func performIncrementalSyncIfApplicable_tracks_cached_woo_core_version_on_started_completed_and_skipped() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics,
+            pluginsService: makePluginsService(wooCommerceVersion: "10.8.1")
+        )
+
+        // When: no full sync exists yet, so the incremental sync is skipped
+        try await sut.performIncrementalSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncSkipped = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_skipped" }
+        #expect(syncSkipped?.properties?["sync_type"] as? String == "incremental")
+        #expect(syncSkipped?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+
+        // When: a full sync exists, so the incremental sync runs to completion
+        try createSiteInDatabase(siteID: sampleSiteID, lastFullSyncDate: Date().addingTimeInterval(-30 * 60))
+        try await sut.performIncrementalSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncStarted = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_started" }
+        #expect(syncStarted?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+        let syncCompleted = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_completed" }
+        #expect(syncCompleted?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+    }
+
     @Test func performFullSyncIfApplicable_when_blocked_on_WC_11_does_not_fall_back_on_first_attempt() async throws {
         // Given
         let sut = POSCatalogSyncCoordinator(

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -1425,6 +1425,103 @@ extension POSCatalogSyncCoordinatorTests {
         #expect(mockSiteSettings.mockPOSCatalogFileBlockedByHostAt != nil)
     }
 
+    // MARK: - Cached WooCommerce Core Version
+
+    @Test func performFullSyncIfApplicable_when_sync_fails_tracks_cached_woo_core_version() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics,
+            pluginsService: makePluginsService(wooCommerceVersion: "10.8.1")
+        )
+        mockSyncService.startFullSyncResult = .failure(NSError(domain: "NetworkingCore.NetworkError", code: 500))
+
+        // When
+        try? await sut.performFullSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncFailed = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_failed" }
+        #expect(syncFailed?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+    }
+
+    @Test func performFullSyncIfApplicable_when_sync_fails_without_stored_plugin_tracks_unknown_cached_woo_core_version() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics
+        )
+        mockSyncService.startFullSyncResult = .failure(NSError(domain: "NetworkingCore.NetworkError", code: 500))
+
+        // When
+        try? await sut.performFullSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncFailed = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_failed" }
+        #expect(syncFailed?.properties?["cached_woo_core_version"] as? String == "unknown")
+    }
+
+    @Test func performFullSyncIfApplicable_when_blocked_tracks_cached_woo_core_version_on_the_failure_event() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics,
+            usesCatalogAPI: true,
+            pluginsService: makePluginsService(wooCommerceVersion: "10.8.1")
+        )
+        mockSyncService.startFullSyncResult = .failure(POSCatalogFileError.downloadFailed(
+            statusCode: 403,
+            contentType: "text/html; charset=UTF-8"
+        ))
+        mockSyncService.startPaginatedFullSyncResult = .success(POSCatalog(products: [POSProduct.fake()], variations: [], syncDate: .now))
+
+        // When
+        try await sut.performFullSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncFailed = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_failed" }
+        #expect(syncFailed?.properties?["error_type"] as? String == "catalog_file_blocked")
+        #expect(syncFailed?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+    }
+
+    @Test func performIncrementalSyncIfApplicable_when_sync_fails_tracks_cached_woo_core_version() async throws {
+        // Given
+        let mockAnalytics = MockAnalytics()
+        let sut = POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings,
+            analytics: mockAnalytics,
+            pluginsService: makePluginsService(wooCommerceVersion: "10.8.1")
+        )
+        try createSiteInDatabase(siteID: sampleSiteID, lastFullSyncDate: Date().addingTimeInterval(-30 * 60))
+        mockIncrementalSyncService.startIncrementalSyncResult = .failure(NSError(domain: "NetworkingCore.NetworkError", code: 500))
+
+        // When
+        try? await sut.performIncrementalSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
+
+        // Then
+        let syncFailed = mockAnalytics.trackedEvents.first { $0.eventName == "local_catalog_sync_failed" }
+        #expect(syncFailed?.properties?["sync_type"] as? String == "incremental")
+        #expect(syncFailed?.properties?["cached_woo_core_version"] as? String == "10.8.1")
+    }
+
     @Test func performFullSyncIfApplicable_when_blocked_on_WC_11_does_not_fall_back_on_first_attempt() async throws {
         // Given
         let sut = POSCatalogSyncCoordinator(


### PR DESCRIPTION
## Description
We add `cached_woo_core_version` to local catalog sync events: 
- `local_catalog_sync_started`
- `local_catalog_sync_completed`
- `local_catalog_sync_skipped`
- `local_catalog_blocked_fell_back_to_remote`
- `local_catalog_sync_failed`

```
🔵 Tracked pos_local_catalog_sync_failed, properties: [cached_woo_core_version: 10.5.3, error_description: Yosemite.POSCatalogSyncError.requestCancelled, sync_strategy: local_catalog_file, error_domain: Yosemite.POSCatalogSyncError, sync_type: full, error_code: 5, error_type: unexpected_error]
```

## Test Steps (Optional) 
- Run POS and see the normal events for catalog sync (started, skipped, completed, ...) contain the new property.
- Fake a catalog sync failure in `POSCatalogSyncCoordinator:198`.
```diff
        // Create a task to perform the sync
        let syncTask = Task<POSCatalog, Error> {
-            try await runFullSyncWithBlockedFallback(for: siteID,
-                                                     regenerateCatalog: regenerateCatalog,
-                                                     allowCellular: allowCellular,
-                                                     isBackgroundSync: isBackgroundSync)
+            throw POSCatalogSyncError.requestCancelled
        }
```
- Trigger full sync in POS > Settings > Local Catalog
- See the event containing `cached_woo_core_version` as well

## Screenshots
n/a
