### PR TITLE
DO NOT MERGE: exercise the TestFlight build from a PR

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,13 +48,15 @@ steps:
     # On-demand only, and only on `trunk`: unlike a Prototype Build, this uploads to App Store
     # Connect, so every build consumes a build code and shows up to the internal testers.
     steps:
+      # DO NOT MERGE: `ainfra-2831-testflight-on-pr` is added so the flow can be exercised from a
+      # PR build before it ships. Revert to the `trunk`-only condition before this branch merges.
       - input: Create TestFlight Build?
         prompt: Build and upload to TestFlight for internal testers?
         key: testflight_build_triggered
-        if: build.branch == "trunk"
+        if: build.branch == "trunk" || build.branch == "ainfra-2831-testflight-on-pr"
       - label: ":testflight: TestFlight Build"
         depends_on: testflight_build_triggered
-        if: build.branch == "trunk"
+        if: build.branch == "trunk" || build.branch == "ainfra-2831-testflight-on-pr"
         command: .buildkite/commands/testflight-build.sh
         plugins: [$CI_TOOLKIT]
         notify:


### PR DESCRIPTION
Part of: AINFRA-2831

Stacked on #17679. **Never merge this** — it exists to test that PR and should be closed once the flow is confirmed.

## Description

The TestFlight button in #17679 is gated on `trunk`, so there is no way to exercise it before it ships. This widens the condition to this branch only, so the upload can run against a PR build once.

What the run should confirm, none of which is verifiable statically:

- the Fastfile loads and the new lane resolves,
- App Store Connect code signing resolves for a non-release branch,
- the generated build code is accepted rather than rejected as a duplicate or closed-train version,
- the build lands for internal testers without touching beta review.

## Test Steps

1. Open this PR's Buildkite build.
2. Unblock the `Create TestFlight Build?` step.
3. Confirm the job builds, uploads, and the build appears in App Store Connect for internal testers only.

## Screenshots

N/A

<details>
<summary>AI-generated details</summary>

The only change is the `if:` condition on both steps of the `TestFlight Build` group, from `build.branch == "trunk"` to `build.branch == "trunk" || build.branch == "ainfra-2831-testflight-on-pr"`, plus a `DO NOT MERGE` comment above them.

Naming this branch explicitly rather than using `build.pull_request.id != null` keeps the button off every other open PR while it is being tested.

Base branch is `ainfra-2831-wcios-non-release-testflight-builds`, so the diff shown here is only the condition change. If #17679 lands first, this PR retargets to `trunk` and must be closed rather than merged.

</details>

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.