### PR TITLE
[Woo POS] Harden the server-calculated refund flow

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.mobile-mcp]
+command = "npx"
+args = [
+    "-y",
+    "@mobilenext/mobile-mcp@latest",
+]

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -105,7 +105,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .starReceiptPrinterSupport:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .posRefundsV4:
+        case .posServerCalculatedRefunds:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -245,8 +245,7 @@ public enum FeatureFlag: Int, CaseIterable {
     case starReceiptPrinterSupport
 
     /// Enables server-calculated POS refunds: the `/wc/v3` refund preview and `compute_totals`
-    /// create endpoints (WC 11.1.0+). The case name predates the port of the endpoints from
-    /// `wc/v4` to `/wc/v3` and is kept for continuity.
+    /// create endpoints (WC 11.1.0+).
     ///
-    case posRefundsV4
+    case posServerCalculatedRefunds
 }

--- a/Modules/Sources/Networking/Remote/RefundsRemote.swift
+++ b/Modules/Sources/Networking/Remote/RefundsRemote.swift
@@ -188,7 +188,10 @@ public final class RefundsRemote: Remote, RefundsRemoteProtocol {
     ///     - apiRestock: Whether refunded items are restocked (`api_restock`). Always sent
     ///       explicitly — the v3 endpoint defaults it to `true`.
     ///     - amount: Optional order-level total override. When omitted the server derives the
-    ///       amount from the line items.
+    ///       amount from the line items. POS always omits it — refund amount calculation is
+    ///       delegated to the backend at create time, Interac card-present refunds included — so
+    ///       this exists to mirror the endpoint's contract for any future caller that needs to pin
+    ///       a total, not because the current flow uses it.
     ///     - lineItems: What to refund; the server computes all monetary values.
     ///
     public func createComputedRefund(for siteID: Int64,

--- a/Modules/Sources/NetworkingCore/Model/Refund/ComputedRefundLineItem.swift
+++ b/Modules/Sources/NetworkingCore/Model/Refund/ComputedRefundLineItem.swift
@@ -35,13 +35,8 @@ public struct ComputedRefundLineItem: Encodable, Equatable {
         ComputedRefundLineItem(lineItemID: lineItemID, quantity: nil, refundTotal: refundTotal)
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(lineItemID, forKey: .lineItemID)
-        try container.encodeIfPresent(quantity, forKey: .quantity)
-        try container.encodeIfPresent(refundTotal, forKey: .refundTotal)
-    }
-
+    // Encoding is synthesized: optionals encode via `encodeIfPresent`, so a nil `quantity` or
+    // `refund_total` is omitted rather than sent as null.
     private enum CodingKeys: String, CodingKey {
         case lineItemID = "id"
         case quantity

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.4
 -----
+- [Internal] POS refunds: bound the server-calculated preview total to the selection it was calculated for, so the submitted amount always matches the reviewed one. [https://github.com/woocommerce/woocommerce-ios/pull/17636]
 - [*] Fixed magic link login not navigating to the store dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/17622]
 - [*] Login: Fixed stores failing to load when hosting blocks one of the WordPress REST API URL formats. [https://github.com/woocommerce/woocommerce-ios/pull/17602]
 - [*] Order statuses now display in the store's language across the order list, search, filters, and the dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/17595]

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundFlowResolver.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundFlowResolver.swift
@@ -16,7 +16,7 @@ enum POSRefundFlow: Equatable {
 /// Decides which refund calculation flow a site is eligible for.
 ///
 /// `serverComputed` requires all of:
-/// - the `posRefundsV4` feature flag (the name predates the port of the endpoints to `/wc/v3`),
+/// - the `posServerCalculatedRefunds` feature flag,
 /// - the site not being cached as unavailable (a preview already returned `rest_no_route`),
 /// - a cached WooCommerce version that is known and at least
 ///   ``Constants/minimumWooVersionForServerRefunds``; an unknown version fails closed to
@@ -50,7 +50,7 @@ struct POSRefundFlowResolver {
     }
 
     func resolveFlow(siteID: Int64) -> POSRefundFlow {
-        guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4) else {
+        guard featureFlagService.isFeatureFlagEnabled(.posServerCalculatedRefunds) else {
             return .localComputed
         }
         guard availabilityCache.isAvailable(siteID: siteID) != false else {

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -29,7 +29,24 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
     private var preloadedRefundSnapshots: [Int64: PreparedRefundSnapshot] = [:]
     private var preloadTasks: [Int64: (id: UUID, task: Task<PreparedRefundSnapshot, Error>)] = [:]
     private var preparedContexts: [Int64: POSRefundSubmissionMapping.PreparedRefundContext] = [:]
-    private var serverPreviewTotals: [Int64: Decimal] = [:]
+    /// Identifies one refund selection within an order. Two selections of the same items are the
+    /// same key, and any change to which units are selected produces a different one.
+    private struct SelectionKey: Hashable {
+        let orderID: Int64
+        private let selectedItemIDs: Set<String>
+
+        init(orderID: Int64, selectedItems: [POSRefundSelectableItem]) {
+            self.orderID = orderID
+            self.selectedItemIDs = Set(selectedItems.map(\.id))
+        }
+    }
+
+    /// Server-calculated totals from a successful preview, keyed by the selection they were
+    /// calculated for. Keying by selection rather than by order is what makes the displayed total
+    /// and the submitted total the same value: a preview for a superseded selection cannot be read
+    /// back for a different one, so overlapping previews resolving out of order can no longer leave
+    /// the submit path using a total the cashier never saw.
+    private var serverPreviewTotals: [SelectionKey: Decimal] = [:]
     private var submissionUseCase: RefundSubmissionUseCase<CardPresentPaymentBluetoothReaderConnectionAlertsProvider, POSRefundCardPresentPaymentAlertsPresenter>?
     private var onboardingSubscription: AnyCancellable?
 
@@ -103,7 +120,10 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
             throw POSRefundSubmissionAdaptorError.missingPreparedRefund
         }
 
-        serverPreviewTotals[preparation.orderID] = nil
+        // Reset only this selection's total. Other selections keep theirs, so a preview that
+        // resolves late cannot invalidate the selection the cashier is actually looking at.
+        let selectionKey = SelectionKey(orderID: preparation.orderID, selectedItems: selectedItems)
+        serverPreviewTotals[selectionKey] = nil
 
         let lineItems = refundMapping.refundPreviewLineItems(from: selectedItems, context: context)
         let previewResult = await serverRefundPreviewUseCase.previewRefund(siteID: context.order.siteID,
@@ -113,7 +133,7 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
 
         switch previewResult {
         case .serverCalculated(let preview):
-            serverPreviewTotals[preparation.orderID] = preview.total
+            serverPreviewTotals[selectionKey] = preview.total
             return reviewData(subtotal: preview.subtotal,
                               tax: preview.tax,
                               total: preview.total,
@@ -122,7 +142,7 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
                               selectedItems: selectedItems,
                               reason: reason)
         case .fallbackToLocal:
-            serverPreviewTotals[preparation.orderID] = nil
+            serverPreviewTotals[selectionKey] = nil
             let components = refundMapping.refundComponents(from: selectedItems, context: context)
             let values = refundMapping.refundValues(items: components.items, fees: components.fees)
             return reviewData(subtotal: values.subtotal,
@@ -137,6 +157,8 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
             // carries the cashier-facing copy shown inline on the selection step.
             throw rejection
         case .error:
+            // The use case has already logged the underlying error; the cashier sees the generic
+            // preview failure with a retry affordance.
             throw POSRefundSubmissionError.refundPreviewFailed
         }
     }
@@ -174,7 +196,8 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         let values = refundMapping.refundValues(items: components.items, fees: components.fees)
         // A server-computed create is only allowed when this exact selection was previewed
         // successfully; otherwise the classic v3 create path is used.
-        let serverPreviewTotal = serverPreviewTotals[preparation.orderID]
+        let serverPreviewTotal = serverPreviewTotals[SelectionKey(orderID: preparation.orderID,
+                                                                 selectedItems: selectedItems)]
         let serverLineItems = serverPreviewTotal != nil ? refundMapping.computedRefundLineItems(from: selectedItems, context: context) : nil
         let amount = refundMapping.apiAmountString(for: serverPreviewTotal ?? values.total)
         let refund = RefundCreationUseCase(amount: amount,
@@ -260,12 +283,16 @@ private extension POSRefundSubmissionAdaptor {
         preloadedRefundSnapshots[orderID] = nil
         preloadTasks[orderID]?.task.cancel()
         preloadTasks[orderID] = nil
-        serverPreviewTotals[orderID] = nil
+        serverPreviewTotals = serverPreviewTotals.filter { $0.key.orderID != orderID }
+        // Prepared contexts hold the full order, charge, and refundable items, so they are dropped
+        // alongside the rest of the refund's state instead of accumulating for the whole session.
+        preparedContexts[orderID] = nil
     }
 
     func removePreloadedRefunds(except orderID: Int64) {
         preloadedRefundSnapshots = preloadedRefundSnapshots.filter { $0.key == orderID }
-        serverPreviewTotals = serverPreviewTotals.filter { $0.key == orderID }
+        serverPreviewTotals = serverPreviewTotals.filter { $0.key.orderID == orderID }
+        preparedContexts = preparedContexts.filter { $0.key == orderID }
         for preloadedOrderID in Array(preloadTasks.keys) where preloadedOrderID != orderID {
             removePreloadedRefund(for: preloadedOrderID)
         }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
@@ -106,37 +106,40 @@ struct POSRefundSubmissionMapping {
     /// Builds the preview request lines: products refunded by quantity, fees by tax-inclusive amount.
     func refundPreviewLineItems(from selectedItems: [POSRefundSelectableItem],
                                 context: PreparedRefundContext) -> [RefundPreviewLineItem] {
-        let components = refundComponents(from: selectedItems, context: context)
-
-        let productLines = components.items.map {
-            RefundPreviewLineItem.quantityBased(lineItemID: $0.item.itemID, quantity: Decimal($0.quantity))
-        }
-
-        let feeLines = components.fees.compactMap { fee -> RefundPreviewLineItem? in
-            guard let refundTotal = grossRefundTotal(for: fee) else {
-                return nil
-            }
-            return RefundPreviewLineItem.amountBased(lineItemID: fee.feeID, refundTotal: refundTotal)
-        }
-
-        return productLines + feeLines
+        refundLines(from: selectedItems,
+                    context: context,
+                    quantityBased: RefundPreviewLineItem.quantityBased,
+                    amountBased: RefundPreviewLineItem.amountBased)
     }
 
     /// Builds the `compute_totals` creation request lines. Same construction as
     /// `refundPreviewLineItems(from:context:)`, but the creation endpoint keys lines by `id`.
     func computedRefundLineItems(from selectedItems: [POSRefundSelectableItem],
                                  context: PreparedRefundContext) -> [ComputedRefundLineItem] {
+        refundLines(from: selectedItems,
+                    context: context,
+                    quantityBased: ComputedRefundLineItem.quantityBased,
+                    amountBased: ComputedRefundLineItem.amountBased)
+    }
+
+    /// Shared construction for both request shapes. The safety invariant is that a computed create
+    /// sends exactly what was previewed, so the two differ only in the line type they build — never
+    /// in which lines they include or what amounts those lines carry.
+    private func refundLines<Line>(from selectedItems: [POSRefundSelectableItem],
+                                   context: PreparedRefundContext,
+                                   quantityBased: (Int64, Decimal) -> Line,
+                                   amountBased: (Int64, Decimal) -> Line) -> [Line] {
         let components = refundComponents(from: selectedItems, context: context)
 
         let productLines = components.items.map {
-            ComputedRefundLineItem.quantityBased(lineItemID: $0.item.itemID, quantity: Decimal($0.quantity))
+            quantityBased($0.item.itemID, Decimal($0.quantity))
         }
 
-        let feeLines = components.fees.compactMap { fee -> ComputedRefundLineItem? in
+        let feeLines = components.fees.compactMap { fee -> Line? in
             guard let refundTotal = grossRefundTotal(for: fee) else {
                 return nil
             }
-            return ComputedRefundLineItem.amountBased(lineItemID: fee.feeID, refundTotal: refundTotal)
+            return amountBased(fee.feeID, refundTotal)
         }
 
         return productLines + feeLines

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSServerRefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSServerRefundPreviewUseCase.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import Foundation
 import Yosemite
 import Experiments
@@ -15,13 +16,17 @@ import enum NetworkingCore.NetworkError
 @MainActor
 final class POSServerRefundPreviewUseCase {
 
-    enum Result: Equatable {
+    enum Result {
         case serverCalculated(RefundPreview)
         case fallbackToLocal
         /// The server rejected the requested refund with an actionable code (for example the
         /// order changed since the screen was loaded); the rejection carries cashier-facing copy.
         case rejected(RefundAPIError)
-        case error
+        /// The preview failed for a reason with no cashier-facing mapping: a transport failure, or
+        /// a server error whose code we do not recognise. The error is carried so the cause is
+        /// attributable in logs rather than collapsing every failure into one indistinguishable
+        /// state.
+        case error(Error)
     }
 
     private let refundService: RefundServiceProtocol
@@ -65,9 +70,11 @@ final class POSServerRefundPreviewUseCase {
                 return .fallbackToLocal
             }
             if let rejection = RefundAPIError(error) {
+                DDLogWarn("POS refund preview rejected for order \(orderID): \(rejection)")
                 return .rejected(rejection)
             }
-            return .error
+            DDLogError("⛔️ POS refund preview failed for order \(orderID): \(error)")
+            return .error(error)
         }
     }
 
@@ -79,5 +86,24 @@ final class POSServerRefundPreviewUseCase {
             return true
         }
         return false
+    }
+}
+
+extension POSServerRefundPreviewUseCase.Result: Equatable {
+    /// Two failures compare equal regardless of the underlying error: the payload is carried for
+    /// logging, not to distinguish one failure from another.
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case let (.serverCalculated(lhsPreview), .serverCalculated(rhsPreview)):
+            return lhsPreview == rhsPreview
+        case (.fallbackToLocal, .fallbackToLocal):
+            return true
+        case let (.rejected(lhsRejection), .rejected(rhsRejection)):
+            return lhsRejection == rhsRejection
+        case (.error, .error):
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -428,7 +428,12 @@ private extension RefundSubmissionUseCase {
             return
         }
         if details.serverLineItems != nil {
-            DDLogError("⛔️ Server refund line items provided without a RefundService — falling back to the classic submission path")
+            // Refuse rather than fall through. `details.amount` is the server preview total while
+            // the refund's line items carry locally computed totals, so submitting here would
+            // record a refund whose total need not equal the sum of its lines. A misconfigured
+            // caller must fail loudly instead of booking money against inconsistent figures.
+            DDLogError("⛔️ Server refund line items provided without a RefundService — refusing to submit")
+            return onCompletion(.failure(RefundSubmissionUseCaseSubmissionError.missingRefundService))
         }
 
         let action = RefundAction.createRefund(siteID: details.order.siteID, orderID: details.order.orderID, refund: refund) { [weak self]
@@ -590,6 +595,9 @@ enum RefundSubmissionUseCaseSubmissionError: Error, Equatable {
     case unknownPaymentGatewayAccount
     case canceledByUser
     case missingCreatedRefund
+    /// Server-computed line items were supplied without the service needed to submit them, so the
+    /// refund cannot be sent through the path its amount was calculated for.
+    case missingRefundService
 }
 
 private enum RefundSubmissionUseCaseDefinitions {

--- a/WooCommerce/WooCommerceTests/POS/POSRefundFlowResolverTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundFlowResolverTests.swift
@@ -105,7 +105,7 @@ private extension POSRefundFlowResolverTests {
         session.cachedWooCommerceVersion = cachedWooVersion
         let stores = MockStoresManager(sessionManager: session)
         let flags = MockFeatureFlagService()
-        flags.isFeatureFlagEnabledReturnValue = [.posRefundsV4: flagEnabled]
+        flags.isFeatureFlagEnabledReturnValue = [.posServerCalculatedRefunds: flagEnabled]
         return POSRefundFlowResolver(stores: stores,
                                      featureFlagService: flags,
                                      availabilityCache: cache,

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
@@ -128,6 +128,80 @@ struct POSRefundSubmissionAdaptorTests {
         #expect(amount == "22")
     }
 
+    @Test func submitRefund_when_uncancelled_previews_resolve_out_of_order_uses_the_reviewed_total() async throws {
+        // Given two previews in flight for different selections and neither cancelled, so both
+        // write their result. Totals are stored per selection, so the order in which they land
+        // cannot change what a given selection submits.
+        let harness = makeHarness(previewResult: nil, manualPreviewResolution: true, orderQuantity: 2)
+        let preparation = try await harness.adaptor.prepareRefund(for: posOrder())
+        let selectionA = Array(preparation.selectableItems.prefix(1))
+        let selectionB = preparation.selectableItems
+
+        let taskA = Task { @MainActor in
+            try await harness.adaptor.prepareReviewData(for: posOrder(),
+                                                        preparation: preparation,
+                                                        selectedItems: selectionA,
+                                                        reason: nil)
+        }
+        while harness.service.pendingPreviewCompletions.count < 1 {
+            await Task.yield()
+        }
+
+        let taskB = Task { @MainActor in
+            try await harness.adaptor.prepareReviewData(for: posOrder(),
+                                                        preparation: preparation,
+                                                        selectedItems: selectionB,
+                                                        reason: nil)
+        }
+        while harness.service.pendingPreviewCompletions.count < 2 {
+            await Task.yield()
+        }
+
+        // When selection B resolves first ($22, the reviewed selection) and selection A resolves
+        // afterwards ($10)
+        harness.service.pendingPreviewCompletions[1](.success(preview(total: 22)))
+        _ = try await taskB.value
+        harness.service.pendingPreviewCompletions[0](.success(preview(total: 10)))
+        _ = try await taskA.value
+
+        try await harness.adaptor.submitRefund(for: posOrder(),
+                                               preparation: preparation,
+                                               selectedItems: selectionB,
+                                               reason: nil)
+
+        // Then selection B is charged its own server total, not the late arrival's
+        #expect(harness.service.createRefundLineItems?.count == 1)
+        #expect(harness.service.createRefundLineItems?.first?.quantity == 2)
+        let createEventIndex = try #require(harness.analyticsProvider.receivedEvents.firstIndex(of: WooAnalyticsStat.refundCreate.rawValue))
+        let amount = harness.analyticsProvider.receivedProperties[createEventIndex]["amount"] as? String
+        #expect(amount == "22")
+    }
+
+    @Test func submitRefund_when_a_previewed_selection_falls_back_then_the_classic_create_is_used() async throws {
+        // Given a selection previewed successfully, then previewed again with the server flow no
+        // longer available (the clearing side of the ghost-refund invariant).
+        let harness = makeHarness(previewResult: .success(preview(total: 22)))
+        let preparation = try await harness.adaptor.prepareRefund(for: posOrder())
+        _ = try await harness.adaptor.prepareReviewData(for: posOrder(),
+                                                        preparation: preparation,
+                                                        selectedItems: preparation.selectableItems,
+                                                        reason: nil)
+
+        // When the same selection is re-previewed and the site now reports the local fallback
+        harness.flags.isFeatureFlagEnabledReturnValue = [.posServerCalculatedRefunds: false]
+        _ = try await harness.adaptor.prepareReviewData(for: posOrder(),
+                                                        preparation: preparation,
+                                                        selectedItems: preparation.selectableItems,
+                                                        reason: nil)
+        try await harness.adaptor.submitRefund(for: posOrder(),
+                                               preparation: preparation,
+                                               selectedItems: preparation.selectableItems,
+                                               reason: nil)
+
+        // Then no computed create is sent: the stale server total was cleared for that selection.
+        #expect(harness.service.createRefundLineItems == nil)
+    }
+
     @Test func prepareReviewData_when_preview_errors_then_throws_refundPreviewFailed() async throws {
         // Given
         let harness = makeHarness(previewResult: .failure(NetworkError.timeout()))
@@ -237,6 +311,8 @@ private extension POSRefundSubmissionAdaptorTests {
         let service: MockManualRefundService
         let spy: RefundActionSpy
         let analyticsProvider: MockAnalyticsProvider
+        /// Exposed so a test can change eligibility between two previews of the same selection.
+        let flags: MockFeatureFlagService
     }
 
     /// Builds the adaptor with a mocked order service, refund service, stores manager, and a fresh
@@ -277,7 +353,7 @@ private extension POSRefundSubmissionAdaptorTests {
         }
 
         let flags = MockFeatureFlagService()
-        flags.isFeatureFlagEnabledReturnValue = [.posRefundsV4: flagEnabled]
+        flags.isFeatureFlagEnabledReturnValue = [.posServerCalculatedRefunds: flagEnabled]
         let previewUseCase = POSServerRefundPreviewUseCase(refundService: service,
                                                            stores: stores,
                                                            featureFlagService: flags,
@@ -295,7 +371,11 @@ private extension POSRefundSubmissionAdaptorTests {
                                                  currencySettings: usdCurrencySettings(),
                                                  analytics: WooAnalytics(analyticsProvider: analyticsProvider),
                                                  serverRefundPreviewUseCase: previewUseCase)
-        return Harness(adaptor: adaptor, service: service, spy: spy, analyticsProvider: analyticsProvider)
+        return Harness(adaptor: adaptor,
+                       service: service,
+                       spy: spy,
+                       analyticsProvider: analyticsProvider,
+                       flags: flags)
     }
 
     func usdCurrencySettings() -> CurrencySettings {

--- a/WooCommerce/WooCommerceTests/POS/POSServerRefundPreviewUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSServerRefundPreviewUseCaseTests.swift
@@ -171,7 +171,7 @@ struct POSServerRefundPreviewUseCaseTests {
         let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
 
         // Then the server flow stays enabled for the session; only `rest_no_route` may disable it.
-        #expect(result == .error)
+        #expect(isError(result))
         #expect(cache.isAvailable(siteID: siteID) == nil)
     }
 
@@ -184,7 +184,7 @@ struct POSServerRefundPreviewUseCaseTests {
         let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
 
         // Then
-        #expect(result == .error)
+        #expect(isError(result))
         #expect(cache.isAvailable(siteID: siteID) == nil)
     }
 
@@ -212,7 +212,7 @@ struct POSServerRefundPreviewUseCaseTests {
         let result = await sut.previewRefund(siteID: siteID, orderID: orderID, lineItems: [lineItem()])
 
         // Then
-        #expect(result == .error)
+        #expect(isError(result))
         #expect(cache.isAvailable(siteID: siteID) == nil)
     }
 }
@@ -233,7 +233,7 @@ private extension POSServerRefundPreviewUseCaseTests {
         let service = MockRefundService()
         service.previewRefundResult = previewResult
         let flags = MockFeatureFlagService()
-        flags.isFeatureFlagEnabledReturnValue = [.posRefundsV4: flagEnabled]
+        flags.isFeatureFlagEnabledReturnValue = [.posServerCalculatedRefunds: flagEnabled]
         let sut = POSServerRefundPreviewUseCase(refundService: service,
                                             stores: stores,
                                             featureFlagService: flags,
@@ -244,6 +244,14 @@ private extension POSServerRefundPreviewUseCaseTests {
 
     func lineItem() -> RefundPreviewLineItem {
         .quantityBased(lineItemID: 10, quantity: 1)
+    }
+
+    /// `.error` carries the underlying error for logging, so match on the case rather than a value.
+    func isError(_ result: POSServerRefundPreviewUseCase.Result) -> Bool {
+        if case .error = result {
+            return true
+        }
+        return false
     }
 
     func preview() -> RefundPreview {


### PR DESCRIPTION
WOOMOB-3748

Follow-ups from the review of #17636. None of these block the WC 11.1.0 rollout; they were deliberately kept out of that PR to keep it focused. Stacked on the error-mapping branch (WOOMOB-3719), which this branch's base points at.

## Description

**Correctness — the reviewed total and the submitted total could differ.** `serverPreviewTotals` was keyed by order id and cleared before awaiting the preview, so nothing tied a stored total to the review actually on screen. With two previews in flight and neither cancelled, the later-resolving one wrote last, and submitting could charge a total the cashier never saw.

The total is now keyed by the selection it was calculated for (`SelectionKey`: order id plus the selected item ids), so display and submission read the same value by construction rather than by careful ordering. A preview for a superseded selection can no longer be read back for a different one, and each selection's stored total is independent.

**Correctness — the defensive branch mixed two math sources.** When `serverLineItems` was set but `refundService` was nil, `submitRefundToSite` fell through to the classic create, whose `amount` is the server preview total while its line items carry locally computed totals — a refund whose recorded total need not equal the sum of its lines. It now fails with `RefundSubmissionUseCaseSubmissionError.missingRefundService` instead of booking money against inconsistent figures. Unreachable today (the POS adaptor always injects the service), but a misconfigured caller should fail loudly.

**Diagnosability.** `POSServerRefundPreviewUseCase.Result.error` discarded the underlying error entirely — no payload, no log — so a deterministic server rejection was indistinguishable from a timeout in a field report. It now carries the error and logs it. `Equatable` is hand-written because `Error` isn't equatable; two failures compare equal, since the payload exists for logging rather than to distinguish states.

**Smaller items.** The preview and computed-create line builders were line-for-line duplicates over two model types differing in one JSON key; they now share one generic builder, so "the create sends exactly what was previewed" holds structurally. Renamed the feature flag to `posServerCalculatedRefunds` now that the endpoints are v3 (build-config only, no persisted or remote key, so the rename is compile-time). `preparedContexts` is pruned alongside the rest of a refund's state instead of accumulating full order contexts for the session. Removed a `ComputedRefundLineItem.encode(to:)` that restated synthesized `Encodable` behaviour.

The `amount` override stays, with a comment explaining why: POS delegates the refund amount to the backend at create time (Interac included), and the parameter mirrors the endpoint's contract for any future caller.

**Tests added:** un-cancelled previews resolving out of order (the regression this pins), and the clearing side of the ghost-refund invariant — a selection previewed successfully, then re-previewed with the server flow unavailable, must not send a computed create.

## Test Steps

1. On a store running WooCommerce 11.1.0+ with the `posServerCalculatedRefunds` flag enabled, issue a POS refund by item selection. The review screen totals come from the server preview, and the created refund shows server-computed amounts in wp-admin.
2. Change the selection on the review step a few times in quick succession, then confirm. The amount charged must match the totals shown for the final selection.
3. On a store below 11.1.0, or with the flag off, the flow falls back to local calculation with no user-visible difference.
4. Trigger a preview failure (for example, point at a store where the route 500s) and confirm the underlying error now appears in the console/logs rather than a bare failure.

Unit coverage: 31 tests across `POSRefundSubmissionMappingTests`, `POSServerRefundPreviewUseCaseTests`, `POSRefundSubmissionAdaptorTests`, and `POSRefundFlowResolverTests`, all green. SwiftLint was not run locally (not installed); CI covers it.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.