### PR TITLE
Prevent iOS 26 product detail navigation crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.4
 -----
+- [*] Products: Fixed a crash when returning from product details on iOS 26. [https://github.com/woocommerce/woocommerce-ios/pull/17671]
 - [Internal] POS: Phone POS is now available on US stores for Automattic accounts behind the woo_pos_phone_us remote feature flag. [https://github.com/woocommerce/woocommerce-ios/pull/17663]
 - [*] Fixed magic link login not navigating to the store dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/17622]
 - [*] Login: Fixed stores failing to load when hosting blocks one of the WordPress REST API URL formats. [https://github.com/woocommerce/woocommerce-ios/pull/17602]

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -307,6 +307,21 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         super.viewWillDisappear(animated)
 
         finishBulkEditing()
+
+        // On iOS 26, keeping the native refresh control attached during a navigation transition can cause
+        // UINavigationController's refresh control host and content overlay updates to recursively trigger each other.
+        // Detach it while this screen is covered, then restore it once the products list is fully visible again.
+        if #available(iOS 26.0, *) {
+            uninstallRefreshControl()
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if #available(iOS 26.0, *) {
+            installRefreshControl()
+        }
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
Closes: WOOMOB-3706

## Description
This is a speculative crash fix — I wasn't able to reproduce the issue.

The theory is that on iOS 26, navigating between the Products list and Product Detail can recursively alternate between UIRefreshControl layout updates, navigation-bar overlay updates, and table-view safe-area updates until the app overflows its stack.

To break the recursion we are trying to remove the refresh control when the list is invisible, and restore it after the list is fully visible again. The workaround is limited to iOS 26.

## Test Steps
1. On an iOS 26 device or simulator, open the Products tab.
2. Pull to refresh and confirm the native refresh presentation still works.
3. Open a product, then return using the Products back button. Repeat the transition.
4. Open another product and return with the interactive swipe-back gesture.
5. Confirm the Products list remains usable and the app does not crash.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.