### PR TITLE
Mobile Status Report [1/4]: the lookups and the system snapshot

### DIFF
--- a/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
@@ -141,8 +141,8 @@ class EmptyPOSConnectivityProvider: POSConnectivityProviding {
 
 class EmptyPOSConnectivity: ConnectivityObserver {
     @Published private(set) var currentStatus: ConnectivityStatus = .reachable(type: .ethernetOrWiFi)
-    var isCurrentPathExpensive: Bool? { nil }
-    var isCurrentPathConstrained: Bool? { nil }
+    var isConnectionMetered: Bool? { nil }
+    var isLowDataModeEnabled: Bool? { nil }
     var statusPublisher: AnyPublisher<ConnectivityStatus, Never> { $currentStatus.eraseToAnyPublisher() }
     init() {}
 }

--- a/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
@@ -141,6 +141,8 @@ class EmptyPOSConnectivityProvider: POSConnectivityProviding {
 
 class EmptyPOSConnectivity: ConnectivityObserver {
     @Published private(set) var currentStatus: ConnectivityStatus = .reachable(type: .ethernetOrWiFi)
+    var isCurrentPathExpensive: Bool? { nil }
+    var isCurrentPathConstrained: Bool? { nil }
     var statusPublisher: AnyPublisher<ConnectivityStatus, Never> { $currentStatus.eraseToAnyPublisher() }
     init() {}
 }

--- a/Modules/Sources/WooFoundation/Utilities/Connectivity/ConnectivityObserver.swift
+++ b/Modules/Sources/WooFoundation/Utilities/Connectivity/ConnectivityObserver.swift
@@ -6,12 +6,13 @@ public protocol ConnectivityObserver {
     /// Getter for current state of the connectivity.
     var currentStatus: ConnectivityStatus { get }
 
-    /// Whether the system considers the current network path expensive — typically cellular or a personal
+    /// Whether the current connection is metered (`NWPath.isExpensive`) — typically cellular or a personal
     /// hotspot. `nil` until the first path update arrives.
-    var isCurrentPathExpensive: Bool? { get }
+    var isConnectionMetered: Bool? { get }
 
-    /// Whether Low Data Mode constrains the current network path. `nil` until the first path update arrives.
-    var isCurrentPathConstrained: Bool? { get }
+    /// Whether Low Data Mode (`NWPath.isConstrained`) applies to the current connection. `nil` until the
+    /// first path update arrives.
+    var isLowDataModeEnabled: Bool? { get }
 
     /// Publisher for connectivity availability.
     var statusPublisher: AnyPublisher<ConnectivityStatus, Never> { get }

--- a/Modules/Sources/WooFoundation/Utilities/Connectivity/ConnectivityObserver.swift
+++ b/Modules/Sources/WooFoundation/Utilities/Connectivity/ConnectivityObserver.swift
@@ -17,11 +17,6 @@ public protocol ConnectivityObserver {
     var statusPublisher: AnyPublisher<ConnectivityStatus, Never> { get }
 }
 
-public extension ConnectivityObserver {
-    var isCurrentPathExpensive: Bool? { nil }
-    var isCurrentPathConstrained: Bool? { nil }
-}
-
 /// Defines the various states of network connectivity.
 ///
 /// - unknown:      It is unknown whether the network is reachable.

--- a/Modules/Sources/WooFoundation/Utilities/Connectivity/ConnectivityObserver.swift
+++ b/Modules/Sources/WooFoundation/Utilities/Connectivity/ConnectivityObserver.swift
@@ -6,8 +6,20 @@ public protocol ConnectivityObserver {
     /// Getter for current state of the connectivity.
     var currentStatus: ConnectivityStatus { get }
 
+    /// Whether the system considers the current network path expensive — typically cellular or a personal
+    /// hotspot. `nil` until the first path update arrives.
+    var isCurrentPathExpensive: Bool? { get }
+
+    /// Whether Low Data Mode constrains the current network path. `nil` until the first path update arrives.
+    var isCurrentPathConstrained: Bool? { get }
+
     /// Publisher for connectivity availability.
     var statusPublisher: AnyPublisher<ConnectivityStatus, Never> { get }
+}
+
+public extension ConnectivityObserver {
+    var isCurrentPathExpensive: Bool? { nil }
+    var isCurrentPathConstrained: Bool? { nil }
 }
 
 /// Defines the various states of network connectivity.

--- a/Modules/Sources/WooFoundation/Utilities/Connectivity/DefaultConnectivityObserver.swift
+++ b/Modules/Sources/WooFoundation/Utilities/Connectivity/DefaultConnectivityObserver.swift
@@ -10,8 +10,8 @@ public final class DefaultConnectivityObserver: ConnectivityObserver {
 
     @Published public private(set) var currentStatus: ConnectivityStatus = .unknown
 
-    public private(set) var isCurrentPathExpensive: Bool?
-    public private(set) var isCurrentPathConstrained: Bool?
+    public private(set) var isConnectionMetered: Bool?
+    public private(set) var isLowDataModeEnabled: Bool?
 
     public var statusPublisher: AnyPublisher<ConnectivityStatus, Never> {
         $currentStatus.eraseToAnyPublisher()
@@ -29,8 +29,8 @@ public final class DefaultConnectivityObserver: ConnectivityObserver {
             DispatchQueue.main.async {
                 // Before `currentStatus`, whose publisher fires synchronously: a subscriber reacting to the
                 // status change must already see this path's flags.
-                self.isCurrentPathExpensive = path.isExpensive
-                self.isCurrentPathConstrained = path.isConstrained
+                self.isConnectionMetered = path.isExpensive
+                self.isLowDataModeEnabled = path.isConstrained
                 self.currentStatus = self.connectivityStatus(from: path)
             }
         }

--- a/Modules/Sources/WooFoundation/Utilities/Connectivity/DefaultConnectivityObserver.swift
+++ b/Modules/Sources/WooFoundation/Utilities/Connectivity/DefaultConnectivityObserver.swift
@@ -10,6 +10,9 @@ public final class DefaultConnectivityObserver: ConnectivityObserver {
 
     @Published public private(set) var currentStatus: ConnectivityStatus = .unknown
 
+    public private(set) var isCurrentPathExpensive: Bool?
+    public private(set) var isCurrentPathConstrained: Bool?
+
     public var statusPublisher: AnyPublisher<ConnectivityStatus, Never> {
         $currentStatus.eraseToAnyPublisher()
     }
@@ -24,6 +27,10 @@ public final class DefaultConnectivityObserver: ConnectivityObserver {
         networkMonitor.networkUpdateHandler = { [weak self] path in
             guard let self else { return }
             DispatchQueue.main.async {
+                // Before `currentStatus`, whose publisher fires synchronously: a subscriber reacting to the
+                // status change must already see this path's flags.
+                self.isCurrentPathExpensive = path.isExpensive
+                self.isCurrentPathConstrained = path.isConstrained
                 self.currentStatus = self.connectivityStatus(from: path)
             }
         }
@@ -78,6 +85,12 @@ protocol NetworkMonitoring: AnyObject {
 protocol NetworkMonitorable {
     /// A status indicating whether a network can be used by connections.
     var status: NWPath.Status { get }
+
+    /// Whether the path uses an interface the system considers expensive.
+    var isExpensive: Bool { get }
+
+    /// Whether the path uses an interface constrained by Low Data Mode.
+    var isConstrained: Bool { get }
 
     /// Checks if the network uses an NWInterface with the specified type
     func usesInterfaceType(_ type: NWInterface.InterfaceType) -> Bool

--- a/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
+++ b/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
@@ -446,4 +446,8 @@ public enum AppSettingsAction: Action {
 
     /// Gets whether we should allow cellular data use downloading POS catalogs for a specific site
     case getPOSLocalCatalogCellularDataAllowed(siteID: Int64, onCompletion: (Bool) -> Void)
+
+    /// Gets whether the host blocked the site's POS catalog file download. Recorded when a file sync fails
+    /// with a blocked error and cleared when the file syncs successfully again.
+    case getPOSCatalogFileBlockedByHost(siteID: Int64, onCompletion: (Bool) -> Void)
 }

--- a/Modules/Sources/Yosemite/Actions/FeatureFlagAction.swift
+++ b/Modules/Sources/Yosemite/Actions/FeatureFlagAction.swift
@@ -4,4 +4,14 @@ import Foundation
 ///
 public enum FeatureFlagAction: Action {
     case isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag, defaultValue: Bool, useCache: Bool = true, completion: (Bool) -> Void)
+
+    /// Reports the remote feature flag values the app is currently acting on, without triggering a fetch.
+    ///
+    /// `nil` when there are no usable values — no fetch has succeeded since launch, or the cached values have
+    /// aged out. `isRemoteFeatureFlagEnabled` does not consult an expired cache: it refetches, and until that
+    /// returns each caller falls back to its own default, so expired values are not what the app is acting on.
+    ///
+    /// For diagnostics. Callers deciding behaviour should keep using `isRemoteFeatureFlagEnabled`.
+    ///
+    case loadRemoteFeatureFlagsInEffect(completion: ([RemoteFeatureFlag: Bool]?) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -167,6 +167,8 @@ public class MockStoresManager: StoresManager {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         default:
             let message = "⚠️ [MockStoresManager] Unhandled action type: \(action.identifier) \(String(describing: action))"

--- a/Modules/Sources/Yosemite/Protocols/POSLocalCatalogEligibilityServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/Protocols/POSLocalCatalogEligibilityServiceProtocol.swift
@@ -50,6 +50,13 @@ public protocol POSLocalCatalogEligibilityServiceProtocol {
     /// - Returns: Cached eligibility state, or eligible if not yet checked
     func catalogEligibility(for siteID: Int64) async throws -> POSLocalCatalogEligibilityState
 
+    /// The eligibility state already computed for the site, without evaluating anything: unlike
+    /// `catalogEligibility(for:)` a cache miss does not trigger a refresh, which can fetch.
+    /// `nil` when nothing has evaluated eligibility for the site this session.
+    ///
+    /// For diagnostics. Callers deciding behaviour should use `catalogEligibility(for:)`.
+    func cachedCatalogEligibility(for siteID: Int64) async -> POSLocalCatalogEligibilityState?
+
     /// Update POS eligibility and refresh catalog eligibility for the specified site
     /// - Parameters:
     ///   - isEligible: Whether POS is eligible for the site

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -336,6 +336,8 @@ public class AppSettingsStore: Store {
             setPOSLocalCatalogCellularDataAllowed(siteID: siteID, allowed: allowed, onCompletion: onCompletion)
         case .getPOSLocalCatalogCellularDataAllowed(let siteID, let onCompletion):
             getPOSLocalCatalogCellularDataAllowed(siteID: siteID, onCompletion: onCompletion)
+        case .getPOSCatalogFileBlockedByHost(let siteID, let onCompletion):
+            getPOSCatalogFileBlockedByHost(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -1467,6 +1469,10 @@ private extension AppSettingsStore {
     func getPOSLocalCatalogCellularDataAllowed(siteID: Int64, onCompletion: (Bool) -> Void) {
         let allowed = siteSpecificAppSettingsStoreMethods.getPOSLocalCatalogCellularDataAllowed(siteID: siteID)
         onCompletion(allowed)
+    }
+
+    func getPOSCatalogFileBlockedByHost(siteID: Int64, onCompletion: (Bool) -> Void) {
+        onCompletion(siteSpecificAppSettingsStoreMethods.isPOSCatalogFileBlockedByHost(siteID: siteID))
     }
 }
 

--- a/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
+++ b/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
@@ -66,6 +66,8 @@ public final class FeatureFlagStore: Store {
         switch action {
         case let .isRemoteFeatureFlagEnabled(featureFlag, defaultValue, useCache, completion):
             isRemoteFeatureFlagEnabled(featureFlag, defaultValue: defaultValue, useCache: useCache, completion: completion)
+        case let .loadRemoteFeatureFlagsInEffect(completion):
+            completion(remoteFeatureFlagsInEffect)
         }
     }
 }
@@ -73,6 +75,16 @@ public final class FeatureFlagStore: Store {
 // MARK: - Services
 //
 private extension FeatureFlagStore {
+
+    /// Mirrors exactly what `isRemoteFeatureFlagEnabled` would consult, so a report built from this can never
+    /// contradict the values the app is actually acting on: `nil` unless a fetch succeeded and has not aged out.
+    var remoteFeatureFlagsInEffect: [RemoteFeatureFlag: Bool]? {
+        guard let cachedFeatureFlags, !isCacheExpired else {
+            return nil
+        }
+        return cachedFeatureFlags
+    }
+
     var isCacheExpired: Bool {
         guard let cacheTimestamp else { return true }
         return currentDate().timeIntervalSince(cacheTimestamp) >= cacheMaxAge

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -71,6 +71,11 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         return try await refreshEligibilityState(for: siteID)
     }
 
+    /// The cached state without evaluating: `catalogEligibility(for:)` refreshes on a miss, which can fetch.
+    public func cachedCatalogEligibility(for siteID: Int64) -> POSLocalCatalogEligibilityState? {
+        eligibilityStates[siteID]
+    }
+
     /// Fetch and cache the remote feature flag value
     /// Returns cached value if available, otherwise returns true (assumes eligible)
     private func isRemoteCatalogFeatureFlagEnabled() async -> Bool {

--- a/Modules/Tests/WooFoundationTests/Utilities/DefaultConnectivityObserverTests.swift
+++ b/Modules/Tests/WooFoundationTests/Utilities/DefaultConnectivityObserverTests.swift
@@ -74,6 +74,32 @@ final class DefaultConnectivityObserverTests: XCTestCase {
         XCTAssertEqual(observer.currentStatus, .notReachable)
         XCTAssertEqual(result, .notReachable)
     }
+
+    func test_path_flags_are_nil_before_the_first_update_and_reflect_the_path_afterwards() {
+        // Given
+        let networkMonitor = MockNetworkMonitor()
+        let expectation = expectation(description: "Path flags updated")
+        let observer = DefaultConnectivityObserver(networkMonitor: networkMonitor)
+        XCTAssertNil(observer.isCurrentPathExpensive)
+        XCTAssertNil(observer.isCurrentPathConstrained)
+
+        // When
+        observer.statusPublisher
+            .dropFirst()
+            .sink { _ in
+                expectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        networkMonitor.fakeNetworkUpdate(network: MockNetwork(status: .satisfied,
+                                                              currentInterface: .cellular,
+                                                              isExpensive: true,
+                                                              isConstrained: true))
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(observer.isCurrentPathExpensive, true)
+        XCTAssertEqual(observer.isCurrentPathConstrained, true)
+    }
 }
 
 final class MockNetworkMonitor: NetworkMonitoring {
@@ -99,11 +125,18 @@ final class MockNetworkMonitor: NetworkMonitoring {
 
 private struct MockNetwork: NetworkMonitorable {
     let status: NWPath.Status
+    let isExpensive: Bool
+    let isConstrained: Bool
     private let currentInterface: NWInterface.InterfaceType
 
-    init(status: NWPath.Status, currentInterface: NWInterface.InterfaceType) {
+    init(status: NWPath.Status,
+         currentInterface: NWInterface.InterfaceType,
+         isExpensive: Bool = false,
+         isConstrained: Bool = false) {
         self.status = status
         self.currentInterface = currentInterface
+        self.isExpensive = isExpensive
+        self.isConstrained = isConstrained
     }
 
     func usesInterfaceType(_ type: NWInterface.InterfaceType) -> Bool {

--- a/Modules/Tests/WooFoundationTests/Utilities/DefaultConnectivityObserverTests.swift
+++ b/Modules/Tests/WooFoundationTests/Utilities/DefaultConnectivityObserverTests.swift
@@ -80,8 +80,8 @@ final class DefaultConnectivityObserverTests: XCTestCase {
         let networkMonitor = MockNetworkMonitor()
         let expectation = expectation(description: "Path flags updated")
         let observer = DefaultConnectivityObserver(networkMonitor: networkMonitor)
-        XCTAssertNil(observer.isCurrentPathExpensive)
-        XCTAssertNil(observer.isCurrentPathConstrained)
+        XCTAssertNil(observer.isConnectionMetered)
+        XCTAssertNil(observer.isLowDataModeEnabled)
 
         // When
         observer.statusPublisher
@@ -97,8 +97,8 @@ final class DefaultConnectivityObserverTests: XCTestCase {
 
         // Then
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(observer.isCurrentPathExpensive, true)
-        XCTAssertEqual(observer.isCurrentPathConstrained, true)
+        XCTAssertEqual(observer.isConnectionMetered, true)
+        XCTAssertEqual(observer.isLowDataModeEnabled, true)
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSLocalCatalogEligibilityService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSLocalCatalogEligibilityService.swift
@@ -19,6 +19,10 @@ actor MockPOSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServicePr
         return eligibilityStates[siteID] ?? .eligible
     }
 
+    func cachedCatalogEligibility(for siteID: Int64) async -> POSLocalCatalogEligibilityState? {
+        eligibilityStates[siteID]
+    }
+
     func updatePOSEligibility(isEligible: Bool, for siteID: Int64) async {
         // No-op for tests
     }

--- a/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1815,6 +1815,38 @@ extension AppSettingsStoreTests {
         XCTAssertTrue(isAllowed)
     }
 
+    // MARK: - POS Catalog File Blocked Tests
+
+    func test_getPOSCatalogFileBlockedByHost_when_no_block_is_recorded_then_returns_false() throws {
+        // When
+        let isBlocked: Bool = waitFor { promise in
+            let action = AppSettingsAction.getPOSCatalogFileBlockedByHost(siteID: TestConstants.siteID) { isBlocked in
+                promise(isBlocked)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        XCTAssertFalse(isBlocked)
+    }
+
+    func test_getPOSCatalogFileBlockedByHost_when_a_block_is_recorded_then_returns_true() throws {
+        // Given
+        mockSiteSpecificAppSettingsStoreMethods.mockPOSCatalogFileBlockedByHostAt = Date()
+
+        // When
+        let isBlocked: Bool = waitFor { promise in
+            let action = AppSettingsAction.getPOSCatalogFileBlockedByHost(siteID: TestConstants.siteID) { isBlocked in
+                promise(isBlocked)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(mockSiteSpecificAppSettingsStoreMethods.isPOSCatalogFileBlockedByHostCalled)
+        XCTAssertTrue(isBlocked)
+    }
+
     func test_setPOSLocalCatalogCellularDataAllowed_saves_value_successfully() throws {
         // When
         waitFor { promise in

--- a/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
@@ -226,4 +226,89 @@ final class FeatureFlagStoreTests: XCTestCase {
         XCTAssertFalse(isEnabled)
         XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
     }
+
+    func test_loadRemoteFeatureFlagsInEffect_reports_nothing_when_no_fetch_has_succeeded() throws {
+        // Given
+        // No fetch has been performed.
+
+        // When
+        let values: [RemoteFeatureFlag: Bool]? = waitFor { promise in
+            self.store.onAction(FeatureFlagAction.loadRemoteFeatureFlagsInEffect { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertNil(values)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 0)
+    }
+
+    func test_loadRemoteFeatureFlagsInEffect_reports_nothing_when_the_only_fetch_failed() throws {
+        // Given
+        remote.whenLoadingAllFeatureFlags(thenReturn: .failure(NetworkError.timeout()))
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+
+        // When
+        let values: [RemoteFeatureFlag: Bool]? = waitFor { promise in
+            self.store.onAction(FeatureFlagAction.loadRemoteFeatureFlagsInEffect { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertNil(values)
+    }
+
+    func test_loadRemoteFeatureFlagsInEffect_reports_fetched_values_without_fetching_again() throws {
+        // Given
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true,
+                                                                .pointOfSale: false]))
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+
+        // When
+        let values: [RemoteFeatureFlag: Bool]? = waitFor { promise in
+            self.store.onAction(FeatureFlagAction.loadRemoteFeatureFlagsInEffect { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertEqual(values, [.storeCreationCompleteNotification: true, .pointOfSale: false])
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 1)
+    }
+
+    /// An expired cache is not consulted by `isRemoteFeatureFlagEnabled`, so reporting its values would describe
+    /// behaviour the app is not exhibiting.
+    func test_loadRemoteFeatureFlagsInEffect_reports_nothing_rather_than_the_aged_out_values() throws {
+        // Given
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+        currentDate = currentDate.addingTimeInterval(25 * 60 * 60)
+
+        // When
+        let values: [RemoteFeatureFlag: Bool]? = waitFor { promise in
+            self.store.onAction(FeatureFlagAction.loadRemoteFeatureFlagsInEffect { result in
+                promise(result)
+            })
+        }
+
+        // Then - the aged-out values are not reported, and no fetch was triggered to find out
+        XCTAssertNil(values)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 1)
+    }
 }

--- a/WooCommerce/Classes/Extensions/Int64+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Int64+Helpers.swift
@@ -18,7 +18,7 @@ extension Int64 {
         var sizeAbbreviationsIndex = 0
         var capacity = Double(self)
 
-        while capacity > 1024 && sizeAbbreviationsIndex < sizeAbbreviations.count - 1 {
+        while capacity >= 1024 && sizeAbbreviationsIndex < sizeAbbreviations.count - 1 {
             capacity /= 1024
             sizeAbbreviationsIndex += 1
         }

--- a/WooCommerce/Classes/Extensions/Int64+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Int64+Helpers.swift
@@ -6,4 +6,23 @@ extension Int64 {
     var byteCountRepresentable: String {
         ByteCountFormatter.string(fromByteCount: self, countStyle: .memory)
     }
+
+    /// Byte count in English, e.g. `12.40 GB`.
+    ///
+    /// `ByteCountFormatter` translates its units and offers no locale setting, so it cannot be used for values
+    /// that leave the device: support tickets and status reports are read by Happiness Engineers rather than by
+    /// the merchant, and must not follow the device's language.
+    ///
+    var englishByteCountRepresentable: String {
+        let sizeAbbreviations = ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+        var sizeAbbreviationsIndex = 0
+        var capacity = Double(self)
+
+        while capacity > 1024 && sizeAbbreviationsIndex < sizeAbbreviations.count - 1 {
+            capacity /= 1024
+            sizeAbbreviationsIndex += 1
+        }
+
+        return String(format: "%4.2f", capacity) + " " + sizeAbbreviations[sizeAbbreviationsIndex]
+    }
 }

--- a/WooCommerce/Classes/Extensions/UIDevice+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIDevice+Woo.swift
@@ -16,4 +16,17 @@ extension UIDevice {
 
         return String(cString: machine)
     }
+
+    /// The device's available disk space in English, e.g. `12.40 GB`, or `nil` when the volume cannot be read.
+    ///
+    /// English (not `ByteCountFormatter`, which translates its units) because every consumer — support ticket
+    /// metadata and the Mobile Status Report — leaves the device to be read by Happiness Engineers.
+    ///
+    var freeDiskSpaceInEnglish: String? {
+        guard let values = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeAvailableCapacityKey]),
+              let capacity = values.volumeAvailableCapacity else {
+            return nil
+        }
+        return Int64(capacity).englishByteCountRepresentable
+    }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -92,6 +92,12 @@ final class PushNotificationsManager: PushNotesManager {
         registrationState.deviceID
     }
 
+    /// Apple's Push Notification device token, as last received from APNs.
+    ///
+    var deviceToken: String? {
+        registrationState.deviceToken
+    }
+
     var wooPushNotificationToken: String? {
         registrationState.wooPushNotificationToken
     }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -33,6 +33,12 @@ protocol PushNotesManager {
     ///
     var deviceID: String? { get }
 
+    /// Apple's Push Notification device token, as last received from APNs.
+    ///
+    /// `nil` means the app never obtained one, which blocks both push systems.
+    ///
+    var deviceToken: String? { get }
+
     /// Self-driven push notification token ID
     ///
     var wooPushNotificationToken: String? { get }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -35,7 +35,8 @@ protocol PushNotesManager {
 
     /// Apple's Push Notification device token, as last received from APNs.
     ///
-    /// `nil` means the app never obtained one, which blocks both push systems.
+    /// `nil` means the app holds no current token — never obtained, cleared on unregistration, or APNs
+    /// registration failed — any of which blocks both push systems.
     ///
     var deviceToken: String? { get }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
@@ -77,14 +77,8 @@ private extension MobileStatusReportSystemSnapshot {
 
     static let unknown = "unknown"
 
-    /// Not `ByteCountFormatter`, which translates its units: the report leaves the device and is read by
-    /// Happiness Engineers rather than by the merchant.
     static func freeSpace() -> String {
-        guard let values = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeAvailableCapacityKey]),
-              let capacity = values.volumeAvailableCapacity else {
-            return unknown
-        }
-        return Int64(capacity).englishByteCountRepresentable
+        UIDevice.current.freeDiskSpaceInEnglish ?? unknown
     }
 
     /// The idiom alongside the size is what actually answers "phone or tablet" when triaging POS.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
@@ -60,13 +60,13 @@ extension MobileStatusReportSystemSnapshot {
                                          lowDataMode: connectivityObserver.isLowDataModeEnabled
                                             .map(String.init) ?? unknown,
                                          apnsEnvironment: apnsEnvironment,
-                                         authorizationStatus: String(describing: notifications.authorizationStatus),
+                                         authorizationStatus: notifications.authorizationStatus.description,
                                          alerts: notifications.alertSetting.description,
                                          sounds: notifications.soundSetting.description,
                                          lockScreen: notifications.lockScreenSetting.description,
                                          timeSensitive: notifications.timeSensitiveSetting.description,
                                          scheduledSummary: notifications.scheduledDeliverySetting.description,
-                                         backgroundRefresh: String(describing: UIApplication.shared.backgroundRefreshStatus),
+                                         backgroundRefresh: UIApplication.shared.backgroundRefreshStatus.description,
                                          lowPowerMode: String(ProcessInfo.processInfo.isLowPowerModeEnabled))
     }
 }
@@ -83,7 +83,7 @@ private extension MobileStatusReportSystemSnapshot {
     @MainActor
     static func screen() -> String {
         let size = UIScreen.main.bounds.size
-        return "\(Int(size.width))x\(Int(size.height)) pt (\(String(describing: UIDevice.current.userInterfaceIdiom)))"
+        return "\(Int(size.width))x\(Int(size.height)) pt (\(UIDevice.current.userInterfaceIdiom.description))"
     }
 
     /// Read back from the build rather than the entitlement, which has no runtime API. Tokens are not
@@ -124,6 +124,66 @@ private extension UNNotificationSetting {
             return "disabled"
         case .enabled:
             return "enabled"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}
+
+// The ObjC-imported enums carry no case names — `String(describing:)` renders them as
+// `UNAuthorizationStatus(rawValue: 2)`, which is exactly what the report must not show.
+
+private extension UNAuthorizationStatus {
+    var description: String {
+        switch self {
+        case .notDetermined:
+            return "notDetermined"
+        case .denied:
+            return "denied"
+        case .authorized:
+            return "authorized"
+        case .provisional:
+            return "provisional"
+        case .ephemeral:
+            return "ephemeral"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}
+
+private extension UIBackgroundRefreshStatus {
+    var description: String {
+        switch self {
+        case .restricted:
+            return "restricted"
+        case .denied:
+            return "denied"
+        case .available:
+            return "available"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}
+
+private extension UIUserInterfaceIdiom {
+    var description: String {
+        switch self {
+        case .phone:
+            return "phone"
+        case .pad:
+            return "pad"
+        case .mac:
+            return "mac"
+        case .tv:
+            return "tv"
+        case .carPlay:
+            return "carPlay"
+        case .vision:
+            return "vision"
+        case .unspecified:
+            return "unspecified"
         @unknown default:
             return "unknown"
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
@@ -1,0 +1,139 @@
+import Foundation
+import UIKit
+import UserNotifications
+import enum WooFoundationCore.BuildConfiguration
+import protocol WooFoundation.ConnectivityObserver
+import enum WooFoundation.ConnectivityStatus
+
+/// Everything the Mobile Status Report learns from the device itself, captured in one pass.
+///
+/// Values are captured already formatted. Everything in `current()` reads a live `Bundle`, `UIDevice`,
+/// `UNUserNotificationCenter` or the app-wide connectivity observer and so cannot be exercised by a test at all;
+/// keeping the mapping there
+/// leaves the untestable part thin and at the boundary, and lets the report be tested by building a snapshot
+/// literally.
+///
+struct MobileStatusReportSystemSnapshot: Equatable {
+    let version: String
+    let build: String
+
+    let model: String
+    let os: String
+    let freeSpace: String
+    let screen: String
+    let deviceLocale: String
+    let appLanguage: String
+
+    let networkType: String
+    let expensiveConnection: String
+    let lowDataMode: String
+
+    let apnsEnvironment: String
+    let authorizationStatus: String
+    let alerts: String
+    let sounds: String
+    let lockScreen: String
+    let timeSensitive: String
+    let scheduledSummary: String
+    let backgroundRefresh: String
+    let lowPowerMode: String
+}
+
+extension MobileStatusReportSystemSnapshot {
+
+    @MainActor
+    static func current(connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
+                        notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current()) async -> Self {
+        let notifications = await notificationCenter.notificationSettings()
+
+        return MobileStatusReportSystemSnapshot(version: "\(Bundle.main.marketingVersion) (\(Bundle.main.buildNumber))",
+                                         build: BuildConfiguration.current.rawValue,
+                                         model: UIDevice.current.modelIdentifier,
+                                         os: "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",
+                                         freeSpace: freeSpace(),
+                                         screen: screen(),
+                                         deviceLocale: Locale.current.identifier(.bcp47),
+                                         appLanguage: Bundle.main.preferredLocalizations.first ?? unknown,
+                                         networkType: connectivityObserver.currentStatus.description,
+                                         // From the observer's app-lifetime path monitor — the report must not
+                                         // spin up its own and wait on a first update.
+                                         expensiveConnection: connectivityObserver.isCurrentPathExpensive
+                                            .map(String.init) ?? unknown,
+                                         lowDataMode: connectivityObserver.isCurrentPathConstrained
+                                            .map(String.init) ?? unknown,
+                                         apnsEnvironment: apnsEnvironment,
+                                         authorizationStatus: String(describing: notifications.authorizationStatus),
+                                         alerts: notifications.alertSetting.description,
+                                         sounds: notifications.soundSetting.description,
+                                         lockScreen: notifications.lockScreenSetting.description,
+                                         timeSensitive: notifications.timeSensitiveSetting.description,
+                                         scheduledSummary: notifications.scheduledDeliverySetting.description,
+                                         backgroundRefresh: String(describing: UIApplication.shared.backgroundRefreshStatus),
+                                         lowPowerMode: String(ProcessInfo.processInfo.isLowPowerModeEnabled))
+    }
+}
+
+private extension MobileStatusReportSystemSnapshot {
+
+    static let unknown = "unknown"
+
+    /// Not `ByteCountFormatter`, which translates its units: the report leaves the device and is read by
+    /// Happiness Engineers rather than by the merchant.
+    static func freeSpace() -> String {
+        guard let values = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeAvailableCapacityKey]),
+              let capacity = values.volumeAvailableCapacity else {
+            return unknown
+        }
+        return Int64(capacity).englishByteCountRepresentable
+    }
+
+    /// The idiom alongside the size is what actually answers "phone or tablet" when triaging POS.
+    @MainActor
+    static func screen() -> String {
+        let size = UIScreen.main.bounds.size
+        return "\(Int(size.width))x\(Int(size.height)) pt (\(String(describing: UIDevice.current.userInterfaceIdiom)))"
+    }
+
+    /// Read back from the build rather than the entitlement, which has no runtime API. Tokens are not
+    /// interchangeable between the two environments, so a mismatch against server logs explains push that works
+    /// in one build and not another.
+    static var apnsEnvironment: String {
+        #if DEBUG
+        return "sandbox"
+        #else
+        return "production"
+        #endif
+    }
+}
+
+private extension ConnectivityStatus {
+    var description: String {
+        switch self {
+        case .reachable(.ethernetOrWiFi):
+            return "WiFi or Ethernet"
+        case .reachable(.cellular):
+            return "Cellular"
+        case .reachable(.other):
+            return "Other"
+        case .notReachable:
+            return "Not reachable"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+}
+
+private extension UNNotificationSetting {
+    var description: String {
+        switch self {
+        case .notSupported:
+            return "not supported"
+        case .disabled:
+            return "disabled"
+        case .enabled:
+            return "enabled"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
@@ -7,11 +7,9 @@ import enum WooFoundation.ConnectivityStatus
 
 /// Everything the Mobile Status Report learns from the device itself, captured in one pass.
 ///
-/// Values are captured already formatted. Everything in `current()` reads a live `Bundle`, `UIDevice`,
-/// `UNUserNotificationCenter` or the app-wide connectivity observer and so cannot be exercised by a test at all;
-/// keeping the mapping there
-/// leaves the untestable part thin and at the boundary, and lets the report be tested by building a snapshot
-/// literally.
+/// Values are captured already formatted. The connectivity observer and notification center are injected, so
+/// their mapping is tested; the rest of `current()` reads live singletons (`Bundle`, `UIDevice`, `UIScreen`,
+/// `UIApplication`) at the boundary, and the report itself is tested by building a snapshot literally.
 ///
 struct MobileStatusReportSystemSnapshot: Equatable {
     let version: String

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
@@ -55,9 +55,9 @@ extension MobileStatusReportSystemSnapshot {
                                          networkType: connectivityObserver.currentStatus.description,
                                          // From the observer's app-lifetime path monitor — the report must not
                                          // spin up its own and wait on a first update.
-                                         expensiveConnection: connectivityObserver.isCurrentPathExpensive
+                                         expensiveConnection: connectivityObserver.isConnectionMetered
                                             .map(String.init) ?? unknown,
-                                         lowDataMode: connectivityObserver.isCurrentPathConstrained
+                                         lowDataMode: connectivityObserver.isLowDataModeEnabled
                                             .map(String.init) ?? unknown,
                                          apnsEnvironment: apnsEnvironment,
                                          authorizationStatus: String(describing: notifications.authorizationStatus),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreTelephony
 import Yosemite
+import class UIKit.UIDevice
 import class WordPressAuthenticator.AuthenticatorAnalyticsTracker
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.ConnectivityObserver
@@ -150,26 +151,7 @@ private extension SupportFormMetadataProvider {
     /// Get the device free space: EG `56.34 GB`
     ///
     func getDeviceFreeSpace() -> String {
-        guard let resourceValues = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeAvailableCapacityKey]),
-              let capacityBytes = resourceValues.volumeAvailableCapacity else {
-            return Constants.unknownValue
-        }
-
-        // format string using human readable units. ex: 1.5 GB
-        // Since ByteCountFormatter.string translates the string and has no locale setting,
-        // do the byte conversion manually so the Free Space is in English.
-        let sizeAbbreviations = ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
-        var sizeAbbreviationsIndex = 0
-        var capacity = Double(capacityBytes)
-
-        while capacity > 1024 {
-            capacity /= 1024
-            sizeAbbreviationsIndex += 1
-        }
-
-        let formattedCapacity = String(format: "%4.2f", capacity)
-        let sizeAbbreviation = sizeAbbreviations[sizeAbbreviationsIndex]
-        return "\(formattedCapacity) \(sizeAbbreviation)"
+        UIDevice.current.freeDiskSpaceInEnglish ?? Constants.unknownValue
     }
 
     /// Gets the content of the main/first log file. Trimmed with a character limit.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -207,6 +207,9 @@ private extension POSTabEligibilityChecker {
             guard reason.isDefiniteIneligibility else {
                 return
             }
+            // The literal prefix is quoted by the Mobile Status Report's Point of Sale hint line — keep the
+            // two in step.
+            DDLogInfo("POS cannot be launched for site \(siteID): \(String(describing: reason))")
             eligibilityService.cacheLastKnownPOSEligibility(siteID: siteID, isEligible: false)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -103,7 +103,14 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         // Unknown connectivity (e.g. before the first path update at cold start) proceeds with
         // the full check so a fresh online launch is not stuck with stale cached visibility.
         if case .notReachable = connectivityObserver.currentStatus {
-            return eligibilityService.loadCachedPOSTabVisibility(siteID: site.siteID) ?? false
+            guard let cached = eligibilityService.loadCachedPOSTabVisibility(siteID: site.siteID) else {
+                logNotVisible("offline with no cached visibility for the site")
+                return false
+            }
+            if !cached {
+                logNotVisible("offline, and the last known visibility was hidden")
+            }
+            return cached
         }
 
         async let siteSettingsEligibility = waitAndCheckSiteSettingsEligibility()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -90,9 +90,11 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         }
         let phonePrototypeEnabled = featureFlagService.isFeatureFlagEnabled(.pointOfSalePhonePrototype)
         guard userInterfaceIdiom == .pad || phonePrototypeEnabled else {
+            logNotVisible("the device is not an iPad and the phone prototype flag is off")
             return false
         }
         guard userInterfaceIdiom != .phone || isPhoneOperatingSystemEligible else {
+            logNotVisible("phone POS needs iOS \(Self.minimumPhonePOSOperatingSystemVersion.majorVersion) or later")
             return false
         }
 
@@ -108,13 +110,27 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         async let featureFlagEligibility = checkRemoteFeatureEligibility()
 
         switch await siteSettingsEligibility {
-        case .ineligible(.unsupportedCountry):
-            return false
+        case .ineligible(let reason):
+            if case .unsupportedCountry = reason {
+                logNotVisible(String(describing: reason))
+                return false
+            }
         default:
             break
         }
 
-        return await featureFlagEligibility == .eligible
+        switch await featureFlagEligibility {
+        case .eligible:
+            return true
+        case .ineligible(let reason):
+            logNotVisible(String(describing: reason))
+            return false
+        }
+    }
+
+    /// The literal prefix is quoted by the Mobile Status Report's Point of Sale hint line — keep the two in step.
+    private func logNotVisible(_ reason: String) {
+        DDLogInfo("POS tab not visible for site \(site.siteID): \(reason)")
     }
 
     private var isPhoneOperatingSystemEligible: Bool {

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
@@ -114,6 +114,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -136,6 +138,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(false)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -158,6 +162,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -187,6 +193,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -215,6 +223,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)

--- a/WooCommerce/WooCommerceTests/Extensions/Int64HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Int64HelpersTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import WooCommerce
+
+struct Int64HelpersTests {
+
+    @Test func test_englishByteCountRepresentable_when_below_one_KB_then_renders_bytes() {
+        #expect(Int64(0).englishByteCountRepresentable == "0.00 bytes")
+        #expect(Int64(1023).englishByteCountRepresentable == "1023.00 bytes")
+    }
+
+    @Test func test_englishByteCountRepresentable_when_exactly_1024_then_renders_one_KB() {
+        #expect(Int64(1024).englishByteCountRepresentable == "1.00 KB")
+    }
+
+    @Test func test_englishByteCountRepresentable_when_between_units_then_renders_fraction() {
+        #expect(Int64(1536).englishByteCountRepresentable == "1.50 KB")
+    }
+
+    @Test func test_englishByteCountRepresentable_when_gigabytes_then_renders_GB() {
+        // 12.4 GB, the doc comment's example.
+        #expect(Int64(13314398618).englishByteCountRepresentable == "12.40 GB")
+    }
+
+    @Test func test_englishByteCountRepresentable_when_Int64_max_then_renders_EB_without_overrunning_units() {
+        #expect(Int64.max.englishByteCountRepresentable == "8.00 EB")
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockConnectivityObserver.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockConnectivityObserver.swift
@@ -5,6 +5,9 @@ import WooFoundation
 final class MockConnectivityObserver: ConnectivityObserver {
     @Published private(set) var currentStatus: ConnectivityStatus = .unknown
 
+    var isCurrentPathExpensive: Bool?
+    var isCurrentPathConstrained: Bool?
+
     var statusPublisher: AnyPublisher<ConnectivityStatus, Never> {
         $currentStatus.eraseToAnyPublisher()
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockConnectivityObserver.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockConnectivityObserver.swift
@@ -5,8 +5,8 @@ import WooFoundation
 final class MockConnectivityObserver: ConnectivityObserver {
     @Published private(set) var currentStatus: ConnectivityStatus = .unknown
 
-    var isCurrentPathExpensive: Bool?
-    var isCurrentPathConstrained: Bool?
+    var isConnectionMetered: Bool?
+    var isLowDataModeEnabled: Bool?
 
     var statusPublisher: AnyPublisher<ConnectivityStatus, Never> {
         $currentStatus.eraseToAnyPublisher()

--- a/WooCommerce/WooCommerceTests/Mocks/MockPOSLocalCatalogEligibilityService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPOSLocalCatalogEligibilityService.swift
@@ -1,0 +1,33 @@
+import Yosemite
+
+/// Mock for `POSLocalCatalogEligibilityServiceProtocol`: hands back the configured states without evaluating
+/// anything.
+actor MockPOSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol {
+
+    private var cachedStates: [Int64: POSLocalCatalogEligibilityState]
+
+    init(cachedStates: [Int64: POSLocalCatalogEligibilityState] = [:]) {
+        self.cachedStates = cachedStates
+    }
+
+    func catalogEligibility(for siteID: Int64) async throws -> POSLocalCatalogEligibilityState {
+        cachedStates[siteID] ?? .eligible
+    }
+
+    func cachedCatalogEligibility(for siteID: Int64) async -> POSLocalCatalogEligibilityState? {
+        cachedStates[siteID]
+    }
+
+    func updatePOSEligibility(isEligible: Bool, for siteID: Int64) async throws {
+        // No-op for tests
+    }
+
+    @discardableResult
+    func refreshEligibilityState(for siteID: Int64) async throws -> POSLocalCatalogEligibilityState {
+        cachedStates[siteID] ?? .eligible
+    }
+
+    func isLocalCatalogFeatureEnabled() async -> Bool {
+        true
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -41,6 +41,7 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     private let mockedDeviceID: String?
+    let deviceToken: String?
     let wooPushNotificationToken: String?
     private(set) var siteIDsRegisteredForWooPNs: [Int64]
     let hasStoredSiteIDsRegisteredForWooPNs: Bool
@@ -72,10 +73,12 @@ final class MockPushNotificationsManager: PushNotesManager {
     private(set) var registeredSiteIDsForSelfDrivenPushNotifications: [Int64] = []
 
     init(mockedDeviceID: String? = nil,
+         deviceToken: String? = nil,
          wooPushNotificationToken: String? = nil,
          siteIDsRegisteredForWooPNs: [Int64] = [],
          hasStoredSiteIDsRegisteredForWooPNs: Bool? = nil) {
         self.mockedDeviceID = mockedDeviceID
+        self.deviceToken = deviceToken
         self.wooPushNotificationToken = wooPushNotificationToken
         self.siteIDsRegisteredForWooPNs = siteIDsRegisteredForWooPNs
         self.hasStoredSiteIDsRegisteredForWooPNs = hasStoredSiteIDsRegisteredForWooPNs ?? !siteIDsRegisteredForWooPNs.isEmpty

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -23,6 +23,10 @@ final class MockStoresManager: DefaultStoresManager {
     ///
     var testPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
 
+    /// Optional test checker for POS local catalog eligibility
+    ///
+    var testPOSCatalogEligibilityChecker: POSLocalCatalogEligibilityServiceProtocol?
+
     /// Accept a concrete implementation (in addition to the pre-existing Protocol-based initializer)
     ///
     init(sessionManager: SessionManager) {
@@ -33,6 +37,11 @@ final class MockStoresManager: DefaultStoresManager {
 
     override var posCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? {
         testPOSCatalogSyncCoordinator
+    }
+
+    override var posCatalogEligibilityChecker: POSLocalCatalogEligibilityServiceProtocol? {
+        get { testPOSCatalogEligibilityChecker }
+        set { testPOSCatalogEligibilityChecker = newValue }
     }
 
     // MARK: - Overridden Methods

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -57,9 +57,13 @@ final class MockStoresManager: DefaultStoresManager {
     private func resolveDefaultIfNeeded(_ action: Action) {
         switch action {
         case let action as FeatureFlagAction:
-            // Mirror `FeatureFlagStore`: with no remote override configured, resolve to the local default.
-            if case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion) = action {
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion):
+                // Mirror `FeatureFlagStore`: with no remote override configured, resolve to the local default.
                 completion(defaultValue)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                // Mirror `FeatureFlagStore` before any fetch has succeeded.
+                completion(nil)
             }
         default:
             break

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -25,6 +25,8 @@ final class LocalNotificationSchedulerTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is enabled.
                 completion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 
@@ -45,6 +47,8 @@ final class LocalNotificationSchedulerTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is disabled.
                 completion(false)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 
@@ -78,6 +82,8 @@ final class LocalNotificationSchedulerTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is enabled.
                 completion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -2435,6 +2435,8 @@ private extension PushNotificationsManagerTests {
             case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(isEnabled)
                 onCompletion?()
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
@@ -65,6 +65,8 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion):
                 capturedDefaultValue = defaultValue
                 completion(defaultValue)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 
@@ -88,6 +90,8 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(featureFlag, _, _, completion):
                 capturedFeatureFlag = featureFlag
                 completion(false)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 
@@ -111,6 +115,8 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, useCache, completion):
                 capturedUseCache = useCache
                 completion(false)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 
@@ -146,6 +152,8 @@ private extension WooPushNotificationEligibilityCheckTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(isEnabled)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
@@ -40,6 +40,8 @@ final class ClientSideBannerProviderTests: XCTestCase {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(false)
+            case let .loadRemoteFeatureFlagsInEffect(onCompletion):
+                onCompletion(nil)
             }
         }
 
@@ -239,6 +241,8 @@ final class ClientSideBannerProviderTests: XCTestCase {
                 } else {
                     onCompletion(false)
                 }
+            case let .loadRemoteFeatureFlagsInEffect(onCompletion):
+                onCompletion(nil)
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportSystemSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportSystemSnapshotTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import WooCommerce
+
+/// Covers the injected halves of `MobileStatusReportSystemSnapshot.current()` — the connectivity and
+/// notification-settings mappings. The remaining fields read live singletons at the boundary.
+@MainActor
+struct MobileStatusReportSystemSnapshotTests {
+
+    @Test func test_current_when_path_flags_are_known_then_maps_them_to_bool_strings() async {
+        // Given
+        let connectivity = MockConnectivityObserver()
+        connectivity.setStatus(.reachable(type: .cellular))
+        connectivity.isCurrentPathExpensive = true
+        connectivity.isCurrentPathConstrained = false
+
+        // When
+        let snapshot = await MobileStatusReportSystemSnapshot.current(connectivityObserver: connectivity,
+                                                                      notificationCenter: MockUserNotificationsCenterAdapter())
+
+        // Then
+        #expect(snapshot.networkType == "Cellular")
+        #expect(snapshot.expensiveConnection == "true")
+        #expect(snapshot.lowDataMode == "false")
+    }
+
+    @Test func test_current_when_path_flags_never_arrived_then_reports_unknown() async {
+        // Given
+        let connectivity = MockConnectivityObserver()
+        connectivity.isCurrentPathExpensive = nil
+        connectivity.isCurrentPathConstrained = nil
+
+        // When
+        let snapshot = await MobileStatusReportSystemSnapshot.current(connectivityObserver: connectivity,
+                                                                      notificationCenter: MockUserNotificationsCenterAdapter())
+
+        // Then
+        #expect(snapshot.networkType == "Unknown")
+        #expect(snapshot.expensiveConnection == "unknown")
+        #expect(snapshot.lowDataMode == "unknown")
+    }
+
+    @Test func test_current_when_notifications_authorized_then_maps_status_and_settings() async {
+        // Given: the mock's default coder decodes an authorized status and enabled settings.
+        let notificationCenter = MockUserNotificationsCenterAdapter()
+
+        // When
+        let snapshot = await MobileStatusReportSystemSnapshot.current(connectivityObserver: MockConnectivityObserver(),
+                                                                      notificationCenter: notificationCenter)
+
+        // Then
+        #expect(snapshot.authorizationStatus == "authorized")
+        #expect(snapshot.alerts == "enabled")
+        #expect(snapshot.sounds == "enabled")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportSystemSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportSystemSnapshotTests.swift
@@ -10,8 +10,8 @@ struct MobileStatusReportSystemSnapshotTests {
         // Given
         let connectivity = MockConnectivityObserver()
         connectivity.setStatus(.reachable(type: .cellular))
-        connectivity.isCurrentPathExpensive = true
-        connectivity.isCurrentPathConstrained = false
+        connectivity.isConnectionMetered = true
+        connectivity.isLowDataModeEnabled = false
 
         // When
         let snapshot = await MobileStatusReportSystemSnapshot.current(connectivityObserver: connectivity,
@@ -26,8 +26,8 @@ struct MobileStatusReportSystemSnapshotTests {
     @Test func test_current_when_path_flags_never_arrived_then_reports_unknown() async {
         // Given
         let connectivity = MockConnectivityObserver()
-        connectivity.isCurrentPathExpensive = nil
-        connectivity.isCurrentPathConstrained = nil
+        connectivity.isConnectionMetered = nil
+        connectivity.isLowDataModeEnabled = nil
 
         // When
         let snapshot = await MobileStatusReportSystemSnapshot.current(connectivityObserver: connectivity,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/ApplicationPasswordsExperimentAvailabilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/ApplicationPasswordsExperimentAvailabilityCheckerTests.swift
@@ -67,6 +67,8 @@ final class ApplicationPasswordsExperimentAvailabilityCheckerTests: XCTestCase {
             switch action {
             case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 
@@ -98,6 +100,8 @@ final class ApplicationPasswordsExperimentAvailabilityCheckerTests: XCTestCase {
             switch action {
             case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(false)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -930,6 +930,10 @@ private actor MockLocalCatalogEligibilityService: POSLocalCatalogEligibilityServ
         .eligible
     }
 
+    func cachedCatalogEligibility(for siteID: Int64) async -> POSLocalCatalogEligibilityState? {
+        .eligible
+    }
+
     func updatePOSEligibility(isEligible: Bool, for siteID: Int64) async {}
 
     func refreshEligibilityState(for siteID: Int64) async -> POSLocalCatalogEligibilityState {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -634,6 +634,8 @@ extension POSTabVisibilityCheckerTests {
                 default:
                     completion(false)
                 }
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/ARParcelFittingEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/ARParcelFittingEligibilityCheckerTests.swift
@@ -29,6 +29,8 @@ struct ARParcelFittingEligibilityCheckerTests {
                 switch action {
                 case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                     completion(remoteFF)
+                case let .loadRemoteFeatureFlagsInEffect(completion):
+                    completion(nil)
                 }
             }
             let featureFlagService = MockFeatureFlagService()
@@ -58,6 +60,8 @@ struct ARParcelFittingEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(true)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let featureFlagService = MockFeatureFlagService()
@@ -129,6 +133,8 @@ struct ARParcelFittingEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(false)
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let featureFlagService = MockFeatureFlagService()
@@ -163,6 +169,8 @@ struct ARParcelFittingEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 Task { completion(true) }
+            case let .loadRemoteFeatureFlagsInEffect(completion):
+                completion(nil)
             }
         }
         let featureFlagService = MockFeatureFlagService()


### PR DESCRIPTION
## Description

Part 1 of 4 building the **Mobile Status Report** (`WOOMOB-3704`) — the app-level counterpart to the server-side System Status Report, which carries no device or app information and is empty on tickets filed from the login screen.

This part adds no report of its own. It adds the reads the report needs, each of which is useful to review on its own terms:

- **`FeatureFlagAction.loadRemoteFeatureFlagsInEffect`** — reports what the app is *acting on*, which is not the same as what is in the cache: an expired cache is not consulted, so it resolves to `nil` rather than describing behaviour the app is not exhibiting. The new enum case makes every exhaustive switch over `FeatureFlagAction` incomplete, which is why the mocks and several unrelated test files are touched.
- **`AppSettingsAction.getPOSCatalogFileBlockedByHost`** — the marker recorded when a catalog file sync fails because the host blocked the file, and cleared when it succeeds. `true` explains a store that keeps falling back to the slower paginated sync.
- **POS local catalog eligibility** — exposes the *cached* decision only. The live check refreshes on a cache miss, which can fetch, and a status report must not change what it reports.
- **`ConnectivityObserver`** — widened with the interface type and the expensive-path flag.
- **APNs device token** on `PushNotesManager`, reported redacted.
- **English byte count formatter** — the free-space figure must stay greppable in English on a non-English device.
- **POS visibility/eligibility logging** — the checks that decide POS visibility write their result as a side effect of evaluating, so the report must not recompute them to explain a hidden tab. Logging the reason puts it on the same ticket instead.
- **`MobileStatusReportSystemSnapshot`** — the device, app and connectivity facts gathered behind one value, so the provider stays free of direct UIKit and system calls and can be tested against a fixed snapshot.

The snapshot type has no consumer until part 2; that is the nature of a stacked split.

**Stack:** part 1 (this PR) → part 2 → part 3 → part 4. Each part is under 300 lines of non-test code, and every commit builds on its own.

## Test Steps

Test on the last PR in this chain - I plan to merge all the PRs at the same time.

## Screenshots

N/A — no user-facing change in this part.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<sub>The release note for the feature lands with part 4, where it becomes reachable.</sub>