### PR TITLE
[Woo POS] Server-calculated refunds 1/4: rename posRefundsV4 to posServerCalculatedRefunds

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -103,7 +103,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .starReceiptPrinterSupport:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .posRefundsV4:
+        case .posServerCalculatedRefunds:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -244,5 +244,8 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case starReceiptPrinterSupport
 
-    case posRefundsV4
+    /// Enables server-calculated POS refunds: the `/wc/v3` refund preview and `compute_totals`
+    /// create endpoints (WC 11.1.0+).
+    ///
+    case posServerCalculatedRefunds
 }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSV4RefundPreviewUseCase.swift
@@ -34,7 +34,7 @@ final class POSV4RefundPreviewUseCase {
 
     func previewRefund(siteID: Int64, orderID: Int64, lineItems: [RefundV4LineItem]) async -> Result {
         let cachedAvailability = availabilityCache.isV4Available(siteID: siteID)
-        guard featureFlagService.isFeatureFlagEnabled(.posRefundsV4),
+        guard featureFlagService.isFeatureFlagEnabled(.posServerCalculatedRefunds),
               lineItems.isNotEmpty,
               cachedAvailability != false,
               cachedAvailability == true || !isWooVersionBelowV4Support() else {

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
@@ -236,7 +236,7 @@ private extension POSRefundSubmissionAdaptorTests {
         }
 
         let flags = MockFeatureFlagService()
-        flags.isFeatureFlagEnabledReturnValue = [.posRefundsV4: flagEnabled]
+        flags.isFeatureFlagEnabledReturnValue = [.posServerCalculatedRefunds: flagEnabled]
         let previewUseCase = POSV4RefundPreviewUseCase(refundService: service,
                                                        stores: stores,
                                                        featureFlagService: flags,

--- a/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSV4RefundPreviewUseCaseTests.swift
@@ -201,7 +201,7 @@ private extension POSV4RefundPreviewUseCaseTests {
         let service = MockRefundService()
         service.previewRefundResult = previewResult
         let flags = MockFeatureFlagService()
-        flags.isFeatureFlagEnabledReturnValue = [.posRefundsV4: flagEnabled]
+        flags.isFeatureFlagEnabledReturnValue = [.posServerCalculatedRefunds: flagEnabled]
         let sut = POSV4RefundPreviewUseCase(refundService: service,
                                             stores: stores,
                                             featureFlagService: flags,


### PR DESCRIPTION
Part of: WOOMOB-3717 (split of #17636 per review; folds the flag rename from #17651 / WOOMOB-3748)

## Stack

- **#17664 1/4 feature flag rename (this PR)**
- #17665 2/4 wc/v3 networking layer
- #17666 3/4 flow resolver and availability cache
- #17667 4/4 flow switch and v4 removal
- #17637 error mapping (stacked on top)

Each part is based on the previous one; review and merge in order.

## Description
First part of splitting #17636 into independently reviewable chunks (feature flag, networking, eligibility, flow switch). The flag gates the POS server-calculated refund flow, which moves from the experimental wc/v4 endpoints to wc/v3 (WooCommerce 11.1.0) in parts 2 to 4. The name now describes the capability rather than the API version. Mechanical rename, no behavior change: the flag still gates the v4 flow until part 4 lands the switch.

## Test Steps
Rename only, covered by the existing unit suites that reference the flag (POSRefundSubmissionAdaptorTests, POSV4RefundPreviewUseCaseTests). No user-visible behavior changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
