### PR TITLE
[WOOMOB-2398] Fix empty screen and silently discarded edits on tab re-selection

### DIFF
--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -20,18 +20,47 @@ extension UINavigationController {
     }
 
     /// Two-stage tab re-selection: pop to root, or scroll to top when already at root.
-    func popToRootOrScrollToTop(animated: Bool) {
-        if viewControllers.count > 1 {
-            // Every screen being popped must permit it (unsaved-changes guard), like tapping Back through them.
-            for viewController in viewControllers.dropFirst().reversed() {
-                guard viewController.shouldPopOnBackButton() else {
-                    return
+    /// Every screen being popped must permit it (`shouldPopOnBackButton`), like tapping Back
+    /// through them; the first screen that refuses becomes the new top instead. Screens inside
+    /// a nested navigation controller (e.g. a collapsed split view's column) are asked too.
+    /// Returns `true` when the stack ends up at its root, `false` when a screen refused.
+    @discardableResult
+    func popToRootOrScrollToTop(animated: Bool) -> Bool {
+        guard viewControllers.count > 1 else {
+            scrollContentToTop(animated: animated)
+            return true
+        }
+        for element in viewControllers.dropFirst().reversed() {
+            for screen in Self.screens(in: element) {
+                guard screen.shouldPopOnBackButton() else {
+                    revealRefusingScreen(screen, poppedElement: element, animated: animated)
+                    return false
                 }
             }
-            popToRootViewController(animated: animated)
-        } else {
-            scrollContentToTop(animated: animated)
         }
+        popToRootViewController(animated: animated)
+        return true
+    }
+
+    /// The screens a stack element stands for, top-down. A collapsed split view puts its column
+    /// into the stack as a navigation controller, so that element stands for everything inside it.
+    static func screens(in element: UIViewController) -> [UIViewController] {
+        guard let nestedNavigationController = element as? UINavigationController else {
+            return [element]
+        }
+        return nestedNavigationController.viewControllers.reversed()
+    }
+
+    /// Pops down to the screen that refused, making it the visible top.
+    private func revealRefusingScreen(_ screen: UIViewController, poppedElement element: UIViewController, animated: Bool) {
+        if topViewController !== element {
+            popToViewController(element, animated: animated)
+        }
+        guard let nestedNavigationController = element as? UINavigationController,
+              nestedNavigationController.topViewController !== screen else {
+            return
+        }
+        nestedNavigationController.popToViewController(screen, animated: animated)
     }
 
     /// Completion block for popToRootViewController

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -147,7 +147,19 @@ extension HubMenuViewController: DeepLinkNavigator {
 
 extension HubMenuViewController: TabReselectionHandling {
     func handleTabReselection() {
+        // Destinations can push UIKit screens onto the `NavigationStack`'s backing navigation
+        // controller (e.g. Settings → Help), which `navigationPath` knows nothing about.
+        // Popping that controller first keeps `navigationPath` in sync with what is on screen.
+        guard let stackNavigationController,
+              stackNavigationController.popToRootOrScrollToTop(animated: true) else {
+            return
+        }
         viewModel.popToRoot()
+    }
+
+    /// The `UINavigationController` backing the SwiftUI `NavigationStack`.
+    private var stackNavigationController: UINavigationController? {
+        children.compactMap { $0 as? UINavigationController }.first
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -479,12 +479,17 @@ extension MainTabBarController {
             return
         }
         let content = (selectedViewController as? TabContainerController)?.wrappedController ?? selectedViewController
-        let navigationController = content as? UINavigationController
 
-        navigationController?.popToRootOrScrollToTop(animated: true)
+        guard let navigationController = content as? UINavigationController else {
+            (content as? TabReselectionHandling)?.handleTabReselection()
+            return
+        }
 
-        let rootContent = navigationController?.viewControllers.first ?? content
-        (rootContent as? TabReselectionHandling)?.handleTabReselection()
+        // A refused pop skips the root's own reset, so its guarded screens are never bypassed.
+        guard navigationController.popToRootOrScrollToTop(animated: true) else {
+            return
+        }
+        (navigationController.viewControllers.first as? TabReselectionHandling)?.handleTabReselection()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UINavigationControllerWooTests.swift
@@ -53,19 +53,89 @@ struct UINavigationControllerWooTests {
     }
 
     @Test
-    func popToRootOrScrollToTop_when_an_intermediate_screen_refuses_to_pop_then_does_not_pop() {
+    func popToRootOrScrollToTop_when_an_intermediate_screen_refuses_to_pop_then_pops_to_that_screen() {
         // Given a dirty intermediate screen sitting below a clean top screen that would pop.
         let root = UIViewController()
+        let nonPoppable = NonPoppableViewController()
         let navigationController = UINavigationController(rootViewController: root)
-        navigationController.pushViewController(NonPoppableViewController(), animated: false)
+        navigationController.pushViewController(nonPoppable, animated: false)
         navigationController.pushViewController(UIViewController(), animated: false)
         #expect(navigationController.viewControllers.count == 3)
 
         // When re-selecting the tab asks the stack to pop to root.
         navigationController.popToRootOrScrollToTop(animated: false)
 
-        // Then the stack is unchanged, so the clean top can't let the dirty screen below be discarded.
-        #expect(navigationController.viewControllers.count == 3)
+        // Then the stack pops down to the refusing screen, making the unsaved changes visible instead of discarding them.
+        #expect(navigationController.viewControllers.count == 2)
+        #expect(navigationController.topViewController === nonPoppable)
+    }
+
+    @Test
+    func screens_when_element_is_a_plain_screen_then_returns_just_that_screen() {
+        // Given a stack element that is an ordinary screen.
+        let screen = UIViewController()
+
+        // When collecting the screens it stands for.
+        let screens = UINavigationController.screens(in: screen)
+
+        // Then it stands only for itself.
+        #expect(screens == [screen])
+    }
+
+    @Test
+    func screens_when_element_is_a_navigation_controller_then_returns_its_screens_top_down() {
+        // Given a collapsed split view's column, which sits in the stack as a navigation controller.
+        let columnRoot = UIViewController()
+        let pushedScreen = UIViewController()
+        let column = UINavigationController(rootViewController: columnRoot)
+        column.pushViewController(pushedScreen, animated: false)
+
+        // When collecting the screens it stands for.
+        let screens = UINavigationController.screens(in: column)
+
+        // Then every screen inside is asked, starting from the visible one, so a dirty screen
+        // below the top is not skipped.
+        #expect(screens == [pushedScreen, columnRoot])
+    }
+
+    @Test
+    func popToRootOrScrollToTop_when_already_at_root_then_returns_true() {
+        // Given a navigation stack that is already showing its root screen.
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+
+        // When re-selecting the tab asks the stack to pop to root.
+        let atRoot = navigationController.popToRootOrScrollToTop(animated: false)
+
+        // Then the stack reports being at its root.
+        #expect(atRoot)
+    }
+
+    @Test
+    func popToRootOrScrollToTop_when_stack_pops_then_returns_true() {
+        // Given a navigation stack that has been pushed beyond its root.
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        navigationController.pushViewController(UIViewController(), animated: false)
+
+        // When re-selecting the tab asks the stack to pop to root.
+        let atRoot = navigationController.popToRootOrScrollToTop(animated: false)
+
+        // Then the stack pops and reports being at its root.
+        #expect(atRoot)
+        #expect(navigationController.viewControllers.count == 1)
+    }
+
+    @Test
+    func popToRootOrScrollToTop_when_a_screen_refuses_to_pop_then_returns_false() {
+        // Given a stack whose top screen has unsaved changes and refuses to pop.
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        navigationController.pushViewController(NonPoppableViewController(), animated: false)
+
+        // When re-selecting the tab asks the stack to pop to root.
+        let atRoot = navigationController.popToRootOrScrollToTop(animated: false)
+
+        // Then the stack is unchanged and reports the refusal.
+        #expect(!atRoot)
+        #expect(navigationController.viewControllers.count == 2)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -751,6 +751,45 @@ final class MainTabBarControllerTests: XCTestCase {
             navigationController.viewControllers.count == 1
         }
     }
+
+    func test_handleTabReselection_when_navigation_root_is_reselection_handler_then_pops_and_forwards() throws {
+        // Given
+        let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)
+        let reselectionHandler = SpyReselectionController()
+        let navigationController = UINavigationController(rootViewController: reselectionHandler)
+        navigationController.pushViewController(UIViewController(), animated: false)
+        tabBarController.viewControllers = [navigationController]
+        tabBarController.selectedViewController = navigationController
+        window.rootViewController = tabBarController
+
+        // When
+        tabBarController.handleTabReselection()
+
+        // Then
+        // The dispatch must pop the stack to its root and forward to the root's handler.
+        waitUntil {
+            navigationController.viewControllers.count == 1 && reselectionHandler.handledCount == 1
+        }
+    }
+
+    func test_handleTabReselection_when_a_screen_refuses_to_pop_then_root_handler_is_not_notified() throws {
+        // Given
+        let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)
+        let reselectionHandler = SpyReselectionController()
+        let navigationController = UINavigationController(rootViewController: reselectionHandler)
+        navigationController.pushViewController(NonPoppableViewController(), animated: false)
+        tabBarController.viewControllers = [navigationController]
+        tabBarController.selectedViewController = navigationController
+        window.rootViewController = tabBarController
+
+        // When
+        tabBarController.handleTabReselection()
+
+        // Then
+        // A refused pop must leave the stack alone and skip the root's own reset.
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssertEqual(reselectionHandler.handledCount, 0)
+    }
 }
 
 private final class SpyReselectionController: UIViewController, TabReselectionHandling {
@@ -758,6 +797,13 @@ private final class SpyReselectionController: UIViewController, TabReselectionHa
 
     func handleTabReselection() {
         handledCount += 1
+    }
+}
+
+/// Refuses to pop, mimicking a screen with unsaved changes.
+private final class NonPoppableViewController: UIViewController {
+    override func shouldPopOnBackButton() -> Bool {
+        false
     }
 }
 


### PR DESCRIPTION
## Description

Adam is AFK, so I am fixing the two issues I commented on in #17624 myself here.

Note: Android equivalents are included in parentheses.

**1. Menu tab showed an empty screen.**

The Menu tab is written in SwiftUI (the iOS counterpart of Jetpack Compose). In SwiftUI, the open screens are tracked in the `NavigationStack`'s path (like the `NavController` back stack in Navigation Compose): appending to the path pushes a screen (`navigate()`), clearing it returns to the root (`popBackStack()`). But the path is only SwiftUI's own ledger. The screens actually live in a UIKit navigation controller that SwiftUI manages behind the scenes (UIKit being the older View/Fragment world, and `UINavigationController` roughly the `FragmentManager` back stack).

Settings is a UIKit screen, and it opens Help without going through SwiftUI: it pushes directly onto that backing navigation controller (like a Fragment embedded in a Compose screen bypassing the `NavController` and adding transactions straight to `supportFragmentManager`). The real stack ends up as "Settings, Help" while SwiftUI's path still only says "Settings".

On re-selection, the old code cleared the path, so SwiftUI removed the only screen it knew about, Settings, pulling it out from under Help. That left an orphaned screen on the stack and the tab rendered blank. The Menu tab now pops the backing navigation controller instead, and resets the path only once the stack is back at its root.

**2. Unsaved edits were discarded without a prompt.**

On iPhone the split view collapses and sits in the tab's stack as a nested navigation controller. The unsaved-changes guard only asked that nested controller, not the screens inside it. So a dirty screen one level down was popped without asking. Now the guard asks every screen inside nested navigation controllers, and pops down to the first screen that refuses, so its discard sheet shows on a visible screen.

A tab root that handles re-selection itself is now notified only when the whole stack agreed to pop, so a refused pop never resets it underneath.

## Test Steps

**Empty screen**
1. Go to the Menu tab, tap Settings, then tap Help & Support.
2. Tap the Menu tab again.
3. It returns to the Menu root list. Before this change the screen went blank.
4. Tap into Settings again to confirm navigation still works.

**Unsaved edits (iPhone)**
1. Go to the Products tab and open any product.
2. Tap Price, change the price, and do not save.
3. Tap Tax status to push the selector on top of it.
4. Tap the Products tab again.
5. The selector is popped and the discard sheet appears on the Price screen. Before this change the edit was discarded without any prompt.
6. Dismiss the sheet and confirm the edited price is still there.

**Unchanged behaviour**
1. Open a product, then re-tap the Products tab with no unsaved edits. It returns to the list.
2. Re-tap a tab that is already at its root. Nothing happens.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
