### PR TITLE
Mitigate product search navigation crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.3
 -----
+- [Internal] Mitigate a potential navigation crash when opening products from search results. [https://github.com/woocommerce/woocommerce-ios/pull/17645]
 - [Internal] Send a persistent device id in remote feature flag requests so logins without a WordPress.com account are included in progressive rollouts. [https://github.com/woocommerce/woocommerce-ios/pull/17605]
 - [*] Payments: fixed successful in-person payments appearing to fail when the capture response is interrupted. [https://github.com/woocommerce/woocommerce-ios/pull/17593]
 - [Internal] Add `payment_method_type` and `currency` properties to receipt Tracks events for Android parity. [https://github.com/woocommerce/woocommerce-ios/pull/17548]

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -101,7 +101,7 @@ private extension ProductsSplitViewCoordinator {
                 }, onCancel: { [weak self] in
                     guard let self else { return }
                     primaryNavigationController.viewControllers = [productsViewController]
-                    primaryNavigationController.setNavigationBarHidden(false, animated: true)
+                    primaryNavigationController.setNavigationBarHidden(false, animated: false)
                 })
                 let searchViewController = SearchViewController(storeID: siteID,
                                                                 command: searchCommand,

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -18,6 +18,11 @@ final class ProductSearchUICommand: SearchUICommand {
 
     let cancelButtonAccessibilityIdentifier = "product-search-screen-cancel-button"
 
+    /// Product search replaces the primary navigation stack of a split view, unlike Order search, which is presented
+    /// in its own modal navigation controller. Avoid animating the navigation bar while UIKit transfers presentation
+    /// to the secondary navigation stack in a collapsed layout.
+    let animateNavigationBarVisibilityChanges = false
+
     var reloadUIRequests: AnyPublisher<Void, Never> {
         reloadUINeeded.eraseToAnyPublisher()
     }
@@ -155,6 +160,7 @@ final class ProductSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Product, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
+        viewController.view.endEditing(true)
         onProductSelection(model)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -22,6 +22,10 @@ protocol SearchUICommand {
     ///
     var hideNavigationBar: Bool { get }
 
+    /// Whether navigation bar visibility changes should be animated.
+    ///
+    var animateNavigationBarVisibilityChanges: Bool { get }
+
     /// Makes the search bar first responder on start, focusing on there.
     ///
     var makeSearchBarFirstResponderOnStart: Bool { get }
@@ -148,6 +152,10 @@ extension SearchUICommand {
     }
 
     var hideNavigationBar: Bool {
+        true
+    }
+
+    var animateNavigationBarVisibilityChanges: Bool {
         true
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -173,7 +173,7 @@ where Cell.SearchModel == Command.CellViewModel {
         super.viewWillAppear(animated)
 
         if searchUICommand.hideNavigationBar {
-            navigationController?.setNavigationBarHidden(true, animated: true)
+            navigationController?.setNavigationBarHidden(true, animated: searchUICommand.animateNavigationBarVisibilityChanges)
         }
 
         if searchUICommand.makeSearchBarFirstResponderOnStart {
@@ -191,7 +191,7 @@ where Cell.SearchModel == Command.CellViewModel {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationController?.setNavigationBarHidden(false, animated: searchUICommand.animateNavigationBarVisibilityChanges)
     }
 
     // MARK: - UITableViewDataSource Conformance

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
@@ -182,7 +182,7 @@ final class ProductSearchUICommandTests: XCTestCase {
 
     // MARK: - Split view support
 
-    func test_navigation_bar_changes_are_not_animated() {
+    func test_animateNavigationBarVisibilityChanges_when_using_product_search_then_is_false() {
         // Given
         let command = ProductSearchUICommand(siteID: sampleSiteID, isSearchProductsBySKUEnabled: true)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
@@ -182,6 +182,34 @@ final class ProductSearchUICommandTests: XCTestCase {
 
     // MARK: - Split view support
 
+    func test_navigation_bar_changes_are_not_animated() {
+        // Given
+        let command = ProductSearchUICommand(siteID: sampleSiteID, isSearchProductsBySKUEnabled: true)
+
+        // Then
+        XCTAssertFalse(command.animateNavigationBarVisibilityChanges)
+    }
+
+    func test_didSelectSearchResult_ends_editing_before_invoking_onProductSelection() {
+        // Given
+        let product = Product.fake()
+        let view = EndEditingSpyView()
+        let viewController = UIViewController()
+        viewController.view = view
+        var editingHadEndedWhenProductWasSelected = false
+        let command = ProductSearchUICommand(siteID: sampleSiteID,
+                                             isSearchProductsBySKUEnabled: true,
+                                             onProductSelection: { _ in
+            editingHadEndedWhenProductWasSelected = view.didEndEditing
+        }, onCancel: {})
+
+        // When
+        command.didSelectSearchResult(model: product, from: viewController, reloadData: {}, updateActionButton: {})
+
+        // Then
+        XCTAssertTrue(editingHadEndedWhenProductWasSelected)
+    }
+
     func test_onProductSelection_is_invoked_when_didSelectSearchResult_is_called() throws {
         // Given
         let product = Product.fake().copy(name: "Product")
@@ -221,6 +249,15 @@ final class ProductSearchUICommandTests: XCTestCase {
 
         // Then
         XCTAssertFalse(command.shouldDeselectSearchResultOnSelection())
+    }
+}
+
+private final class EndEditingSpyView: UIView {
+    private(set) var didEndEditing = false
+
+    override func endEditing(_ force: Bool) -> Bool {
+        didEndEditing = true
+        return super.endEditing(force)
     }
 }
 


### PR DESCRIPTION
Closes: WOOMOB-3737

## Description
This PR mitigates a navigation-bar ownership crash when opening a product from Product search. It's a speculative fix as I was unable to reproduce the crash.

- Product search replaces the primary navigation stack of the Products split view. (This differs from Orders, where search is modal.)
- When a result is selected in compact, we show the secondary stack while the search controller restores the navigation bar on the primary stack. 
- With this PR, we remove first responder (stops editing) in the search field **before** selection and make Product search navigation-bar visibility changes non-animated, avoiding overlapping navigation and split-view transitions. 
- There is no visual change, despite this non-animated hide/show, because it's done offscreen.
- Other search flows retain their existing behavior.

## Test Steps
I have tested on iPhone and iPad, including split views for smaller display) using both iOS 18 and 26.

1. Open Products and enter search.
2. Search for a product and select it while the keyboard is visible.
3. Confirm Product Details shows a navigation bar and Back returns to search.
4. Cancel search and confirm the Products navigation bar is restored.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.