### PR TITLE
Add on-demand TestFlight build button on trunk

### DIFF
--- a/.buildkite/commands/testflight-build.sh
+++ b/.buildkite/commands/testflight-build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+"$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh"
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Building"
+bundle exec fastlane build_and_upload_testflight_build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,6 +42,26 @@ steps:
               context: Prototype Build
 
   #################
+  # Create TestFlight Build
+  #################
+  - group: ":testflight: TestFlight Build"
+    # On-demand only, and only on `trunk`: unlike a Prototype Build, this uploads to App Store
+    # Connect, so every build consumes a build code and shows up to the internal testers.
+    steps:
+      - input: Create TestFlight Build?
+        prompt: Build and upload to TestFlight for internal testers?
+        key: testflight_build_triggered
+        if: build.branch == "trunk"
+      - label: ":testflight: TestFlight Build"
+        depends_on: testflight_build_triggered
+        if: build.branch == "trunk"
+        command: .buildkite/commands/testflight-build.sh
+        plugins: [$CI_TOOLKIT]
+        notify:
+          - github_commit_status:
+              context: TestFlight Build
+
+  #################
   # Run Unit Tests
   #################
   - label: ":microscope: Unit Tests"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,6 +12,7 @@ fastlane_require 'xcodeproj'
 
 require_relative 'helpers/release_notes_pr_helper'
 require_relative 'helpers/release_notes_ai_helper'
+require_relative 'helpers/testflight_build_helper'
 
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
@@ -925,7 +926,7 @@ platform :ios do
   end
 
   desc 'Builds for distribution to the App Store'
-  lane :build_for_app_store_connect do |fetch_code_signing: true|
+  lane :build_for_app_store_connect do |fetch_code_signing: true, build_code: nil|
     update_certs_and_profiles_app_store if fetch_code_signing
 
     gym(
@@ -933,7 +934,58 @@ platform :ios do
       workspace: WORKSPACE_PATH,
       clean: true,
       export_team_id: APP_STORE_TEAM_ID,
+      # With no `build_code`, the value from `Version.Public.xcconfig` is used as-is.
+      xcargs: build_code.nil? ? nil : { BUILD_CODE_KEY => build_code },
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
+    )
+  end
+
+  # Builds the app and uploads it to TestFlight for internal testers.
+  #
+  # Meant to be triggered on demand from `trunk`, so a branch can be tested in a release-shaped
+  # build without waiting for the release cadence.
+  #
+  # The marketing version (`VERSION_SHORT`) is used as-is; only the build code is stamped — see
+  # `TestFlightBuildHelper.build_code`.
+  #
+  # Known gap: when `trunk`'s `VERSION_SHORT` names a version whose TestFlight train is already
+  # closed on App Store Connect, Apple rejects the upload. Pre-allocating the trunk version after
+  # each code freeze is the fix — see wordpress-mobile/WordPress-iOS#25876.
+  #
+  # @called_by CI
+  #
+  lane :build_and_upload_testflight_build do
+    # Fail before any code signing work if the build code can't be computed.
+    build_code = TestFlightBuildHelper.build_code(
+      release_version: release_version_current,
+      buildkite_build_number: ENV.fetch('BUILDKITE_BUILD_NUMBER', nil)
+    )
+
+    ensure_sentry_installed
+    xcversion # Ensure we're using the right version of Xcode, defined in `.xcode-version` file
+
+    UI.important("Building #{release_version_current} (#{build_code}) for internal TestFlight distribution")
+
+    build_for_app_store_connect(build_code: build_code)
+
+    upload_to_testflight(
+      api_key: app_store_connect_api_key,
+      changelog: TestFlightBuildHelper.changelog(
+        branch: ENV.fetch('BUILDKITE_BRANCH', nil),
+        commit: ENV.fetch('BUILDKITE_COMMIT', nil)
+      ),
+      distribute_external: false,
+      notify_external_testers: false,
+      # These builds don't go through beta review, and must not disturb a release build waiting on it.
+      submit_beta_review: false,
+      reject_build_waiting_for_review: false
+    )
+
+    sentry_debug_files_upload(
+      auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
+      org_slug: 'a8c',
+      project_slug: 'woocommerce-ios',
+      path: [File.join(PROJECT_ROOT_FOLDER, 'WooCommerce.app.dSYM.zip')]
     )
   end
 

--- a/fastlane/helpers/testflight_build_helper.rb
+++ b/fastlane/helpers/testflight_build_helper.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Pure-Ruby helpers for the on-demand TestFlight build lane,
+# `build_and_upload_testflight_build`.
+#
+# Deliberately free of Fastlane dependencies so the build-code and changelog
+# rules can be exercised by unit tests without the Fastlane runtime: the caller
+# passes the Buildkite environment in.
+module TestFlightBuildHelper
+  # Raised when the lane runs somewhere that isn't a Buildkite job, where there
+  # is no build number to derive a unique build code from.
+  class MissingBuildNumberError < StandardError; end
+
+  module_function
+
+  # Number of parts in a WooCommerce iOS build code, e.g. `25.3.0.4567`.
+  BUILD_CODE_PARTS = 4
+
+  # Build code for an on-demand TestFlight build: the release version zero-padded to
+  # `BUILD_CODE_PARTS - 1` parts, with the Buildkite build number as the last part.
+  #
+  # Buildkite build numbers increase monotonically, so each build for a given release version gets
+  # a unique, higher build code — which is all App Store Connect requires.
+  #
+  # @param release_version [String] the marketing version, e.g. `25.3` or `25.3.1` for a hotfix
+  # @param buildkite_build_number [String, nil] the value of `$BUILDKITE_BUILD_NUMBER`
+  #
+  # @raise [MissingBuildNumberError] when the build number is missing or blank
+  #
+  def build_code(release_version:, buildkite_build_number:)
+    raise MissingBuildNumberError, 'BUILDKITE_BUILD_NUMBER is not set — this lane is meant to run on CI' if buildkite_build_number.to_s.strip.empty?
+
+    leading_parts = release_version.to_s.split('.')
+    leading_parts = leading_parts.fill('0', leading_parts.length...(BUILD_CODE_PARTS - 1)).first(BUILD_CODE_PARTS - 1)
+
+    [*leading_parts, buildkite_build_number.to_s.strip].join('.')
+  end
+
+  # The "What to Test" text shown to internal testers, naming the branch and commit the build
+  # came from. These builds are triggered ad hoc, so the source is the only thing worth saying.
+  #
+  # @param branch [String, nil] the value of `$BUILDKITE_BRANCH`
+  # @param commit [String, nil] the value of `$BUILDKITE_COMMIT`
+  #
+  def changelog(branch:, commit:)
+    branch = 'unknown branch' if branch.to_s.strip.empty?
+    commit = commit.to_s.strip.empty? ? 'unknown commit' : commit.to_s.strip[0...7]
+
+    "Automated build from #{branch} (#{commit})."
+  end
+end

--- a/fastlane/helpers/testflight_build_helper_test.rb
+++ b/fastlane/helpers/testflight_build_helper_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Pure-Ruby unit tests for TestFlightBuildHelper. Uses Ruby's stdlib Minitest so
+# no extra gems are required.
+#
+# Run:
+#   ruby fastlane/helpers/testflight_build_helper_test.rb
+
+require 'minitest/autorun'
+require_relative 'testflight_build_helper'
+
+# Unit tests for TestFlightBuildHelper.
+class TestFlightBuildHelperTest < Minitest::Test
+  Helper = TestFlightBuildHelper
+
+  # --- build_code ------------------------------------------------------------
+
+  def test_build_code_appends_the_buildkite_build_number_to_a_four_part_version
+    assert_equal '25.3.0.4567', Helper.build_code(release_version: '25.3', buildkite_build_number: '4567')
+  end
+
+  def test_build_code_stays_four_parts_for_a_hotfix_release_version
+    assert_equal '25.3.1.4567', Helper.build_code(release_version: '25.3.1', buildkite_build_number: '4567')
+  end
+
+  def test_build_code_is_always_four_parts
+    ['25', '25.3', '25.3.1'].each do |release_version|
+      code = Helper.build_code(release_version: release_version, buildkite_build_number: '4567')
+
+      assert_equal 4, code.split('.').length, "expected a four-part build code for #{release_version}, got #{code}"
+    end
+  end
+
+  def test_build_code_sorts_higher_as_the_buildkite_build_number_grows
+    earlier = Helper.build_code(release_version: '25.3', buildkite_build_number: '9')
+    later = Helper.build_code(release_version: '25.3', buildkite_build_number: '10')
+
+    assert_operator Gem::Version.new(later), :>, Gem::Version.new(earlier)
+  end
+
+  def test_build_code_accepts_an_integer_build_number
+    assert_equal '25.3.0.4567', Helper.build_code(release_version: '25.3', buildkite_build_number: 4567)
+  end
+
+  def test_build_code_raises_when_the_build_number_is_missing
+    assert_raises(Helper::MissingBuildNumberError) do
+      Helper.build_code(release_version: '25.3', buildkite_build_number: nil)
+    end
+  end
+
+  def test_build_code_raises_when_the_build_number_is_blank
+    assert_raises(Helper::MissingBuildNumberError) do
+      Helper.build_code(release_version: '25.3', buildkite_build_number: '  ')
+    end
+  end
+
+  # --- changelog -------------------------------------------------------------
+
+  def test_changelog_names_the_branch_and_the_short_commit
+    assert_equal 'Automated build from trunk (abc1234).', Helper.changelog(branch: 'trunk', commit: 'abc1234def5678')
+  end
+
+  def test_changelog_leaves_a_commit_shorter_than_seven_characters_alone
+    assert_equal 'Automated build from trunk (abc12).', Helper.changelog(branch: 'trunk', commit: 'abc12')
+  end
+
+  def test_changelog_falls_back_when_the_buildkite_environment_is_absent
+    assert_equal 'Automated build from unknown branch (unknown commit).', Helper.changelog(branch: nil, commit: nil)
+  end
+end


### PR DESCRIPTION
Part of: AINFRA-2831

## Description

Testing a WCiOS branch in a release-shaped build currently means waiting for the release cadence. That gap has cost us twice recently: POS on iPhone shipped without Tap to Pay because it was validated from an Xcode build (enterprise builds can't carry the entitlement), and POS US-availability needed a remote feature flag as a workaround.

This adds an on-demand TestFlight build, triggered by a button on `trunk` builds.

It is gated behind an `input` step rather than built per commit, following the Prototype Build group directly above it: every upload consumes a build code and is visible to internal testers, so it should be deliberate. Uploads go to internal testers only and neither submit for beta review nor touch a release build already waiting on it.

**Known gap, shipped deliberately:** when `trunk`'s `VERSION_SHORT` names a version whose TestFlight train is already closed on App Store Connect, Apple rejects the upload. The fix is pre-allocating trunk's version after each code freeze, as `wordpress-mobile/WordPress-iOS#25876` does for WordPress. How often this bites is easier to learn from real use than to predict.

## Test Steps

The button only appears on `trunk`, so it can't be exercised from this PR. A stacked PR temporarily widens the branch condition so the flow can run against a PR build — see the linked PR, and check its build for a successful upload.

Otherwise, the pure-Ruby helpers are covered by the Ruby Automation Tests step:

```
ruby fastlane/helpers/testflight_build_helper_test.rb
```

## Screenshots

N/A

<details>
<summary>AI-generated details</summary>

### What changed

- `.buildkite/pipeline.yml` — a `TestFlight Build` group with an `input` step, both gated on `build.branch == "trunk"`.
- `.buildkite/commands/testflight-build.sh` — mirrors `prototype-build.sh`.
- `fastlane/Fastfile` — `build_and_upload_testflight_build`. `build_for_app_store_connect` gains an optional `build_code:`; when omitted it is `nil`, which fastlane treats as unset (`ConfigItem#valid?` returns early on `nil`, and `Configuration#fetch` skips `nil` values), so the release path is unchanged.
- `fastlane/helpers/testflight_build_helper.rb` and its test — build code and changelog rules, kept free of the fastlane runtime so they run under plain `ruby` on the linter queue.

### Why the build code is zero-padded

The obvious form, `"#{release_version}.0.#{build_number}"` (what WordPress-iOS uses), produces a five-part code on a hotfix version like `25.3.1`. That is harmless while this is trunk-only, since trunk is always two-part, but it is a trap if the button ever moves to release branches. The helper pads to four parts instead and a test pins it.

### Verification performed

- `ruby -c`, `bash -n`, YAML parse, and `rubocop` clean on all three Ruby files.
- All `fastlane/helpers/*_test.rb` pass — 54 assertions, 10 of them new.
- The six `upload_to_testflight` option names and gym's `xcargs` checked against the pinned fastlane 2.237.0.

**Not verified:** the Fastfile has never been loaded by fastlane. `bundle install` fails building nokogiri 1.19.4 on the authoring machine (`nokogiri_gumbo.h` not found, every `mkmf` CFLAGS probe returns "no" under Apple clang 21). That breakage is repo-wide and pre-existing, not caused by this branch. A typo-level runtime error in the lane would therefore reach CI rather than being caught locally.

</details>

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.