### PR TITLE
Enable TTP in Phone POS

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -84,9 +84,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleMarkOrderAsPaid:
             return buildConfig == .localDeveloper
         case .pointOfSaleTapToPay:
-            // Behind the flag while the TTP integration lands. localDeveloper-only so
-            // alpha and beta keep showing only Cash + Card reader for now.
-            return buildConfig == .localDeveloper
+            return true
         case .selfDrivenPushToken:
             return true
         case .clientSideDashboardBanner:

--- a/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import PointOfSale
+import ProximityReader
 import enum Experiments.FeatureFlag
 import protocol Experiments.FeatureFlagService
 import enum Yosemite.CardPresentPaymentAction
@@ -42,7 +43,7 @@ final class POSTapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking {
     }
 
     func checkAvailability() async -> POSTapToPayAvailabilityState {
-        guard userInterfaceIdiom == .phone else {
+        guard PaymentCardReader.isSupported else {
             return .unavailable(reason: .deviceNotSupported)
         }
         guard featureFlagService.isFeatureFlagEnabled(.pointOfSaleTapToPay) else {

--- a/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import PointOfSale
 import enum Experiments.FeatureFlag
 import protocol Experiments.FeatureFlagService
@@ -10,11 +11,13 @@ import protocol Yosemite.POSEligibilityServiceProtocol
 
 /// Resolves Tap to Pay availability for the current POS session.
 ///
-/// Three gates, evaluated in order — fail fast on whichever is first to deny:
-/// 1. The `pointOfSaleTapToPay` feature flag (cheapest check, shortcuts the rest).
-/// 2. Device support — Stripe's `Terminal.shared.supportsReaders(of: .appleBuiltIn, ...)`,
+/// Four gates, evaluated in order — fail fast on whichever is first to deny:
+/// 1. Device idiom — POS Tap to Pay is phone-only. iPad POS keeps its Bluetooth-primary
+///    flow, so we deny statically rather than paying for the async device-support check.
+/// 2. The `pointOfSaleTapToPay` feature flag (cheapest remaining check, shortcuts the rest).
+/// 3. Device support — Stripe's `Terminal.shared.supportsReaders(of: .appleBuiltIn, ...)`,
 ///    dispatched via `CardPresentPaymentAction.checkDeviceSupport`.
-/// 3. Site eligibility — proxied off cached POS tab visibility, which is itself driven
+/// 4. Site eligibility — proxied off cached POS tab visibility, which is itself driven
 ///    by IPP/country eligibility checks in `POSTabVisibilityChecker`.
 ///
 /// One-shot — `POSTapToPayAvailabilityController` calls `checkAvailability()` once on
@@ -24,18 +27,24 @@ final class POSTapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
     private let eligibilityService: POSEligibilityServiceProtocol
+    private let userInterfaceIdiom: UIUserInterfaceIdiom
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         eligibilityService: POSEligibilityServiceProtocol) {
+         eligibilityService: POSEligibilityServiceProtocol,
+         userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         self.siteID = siteID
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.eligibilityService = eligibilityService
+        self.userInterfaceIdiom = userInterfaceIdiom
     }
 
     func checkAvailability() async -> POSTapToPayAvailabilityState {
+        guard userInterfaceIdiom == .phone else {
+            return .unavailable(reason: .deviceNotSupported)
+        }
         guard featureFlagService.isFeatureFlagEnabled(.pointOfSaleTapToPay) else {
             return .unavailable(reason: .featureFlagDisabled)
         }

--- a/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 import PointOfSale
 import ProximityReader
 import enum Experiments.FeatureFlag
@@ -13,8 +12,7 @@ import protocol Yosemite.POSEligibilityServiceProtocol
 /// Resolves Tap to Pay availability for the current POS session.
 ///
 /// Four gates, evaluated in order — fail fast on whichever is first to deny:
-/// 1. Device idiom — POS Tap to Pay is phone-only. iPad POS keeps its Bluetooth-primary
-///    flow, so we deny statically rather than paying for the async device-support check.
+/// 1. Hardware support — Apple's `PaymentCardReader.isSupported`.
 /// 2. The `pointOfSaleTapToPay` feature flag (cheapest remaining check, shortcuts the rest).
 /// 3. Device support — Stripe's `Terminal.shared.supportsReaders(of: .appleBuiltIn, ...)`,
 ///    dispatched via `CardPresentPaymentAction.checkDeviceSupport`.
@@ -28,22 +26,22 @@ final class POSTapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
     private let eligibilityService: POSEligibilityServiceProtocol
-    private let userInterfaceIdiom: UIUserInterfaceIdiom
+    private let isTapToPayHardwareSupported: Bool
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          eligibilityService: POSEligibilityServiceProtocol,
-         userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+         isTapToPayHardwareSupported: Bool = PaymentCardReader.isSupported) {
         self.siteID = siteID
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.eligibilityService = eligibilityService
-        self.userInterfaceIdiom = userInterfaceIdiom
+        self.isTapToPayHardwareSupported = isTapToPayHardwareSupported
     }
 
     func checkAvailability() async -> POSTapToPayAvailabilityState {
-        guard PaymentCardReader.isSupported else {
+        guard isTapToPayHardwareSupported else {
             return .unavailable(reason: .deviceNotSupported)
         }
         guard featureFlagService.isFeatureFlagEnabled(.pointOfSaleTapToPay) else {

--- a/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
@@ -1,6 +1,5 @@
 import Testing
 import Foundation
-import UIKit
 import Experiments
 import Yosemite
 @testable import WooCommerce
@@ -11,16 +10,16 @@ struct POSTapToPayAvailabilityCheckerTests {
 
     private let siteID: Int64 = 123
 
-    // MARK: - Device Idiom Gate
+    // MARK: - Hardware Support Gate
 
-    @Test func checkAvailability_when_idiom_is_pad_then_returns_deviceNotSupported() async {
+    @Test func checkAvailability_when_tapToPay_hardware_unsupported_then_returns_deviceNotSupported() async {
         // Given
         let featureFlags = makeEnabledFeatureFlags()
         let eligibilityService = MockPOSEligibilityService()
         eligibilityService.cachedTabVisibility[siteID] = true
         let sut = makeSUT(featureFlagService: featureFlags,
                           eligibilityService: eligibilityService,
-                          userInterfaceIdiom: .pad)
+                          isTapToPayHardwareSupported: false)
 
         // When
         let result = await sut.checkAvailability()
@@ -29,7 +28,7 @@ struct POSTapToPayAvailabilityCheckerTests {
         #expect(result == .unavailable(reason: .deviceNotSupported))
     }
 
-    @Test func checkAvailability_when_idiom_is_pad_then_does_not_dispatch_device_check() async {
+    @Test func checkAvailability_when_tapToPay_hardware_unsupported_then_does_not_dispatch_device_check() async {
         // Given
         let featureFlags = makeEnabledFeatureFlags()
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -39,7 +38,7 @@ struct POSTapToPayAvailabilityCheckerTests {
                 deviceCheckDispatched = true
             }
         }
-        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, userInterfaceIdiom: .pad)
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, isTapToPayHardwareSupported: false)
 
         // When
         _ = await sut.checkAvailability()
@@ -200,20 +199,20 @@ private extension POSTapToPayAvailabilityCheckerTests {
         return service
     }
 
-    /// Defaults to `.phone` so the flag / device / eligibility tests stay deterministic
+    /// Hardware support defaults to `true` so the flag / device / eligibility tests stay deterministic
     /// regardless of the simulator the suite runs on.
     func makeSUT(
         featureFlagService: MockFeatureFlagService = MockFeatureFlagService(),
         stores: MockStoresManager = MockStoresManager(sessionManager: .makeForTesting()),
         eligibilityService: MockPOSEligibilityService = MockPOSEligibilityService(),
-        userInterfaceIdiom: UIUserInterfaceIdiom = .phone
+        isTapToPayHardwareSupported: Bool = true
     ) -> POSTapToPayAvailabilityChecker {
         POSTapToPayAvailabilityChecker(
             siteID: siteID,
             stores: stores,
             featureFlagService: featureFlagService,
             eligibilityService: eligibilityService,
-            userInterfaceIdiom: userInterfaceIdiom
+            isTapToPayHardwareSupported: isTapToPayHardwareSupported
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import UIKit
 import Experiments
 import Yosemite
 @testable import WooCommerce
@@ -9,6 +10,43 @@ import Yosemite
 struct POSTapToPayAvailabilityCheckerTests {
 
     private let siteID: Int64 = 123
+
+    // MARK: - Device Idiom Gate
+
+    @Test func checkAvailability_when_idiom_is_pad_then_returns_deviceNotSupported() async {
+        // Given
+        let featureFlags = makeEnabledFeatureFlags()
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachedTabVisibility[siteID] = true
+        let sut = makeSUT(featureFlagService: featureFlags,
+                          eligibilityService: eligibilityService,
+                          userInterfaceIdiom: .pad)
+
+        // When
+        let result = await sut.checkAvailability()
+
+        // Then
+        #expect(result == .unavailable(reason: .deviceNotSupported))
+    }
+
+    @Test func checkAvailability_when_idiom_is_pad_then_does_not_dispatch_device_check() async {
+        // Given
+        let featureFlags = makeEnabledFeatureFlags()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var deviceCheckDispatched = false
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .checkDeviceSupport = action {
+                deviceCheckDispatched = true
+            }
+        }
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, userInterfaceIdiom: .pad)
+
+        // When
+        _ = await sut.checkAvailability()
+
+        // Then
+        #expect(deviceCheckDispatched == false)
+    }
 
     // MARK: - Feature Flag Gate
 
@@ -162,16 +200,20 @@ private extension POSTapToPayAvailabilityCheckerTests {
         return service
     }
 
+    /// Defaults to `.phone` so the flag / device / eligibility tests stay deterministic
+    /// regardless of the simulator the suite runs on.
     func makeSUT(
         featureFlagService: MockFeatureFlagService = MockFeatureFlagService(),
         stores: MockStoresManager = MockStoresManager(sessionManager: .makeForTesting()),
-        eligibilityService: MockPOSEligibilityService = MockPOSEligibilityService()
+        eligibilityService: MockPOSEligibilityService = MockPOSEligibilityService(),
+        userInterfaceIdiom: UIUserInterfaceIdiom = .phone
     ) -> POSTapToPayAvailabilityChecker {
         POSTapToPayAvailabilityChecker(
             siteID: siteID,
             stores: stores,
             featureFlagService: featureFlagService,
-            eligibilityService: eligibilityService
+            eligibilityService: eligibilityService,
+            userInterfaceIdiom: userInterfaceIdiom
         )
     }
 }


### PR DESCRIPTION
Ref: p1785818819284009-slack-C025A8VV728

## Description
Enables TTP for Phone POS in eligible stores (UK + iOS26)

## Test Steps
Confirm TTP is available and can be used in POS Phone.

AFAIU this can only be 100% verified once the TestFlight build is out:
- Xcode Debug on physical device allows for partial testing, which is what caused the false positive in the first place.
- Alpha/prototype build has no `com.apple.developer.proximity-reader.payment.acceptance` entitlement, so we cannot test it on physical device + release config. Neither using the QR code from CI.
- TestFlight, we'll be able to confirm in TF if works as expected once is out, but this is after the PR has been merged and we made the new build.

https://github.com/user-attachments/assets/c45fa1e3-9d4f-4511-857f-d8800cbb4b51 

## Screenshots

Other payment methods will contain more methods in dev config (1), and how should show in release (2) with `pointOfSaleScanToPay` and `pointOfSaleMarkOrderAsPaid` as false if we could test it:

| (1) | (2) |
|--------|--------|
| <img width="399" height="875" alt="Screenshot 2026-08-04 at 17 41 22" src="https://github.com/user-attachments/assets/fbea0d9a-8e2e-4e05-b925-1a6172aebda8" /> | <img width="397" height="867" alt="Screenshot 2026-08-04 at 17 41 02" src="https://github.com/user-attachments/assets/d80f41fa-688c-4a49-842f-b4398c6c077a" /> | 