### PR TITLE
Stop copying the deleted project.env.example

### DIFF
--- a/.buildkite/commands/build-warning-baseline.sh
+++ b/.buildkite/commands/build-warning-baseline.sh
@@ -161,9 +161,6 @@ pushd "$BASE_WORKTREE"
 
 "$BASE_WORKTREE/.buildkite/commands/shared-set-up.sh"
 
-echo "--- :writing_hand: Copy Files"
-mkdir -pv ~/.configure/woocommerce-ios/secrets
-cp -v fastlane/env/project.env.example ~/.configure/woocommerce-ios/secrets/project.env
 rm -rf fastlane/logs
 
 echo "--- :hammer_and_wrench: Building baseline"


### PR DESCRIPTION
All the below is AI-generated. I reviewed the diff and "approved" it.

## Description

Targets `codex/build-warning-increase-guard` (#17456), not `trunk`.

I landed 1900e639c on trunk, which removed `fastlane/env/project.env.example` along with the `Fastfile` existence check that consumed it and the same three-line copy in `build-for-testing.sh`. The 2026-08-06 trunk merge into #17456 kept the copy in `build-warning-baseline.sh`, making it the only surviving `project.env` reference in the repo at that head.

Under `set -euo pipefail` the missing source aborts the step before it builds, so no baseline is ever produced and `save_toolkit_cache` is never reached — the comparison step then finds no report and posts nothing. The guard is inert on every PR, and silently so, because the baseline step is `soft_fail`. Reproduced on [Buildkite 40048](https://buildkite.com/automattic/woocommerce-ios/builds/40048): `cp: fastlane/env/project.env.example: No such file or directory`.

Sorry for the breakage — this is the minimum to get the guard working again, nothing else.

**Known gap left alone:** a base commit predating 1900e639c (2026-06-29) still needs that file, since the `Fastfile` at those commits hard-fails `before_all` without it. Such a baseline build will now fail instead of the copy failing — same soft-failed outcome, and the population shrinks to zero as PRs rebase. Worth a conditional copy only if you'd rather not think about it.

## Test Steps

Watch this PR's own CI. `BASELINE_SCRIPT_HASH` is part of the cache key, so editing the script forces a cache miss and a real baseline rebuild — the `:warning: Build Warning Baseline` step should get past `shared-set-up.sh` into `fastlane build_for_testing` and write `base-build-warnings.json`.

Locally: `ruby fastlane/helpers/build_warnings_helper_test.rb` (22 runs, 0 failures) and `ruby -e 'require "yaml"; YAML.load_file(".buildkite/pipeline.yml")'`.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.