### PR TITLE
[WOOMOB-3807] Require manual site selection after QR login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.5
 -----
+- [*] Login: QR login now waits for you to choose a store when multiple sites are available. [https://github.com/woocommerce/woocommerce-ios/pull/17681]
 - [*] Toggling Pay in Person now asks for confirmation and explains what changes at your store's checkout. [https://github.com/woocommerce/woocommerce-ios/pull/17658]
 - [*] Orders: Fixed refunds failing with "Invalid refund amount" on stores with tax-inclusive pricing. [https://github.com/woocommerce/woocommerce-ios/pull/17630]
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -428,33 +428,18 @@ extension StorePickerViewController {
 //
 private extension StorePickerViewController {
 
-    /// Sets the first available Store as the default one. If possible!
+    /// Preselects a Store when there is an unambiguous choice.
     ///
     func preselectStoreIfPossible() {
 
-        guard case let .available(sites) = viewModel.state, let firstSite = sites.first(where: { $0.isWooCommerceActive }) else {
+        guard case let .available(sites) = viewModel.state else {
             return
         }
         guard currentlySelectedSite == nil else {
             return
         }
 
-        // If there is a defaultSite already set, select it
-        if let site = ServiceLocator.stores.sessionManager.defaultSite {
-            currentlySelectedSite = site
-            return
-        }
-
-        // If a site address was passed in credentials, select it
-        if case let .wpcom(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials,
-           let site = sites.first(where: { $0.url == siteAddress }),
-           site.isWooCommerceActive {
-            currentlySelectedSite = site
-            return
-        }
-
-        // Otherwise select the first site in the list
-        currentlySelectedSite = firstSite
+        currentlySelectedSite = viewModel.siteToPreselect(from: sites)
     }
 
     /// Reloads the UI.

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.xib
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.xib
@@ -51,7 +51,7 @@
                                         <action selector="addStoreWasPressed" destination="-1" eventType="touchUpInside" id="ceu-IF-kAI"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0KD-hY-YaS" userLabel="Action Button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0KD-hY-YaS" userLabel="Action Button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="70" width="374" height="50"/>
                                     <color key="backgroundColor" red="0.58823529409999997" green="0.34509803919999998" blue="0.54117647059999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -111,6 +111,7 @@ final class StorePickerViewModel {
             return nil
         }
 
+        // Login only preselects an explicit credential match or an unambiguous sole result.
         if configuration != .login, let site = stores.sessionManager.defaultSite {
             return site
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -104,6 +104,31 @@ final class StorePickerViewModel {
         userDefaults.unhideStoreID(siteID)
         updateDisplayedStores()
     }
+
+    /// Returns the store that should be selected when the picker first loads.
+    func siteToPreselect(from sites: [Site]) -> Site? {
+        guard let firstAvailableStore = sites.first(where: \.isWooCommerceActive) else {
+            return nil
+        }
+
+        if configuration != .login, let site = stores.sessionManager.defaultSite {
+            return site
+        }
+
+        if case let .wpcom(_, _, siteAddress) = stores.sessionManager.defaultCredentials,
+           let site = sites.first(where: { $0.url == siteAddress }),
+           site.isWooCommerceActive {
+            return site
+        }
+
+        if configuration != .login {
+            return firstAvailableStore
+        }
+        guard sites.count == 1 else {
+            return nil
+        }
+        return firstAvailableStore
+    }
 }
 
 // MARK: - Private helpers

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
@@ -17,6 +17,114 @@ final class StorePickerViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_siteToPreselect_when_multiple_woo_stores_have_no_matching_site_address_then_returns_nil() {
+        // Given
+        let firstSite = Site.fake().copy(siteID: 123, url: "https://first.example.com", isWooCommerceActive: true)
+        let secondSite = Site.fake().copy(siteID: 456, url: "https://second.example.com", isWooCommerceActive: true)
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
+        sessionManager.defaultCredentials = .wpcom(username: "merchant", authToken: "token", siteAddress: "https://wordpress.com")
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = StorePickerViewModel(configuration: .login, stores: stores, storageManager: storageManager)
+
+        // When
+        let selectedSite = viewModel.siteToPreselect(from: [firstSite, secondSite])
+
+        // Then
+        XCTAssertNil(selectedSite)
+    }
+
+    func test_siteToPreselect_when_multiple_mixed_sites_have_no_matching_site_address_then_returns_nil() {
+        // Given
+        let wooSite = Site.fake().copy(siteID: 123, url: "https://store.example.com", isWooCommerceActive: true)
+        let nonWooSite = Site.fake().copy(siteID: 456, url: "https://blog.example.com", isWooCommerceActive: false)
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
+        sessionManager.defaultCredentials = .wpcom(username: "merchant", authToken: "token", siteAddress: "https://wordpress.com")
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = StorePickerViewModel(configuration: .login, stores: stores, storageManager: storageManager)
+
+        // When
+        let selectedSite = viewModel.siteToPreselect(from: [wooSite, nonWooSite])
+
+        // Then
+        XCTAssertNil(selectedSite)
+    }
+
+    func test_siteToPreselect_when_one_woo_store_is_the_only_site_then_returns_it() {
+        // Given
+        let wooSite = Site.fake().copy(siteID: 123, url: "https://store.example.com", isWooCommerceActive: true)
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
+        sessionManager.defaultCredentials = .wpcom(username: "merchant", authToken: "token", siteAddress: "https://wordpress.com")
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = StorePickerViewModel(configuration: .login, stores: stores, storageManager: storageManager)
+
+        // When
+        let selectedSite = viewModel.siteToPreselect(from: [wooSite])
+
+        // Then
+        XCTAssertEqual(selectedSite, wooSite)
+    }
+
+    func test_siteToPreselect_when_site_address_matches_a_woo_store_then_returns_it() {
+        // Given
+        let firstSite = Site.fake().copy(siteID: 123, url: "https://first.example.com", isWooCommerceActive: true)
+        let matchingSite = Site.fake().copy(siteID: 456, url: "https://matching.example.com", isWooCommerceActive: true)
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
+        sessionManager.defaultCredentials = .wpcom(username: "merchant", authToken: "token", siteAddress: matchingSite.url)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = StorePickerViewModel(configuration: .login, stores: stores, storageManager: storageManager)
+
+        // When
+        let selectedSite = viewModel.siteToPreselect(from: [firstSite, matchingSite])
+
+        // Then
+        XCTAssertEqual(selectedSite, matchingSite)
+    }
+
+    func test_siteToPreselect_when_switching_stores_has_a_default_site_then_returns_it() {
+        // Given
+        let firstSite = Site.fake().copy(siteID: 123, url: "https://first.example.com", isWooCommerceActive: true)
+        let defaultSite = Site.fake().copy(siteID: 456, url: "https://default.example.com", isWooCommerceActive: true)
+        let sessionManager = SessionManager.makeForTesting(defaultSite: defaultSite)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = StorePickerViewModel(configuration: .switchingStores, stores: stores, storageManager: storageManager)
+
+        // When
+        let selectedSite = viewModel.siteToPreselect(from: [firstSite, defaultSite])
+
+        // Then
+        XCTAssertEqual(selectedSite, defaultSite)
+    }
+
+    func test_siteToPreselect_when_switching_stores_has_no_default_site_then_returns_the_first_woo_store() {
+        // Given
+        let firstSite = Site.fake().copy(siteID: 123, url: "https://first.example.com", isWooCommerceActive: true)
+        let secondSite = Site.fake().copy(siteID: 456, url: "https://second.example.com", isWooCommerceActive: true)
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = StorePickerViewModel(configuration: .switchingStores, stores: stores, storageManager: storageManager)
+
+        // When
+        let selectedSite = viewModel.siteToPreselect(from: [firstSite, secondSite])
+
+        // Then
+        XCTAssertEqual(selectedSite, firstSite)
+    }
+
+    func test_siteToPreselect_when_switching_stores_has_only_non_woo_sites_then_returns_nil() {
+        // Given
+        let defaultSite = Site.fake().copy(siteID: 123, url: "https://store.example.com", isWooCommerceActive: true)
+        let nonWooSite = Site.fake().copy(siteID: 456, url: "https://blog.example.com", isWooCommerceActive: false)
+        let sessionManager = SessionManager.makeForTesting(defaultSite: defaultSite)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = StorePickerViewModel(configuration: .switchingStores, stores: stores, storageManager: storageManager)
+
+        // When
+        let selectedSite = viewModel.siteToPreselect(from: [nonWooSite])
+
+        // Then
+        XCTAssertNil(selectedSite)
+    }
+
     func test_multipleStoresAvailable_is_correct_for_single_store() {
         // Given
         let testSite = Site.fake()


### PR DESCRIPTION
Addresses [WOOMOB-3807](https://linear.app/a8c/issue/WOOMOB-3807/review-qr-login-site-selection-ux-on-ios)

## Description

QR login without an entered site address stores the generic WordPress.com URL in the session. When that URL did not match a returned store, the site picker fell back to selecting the first WooCommerce store and immediately ran its requirements check, even though the user had not chosen it.

This moves the initial-selection decision into the store picker view model. During login, it now selects a store only when the supplied address matches an active WooCommerce site or exactly one total site was returned. Multiple returned sites remain unselected for manual choice. Non-login picker behavior is preserved.

Continue now starts disabled and is enabled by the existing eligibility flow only after a valid store is selected.

## Test Steps

1. Start QR login without entering a site address for a WordPress.com account with multiple sites.
2. Confirm the site picker remains visible with no store preselected and Continue is disabled.
3. Select a store and confirm Continue becomes enabled after the store eligibility check succeeds.
4. Repeat with an account that returns exactly one WooCommerce site and confirm it is selected automatically.
5. Repeat with a QR code containing a site address and confirm the matching WooCommerce site is selected.

## Screenshots


https://github.com/user-attachments/assets/015b0c4e-e25e-4c2d-94ef-5a51b799093a

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
