### PR TITLE
Collapse Product Selector header rows while searching in landscape

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -82,11 +82,20 @@ struct ProductSelectorView: View {
         return viewModel.selectProductsTitle
     }
 
+    /// In vertically compact environments the keyboard leaves roughly 100pt of usable height,
+    /// so secondary header rows give way to the results list while the merchant is typing.
+    private var isHeaderCollapsedForKeyboard: Bool {
+        verticalSizeClass == .compact && searchHeaderisBeingEdited
+    }
+
     /// The filter picker is revealed only when the merchant is actively searching or has chosen a
     /// non-default filter, so the row stays minimal during browsing while still being discoverable
     /// once the merchant engages with search.
     private var shouldShowProductSearchFilter: Bool {
-        searchHeaderisBeingEdited || viewModel.searchTerm.isNotEmpty || viewModel.productSearchFilter != .all
+        guard !isHeaderCollapsedForKeyboard else {
+            return false
+        }
+        return searchHeaderisBeingEdited || viewModel.searchTerm.isNotEmpty || viewModel.productSearchFilter != .all
     }
 
     private var productSelectorHeaderSearchRowHeight: CGFloat {
@@ -312,13 +321,17 @@ struct ProductSelectorView: View {
 private extension ProductSelectorView {
     @ViewBuilder var productSelectorHeader: some View {
         if horizontalSizeClass == .regular {
-            productSelectorHeaderTitleRow
+            if !isHeaderCollapsedForKeyboard {
+                productSelectorHeaderTitleRow
+            }
             productSelectorHeaderSearchRow
                 .padding(.bottom, Constants.defaultPadding)
                 .background(Color(.listForeground(modal: false)))
         } else {
             productSelectorHeaderSearchRow
-            productSelectorHeaderTitleRow
+            if !isHeaderCollapsedForKeyboard {
+                productSelectorHeaderTitleRow
+            }
         }
         Divider()
     }


### PR DESCRIPTION
## Description
Follow-up to #17693 for WOOMOB-3598. Even with the layout fix, the fixed header rows (search field, SKU filter picker, Clear selection/Filter row) consume nearly all the height that the landscape keyboard leaves, so no result rows fit while typing.

While the search field is focused in vertically compact environments, the SKU filter picker and the Clear selection/Filter row are now removed from the layout. This leaves room for at least one full result row while the merchant is typing. The rows return as soon as editing ends.

## Test Steps
1. On an iPhone, go to Orders, create a new order, and tap Add Products
2. Rotate to landscape and tap the search field
3. Verify only the search field remains above the results while the keyboard is up, and a result row is visible and tappable
4. Dismiss the keyboard and verify the SKU picker and Clear selection/Filter rows come back
5. In portrait, verify the header is unchanged (all rows visible while searching)

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.