### PR TITLE
POS Phones: Stack setup buttons vertically

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
@@ -109,7 +109,7 @@ struct POSBarcodeScannerSetup: View {
     @ViewBuilder
     private var flowButtons: some View {
         if flowManager.buttonConfiguration.primaryButton != nil || flowManager.buttonConfiguration.secondaryButton != nil {
-            PointOfSaleFlowButtonsView(configuration: flowManager.buttonConfiguration)
+            POSFlowButtonsView(configuration: flowManager.buttonConfiguration)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
@@ -29,22 +29,30 @@ struct PointOfSaleFlowButtonsView: View {
     @ViewBuilder
     private var primaryButton: some View {
         if let primaryButton = configuration.primaryButton {
-            Button(primaryButton.title) {
-                primaryButton.action()
-            }
-            .buttonStyle(POSFilledButtonStyle(size: .normal))
-            .disabled(!primaryButton.isEnabled)
+            button(for: primaryButton)
+                .buttonStyle(POSFilledButtonStyle(size: .normal))
         }
     }
 
     @ViewBuilder
     private var secondaryButton: some View {
         if let secondaryButton = configuration.secondaryButton {
-            Button(secondaryButton.title) {
-                secondaryButton.action()
-            }
-            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-            .disabled(!secondaryButton.isEnabled)
+            button(for: secondaryButton)
+                .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        }
+    }
+
+    @ViewBuilder
+    private func button(for config: PointOfSaleFlowButtonConfiguration.ButtonConfig) -> some View {
+        let button = Button(config.title) {
+            config.action()
+        }
+        .disabled(!config.isEnabled)
+
+        if let accessibilityIdentifier = config.accessibilityIdentifier {
+            button.accessibilityIdentifier(accessibilityIdentifier)
+        } else {
+            button
         }
     }
 }
@@ -57,15 +65,18 @@ struct PointOfSaleFlowButtonConfiguration {
     struct ButtonConfig {
         let title: String
         let isEnabled: Bool
+        let accessibilityIdentifier: String?
         let action: () -> Void
 
         init(
             title: String,
             isEnabled: Bool = true,
+            accessibilityIdentifier: String? = nil,
             action: @escaping () -> Void,
         ) {
             self.title = title
             self.isEnabled = isEnabled
+            self.accessibilityIdentifier = accessibilityIdentifier
             self.action = action
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
@@ -1,27 +1,51 @@
 import SwiftUI
 
 struct PointOfSaleFlowButtonsView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     let configuration: PointOfSaleFlowButtonConfiguration
 
-    var body: some View {
-        HStack(spacing: POSSpacing.medium) {
-            if let secondaryButton = configuration.secondaryButton {
-                Button(secondaryButton.title) {
-                    secondaryButton.action()
-                }
-                .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-                .disabled(!secondaryButton.isEnabled)
-            }
+    static func usesStackedLayout(horizontalSizeClass: UserInterfaceSizeClass?) -> Bool {
+        horizontalSizeClass == .compact
+    }
 
-            if let primaryButton = configuration.primaryButton {
-                Button(primaryButton.title) {
-                    primaryButton.action()
+    var body: some View {
+        Group {
+            if Self.usesStackedLayout(horizontalSizeClass: horizontalSizeClass) {
+                VStack(spacing: POSSpacing.medium) {
+                    primaryButton
+                    secondaryButton
                 }
-                .buttonStyle(POSFilledButtonStyle(size: .normal))
-                .disabled(!primaryButton.isEnabled)
+            } else {
+                HStack(spacing: POSSpacing.medium) {
+                    secondaryButton
+                    primaryButton
+                }
             }
         }
         .geometryGroup()
+    }
+
+    @ViewBuilder
+    private var primaryButton: some View {
+        if let primaryButton = configuration.primaryButton {
+            Button(primaryButton.title) {
+                primaryButton.action()
+            }
+            .buttonStyle(POSFilledButtonStyle(size: .normal))
+            .disabled(!primaryButton.isEnabled)
+        }
+    }
+
+    @ViewBuilder
+    private var secondaryButton: some View {
+        if let secondaryButton = configuration.secondaryButton {
+            Button(secondaryButton.title) {
+                secondaryButton.action()
+            }
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .disabled(!secondaryButton.isEnabled)
+        }
     }
 }
 
@@ -51,3 +75,42 @@ struct PointOfSaleFlowButtonConfiguration {
         .init(primaryButton: nil, secondaryButton: nil)
     }
 }
+
+#if DEBUG
+
+private extension PointOfSaleFlowButtonConfiguration {
+    static func preview(primary: String? = "Next", secondary: String? = "Back") -> PointOfSaleFlowButtonConfiguration {
+        .init(
+            primaryButton: primary.map { .init(title: $0, action: {}) },
+            secondaryButton: secondary.map { .init(title: $0, action: {}) }
+        )
+    }
+}
+
+#Preview("Compact — stacked") {
+    VStack(spacing: POSSpacing.xLarge) {
+        PointOfSaleFlowButtonsView(configuration: .preview())
+        PointOfSaleFlowButtonsView(configuration: .preview(secondary: nil))
+        PointOfSaleFlowButtonsView(configuration: .preview(primary: nil))
+        PointOfSaleFlowButtonsView(configuration: .preview(primary: "Weiter zur Einrichtung",
+                                                           secondary: "Zurück zur Auswahl"))
+    }
+    .padding(POSPadding.xLarge)
+    .background(Color.posSurfaceBright)
+    .environment(\.horizontalSizeClass, .compact)
+}
+
+#Preview("Regular — side by side") {
+    VStack(spacing: POSSpacing.xLarge) {
+        PointOfSaleFlowButtonsView(configuration: .preview())
+        PointOfSaleFlowButtonsView(configuration: .preview(secondary: nil))
+        PointOfSaleFlowButtonsView(configuration: .preview(primary: nil))
+        PointOfSaleFlowButtonsView(configuration: .preview(primary: "Weiter zur Einrichtung",
+                                                           secondary: "Zurück zur Auswahl"))
+    }
+    .padding(POSPadding.xLarge)
+    .background(Color.posSurfaceBright)
+    .environment(\.horizontalSizeClass, .regular)
+}
+
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
@@ -22,7 +22,8 @@ struct PointOfSaleExitPosAlertView: View {
     private var regularBody: some View {
         VStack(spacing: Constants.verticalSpacing) {
             regularCloseButton
-            content
+            messageContent
+            buttons
         }
         .padding(Constants.padding)
     }
@@ -33,9 +34,11 @@ struct PointOfSaleExitPosAlertView: View {
 
             Spacer(minLength: POSSpacing.none)
 
-            content
+            messageContent
 
             Spacer(minLength: POSSpacing.none)
+
+            buttons
         }
         .padding(POSPadding.xLarge)
         .background(Color.posSurfaceBright)
@@ -53,13 +56,12 @@ struct PointOfSaleExitPosAlertView: View {
     private func closeButton(fontStyle: POSFontStyle) -> some View {
         POSModalCloseButton(accessibilityLabel: Localization.closeButtonAccessibilityLabel,
                             accessibilityIdentifier: "pos-exit-modal-close-button",
-                            fontStyle: fontStyle,
-                            foregroundColor: Color.posOnSurfaceVariantLowest) {
+                            fontStyle: fontStyle) {
             isPresented = false
         }
     }
 
-    private var content: some View {
+    private var messageContent: some View {
         VStack(spacing: Constants.verticalSpacing) {
             Text(Localization.exitTitle)
                 .font(.posHeadingBold)
@@ -67,15 +69,33 @@ struct PointOfSaleExitPosAlertView: View {
             Text(Localization.exitBody)
                 .font(.posBodyLargeRegular())
                 .foregroundColor(Color.posOnSurface)
-            Button {
-                analytics.track(.pointOfSaleExitConfirmed)
-                dismiss()
-            } label: {
-                Text(Localization.exitButton)
-            }
-            .accessibilityIdentifier("pos-exit-confirm-button")
-            .buttonStyle(POSFilledButtonStyle(size: .normal))
         }
+    }
+
+    private var buttons: some View {
+        PointOfSaleFlowButtonsView(
+            configuration: .init(
+                primaryButton: .init(title: Localization.exitButton,
+                                     accessibilityIdentifier: "pos-exit-confirm-button",
+                                     action: {
+                                         analytics.track(.pointOfSaleExitConfirmed)
+                                         dismiss()
+                                     }),
+                secondaryButton: backButtonConfig
+            )
+        )
+    }
+
+    /// Regular width keeps the single-button modal, where the close button in the corner is the way out.
+    private var backButtonConfig: PointOfSaleFlowButtonConfiguration.ButtonConfig? {
+        guard horizontalSizeClass == .compact else {
+            return nil
+        }
+        return .init(title: Localization.backButton,
+                     accessibilityIdentifier: "pos-exit-back-button",
+                     action: {
+                         isPresented = false
+                     })
     }
 }
 
@@ -101,6 +121,11 @@ private extension PointOfSaleExitPosAlertView {
             value: "Exit",
             comment: "Button text of the exit Point of Sale modal alert"
         )
+        static let backButton = NSLocalizedString(
+            "pos.exitPOSModal.backButton",
+            value: "Back",
+            comment: "Button on the exit Point of Sale modal that dismisses it and returns to Point of Sale."
+        )
         static let closeButtonAccessibilityLabel = NSLocalizedString(
             "pos.exitPOSModal.closeButton.accessibilityLabel",
             value: "Close",
@@ -110,7 +135,13 @@ private extension PointOfSaleExitPosAlertView {
 }
 
 #if DEBUG
-#Preview {
+#Preview("Compact") {
     PointOfSaleExitPosAlertView(isPresented: .constant(true))
+        .environment(\.horizontalSizeClass, .compact)
+}
+
+#Preview("Regular") {
+    PointOfSaleExitPosAlertView(isPresented: .constant(true))
+        .environment(\.horizontalSizeClass, .regular)
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
@@ -73,7 +73,7 @@ struct PointOfSaleExitPosAlertView: View {
     }
 
     private var buttons: some View {
-        PointOfSaleFlowButtonsView(
+        POSFlowButtonsView(
             configuration: .init(
                 primaryButton: .init(title: Localization.exitButton,
                                      accessibilityIdentifier: "pos-exit-confirm-button",

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
@@ -11,8 +11,12 @@ struct PointOfSaleExitPosAlertView: View {
         self._isPresented = isPresented
     }
 
+    private var isCompactWidth: Bool {
+        horizontalSizeClass == .compact
+    }
+
     var body: some View {
-        if horizontalSizeClass == .compact {
+        if isCompactWidth {
             compactBody
         } else {
             regularBody
@@ -63,12 +67,18 @@ struct PointOfSaleExitPosAlertView: View {
 
     private var messageContent: some View {
         VStack(spacing: Constants.verticalSpacing) {
-            Text(Localization.exitTitle)
-                .font(.posHeadingBold)
-                .foregroundColor(Color.posOnSurface)
-            Text(Localization.exitBody)
-                .font(.posBodyLargeRegular())
-                .foregroundColor(Color.posOnSurface)
+            if isCompactWidth {
+                POSErrorXMark(color: .posPrimary)
+            }
+
+            VStack(spacing: isCompactWidth ? Constants.compactTitleSpacing : Constants.verticalSpacing) {
+                Text(Localization.exitTitle)
+                    .font(.posHeadingBold)
+                    .foregroundColor(Color.posOnSurface)
+                Text(Localization.exitBody)
+                    .font(.posBodyLargeRegular())
+                    .foregroundColor(Color.posOnSurface)
+            }
         }
     }
 
@@ -81,18 +91,18 @@ struct PointOfSaleExitPosAlertView: View {
                                          analytics.track(.pointOfSaleExitConfirmed)
                                          dismiss()
                                      }),
-                secondaryButton: backButtonConfig
+                secondaryButton: cancelButtonConfig
             )
         )
     }
 
     /// Regular width keeps the single-button modal, where the close button in the corner is the way out.
-    private var backButtonConfig: PointOfSaleFlowButtonConfiguration.ButtonConfig? {
-        guard horizontalSizeClass == .compact else {
+    private var cancelButtonConfig: PointOfSaleFlowButtonConfiguration.ButtonConfig? {
+        guard isCompactWidth else {
             return nil
         }
-        return .init(title: Localization.backButton,
-                     accessibilityIdentifier: "pos-exit-back-button",
+        return .init(title: Localization.cancelButton,
+                     accessibilityIdentifier: "pos-exit-cancel-button",
                      action: {
                          isPresented = false
                      })
@@ -102,6 +112,7 @@ struct PointOfSaleExitPosAlertView: View {
 private extension PointOfSaleExitPosAlertView {
     enum Constants {
         static let verticalSpacing: CGFloat = POSSpacing.xLarge
+        static let compactTitleSpacing: CGFloat = POSSpacing.small
         static let padding: CGFloat = POSPadding.medium
     }
 
@@ -121,10 +132,10 @@ private extension PointOfSaleExitPosAlertView {
             value: "Exit",
             comment: "Button text of the exit Point of Sale modal alert"
         )
-        static let backButton = NSLocalizedString(
-            "pos.exitPOSModal.backButton",
-            value: "Back",
-            comment: "Button on the exit Point of Sale modal that dismisses it and returns to Point of Sale."
+        static let cancelButton = NSLocalizedString(
+            "pos.exitPOSModal.cancelButton",
+            value: "Cancel",
+            comment: "Button on the exit Point of Sale modal that dismisses it without exiting Point of Sale."
         )
         static let closeButtonAccessibilityLabel = NSLocalizedString(
             "pos.exitPOSModal.closeButton.accessibilityLabel",

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSErrorXMark.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSErrorXMark.swift
@@ -4,8 +4,11 @@ struct POSErrorXMark: View {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
     private let size: POSErrorAndAlertIconSize
-    init(size: POSErrorAndAlertIconSize = .large) {
+    private let color: Color
+
+    init(size: POSErrorAndAlertIconSize = .large, color: Color = .posAlert) {
         self.size = size
+        self.color = color
     }
 
     var body: some View {
@@ -14,7 +17,7 @@ struct POSErrorXMark: View {
             .aspectRatio(contentMode: .fit)
             .frame(maxHeight: size.dimension)
             .font(.system(size: size.dimension))
-            .foregroundStyle(Color.posAlert)
+            .foregroundStyle(color)
             .accessibilityHidden(true)
             .renderedIf(!dynamicTypeSize.isAccessibilitySize)
     }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSFlowButtonsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSFlowButtonsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct PointOfSaleFlowButtonsView: View {
+struct POSFlowButtonsView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     let configuration: PointOfSaleFlowButtonConfiguration
@@ -100,10 +100,10 @@ private extension PointOfSaleFlowButtonConfiguration {
 
 #Preview("Compact — stacked") {
     VStack(spacing: POSSpacing.xLarge) {
-        PointOfSaleFlowButtonsView(configuration: .preview())
-        PointOfSaleFlowButtonsView(configuration: .preview(secondary: nil))
-        PointOfSaleFlowButtonsView(configuration: .preview(primary: nil))
-        PointOfSaleFlowButtonsView(configuration: .preview(primary: "Weiter zur Einrichtung",
+        POSFlowButtonsView(configuration: .preview())
+        POSFlowButtonsView(configuration: .preview(secondary: nil))
+        POSFlowButtonsView(configuration: .preview(primary: nil))
+        POSFlowButtonsView(configuration: .preview(primary: "Weiter zur Einrichtung",
                                                            secondary: "Zurück zur Auswahl"))
     }
     .padding(POSPadding.xLarge)
@@ -113,10 +113,10 @@ private extension PointOfSaleFlowButtonConfiguration {
 
 #Preview("Regular — side by side") {
     VStack(spacing: POSSpacing.xLarge) {
-        PointOfSaleFlowButtonsView(configuration: .preview())
-        PointOfSaleFlowButtonsView(configuration: .preview(secondary: nil))
-        PointOfSaleFlowButtonsView(configuration: .preview(primary: nil))
-        PointOfSaleFlowButtonsView(configuration: .preview(primary: "Weiter zur Einrichtung",
+        POSFlowButtonsView(configuration: .preview())
+        POSFlowButtonsView(configuration: .preview(secondary: nil))
+        POSFlowButtonsView(configuration: .preview(primary: nil))
+        POSFlowButtonsView(configuration: .preview(primary: "Weiter zur Einrichtung",
                                                            secondary: "Zurück zur Auswahl"))
     }
     .padding(POSPadding.xLarge)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSPrinterSetupModal.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSPrinterSetupModal.swift
@@ -330,12 +330,23 @@ private extension POSPrinterSetupModal {
             return .init(primaryButton: .init(title: Localization.settingsButton, action: {
                 openDeviceSettings()
             }),
-                         secondaryButton: nil)
+                         secondaryButton: cancelButton)
         }
         return .init(primaryButton: .init(title: primaryTitle, action: {
             controller.startDiscovery()
         }),
-                     secondaryButton: nil)
+                     secondaryButton: cancelButton)
+    }
+
+    /// Compact width pairs the primary action with a stacked Cancel. Regular width keeps the
+    /// single-button modal, where the close button in the corner is the way out.
+    var cancelButton: PointOfSaleFlowButtonConfiguration.ButtonConfig? {
+        guard isCompactWidth else {
+            return nil
+        }
+        return .init(title: Localization.cancelButton, action: {
+            isPresented = false
+        })
     }
 
     func openDeviceSettings() {

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSPrinterSetupModal.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSPrinterSetupModal.swift
@@ -64,7 +64,7 @@ struct POSPrinterSetupModal: View {
             .scrollBounceBehavior(.basedOnSize, axes: [.vertical])
 
             if let buttonConfiguration {
-                PointOfSaleFlowButtonsView(configuration: buttonConfiguration)
+                POSFlowButtonsView(configuration: buttonConfiguration)
             }
         }
         .posModalCloseButton(action: {

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSFlowButtonsViewTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSFlowButtonsViewTests.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import Testing
+@testable import PointOfSale
+
+struct POSFlowButtonsViewTests {
+    @Test func test_usesStackedLayout_when_horizontalSizeClass_is_compact_then_returns_true() {
+        // Given
+        let sizeClass: UserInterfaceSizeClass = .compact
+
+        // When
+        let result = POSFlowButtonsView.usesStackedLayout(horizontalSizeClass: sizeClass)
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func test_usesStackedLayout_when_horizontalSizeClass_is_regular_then_returns_false() {
+        // Given
+        let sizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = POSFlowButtonsView.usesStackedLayout(horizontalSizeClass: sizeClass)
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func test_usesStackedLayout_when_horizontalSizeClass_is_nil_then_returns_false() {
+        // Given
+        let sizeClass: UserInterfaceSizeClass? = nil
+
+        // When
+        let result = POSFlowButtonsView.usesStackedLayout(horizontalSizeClass: sizeClass)
+
+        // Then
+        #expect(result == false)
+    }
+}


### PR DESCRIPTION
Closes WOOMOB-3485

## Description
Addresses one of the items from Phone POS UX quick wins: pdfdoF-9eM-p2 by making the flow setup buttons vertically stackable. 

Changes are Phone POS only, I left iPad views untouched. This PR touches 3 screens:

| Scanner setup | Printer setup | Exit POS |
|--------|--------|--------|
| <img width="585" height="1266" alt="IMG_2921" src="https://github.com/user-attachments/assets/4d6e789b-7b07-4caa-9fd3-d9590e8099a5" /> | <img width="585" height="1266" alt="IMG_2923" src="https://github.com/user-attachments/assets/3d9a50b6-c2a0-4f31-8961-fe942906b71b" /> | <img width="585" height="1266" alt="My Store 3" src="https://github.com/user-attachments/assets/ed0f341a-853a-47c1-a931-96c4724a3b99" /> | 

I've also updated the close `x` button in exit pos color to be consistent with the rest and added the xmark image as requested by Rubens here pdfdoF-9eM#comment-10751-p2. 

I tried to modify its position as well  so isn't as closer to the iPhone's battery icon but I'll leave this for a separate PR, as touches more views and needs separate testing.

## Test Steps
- In phone POS navigate to settings > Hardware. Observe previous buttons stacked horizontally are now vertical, and printer has a new "cancel" button stacked as well
- Exit POS, see the new back button  and xmark illustration. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




