### PR TITLE
Mobile Status Report [2/4]: the report and its app-wide sections

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -1,6 +1,7 @@
 import Experiments
 import Foundation
 import Yosemite
+import enum Networking.RemoteFeatureFlag
 import protocol Storage.StorageManagerType
 
 /// Builds the Mobile Status Report. A protocol so the ticket-creation callers can be tested against a canned
@@ -59,7 +60,7 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
         report += await section("## Connectivity") { self.connectivitySection(system) }
         report += await section("## Notifications") { self.notificationsSection(system) }
         report += await section("## Account & Stores") { self.accountSection(siteAddress) }
-        report += await section("## Feature Flags") { self.featureFlagsSection() }
+        report += await section("## Feature Flags") { await self.featureFlagsSection() }
 
         return report.joined(separator: "\n")
     }
@@ -116,10 +117,10 @@ private extension MobileStatusReportProvider {
                 entry("Connected stores", String(sites.count))].compactMap { $0 } + siteList(sites)
     }
 
-    /// Every flag is listed, not only the enabled ones: an absent key would be ambiguous between disabled,
-    /// renamed and deleted.
-    func featureFlagsSection() -> [String] {
-        ["", "### Local flags"] + localFeatureFlags()
+    /// Two independent systems holding different flags, so both are reported and labelled. Every flag is listed,
+    /// not only the enabled ones: an absent key would be ambiguous between disabled, renamed and deleted.
+    func featureFlagsSection() async -> [String] {
+        ["", "### Local flags"] + localFeatureFlags() + ["", "### Remote flags"] + (await remoteFeatureFlags())
     }
 }
 
@@ -132,6 +133,22 @@ private extension MobileStatusReportProvider {
     func localFeatureFlags() -> [String] {
         FeatureFlag.allCases.filter { $0 != .null }
             .map { entry(String(describing: $0), String(featureFlagService.isFeatureFlagEnabled($0))) }
+    }
+
+    /// What the app is acting on, which is not the same as what is in the cache: an expired cache is not
+    /// consulted, so listing it would describe behaviour the app is not exhibiting.
+    func remoteFeatureFlags() async -> [String] {
+        // The action deliberately does not fetch. A dropped dispatch degrades to nil, the safe reading.
+        let values = await awaitedDispatch(fallback: [RemoteFeatureFlag: Bool]?.none) { completion in
+            FeatureFlagAction.loadRemoteFeatureFlagsInEffect(completion: completion)
+        }
+
+        guard let values else {
+            return [entry("Remote values loaded", "false (nothing fetched this session, or the last fetch aged out)")]
+        }
+        return [entry("Remote values loaded", "true")] + RemoteFeatureFlag.allCases.map { flag in
+            entry(String(describing: flag), values[flag].map { "\($0) (remote)" } ?? "not returned by server")
+        }
     }
 
     /// Only stores running WooCommerce: the storage holds every site on the WPCom account, and the Android
@@ -186,6 +203,30 @@ private extension MobileStatusReportProvider {
     func entry(_ key: String, _ value: String) -> String {
         "\(key): \(value)"
     }
+
+    /// Dispatches an action answered from local state and returns its completion value.
+    ///
+    /// The await is bounded because a dispatch is not guaranteed an answer: the deauthenticated stores manager
+    /// drops actions for stores it does not run (`AppSettingsStore` among them), and no completion ever comes.
+    /// After `Constants.dispatchTimeout` the value degrades to `fallback` — a field reading "not set" is
+    /// recoverable, a report that never finishes while a merchant files a ticket is not.
+    func awaitedDispatch<Value>(fallback: Value,
+                                _ makeAction: (@escaping (Value) -> Void) -> Action) async -> Value {
+        await withCheckedContinuation { continuation in
+            var resumed = false
+            let resumeOnce: (Value) -> Void = { value in
+                guard !resumed else { return }
+                resumed = true
+                continuation.resume(returning: value)
+            }
+            stores.dispatch(makeAction { value in
+                // Stores answer these inline on the main queue today; the hop keeps `resumed` main-only if one
+                // ever answers from elsewhere.
+                DispatchQueue.main.async { resumeOnce(value) }
+            })
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.dispatchTimeout) { resumeOnce(fallback) }
+        }
+    }
 }
 
 extension MobileStatusReportProvider {
@@ -199,6 +240,9 @@ extension MobileStatusReportProvider {
 
         static let sectionUnavailable = "Info not found"
         static let unknown = "unknown"
+
+        /// How long `awaitedDispatch` waits before degrading to its fallback.
+        static let dispatchTimeout: TimeInterval = 1
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -202,7 +202,11 @@ private extension MobileStatusReportProvider {
     }
 
     func fetched<T>(_ controller: ResultsController<T>) -> [T.ReadOnlyType] {
-        try? controller.performFetch()
+        do {
+            try controller.performFetch()
+        } catch {
+            DDLogError("⛔️ MobileStatusReportProvider: fetching \(T.entityName) failed: \(error)")
+        }
         return controller.fetchedObjects
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -280,7 +280,7 @@ private extension MobileStatusReportProvider {
     }
 }
 
-extension MobileStatusReportProvider {
+private extension MobileStatusReportProvider {
     enum Constants {
         static let heading = "### Mobile Status Report generated via the WooCommerce iOS app ###"
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -40,18 +40,24 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
     private let featureFlagService: FeatureFlagService
     private let generalAppSettings: GeneralAppSettingsStorage
 
+    /// How long `awaitedDispatch` waits before an unanswered dispatch degrades to its fallback. Injectable so
+    /// tests can exercise the degradation without waiting out the production value.
+    private let dispatchTimeout: TimeInterval
+
     nonisolated init(systemSnapshot: @escaping () async -> MobileStatusReportSystemSnapshot = { await .current() },
                      pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-                     generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings) {
+                     generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
+                     dispatchTimeout: TimeInterval = 1) {
         self.systemSnapshot = systemSnapshot
         self.pushNotesManager = pushNotesManager
         self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
         self.generalAppSettings = generalAppSettings
+        self.dispatchTimeout = dispatchTimeout
     }
 
     func generateReport(siteAddress: String?) async -> String {
@@ -253,8 +259,8 @@ private extension MobileStatusReportProvider {
     ///
     /// The await is bounded because a dispatch is not guaranteed an answer: the deauthenticated stores manager
     /// drops actions for stores it does not run (`AppSettingsStore` among them), and no completion ever comes.
-    /// After `Constants.dispatchTimeout` the value degrades to `fallback` — a field reading "not set" is
-    /// recoverable, a report that never finishes while a merchant files a ticket is not.
+    /// After `dispatchTimeout` the value degrades to `fallback` — a field reading "not set" is recoverable, a
+    /// report that never finishes while a merchant files a ticket is not.
     func awaitedDispatch<Value>(fallback: Value,
                                 _ makeAction: (@escaping (Value) -> Void) -> Action) async -> Value {
         await withCheckedContinuation { continuation in
@@ -269,7 +275,7 @@ private extension MobileStatusReportProvider {
                 // ever answers from elsewhere.
                 DispatchQueue.main.async { resumeOnce(value) }
             })
-            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.dispatchTimeout) { resumeOnce(fallback) }
+            DispatchQueue.main.asyncAfter(deadline: .now() + dispatchTimeout) { resumeOnce(fallback) }
         }
     }
 }
@@ -285,9 +291,6 @@ extension MobileStatusReportProvider {
 
         static let sectionUnavailable = "Info not found"
         static let unknown = "unknown"
-
-        /// How long `awaitedDispatch` waits before degrading to its fallback.
-        static let dispatchTimeout: TimeInterval = 1
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
 
 /// Builds the Mobile Status Report. A protocol so the ticket-creation callers can be tested against a canned
 /// report instead of assembling the provider's dependencies.
@@ -30,11 +32,17 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
 
     private let systemSnapshot: () async -> MobileStatusReportSystemSnapshot
     private let pushNotesManager: PushNotesManager
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
 
     nonisolated init(systemSnapshot: @escaping () async -> MobileStatusReportSystemSnapshot = { await .current() },
-                     pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+                     pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
+                     stores: StoresManager = ServiceLocator.stores,
+                     storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.systemSnapshot = systemSnapshot
         self.pushNotesManager = pushNotesManager
+        self.stores = stores
+        self.storageManager = storageManager
     }
 
     func generateReport(siteAddress: String?) async -> String {
@@ -46,6 +54,7 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
         report += await section("## Device") { self.deviceSection(system) }
         report += await section("## Connectivity") { self.connectivitySection(system) }
         report += await section("## Notifications") { self.notificationsSection(system) }
+        report += await section("## Account & Stores") { self.accountSection(siteAddress) }
 
         return report.joined(separator: "\n")
     }
@@ -94,11 +103,46 @@ private extension MobileStatusReportProvider {
          entry("Background refresh", system.backgroundRefresh),
          entry("Low Power Mode", system.lowPowerMode)]
     }
+
+    func accountSection(_ siteAddress: String?) -> [String] {
+        let sites = allSites()
+        return [entry("WPCom user ID", stores.sessionManager.defaultAccount.map { String($0.userID) } ?? "not logged in"),
+                siteAddress?.nilIfEmpty.map { entry("Address given in the form", $0) },
+                entry("Connected stores", String(sites.count))].compactMap { $0 } + siteList(sites)
+    }
 }
 
 // MARK: - Values
 
 private extension MobileStatusReportProvider {
+
+    /// Only stores running WooCommerce: the storage holds every site on the WPCom account, and the Android
+    /// report counts Woo stores, so the same merchant must not get two different counts on a cross-platform
+    /// ticket.
+    func allSites() -> [Site] {
+        fetched(ResultsController<StorageSite>(storageManager: storageManager,
+                                               matching: NSPredicate(format: "isWooCommerceActive == YES"),
+                                               sortedBy: [NSSortDescriptor(key: "name", ascending: true)]))
+    }
+
+    func fetched<T>(_ controller: ResultsController<T>) -> [T.ReadOnlyType] {
+        try? controller.performFetch()
+        return controller.fetchedObjects
+    }
+
+    /// Merchants often report a problem on a store other than the selected one. Only the selected store's plugins
+    /// have usually been fetched, so these lines carry no plugin versions.
+    func siteList(_ sites: [Site]) -> [String] {
+        guard sites.isNotEmpty else {
+            return []
+        }
+
+        return ["", "All connected stores:"] + sites.map { site in
+            entry(site.url.nilIfEmpty ?? Constants.unknown,
+                  "Plan: \(site.plan.nilIfEmpty ?? Constants.unknown) " +
+                  "Jetpack: installed=\(site.isJetpackThePluginInstalled) connected=\(site.isJetpackConnected)")
+        }
+    }
 
     /// Enough to compare against server logs, not enough to address the device.
     func redactedToken(_ token: String?) -> String {
@@ -136,6 +180,7 @@ extension MobileStatusReportProvider {
             "https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/mobile-status-report.md"
 
         static let sectionUnavailable = "Info not found"
+        static let unknown = "unknown"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -117,7 +117,7 @@ private extension MobileStatusReportProvider {
 
     func accountSection(_ siteAddress: String?) -> [String] {
         let sites = allSites()
-        return [entry("WPCom user ID", stores.sessionManager.defaultAccount.map { String($0.userID) } ?? "not logged in"),
+        return [entry("WPCom user ID", wpcomUserID()),
                 siteAddress?.nilIfEmpty.map { entry("Address given in the form", $0) },
                 entry("Connected stores", String(sites.count))].compactMap { $0 } + siteList(sites)
     }
@@ -138,6 +138,22 @@ private extension MobileStatusReportProvider {
 // MARK: - Values
 
 private extension MobileStatusReportProvider {
+
+    /// An account exists only for WPCom logins, so its absence alone does not distinguish a merchant using site
+    /// credentials or application passwords from one who is not logged in at all — the held credentials do.
+    func wpcomUserID() -> String {
+        if let account = stores.sessionManager.defaultAccount {
+            return String(account.userID)
+        }
+        switch stores.sessionManager.defaultCredentials {
+        case .wpcom:
+            return "\(Constants.unknown) (WPCom login, account not synced)"
+        case .wporg, .applicationPassword:
+            return "N/A (no WPCom account)"
+        case .none:
+            return "not logged in"
+        }
+    }
 
     /// `.null` is skipped: it is a throwaway case that exists only so the enum can declare a raw type, and the
     /// service answers it through the `default` branch, so it would appear as a real flag that is switched on.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -41,6 +41,7 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
 
         report += await section("## App") { self.appSection(system) }
         report += await section("## Device") { self.deviceSection(system) }
+        report += await section("## Connectivity") { self.connectivitySection(system) }
 
         return report.joined(separator: "\n")
     }
@@ -62,6 +63,12 @@ private extension MobileStatusReportProvider {
          entry("Screen", system.screen),
          entry("Device locale", system.deviceLocale),
          entry("App language", system.appLanguage)]
+    }
+
+    func connectivitySection(_ system: MobileStatusReportSystemSnapshot) -> [String] {
+        [entry("Network type", system.networkType),
+         entry("Expensive connection", system.expensiveConnection),
+         entry("Low Data Mode", system.lowDataMode)]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -91,7 +91,7 @@ private extension MobileStatusReportProvider {
 
     func connectivitySection(_ system: MobileStatusReportSystemSnapshot) -> [String] {
         [entry("Network type", system.networkType),
-         entry("Expensive connection", system.expensiveConnection),
+         entry("Metered connection", system.meteredConnection),
          entry("Low Data Mode", system.lowDataMode)]
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -1,5 +1,6 @@
 import Experiments
 import Foundation
+import WordPressShared
 import Yosemite
 import enum Networking.RemoteFeatureFlag
 import struct Storage.GeneralAppSettingsStorage
@@ -124,7 +125,7 @@ private extension MobileStatusReportProvider {
     func accountSection(_ siteAddress: String?) -> [String] {
         let sites = allSites()
         return [entry("WPCom user ID", wpcomUserID()),
-                siteAddress?.nilIfEmpty.map { entry("Address given in the form", $0) },
+                siteAddress?.nonEmptyString().map { entry("Address given in the form", $0) },
                 entry("Connected stores", String(sites.count))].compactMap { $0 } + siteList(sites)
     }
 
@@ -224,15 +225,15 @@ private extension MobileStatusReportProvider {
         }
 
         return ["", "All connected stores:"] + sites.map { site in
-            entry(site.url.nilIfEmpty ?? Constants.unknown,
-                  "Plan: \(site.plan.nilIfEmpty ?? Constants.unknown) " +
+            entry(site.url.nonEmptyString() ?? Constants.unknown,
+                  "Plan: \(site.plan.nonEmptyString() ?? Constants.unknown) " +
                   "Jetpack: installed=\(site.isJetpackThePluginInstalled) connected=\(site.isJetpackConnected)")
         }
     }
 
     /// Enough to compare against server logs, not enough to address the device.
     func redactedToken(_ token: String?) -> String {
-        token?.nilIfEmpty.map { "present (…\($0.suffix(6)))" } ?? "missing"
+        token?.nonEmptyString().map { "present (…\($0.suffix(6)))" } ?? "missing"
     }
 }
 
@@ -291,11 +292,5 @@ private extension MobileStatusReportProvider {
 
         static let sectionUnavailable = "Info not found"
         static let unknown = "unknown"
-    }
-}
-
-private extension String {
-    var nilIfEmpty: String? {
-        isEmpty ? nil : self
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -40,6 +40,7 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
         var report = [Constants.heading, Constants.fieldReference]
 
         report += await section("## App") { self.appSection(system) }
+        report += await section("## Device") { self.deviceSection(system) }
 
         return report.joined(separator: "\n")
     }
@@ -52,6 +53,15 @@ private extension MobileStatusReportProvider {
     func appSection(_ system: MobileStatusReportSystemSnapshot) -> [String] {
         [entry("Version", system.version),
          entry("Build", system.build)]
+    }
+
+    func deviceSection(_ system: MobileStatusReportSystemSnapshot) -> [String] {
+        [entry("Model", system.model),
+         entry("OS", system.os),
+         entry("Free space", system.freeSpace),
+         entry("Screen", system.screen),
+         entry("Device locale", system.deviceLocale),
+         entry("App language", system.appLanguage)]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -29,9 +29,12 @@ extension MobileStatusReportProviding {
 final class MobileStatusReportProvider: MobileStatusReportProviding {
 
     private let systemSnapshot: () async -> MobileStatusReportSystemSnapshot
+    private let pushNotesManager: PushNotesManager
 
-    nonisolated init(systemSnapshot: @escaping () async -> MobileStatusReportSystemSnapshot = { await .current() }) {
+    nonisolated init(systemSnapshot: @escaping () async -> MobileStatusReportSystemSnapshot = { await .current() },
+                     pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.systemSnapshot = systemSnapshot
+        self.pushNotesManager = pushNotesManager
     }
 
     func generateReport(siteAddress: String?) async -> String {
@@ -83,7 +86,23 @@ private extension MobileStatusReportProvider {
          entry("Sounds", system.sounds),
          entry("Lock screen", system.lockScreen),
          entry("Time-sensitive", system.timeSensitive),
-         entry("Scheduled summary", system.scheduledSummary)]
+         entry("Scheduled summary", system.scheduledSummary),
+         entry("APNs device token", redactedToken(pushNotesManager.deviceToken)),
+         // Redacted like the APNs token: the last characters are enough to match against server logs, which is
+         // the only reason to report it.
+         entry("Woo push token ID", redactedToken(pushNotesManager.wooPushNotificationToken)),
+         entry("Background refresh", system.backgroundRefresh),
+         entry("Low Power Mode", system.lowPowerMode)]
+    }
+}
+
+// MARK: - Values
+
+private extension MobileStatusReportProvider {
+
+    /// Enough to compare against server logs, not enough to address the device.
+    func redactedToken(_ token: String?) -> String {
+        token?.nilIfEmpty.map { "present (…\($0.suffix(6)))" } ?? "missing"
     }
 }
 
@@ -117,5 +136,11 @@ extension MobileStatusReportProvider {
             "https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/mobile-status-report.md"
 
         static let sectionUnavailable = "Info not found"
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -1,3 +1,4 @@
+import Experiments
 import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
@@ -34,15 +35,18 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
     private let pushNotesManager: PushNotesManager
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private let featureFlagService: FeatureFlagService
 
     nonisolated init(systemSnapshot: @escaping () async -> MobileStatusReportSystemSnapshot = { await .current() },
                      pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
                      stores: StoresManager = ServiceLocator.stores,
-                     storageManager: StorageManagerType = ServiceLocator.storageManager) {
+                     storageManager: StorageManagerType = ServiceLocator.storageManager,
+                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.systemSnapshot = systemSnapshot
         self.pushNotesManager = pushNotesManager
         self.stores = stores
         self.storageManager = storageManager
+        self.featureFlagService = featureFlagService
     }
 
     func generateReport(siteAddress: String?) async -> String {
@@ -55,6 +59,7 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
         report += await section("## Connectivity") { self.connectivitySection(system) }
         report += await section("## Notifications") { self.notificationsSection(system) }
         report += await section("## Account & Stores") { self.accountSection(siteAddress) }
+        report += await section("## Feature Flags") { self.featureFlagsSection() }
 
         return report.joined(separator: "\n")
     }
@@ -110,11 +115,24 @@ private extension MobileStatusReportProvider {
                 siteAddress?.nilIfEmpty.map { entry("Address given in the form", $0) },
                 entry("Connected stores", String(sites.count))].compactMap { $0 } + siteList(sites)
     }
+
+    /// Every flag is listed, not only the enabled ones: an absent key would be ambiguous between disabled,
+    /// renamed and deleted.
+    func featureFlagsSection() -> [String] {
+        ["", "### Local flags"] + localFeatureFlags()
+    }
 }
 
 // MARK: - Values
 
 private extension MobileStatusReportProvider {
+
+    /// `.null` is skipped: it is a throwaway case that exists only so the enum can declare a raw type, and the
+    /// service answers it through the `default` branch, so it would appear as a real flag that is switched on.
+    func localFeatureFlags() -> [String] {
+        FeatureFlag.allCases.filter { $0 != .null }
+            .map { entry(String(describing: $0), String(featureFlagService.isFeatureFlagEnabled($0))) }
+    }
 
     /// Only stores running WooCommerce: the storage holds every site on the WPCom account, and the Android
     /// report counts Woo stores, so the same merchant must not get two different counts on a cross-platform

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -42,6 +42,7 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
         report += await section("## App") { self.appSection(system) }
         report += await section("## Device") { self.deviceSection(system) }
         report += await section("## Connectivity") { self.connectivitySection(system) }
+        report += await section("## Notifications") { self.notificationsSection(system) }
 
         return report.joined(separator: "\n")
     }
@@ -69,6 +70,20 @@ private extension MobileStatusReportProvider {
         [entry("Network type", system.networkType),
          entry("Expensive connection", system.expensiveConnection),
          entry("Low Data Mode", system.lowDataMode)]
+    }
+
+    /// Push registration is the one notification value keyed on a single store, so it is reported with that store
+    /// rather than among these device-level settings.
+    func notificationsSection(_ system: MobileStatusReportSystemSnapshot) -> [String] {
+        [entry("APNs environment", system.apnsEnvironment),
+         // The raw state, because `provisional` means the app delivers quietly — notifications arrive with no
+         // banner and no sound, which a merchant reads as none arriving at all.
+         entry("Authorization status", system.authorizationStatus),
+         entry("Alerts", system.alerts),
+         entry("Sounds", system.sounds),
+         entry("Lock screen", system.lockScreen),
+         entry("Time-sensitive", system.timeSensitive),
+         entry("Scheduled summary", system.scheduledSummary)]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Builds the Mobile Status Report. A protocol so the ticket-creation callers can be tested against a canned
+/// report instead of assembling the provider's dependencies.
+protocol MobileStatusReportProviding {
+    /// - Parameter siteAddress: the address the merchant typed into the support form, which can differ from the
+    /// selected store when they are contacting us precisely because the app picked up the wrong one.
+    func generateReport(siteAddress: String?) async -> String
+}
+
+extension MobileStatusReportProviding {
+    func generateReport() async -> String {
+        await generateReport(siteAddress: nil)
+    }
+}
+
+/// Builds the Mobile Status Report attached to support tickets and shown to merchants in Help & Support — the
+/// app-level counterpart to the server-side System Status Report, which carries no device or app information and
+/// is empty on tickets filed from the login screen.
+///
+/// Two rules hold for every section:
+///
+/// - **Nothing here touches the network.** Adding a read that does would put ticket creation behind it and stop
+///   Help & Support rendering instantly when logged out.
+/// - **A failing lookup degrades to `Info not found` rather than failing the report.** This runs while a merchant
+///   is trying to reach support and must never be the reason they cannot.
+///
+@MainActor
+final class MobileStatusReportProvider: MobileStatusReportProviding {
+
+    private let systemSnapshot: () async -> MobileStatusReportSystemSnapshot
+
+    nonisolated init(systemSnapshot: @escaping () async -> MobileStatusReportSystemSnapshot = { await .current() }) {
+        self.systemSnapshot = systemSnapshot
+    }
+
+    func generateReport(siteAddress: String?) async -> String {
+        let system = await systemSnapshot()
+
+        var report = [Constants.heading, Constants.fieldReference]
+
+        report += await section("## App") { self.appSection(system) }
+
+        return report.joined(separator: "\n")
+    }
+}
+
+// MARK: - Sections
+
+private extension MobileStatusReportProvider {
+
+    func appSection(_ system: MobileStatusReportSystemSnapshot) -> [String] {
+        [entry("Version", system.version),
+         entry("Build", system.build)]
+    }
+}
+
+// MARK: - Report structure
+
+private extension MobileStatusReportProvider {
+
+    func section(_ heading: String, content: () async throws -> [String]) async -> [String] {
+        let lines: [String]
+        do {
+            lines = try await content()
+        } catch {
+            DDLogError("⛔️ MobileStatusReportProvider: \(heading) unavailable: \(error)")
+            lines = [Constants.sectionUnavailable]
+        }
+        return ["", heading] + lines
+    }
+
+    func entry(_ key: String, _ value: String) -> String {
+        "\(key): \(value)"
+    }
+}
+
+extension MobileStatusReportProvider {
+    enum Constants {
+        static let heading = "### Mobile Status Report generated via the WooCommerce iOS app ###"
+
+        /// Field meanings live in the repository. Inline they would double the length of something attached to
+        /// every ticket, for readers who already know the fields.
+        static let fieldReference = "Field reference: " +
+            "https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/mobile-status-report.md"
+
+        static let sectionUnavailable = "Info not found"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportProvider.swift
@@ -2,6 +2,7 @@ import Experiments
 import Foundation
 import Yosemite
 import enum Networking.RemoteFeatureFlag
+import struct Storage.GeneralAppSettingsStorage
 import protocol Storage.StorageManagerType
 
 /// Builds the Mobile Status Report. A protocol so the ticket-creation callers can be tested against a canned
@@ -37,17 +38,20 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let featureFlagService: FeatureFlagService
+    private let generalAppSettings: GeneralAppSettingsStorage
 
     nonisolated init(systemSnapshot: @escaping () async -> MobileStatusReportSystemSnapshot = { await .current() },
                      pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
-                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+                     generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings) {
         self.systemSnapshot = systemSnapshot
         self.pushNotesManager = pushNotesManager
         self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
+        self.generalAppSettings = generalAppSettings
     }
 
     func generateReport(siteAddress: String?) async -> String {
@@ -61,6 +65,7 @@ final class MobileStatusReportProvider: MobileStatusReportProviding {
         report += await section("## Notifications") { self.notificationsSection(system) }
         report += await section("## Account & Stores") { self.accountSection(siteAddress) }
         report += await section("## Feature Flags") { await self.featureFlagsSection() }
+        report += await section("## Experimental Features") { self.experimentalFeaturesSection() }
 
         return report.joined(separator: "\n")
     }
@@ -122,6 +127,12 @@ private extension MobileStatusReportProvider {
     func featureFlagsSection() async -> [String] {
         ["", "### Local flags"] + localFeatureFlags() + ["", "### Remote flags"] + (await remoteFeatureFlags())
     }
+
+    /// `BetaFeature` is the same list the settings screen renders, so a toggle added there appears here — and
+    /// the exhaustive switch in `reportName(of:)` then forces it to be given a report label.
+    func experimentalFeaturesSection() -> [String] {
+        BetaFeature.allCases.map { entry(reportName(of: $0), String(generalAppSettings.betaFeatureEnabled($0))) }
+    }
 }
 
 // MARK: - Values
@@ -148,6 +159,20 @@ private extension MobileStatusReportProvider {
         }
         return [entry("Remote values loaded", "true")] + RemoteFeatureFlag.allCases.map { flag in
             entry(String(describing: flag), values[flag].map { "\($0) (remote)" } ?? "not returned by server")
+        }
+    }
+
+    /// Stable English labels, not `title`: that is localized UI copy, which would put translated keys in a
+    /// report Happiness Engineers grep in English. `Product add-ons` and `POS local catalog` are the labels the
+    /// Android report uses for its equivalent toggles.
+    func reportName(of feature: BetaFeature) -> String {
+        switch feature {
+        case .viewAddOns:
+            return "Product add-ons"
+        case .applicationPasswords:
+            return "Application passwords"
+        case .posLocalCatalog:
+            return "POS local catalog"
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/MobileStatusReport/MobileStatusReportSystemSnapshot.swift
@@ -23,7 +23,7 @@ struct MobileStatusReportSystemSnapshot: Equatable {
     let appLanguage: String
 
     let networkType: String
-    let expensiveConnection: String
+    let meteredConnection: String
     let lowDataMode: String
 
     let apnsEnvironment: String
@@ -55,7 +55,7 @@ extension MobileStatusReportSystemSnapshot {
                                          networkType: connectivityObserver.currentStatus.description,
                                          // From the observer's app-lifetime path monitor — the report must not
                                          // spin up its own and wait on a first update.
-                                         expensiveConnection: connectivityObserver.isConnectionMetered
+                                         meteredConnection: connectivityObserver.isConnectionMetered
                                             .map(String.init) ?? unknown,
                                          lowDataMode: connectivityObserver.isLowDataModeEnabled
                                             .map(String.init) ?? unknown,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -1,15 +1,18 @@
 import Testing
 import Foundation
+import Experiments
 import Networking
 import Yosemite
 import YosemiteTestHelpers
+import struct Storage.GeneralAppSettingsStorage
 @testable import WooCommerce
 
 /// The report is a text artifact, so most of it is pinned by comparing the whole thing: that catches an omitted
 /// field and a lost section in one assertion, which per-field tests do not.
 ///
-/// The Feature Flags body is redacted from those comparisons — it enumerates `FeatureFlag.allCases`, so an
-/// inline expectation would fail on every unrelated PR that adds a flag. It has its own tests below.
+/// The Feature Flags and Experimental Features bodies are redacted from those comparisons — they enumerate
+/// `FeatureFlag.allCases` and `BetaFeature.allCases`, so an inline expectation would fail on every unrelated PR
+/// that adds a flag. They have their own tests below.
 ///
 /// Serialized because `SessionManager.testingInstance` is backed by a shared `UserDefaults` suite: every test
 /// here sets a selected store, and in parallel they overwrite each other's.
@@ -20,17 +23,20 @@ struct MobileStatusReportProviderTests {
     private let sessionManager: SessionManager
     private let stores: MockStoresManager
     private let storageManager: MockStorageManager
+    private let pushNotesManager: MockPushNotificationsManager
+    private let appSettings = GeneralAppSettingsStorage(fileStorage: MockInMemoryStorage())
 
     init() {
         sessionManager = SessionManager.testingInstance
         stores = MockStoresManager(sessionManager: sessionManager)
         storageManager = MockStorageManager()
+        pushNotesManager = MockPushNotificationsManager()
         sessionManager.defaultSite = nil
         sessionManager.defaultAccount = nil
         sessionManager.defaultCredentials = nil
     }
 
-    @Test func report_carries_every_section() async {
+    @Test func report_when_no_store_is_selected() async {
         // Given, When
         let report = await makeProvider().generateReport()
 
@@ -74,6 +80,9 @@ struct MobileStatusReportProviderTests {
         Connected stores: 0
 
         ## Feature Flags
+        <redacted>
+
+        ## Experimental Features
         <redacted>
         """)
     }
@@ -156,21 +165,37 @@ struct MobileStatusReportProviderTests {
         // Then
         #expect(report.contains("Remote values loaded: false (nothing fetched this session, or the last fetch aged out)"))
     }
+
+    @Test func experimental_features_lists_every_toggle_from_the_settings_screen() async throws {
+        // Given
+        try appSettings.setValue(true, for: BetaFeature.viewAddOns.settingsKey)
+
+        // When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        let lines = section("## Experimental Features", in: report)
+        #expect(lines.count == BetaFeature.allCases.count)
+        // The stable English report label, not `BetaFeature.title`: that is localized UI copy, and a report
+        // generated on a non-English device must still carry greppable English keys.
+        #expect(lines.contains("Product add-ons: true"))
+    }
 }
 
 // MARK: - Helpers
 
 private extension MobileStatusReportProviderTests {
 
-    func makeProvider(pushNotesManager: PushNotesManager = MockPushNotificationsManager()) -> MobileStatusReportProvider {
+    func makeProvider(pushNotesManager: PushNotesManager? = nil) -> MobileStatusReportProvider {
         MobileStatusReportProvider(systemSnapshot: { .fixture() },
-                                   pushNotesManager: pushNotesManager,
+                                   pushNotesManager: pushNotesManager ?? self.pushNotesManager,
                                    stores: stores,
                                    storageManager: storageManager,
-                                   featureFlagService: MockFeatureFlagService())
+                                   featureFlagService: MockFeatureFlagService(),
+                                   generalAppSettings: appSettings)
     }
 
-    /// Replaces the bodies of the sections that enumerate every known flag and beta toggle, so an unrelated
+    /// Replaces the bodies of the two sections that enumerate every known flag and beta toggle, so an unrelated
     /// addition to either list does not fail a whole-report comparison.
     func redactingEnumeratedSections(_ report: String) -> String {
         ["## Feature Flags", "## Experimental Features"].reduce(report) { report, heading in
@@ -186,6 +211,14 @@ private extension MobileStatusReportProviderTests {
             return (lines[...start] + ["<redacted>"] + separators + lines[(start + 1 + body.count)...])
                 .joined(separator: "\n")
         }
+    }
+
+    func section(_ heading: String, in report: String) -> [String] {
+        let lines = report.components(separatedBy: "\n")
+        guard let start = lines.firstIndex(of: heading) else {
+            return []
+        }
+        return lines[lines.index(after: start)...].prefix { !$0.hasPrefix("## ") && !$0.hasPrefix("# ") }.filter { !$0.isEmpty }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -7,7 +7,7 @@ import Foundation
 @MainActor
 struct MobileStatusReportProviderTests {
 
-    @Test func report_carries_the_heading_and_the_app_section() async {
+    @Test func report_carries_every_section() async {
         // Given, When
         let report = await makeProvider().generateReport()
 
@@ -19,6 +19,14 @@ struct MobileStatusReportProviderTests {
         ## App
         Version: 21.3 (2103003)
         Build: appStore
+
+        ## Device
+        Model: iPhone17,1
+        OS: iOS 18.4
+        Free space: 12.40 GB
+        Screen: 393x852 pt (phone)
+        Device locale: en-US
+        App language: en-GB
         """)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -104,6 +104,41 @@ struct MobileStatusReportProviderTests {
         #expect(!report.contains("4815162342"))
     }
 
+    @Test func every_connected_woo_store_is_listed_with_its_plan_and_jetpack_state() async {
+        // Given
+        await insert(sites: [
+            .fake().copy(siteID: 1,
+                         name: "Alpha",
+                         url: "https://alpha.example.com",
+                         plan: "business-bundle",
+                         isJetpackThePluginInstalled: true,
+                         isJetpackConnected: true,
+                         isWooCommerceActive: true),
+            .fake().copy(siteID: 2,
+                         name: "Beta",
+                         url: "https://beta.example.com",
+                         plan: "",
+                         isJetpackThePluginInstalled: false,
+                         isJetpackConnected: false,
+                         isWooCommerceActive: true),
+            // A WPCom site without WooCommerce: on the account, but not a store the count or list may include.
+            .fake().copy(siteID: 3,
+                         name: "Blog",
+                         url: "https://blog.example.com",
+                         isWooCommerceActive: false)
+        ])
+
+        // When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(report.contains("Connected stores: 2"))
+        #expect(report.contains("All connected stores:"))
+        #expect(report.contains("https://alpha.example.com: Plan: business-bundle Jetpack: installed=true connected=true"))
+        #expect(report.contains("https://beta.example.com: Plan: unknown Jetpack: installed=false connected=false"))
+        #expect(!report.contains("https://blog.example.com"))
+    }
+
     /// `defaultAccount` exists only for WPCom logins. A merchant authenticated with site credentials or an
     /// application password has none, and their report must not claim they are not logged in.
     @Test func a_login_without_a_wpcom_account_is_not_reported_as_logged_out() async {
@@ -227,6 +262,16 @@ private extension MobileStatusReportProviderTests {
                                    featureFlagService: MockFeatureFlagService(),
                                    generalAppSettings: appSettings,
                                    dispatchTimeout: 0.05)
+    }
+
+    func insert(sites: [Site]) async {
+        await withCheckedContinuation { continuation in
+            storageManager.performAndSave({ [storageManager] _ in
+                sites.forEach { storageManager.insertSampleSite(readOnlySite: $0) }
+            }, completion: {
+                continuation.resume()
+            }, on: .main)
+        }
     }
 
     /// Replaces the bodies of the two sections that enumerate every known flag and beta toggle, so an unrelated

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -27,6 +27,11 @@ struct MobileStatusReportProviderTests {
         Screen: 393x852 pt (phone)
         Device locale: en-US
         App language: en-GB
+
+        ## Connectivity
+        Network type: WiFi or Ethernet
+        Expensive connection: false
+        Low Data Mode: false
         """)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -41,7 +41,28 @@ struct MobileStatusReportProviderTests {
         Lock screen: enabled
         Time-sensitive: enabled
         Scheduled summary: disabled
+        APNs device token: missing
+        Woo push token ID: missing
+        Background refresh: available
+        Low Power Mode: false
         """)
+    }
+
+    // MARK: - Values a whole-report comparison would not make obvious
+
+    @Test func no_push_token_reaches_the_report_in_full() async {
+        // Given
+        let pushNotesManager = MockPushNotificationsManager(deviceToken: "0123456789abcdef",
+                                                            wooPushNotificationToken: "4815162342")
+
+        // When
+        let report = await makeProvider(pushNotesManager: pushNotesManager).generateReport()
+
+        // Then
+        #expect(report.contains("APNs device token: present (…abcdef)"))
+        #expect(!report.contains("0123456789abcdef"))
+        #expect(report.contains("Woo push token ID: present (…162342)"))
+        #expect(!report.contains("4815162342"))
     }
 }
 
@@ -49,8 +70,9 @@ struct MobileStatusReportProviderTests {
 
 private extension MobileStatusReportProviderTests {
 
-    func makeProvider() -> MobileStatusReportProvider {
-        MobileStatusReportProvider(systemSnapshot: { .fixture() })
+    func makeProvider(pushNotesManager: PushNotesManager = MockPushNotificationsManager()) -> MobileStatusReportProvider {
+        MobileStatusReportProvider(systemSnapshot: { .fixture() },
+                                   pushNotesManager: pushNotesManager)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import Foundation
+@testable import WooCommerce
+
+/// The report is a text artifact, so most of it is pinned by comparing the whole thing: that catches an omitted
+/// field and a lost section in one assertion, which per-field tests do not.
+@MainActor
+struct MobileStatusReportProviderTests {
+
+    @Test func report_carries_the_heading_and_the_app_section() async {
+        // Given, When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(report == """
+        ### Mobile Status Report generated via the WooCommerce iOS app ###
+        Field reference: https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/mobile-status-report.md
+
+        ## App
+        Version: 21.3 (2103003)
+        Build: appStore
+        """)
+    }
+}
+
+// MARK: - Helpers
+
+private extension MobileStatusReportProviderTests {
+
+    func makeProvider() -> MobileStatusReportProvider {
+        MobileStatusReportProvider(systemSnapshot: { .fixture() })
+    }
+}
+
+private extension MobileStatusReportSystemSnapshot {
+    static func fixture() -> Self {
+        MobileStatusReportSystemSnapshot(version: "21.3 (2103003)",
+                                         build: "appStore",
+                                         model: "iPhone17,1",
+                                         os: "iOS 18.4",
+                                         freeSpace: "12.40 GB",
+                                         screen: "393x852 pt (phone)",
+                                         deviceLocale: "en-US",
+                                         appLanguage: "en-GB",
+                                         networkType: "WiFi or Ethernet",
+                                         expensiveConnection: "false",
+                                         lowDataMode: "false",
+                                         apnsEnvironment: "production",
+                                         authorizationStatus: "authorized",
+                                         alerts: "enabled",
+                                         sounds: "enabled",
+                                         lockScreen: "enabled",
+                                         timeSensitive: "enabled",
+                                         scheduledSummary: "disabled",
+                                         backgroundRefresh: "available",
+                                         lowPowerMode: "false")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -32,6 +32,15 @@ struct MobileStatusReportProviderTests {
         Network type: WiFi or Ethernet
         Expensive connection: false
         Low Data Mode: false
+
+        ## Notifications
+        APNs environment: production
+        Authorization status: authorized
+        Alerts: enabled
+        Sounds: enabled
+        Lock screen: enabled
+        Time-sensitive: enabled
+        Scheduled summary: disabled
         """)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -104,6 +104,37 @@ struct MobileStatusReportProviderTests {
         #expect(!report.contains("4815162342"))
     }
 
+    /// `defaultAccount` exists only for WPCom logins. A merchant authenticated with site credentials or an
+    /// application password has none, and their report must not claim they are not logged in.
+    @Test func a_login_without_a_wpcom_account_is_not_reported_as_logged_out() async {
+        // Given
+        sessionManager.defaultCredentials = .applicationPassword(username: "merchant",
+                                                                 password: "secret",
+                                                                 siteAddress: "https://store.example.com")
+
+        // When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(report.contains("WPCom user ID: N/A (no WPCom account)"))
+        #expect(!report.contains("not logged in"))
+    }
+
+    /// The remaining `defaultAccount == nil` state: WPCom credentials whose account object has not synced yet,
+    /// which is neither "no WPCom account" nor "not logged in".
+    @Test func a_wpcom_login_without_a_synced_account_is_reported_as_unknown() async {
+        // Given
+        sessionManager.defaultCredentials = .wpcom(username: "merchant",
+                                                   authToken: "token",
+                                                   siteAddress: "https://store.example.com")
+
+        // When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(report.contains("WPCom user ID: unknown (WPCom login, account not synced)"))
+    }
+
     // MARK: - Feature flags
 
     /// `FeatureFlag.null` exists only so the enum can declare a raw type. The feature flag service answers it

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -1,11 +1,30 @@
 import Testing
 import Foundation
+import Yosemite
+import YosemiteTestHelpers
 @testable import WooCommerce
 
 /// The report is a text artifact, so most of it is pinned by comparing the whole thing: that catches an omitted
 /// field and a lost section in one assertion, which per-field tests do not.
+///
+/// Serialized because `SessionManager.testingInstance` is backed by a shared `UserDefaults` suite: every test
+/// here sets a selected store, and in parallel they overwrite each other's.
 @MainActor
+@Suite(.serialized)
 struct MobileStatusReportProviderTests {
+
+    private let sessionManager: SessionManager
+    private let stores: MockStoresManager
+    private let storageManager: MockStorageManager
+
+    init() {
+        sessionManager = SessionManager.testingInstance
+        stores = MockStoresManager(sessionManager: sessionManager)
+        storageManager = MockStorageManager()
+        sessionManager.defaultSite = nil
+        sessionManager.defaultAccount = nil
+        sessionManager.defaultCredentials = nil
+    }
 
     @Test func report_carries_every_section() async {
         // Given, When
@@ -45,6 +64,10 @@ struct MobileStatusReportProviderTests {
         Woo push token ID: missing
         Background refresh: available
         Low Power Mode: false
+
+        ## Account & Stores
+        WPCom user ID: not logged in
+        Connected stores: 0
         """)
     }
 
@@ -72,7 +95,9 @@ private extension MobileStatusReportProviderTests {
 
     func makeProvider(pushNotesManager: PushNotesManager = MockPushNotificationsManager()) -> MobileStatusReportProvider {
         MobileStatusReportProvider(systemSnapshot: { .fixture() },
-                                   pushNotesManager: pushNotesManager)
+                                   pushNotesManager: pushNotesManager,
+                                   stores: stores,
+                                   storageManager: storageManager)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -218,12 +218,15 @@ struct MobileStatusReportProviderTests {
 private extension MobileStatusReportProviderTests {
 
     func makeProvider(pushNotesManager: PushNotesManager? = nil) -> MobileStatusReportProvider {
+        // A short timeout so the unanswered-dispatch test exercises the degradation without waiting out the
+        // production value.
         MobileStatusReportProvider(systemSnapshot: { .fixture() },
                                    pushNotesManager: pushNotesManager ?? self.pushNotesManager,
                                    stores: stores,
                                    storageManager: storageManager,
                                    featureFlagService: MockFeatureFlagService(),
-                                   generalAppSettings: appSettings)
+                                   generalAppSettings: appSettings,
+                                   dispatchTimeout: 0.05)
     }
 
     /// Replaces the bodies of the two sections that enumerate every known flag and beta toggle, so an unrelated

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -59,7 +59,7 @@ struct MobileStatusReportProviderTests {
 
         ## Connectivity
         Network type: WiFi or Ethernet
-        Expensive connection: false
+        Metered connection: false
         Low Data Mode: false
 
         ## Notifications
@@ -233,7 +233,7 @@ private extension MobileStatusReportSystemSnapshot {
                                          deviceLocale: "en-US",
                                          appLanguage: "en-GB",
                                          networkType: "WiFi or Ethernet",
-                                         expensiveConnection: "false",
+                                         meteredConnection: "false",
                                          lowDataMode: "false",
                                          apnsEnvironment: "production",
                                          authorizationStatus: "authorized",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -7,6 +7,9 @@ import YosemiteTestHelpers
 /// The report is a text artifact, so most of it is pinned by comparing the whole thing: that catches an omitted
 /// field and a lost section in one assertion, which per-field tests do not.
 ///
+/// The Feature Flags body is redacted from those comparisons — it enumerates `FeatureFlag.allCases`, so an
+/// inline expectation would fail on every unrelated PR that adds a flag. It has its own tests below.
+///
 /// Serialized because `SessionManager.testingInstance` is backed by a shared `UserDefaults` suite: every test
 /// here sets a selected store, and in parallel they overwrite each other's.
 @MainActor
@@ -31,7 +34,7 @@ struct MobileStatusReportProviderTests {
         let report = await makeProvider().generateReport()
 
         // Then
-        #expect(report == """
+        #expect(redactingEnumeratedSections(report) == """
         ### Mobile Status Report generated via the WooCommerce iOS app ###
         Field reference: https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/mobile-status-report.md
 
@@ -68,6 +71,9 @@ struct MobileStatusReportProviderTests {
         ## Account & Stores
         WPCom user ID: not logged in
         Connected stores: 0
+
+        ## Feature Flags
+        <redacted>
         """)
     }
 
@@ -87,6 +93,18 @@ struct MobileStatusReportProviderTests {
         #expect(report.contains("Woo push token ID: present (…162342)"))
         #expect(!report.contains("4815162342"))
     }
+
+    /// `FeatureFlag.null` exists only so the enum can declare a raw type. The feature flag service answers it
+    /// through its `default` branch, so without filtering it the local flag list opens with `null: true`,
+    /// which reads as a real feature that is switched on.
+    @Test func the_placeholder_feature_flag_case_is_not_reported() async {
+        // Given, When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(!report.contains("\nnull: "))
+        #expect(report.contains("### Local flags"))
+    }
 }
 
 // MARK: - Helpers
@@ -97,7 +115,26 @@ private extension MobileStatusReportProviderTests {
         MobileStatusReportProvider(systemSnapshot: { .fixture() },
                                    pushNotesManager: pushNotesManager,
                                    stores: stores,
-                                   storageManager: storageManager)
+                                   storageManager: storageManager,
+                                   featureFlagService: MockFeatureFlagService())
+    }
+
+    /// Replaces the bodies of the sections that enumerate every known flag and beta toggle, so an unrelated
+    /// addition to either list does not fail a whole-report comparison.
+    func redactingEnumeratedSections(_ report: String) -> String {
+        ["## Feature Flags", "## Experimental Features"].reduce(report) { report, heading in
+            let lines = report.components(separatedBy: "\n")
+            guard let start = lines.firstIndex(of: heading) else {
+                return report
+            }
+            // Sections end at the next `## ` section heading or the `# ` selected-store band — but not at the
+            // `### ` subsection headings inside the Feature Flags body.
+            let body = Array(lines[lines.index(after: start)...].prefix { !$0.hasPrefix("## ") && !$0.hasPrefix("# ") })
+            // The blank line before the next heading belongs to the layout, not the section, so it survives.
+            let separators = Array(repeating: "", count: body.reversed().prefix { $0.isEmpty }.count)
+            return (lines[...start] + ["<redacted>"] + separators + lines[(start + 1 + body.count)...])
+                .joined(separator: "\n")
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportProviderTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Networking
 import Yosemite
 import YosemiteTestHelpers
 @testable import WooCommerce
@@ -94,6 +95,8 @@ struct MobileStatusReportProviderTests {
         #expect(!report.contains("4815162342"))
     }
 
+    // MARK: - Feature flags
+
     /// `FeatureFlag.null` exists only so the enum can declare a raw type. The feature flag service answers it
     /// through its `default` branch, so without filtering it the local flag list opens with `null: true`,
     /// which reads as a real feature that is switched on.
@@ -104,6 +107,54 @@ struct MobileStatusReportProviderTests {
         // Then
         #expect(!report.contains("\nnull: "))
         #expect(report.contains("### Local flags"))
+    }
+
+    /// An aged-out cache is not what `isRemoteFeatureFlagEnabled` returns, so listing its values would describe
+    /// behaviour the app is not exhibiting.
+    @Test func remote_flags_are_not_listed_when_none_are_in_effect() async {
+        // Given
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            if case let .loadRemoteFeatureFlagsInEffect(completion) = action {
+                completion(nil)
+            }
+        }
+
+        // When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(report.contains("Remote values loaded: false (nothing fetched this session, or the last fetch aged out)"))
+        #expect(!report.contains("(remote)"))
+    }
+
+    @Test func remote_flags_report_the_server_value_and_the_keys_it_omitted() async {
+        // Given
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            if case let .loadRemoteFeatureFlagsInEffect(completion) = action {
+                completion([.pointOfSale: true])
+            }
+        }
+
+        // When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(report.contains("Remote values loaded: true"))
+        #expect(report.contains("pointOfSale: true (remote)"))
+        #expect(report.contains("qrCodeLogin: not returned by server"))
+    }
+
+    /// The deauthenticated stores manager drops actions for stores it does not run, and a dropped dispatch has
+    /// no completion coming. The report must degrade to the fallback value rather than wait on it forever.
+    @Test func an_unanswered_dispatch_degrades_instead_of_stalling_the_report() async {
+        // Given: nothing ever answers the feature-flag action
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { _ in }
+
+        // When
+        let report = await makeProvider().generateReport()
+
+        // Then
+        #expect(report.contains("Remote values loaded: false (nothing fetched this session, or the last fetch aged out)"))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportSystemSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/Help/MobileStatusReportSystemSnapshotTests.swift
@@ -19,7 +19,7 @@ struct MobileStatusReportSystemSnapshotTests {
 
         // Then
         #expect(snapshot.networkType == "Cellular")
-        #expect(snapshot.expensiveConnection == "true")
+        #expect(snapshot.meteredConnection == "true")
         #expect(snapshot.lowDataMode == "false")
     }
 
@@ -35,7 +35,7 @@ struct MobileStatusReportSystemSnapshotTests {
 
         // Then
         #expect(snapshot.networkType == "Unknown")
-        #expect(snapshot.expensiveConnection == "unknown")
+        #expect(snapshot.meteredConnection == "unknown")
         #expect(snapshot.lowDataMode == "unknown")
     }
 


### PR DESCRIPTION
## Description

Part 2 of 4 building the **Mobile Status Report** (`WOOMOB-3704`).

⚠️ **Base is `WOOMOB-3704-mobile-status-report-part-1`, not `trunk`.** Review [#17641](https://github.com/woocommerce/woocommerce-ios/pull/17641) first.

Adds `MobileStatusReportProvider` and the sections that describe **the whole app on this device**: App, Device, Connectivity, Notifications, Account & Stores, Feature Flags and Experimental Features. The store-scoped sections follow in part 3, and nothing is wired into UI until part 4.

Two rules hold for every section, and are worth checking when reviewing:

- **Nothing here touches the network.** Adding a read that does would put ticket creation behind it and stop Help & Support rendering instantly when logged out.
- **A failing lookup degrades to `Info not found` rather than failing the report.** This runs while a merchant is trying to reach support and must never be the reason they cannot.

Points worth a closer look:

- **`awaitedDispatch` is bounded.** A dispatch is not guaranteed an answer — the deauthenticated stores manager drops actions for stores it does not run — so after a timeout the value degrades to a fallback. A field reading "not set" is recoverable; a report that never finishes while a merchant files a ticket is not.
- **Tokens are redacted** to their last characters: enough to match against server logs, which is the only reason to carry them, and not enough to address the device.
- **Every flag is listed, not only the enabled ones.** An absent key would be ambiguous between disabled, renamed and deleted.
- **Experimental toggles use stable English labels, not `BetaFeature.title`** — that is localized UI copy, which would put translated keys in a report Happiness Engineers grep in English. The exhaustive switch forces any new toggle to be given a label.
- **Only stores running WooCommerce are counted**, matching how the Android report counts, so the same merchant does not get two different counts on a cross-platform ticket.

The commits are one section each, in the order the report renders them, so they can be reviewed one at a time.

## Test Steps

Test on the last PR in this chain - I plan to merge all the PRs at the same time.

## Screenshots

N/A — no user-facing change in this part.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<sub>The release note for the feature lands with part 4, where it becomes reachable.</sub>