### PR TITLE
[WOOMOB-3815] Fix Google Ads dashboard campaign date range

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.5
 -----
+- [*] Google Ads: Fixed the dashboard campaign card failing to show existing campaign performance data. [https://github.com/woocommerce/woocommerce-ios/pull/17706]
 - [*] POS: Fixed the barcode scanner setup test not recognizing scans on phones. [https://github.com/woocommerce/woocommerce-ios/pull/17702]
 - [*] Dashboard: Fixed the Stock card not refreshing after product edits or when its data becomes stale. [https://github.com/woocommerce/woocommerce-ios/pull/17707]
 - [*] Orders: Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin. [https://github.com/woocommerce/woocommerce-ios/pull/17691]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -126,8 +126,8 @@ private extension GoogleAdsDashboardCardViewModel {
             stores.dispatch(GoogleAdsAction.retrieveCampaignStats(
                 siteID: siteID,
                 timeZone: TimeZone.siteTimezone,
-                earliestDateToInclude: Date(),
-                latestDateToInclude: Date.distantPast) { result in
+                earliestDateToInclude: Date(timeIntervalSince1970: 0),
+                latestDateToInclude: Date.now) { result in
                     continuation.resume(with: result)
                 }
             )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -13,6 +13,7 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
     private let stores: StoresManager
     private let analytics: Analytics
     private let eligibilityChecker: GoogleAdsEligibilityChecker
+    private let timeZone: TimeZone
 
     var shouldShowErrorState: Bool {
         syncingError != nil
@@ -40,11 +41,13 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
     init(siteID: Int64,
          eligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker(),
          stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         timeZone: TimeZone = .siteTimezone) {
         self.siteID = siteID
         self.stores = stores
         self.analytics = analytics
         self.eligibilityChecker = eligibilityChecker
+        self.timeZone = timeZone
         trackEntryPointDisplayedIfNeeded()
     }
 
@@ -122,11 +125,18 @@ private extension GoogleAdsDashboardCardViewModel {
 
     @MainActor
     func retrieveCampaignStats() async throws -> GoogleAdsCampaignStats {
-        try await withCheckedThrowingContinuation { continuation in
+        // Use midnight in the store timezone so negative offsets do not serialize the lower bound as 1969-12-31.
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        let epoch = Date(timeIntervalSince1970: 0)
+        let fallbackDate = epoch.addingTimeInterval(TimeInterval(-timeZone.secondsFromGMT(for: epoch)))
+        let earliestDateToInclude = calendar.date(from: DateComponents(year: 1970, month: 1, day: 1)) ?? fallbackDate
+
+        return try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(GoogleAdsAction.retrieveCampaignStats(
                 siteID: siteID,
-                timeZone: TimeZone.siteTimezone,
-                earliestDateToInclude: Date(timeIntervalSince1970: 0),
+                timeZone: timeZone,
+                earliestDateToInclude: earliestDateToInclude,
                 latestDateToInclude: Date.now) { result in
                     continuation.resume(with: result)
                 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
@@ -125,17 +125,20 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_reloadCard_when_campaign_exists_retrieves_stats_from_epoch_through_current_date() async {
+    func test_reloadCard_when_campaign_exists_retrieves_stats_from_January_1_1970_in_store_timezone_through_current_date() async throws {
         // Given
-        let viewModel = GoogleAdsDashboardCardViewModel(siteID: sampleSiteID, stores: stores)
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "America/Los_Angeles"))
+        let viewModel = GoogleAdsDashboardCardViewModel(siteID: sampleSiteID, stores: stores, timeZone: timeZone)
         let dateBeforeReload = Date.now
+        var requestedTimeZone: TimeZone?
         var requestedEarliestDate: Date?
         var requestedLatestDate: Date?
         stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
             switch action {
             case let .fetchAdsCampaigns(_, onCompletion):
                 onCompletion(.success([.fake()]))
-            case let .retrieveCampaignStats(_, _, _, earliestDateToInclude, latestDateToInclude, onCompletion):
+            case let .retrieveCampaignStats(_, _, timeZone, earliestDateToInclude, latestDateToInclude, onCompletion):
+                requestedTimeZone = timeZone
                 requestedEarliestDate = earliestDateToInclude
                 requestedLatestDate = latestDateToInclude
                 onCompletion(.success(.fake()))
@@ -149,7 +152,12 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
 
         // Then
         let dateAfterReload = Date.now
-        XCTAssertEqual(requestedEarliestDate, Date(timeIntervalSince1970: 0))
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        dateFormatter.timeZone = timeZone
+        XCTAssertEqual(requestedTimeZone, timeZone)
+        XCTAssertEqual(dateFormatter.string(from: try XCTUnwrap(requestedEarliestDate)), "1970-01-01T00:00:00")
         XCTAssertGreaterThanOrEqual(try XCTUnwrap(requestedLatestDate), dateBeforeReload)
         XCTAssertLessThanOrEqual(try XCTUnwrap(requestedLatestDate), dateAfterReload)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
@@ -125,6 +125,36 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_reloadCard_when_campaign_exists_retrieves_stats_from_epoch_through_current_date() async {
+        // Given
+        let viewModel = GoogleAdsDashboardCardViewModel(siteID: sampleSiteID, stores: stores)
+        let dateBeforeReload = Date.now
+        var requestedEarliestDate: Date?
+        var requestedLatestDate: Date?
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .fetchAdsCampaigns(_, onCompletion):
+                onCompletion(.success([.fake()]))
+            case let .retrieveCampaignStats(_, _, _, earliestDateToInclude, latestDateToInclude, onCompletion):
+                requestedEarliestDate = earliestDateToInclude
+                requestedLatestDate = latestDateToInclude
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.reloadCard()
+
+        // Then
+        let dateAfterReload = Date.now
+        XCTAssertEqual(requestedEarliestDate, Date(timeIntervalSince1970: 0))
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(requestedLatestDate), dateBeforeReload)
+        XCTAssertLessThanOrEqual(try XCTUnwrap(requestedLatestDate), dateAfterReload)
+    }
+
+    @MainActor
     func test_performanceStats_is_updated_correctly() async {
         // Given
         let viewModel = GoogleAdsDashboardCardViewModel(siteID: sampleSiteID, stores: stores)


### PR DESCRIPTION
Fixes WOOMOB-3815

## Description
The Google Ads dashboard card always failed to load.

The app requested campaign statistics with earliest and latest dates reversed. Its also used Date.distantPast, which formats to year 1 AD and is outside the supported reporting range.

This PR uses 1 January 1970 as the lower bound and the current date as the upper bound, allowing the stats to load. 

## Test Steps (optional)
You can use pe5sF9-2Qo-p2 as a guide for setting up Google Ads on your store, or ping me and I'll invite you to mine

1. Use an eligible store with an existing Google Ads campaign.
2. Open the dashboard and enable the Google Ads card if needed.
3. Confirm the card loads the existing campaign performance statistics without showing an error.

## Screenshots

<img width="2360" height="1640" alt="google ads dashboard card fixed" src="https://github.com/user-attachments/assets/f01a9d4e-bff1-4bc3-bedb-fc430108bada" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.