### PR TITLE
Prevent A/B test startup from racing user switching

### DIFF
--- a/Modules/Sources/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
+++ b/Modules/Sources/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
@@ -3,8 +3,8 @@ import Foundation
 public final class MockAnalyticsProviderPreview: AnalyticsProvider {
     public init() {}
 
-    public func refreshUserData() {
-        //
+    public func refreshUserData(completion: @escaping () -> Void) {
+        completion()
     }
 
     public func track(_ eventName: String) {

--- a/Modules/Sources/WooFoundation/Protocols/Analytics/AnalyticsProvider.swift
+++ b/Modules/Sources/WooFoundation/Protocols/Analytics/AnalyticsProvider.swift
@@ -7,6 +7,12 @@ public protocol AnalyticsProvider {
     ///
     func refreshUserData()
 
+    /// Refresh the tracking metadata for the current user and notify the caller when the refresh has completed.
+    ///
+    /// Providers that perform the refresh asynchronously should override this method so dependent work does not
+    /// race with a user switch.
+    func refreshUserData(completion: @escaping () -> Void)
+
     /// Track a spcific event without any associated properties
     ///
     /// - Parameter eventName: the event name
@@ -29,4 +35,11 @@ public protocol AnalyticsProvider {
     /// Switch between an authed user and anon user
     ///
     func clearUsers()
+}
+
+public extension AnalyticsProvider {
+    func refreshUserData(completion: @escaping () -> Void) {
+        refreshUserData()
+        completion()
+    }
 }

--- a/Modules/Sources/WooFoundation/Protocols/Analytics/AnalyticsProvider.swift
+++ b/Modules/Sources/WooFoundation/Protocols/Analytics/AnalyticsProvider.swift
@@ -3,14 +3,8 @@
 ///
 public protocol AnalyticsProvider {
 
-    /// Refresh the tracking metadata for the current user
-    ///
-    func refreshUserData()
-
     /// Refresh the tracking metadata for the current user and notify the caller when the refresh has completed.
     ///
-    /// Providers that perform the refresh asynchronously should override this method so dependent work does not
-    /// race with a user switch.
     func refreshUserData(completion: @escaping () -> Void)
 
     /// Track a spcific event without any associated properties
@@ -35,11 +29,4 @@ public protocol AnalyticsProvider {
     /// Switch between an authed user and anon user
     ///
     func clearUsers()
-}
-
-public extension AnalyticsProvider {
-    func refreshUserData(completion: @escaping () -> Void) {
-        refreshUserData()
-        completion()
-    }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockAnalytics.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockAnalytics.swift
@@ -28,7 +28,7 @@ final class MockAnalytics: Analytics {
 
 /// Minimal mock for AnalyticsProvider
 final class MockAnalyticsProvider: AnalyticsProvider {
-    func refreshUserData() {}
+    func refreshUserData(completion: @escaping () -> Void) { completion() }
     func track(_ eventName: String) {}
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {}
     func clearEvents() {}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.3
 -----
+- [Internal] Prevent A/B test startup from racing Tracks user switching. [https://github.com/woocommerce/woocommerce-ios/pull/PENDING]
 - [*] Dashboard: Fixed a crash on the store performance card when a store returns stats with an invalid date. [https://github.com/woocommerce/woocommerce-ios/pull/17628]
 - [Internal] Mitigate a potential navigation crash when opening products from search results. [https://github.com/woocommerce/woocommerce-ios/pull/17645]
 - [Internal] Prevent offline banner updates from overlapping navigation transitions. [https://github.com/woocommerce/woocommerce-ios/pull/17611]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 
 25.3
 -----
-- [Internal] Prevent A/B test startup from racing Tracks user switching. [https://github.com/woocommerce/woocommerce-ios/pull/PENDING]
+- [Internal] Prevent A/B test startup from racing Tracks user switching. [https://github.com/woocommerce/woocommerce-ios/pull/17657]
 - [*] Dashboard: Fixed a crash on the store performance card when a store returns stats with an invalid date. [https://github.com/woocommerce/woocommerce-ios/pull/17628]
 - [Internal] Mitigate a potential navigation crash when opening products from search results. [https://github.com/woocommerce/woocommerce-ios/pull/17645]
 - [Internal] Prevent offline banner updates from overlapping navigation transitions. [https://github.com/woocommerce/woocommerce-ios/pull/17611]

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -79,10 +79,6 @@ extension TracksProvider {
 // MARK: - AnalyticsProvider Conformance
 //
 public extension TracksProvider {
-    func refreshUserData() {
-        refreshUserData(completion: {})
-    }
-
     func refreshUserData(completion: @escaping () -> Void) {
         switchTracksUsersIfNeeded(completion: completion)
         refreshTracksMetadata()

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -80,7 +80,11 @@ extension TracksProvider {
 //
 public extension TracksProvider {
     func refreshUserData() {
-        switchTracksUsersIfNeeded()
+        refreshUserData(completion: {})
+    }
+
+    func refreshUserData(completion: @escaping () -> Void) {
+        switchTracksUsersIfNeeded(completion: completion)
         refreshTracksMetadata()
     }
 
@@ -139,7 +143,7 @@ public extension TracksProvider {
 // MARK: - Private Helpers
 //
 private extension TracksProvider {
-    func switchTracksUsersIfNeeded() {
+    func switchTracksUsersIfNeeded(completion: @escaping () -> Void = {}) {
         let currentAnalyticsUsername = UserDefaults.standard[.analyticsUsername] as? String ?? ""
         let anonymousID = ServiceLocator.stores.sessionManager.anonymousUserID
         if ServiceLocator.stores.isAuthenticated,
@@ -153,6 +157,7 @@ private extension TracksProvider {
                                                            userID: String(account.userID),
                                                            wpComToken: authToken,
                                                            skipAliasEventCreation: false)
+                    completion()
                 }
             } else if currentAnalyticsUsername == account.username {
                 // Username did not change - just make sure Tracks client has it
@@ -161,6 +166,7 @@ private extension TracksProvider {
                                                            userID: String(account.userID),
                                                            wpComToken: authToken,
                                                            skipAliasEventCreation: true)
+                    completion()
                 }
             } else {
                 // Username changed for some reason - switch back to anonymous first
@@ -170,12 +176,14 @@ private extension TracksProvider {
                                                            userID: String(account.userID),
                                                            wpComToken: authToken,
                                                            skipAliasEventCreation: false)
+                    completion()
                 }
             }
         } else {
             UserDefaults.standard[.analyticsUsername] = nil
             Self.TracksServiceExecutor.enqueue { tracksService in
                 tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
+                completion()
             }
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -13,6 +13,8 @@ import WooFoundationCore
 
 final class WooAnalytics: Analytics {
 
+    typealias ABTestStarter = @MainActor (ExperimentContext) async -> Void
+
     // MARK: - Properties
 
     /// AnalyticsProvider: Interface to the actual analytics implementation
@@ -28,6 +30,8 @@ final class WooAnalytics: Analytics {
     /// Defaults database used to persist the analytics opt-in state
     ///
     private let userDefaults: UserDefaults
+
+    private let startABTest: ABTestStarter
 
     /// Check user opt-in for analytics
     ///
@@ -47,9 +51,12 @@ final class WooAnalytics: Analytics {
 
     /// Designated Initializer
     ///
-    init(analyticsProvider: AnalyticsProvider & WPAnalyticsTracker, userDefaults: UserDefaults = .standard) {
+    init(analyticsProvider: AnalyticsProvider & WPAnalyticsTracker,
+         userDefaults: UserDefaults = .standard,
+         startABTest: @escaping ABTestStarter = { await ABTest.start(for: $0) }) {
         self.analyticsProvider = analyticsProvider
         self.userDefaults = userDefaults
+        self.startABTest = startABTest
         WPAnalytics.register(analyticsProvider)
     }
 }
@@ -76,17 +83,20 @@ extension WooAnalytics {
 
         // Skips refreshing user data when user is authenticated without WPCom
         // since they are still identified with anonymous ID.
-        if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
-            analyticsProvider.refreshUserData()
-        }
-
-        // Refreshes A/B experiments since `ExPlat.shared` is reset after each `TracksProvider.refreshUserData` call
-        // and any A/B test assignments that come back after the shared instance is reset won't be saved for later
-        // access.
         let context: ExperimentContext = ServiceLocator.stores.isAuthenticated ?
             .loggedIn: .loggedOut
-        Task { @MainActor in
-            await ABTest.start(for: context)
+
+        let refreshABTests: () -> Void = { [startABTest] in
+            Task { @MainActor in
+                await startABTest(context)
+            }
+        }
+
+        // Refreshes A/B experiments after Tracks finishes switching users because that switch resets `ExPlat.shared`.
+        if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
+            analyticsProvider.refreshUserData(completion: refreshABTests)
+        } else {
+            refreshABTests()
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Analytics/TracksProviderThreadSafetyTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/TracksProviderThreadSafetyTests.swift
@@ -28,4 +28,18 @@ final class TracksProviderThreadSafetyTests: XCTestCase {
         // Then — reaching here without EXC_BAD_ACCESS or NSGenericException means the fix works
         wait(for: [allDone], timeout: 30.0)
     }
+
+    func test_refreshUserData_calls_completion_after_queued_refresh() {
+        // Given
+        let provider = TracksProvider()
+        let refreshCompleted = expectation(description: "Refresh completed")
+
+        // When
+        provider.refreshUserData {
+            refreshCompleted.fulfill()
+        }
+
+        // Then
+        wait(for: [refreshCompleted], timeout: 5.0)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Analytics/TracksProviderThreadSafetyTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/TracksProviderThreadSafetyTests.swift
@@ -20,8 +20,9 @@ final class TracksProviderThreadSafetyTests: XCTestCase {
                 allDone.fulfill()
             }
             DispatchQueue.global().async {
-                provider.refreshUserData()
-                allDone.fulfill()
+                provider.refreshUserData {
+                    allDone.fulfill()
+                }
             }
         }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -24,6 +24,8 @@ public class MockAnalyticsProvider: NSObject, AnalyticsProvider, WPAnalyticsTrac
 
     var userID: String?
     var userOptedIn = true
+    var defersRefreshUserDataCompletion = false
+    private var refreshUserDataCompletion: (() -> Void)?
 }
 
 // MARK: - AnalyticsProvider Conformance
@@ -32,6 +34,20 @@ public extension MockAnalyticsProvider {
 
     func refreshUserData() {
         userID = "aGeneratedUserGUID"
+    }
+
+    func refreshUserData(completion: @escaping () -> Void) {
+        refreshUserData()
+        if defersRefreshUserDataCompletion {
+            refreshUserDataCompletion = completion
+        } else {
+            completion()
+        }
+    }
+
+    func completeRefreshUserData() {
+        refreshUserDataCompletion?()
+        refreshUserDataCompletion = nil
     }
 
     func track(_ eventName: String) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -25,6 +25,7 @@ public class MockAnalyticsProvider: NSObject, AnalyticsProvider, WPAnalyticsTrac
     var userID: String?
     var userOptedIn = true
     var defersRefreshUserDataCompletion = false
+    private(set) var refreshUserDataCallCount = 0
     private var refreshUserDataCompletion: (() -> Void)?
 }
 
@@ -33,6 +34,7 @@ public class MockAnalyticsProvider: NSObject, AnalyticsProvider, WPAnalyticsTrac
 public extension MockAnalyticsProvider {
 
     func refreshUserData(completion: @escaping () -> Void) {
+        refreshUserDataCallCount += 1
         userID = "aGeneratedUserGUID"
         if defersRefreshUserDataCompletion {
             refreshUserDataCompletion = completion

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -32,12 +32,8 @@ public class MockAnalyticsProvider: NSObject, AnalyticsProvider, WPAnalyticsTrac
 //
 public extension MockAnalyticsProvider {
 
-    func refreshUserData() {
-        userID = "aGeneratedUserGUID"
-    }
-
     func refreshUserData(completion: @escaping () -> Void) {
-        refreshUserData()
+        userID = "aGeneratedUserGUID"
         if defersRefreshUserDataCompletion {
             refreshUserDataCompletion = completion
         } else {

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -1,4 +1,5 @@
 import EventHorizonSDK
+import Experiments
 import XCTest
 @testable import WooCommerce
 @testable import Yosemite
@@ -171,6 +172,34 @@ class WooAnalyticsTests: XCTestCase {
     func testClearAllEvents() {
         testingProvider?.clearEvents()
         XCTAssertEqual(testingProvider?.receivedEvents.count, 0)
+    }
+
+    @MainActor
+    func test_refreshUserData_starts_AB_tests_after_provider_refresh_completes() async {
+        // Given
+        guard let testingProvider else {
+            return XCTFail("Testing provider not available")
+        }
+        testingProvider.defersRefreshUserDataCompletion = true
+        let abTestStarted = expectation(description: "A/B test started")
+        var startedContexts: [ExperimentContext] = []
+        analytics = WooAnalytics(analyticsProvider: testingProvider,
+                                 userDefaults: userDefaults,
+                                 startABTest: { context in
+            startedContexts.append(context)
+            abTestStarted.fulfill()
+        })
+
+        // When
+        analytics.refreshUserData()
+        await Task.yield()
+
+        // Then
+        XCTAssertTrue(startedContexts.isEmpty)
+
+        testingProvider.completeRefreshUserData()
+        await fulfillment(of: [abTestStarted], timeout: 1.0)
+        XCTAssertEqual(startedContexts, [.loggedOut])
     }
 
     func test_events_when_logged_in_include_site_properties() {

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -202,6 +202,32 @@ class WooAnalyticsTests: XCTestCase {
         XCTAssertEqual(startedContexts, [.loggedOut])
     }
 
+    @MainActor
+    func test_refreshUserData_when_authenticated_without_WPCom_then_starts_AB_tests_without_refreshing_provider() async {
+        // Given
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        ServiceLocator.setStores(stores)
+
+        let provider = MockAnalyticsProvider()
+        provider.defersRefreshUserDataCompletion = true
+        let abTestStarted = expectation(description: "A/B test started")
+        var startedContexts: [ExperimentContext] = []
+        analytics = WooAnalytics(analyticsProvider: provider,
+                                 userDefaults: userDefaults,
+                                 startABTest: { context in
+            startedContexts.append(context)
+            abTestStarted.fulfill()
+        })
+
+        // When
+        analytics.refreshUserData()
+
+        // Then
+        await fulfillment(of: [abTestStarted], timeout: 1.0)
+        XCTAssertEqual(startedContexts, [.loggedIn])
+        XCTAssertEqual(provider.refreshUserDataCallCount, 0)
+    }
+
     func test_events_when_logged_in_include_site_properties() {
         // Given
         guard let testingProvider else {

--- a/WooCommerce/WooCommerceTests/Universal Links/Routes/ReportsRouteTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/Routes/ReportsRouteTests.swift
@@ -224,7 +224,7 @@ private final class SpyAnalytics: Analytics {
 }
 
 private final class SpyAnalyticsProvider: AnalyticsProvider {
-    func refreshUserData() {}
+    func refreshUserData(completion: @escaping () -> Void) { completion() }
     func track(_ eventName: String) {}
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {}
     func clearEvents() {}


### PR DESCRIPTION
Closes: WOOMOB-3762

## Description
This PR speculatively fixes a crash on launch.

`WooAnalytics.refreshUserData()` started A/B experiments immediately after asking Tracks to refresh its user data. During a user switch, Tracks could reset `ExPlat.shared`, giving two lots of experiment registration during app launch.

This waits for the Tracks user switch before starting A/B experiments.

## Test Steps

I couldn't repro the crash. Check that the app launches, unit tests pass on CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
