### PR TITLE
Fix stale data in dashboard Stock card

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.5
 -----
+- [*] Dashboard: Fixed the Stock card not refreshing after product edits or when its data becomes stale. [https://github.com/woocommerce/woocommerce-ios/pull/17707]
 - [*] Orders: Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin. [https://github.com/woocommerce/woocommerce-ios/pull/17691]
 - [*] Orders: Fixed Custom Fields and refunded-product rows becoming centered after scrolling order details. [https://github.com/woocommerce/woocommerce-ios/pull/17689]
 - [*] In-Person Payments: Fixed the Manage Card Reader sheet truncating its Learn More text on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17690]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -724,9 +724,9 @@ private extension DashboardViewModel {
             return
         }
 
-        var supportedCards = Set(DashboardTimestampStore.Card.allCases.map { $0.dashboardCard } )
-        supportedCards.insert(.stock)
-        let supportedVisibleCards = showOnDashboardCards.filter { supportedCards.contains($0.type) }
+        var cardsSupportingRefreshOnAppearance = Set(DashboardTimestampStore.Card.allCases.map { $0.dashboardCard } )
+        cardsSupportingRefreshOnAppearance.insert(.stock)
+        let supportedVisibleCards = showOnDashboardCards.filter { cardsSupportingRefreshOnAppearance.contains($0.type) }
 
         await reloadCardsIfNeeded(supportedVisibleCards)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -696,7 +696,7 @@ private extension DashboardViewModel {
                     }
                 case .stock:
                     group.addTask { [weak self] in
-                        await self?.productStockCardViewModel.reloadData()
+                        await self?.productStockCardViewModel.reloadDataIfNeeded(forceRefresh: forceRefresh)
                     }
                 case .reviews:
                     group.addTask { [weak self] in
@@ -724,7 +724,8 @@ private extension DashboardViewModel {
             return
         }
 
-        let supportedCards = Set(DashboardTimestampStore.Card.allCases.map { $0.dashboardCard } )
+        var supportedCards = Set(DashboardTimestampStore.Card.allCases.map { $0.dashboardCard } )
+        supportedCards.insert(.stock)
         let supportedVisibleCards = showOnDashboardCards.filter { supportedCards.contains($0.type) }
 
         await reloadCardsIfNeeded(supportedVisibleCards)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -28,7 +28,7 @@ struct ProductStockDashboardCard: View {
             if !viewModel.analyticsEnabled {
                 UnavailableAnalyticsView(title: Localization.unavailableAnalytics)
                     .padding(.horizontal, Layout.padding)
-            } else if viewModel.syncingError != nil {
+            } else if viewModel.syncingError != nil && viewModel.reports.isEmpty {
                 DashboardCardErrorView(onRetry: {
                     ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .stock))
                     Task {
@@ -46,15 +46,23 @@ struct ProductStockDashboardCard: View {
                         .padding(.horizontal, Layout.padding)
                 }
             }
-            .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-            .shimmering(active: viewModel.syncingData)
-            .renderedIf(viewModel.syncingError == nil)
+            .redacted(reason: viewModel.syncingData && viewModel.reports.isEmpty ? [.placeholder] : [])
+            .shimmering(active: viewModel.syncingData && viewModel.reports.isEmpty)
+            .renderedIf(viewModel.syncingError == nil || viewModel.reports.isNotEmpty)
+
+            timestampView
+                .padding(.horizontal, Layout.padding)
+                .renderedIf(viewModel.lastUpdatedTimestamp.isNotEmpty)
         }
         .padding(.vertical, Layout.padding)
         .background(Color(.listForeground(modal: false)))
         .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
         .padding(.horizontal, Layout.padding)
-        .sheet(item: $selectedItem) { item in
+        .sheet(item: $selectedItem, onDismiss: {
+            Task {
+                await viewModel.onProductDetailDismissed()
+            }
+        }) { item in
             ViewControllerContainer(productDetailView(for: item))
         }
     }
@@ -161,6 +169,19 @@ private extension ProductStockDashboardCard {
         .frame(maxWidth: .infinity)
     }
 
+    var timestampView: some View {
+        HStack(spacing: Layout.timestampSpacing) {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(Color(.error))
+                .renderedIf(viewModel.isShowingStaleData)
+            Text(viewModel.isShowingStaleData ?
+                 Localization.refreshFailedText(time: viewModel.lastUpdatedTimestamp) :
+                 Localization.lastUpdatedText(time: viewModel.lastUpdatedTimestamp))
+                .footnoteStyle()
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
     func productDetailView(for item: ProductReport) -> UIViewController {
         let model: ProductLoaderViewController.Model = {
             if let variationID = item.variationID {
@@ -181,6 +202,7 @@ private extension ProductStockDashboardCard {
         static let padding: CGFloat = 16
         static let cornerSize = CGSize(width: 8.0, height: 8.0)
         static let hideIconVerticalPadding: CGFloat = 8
+        static let timestampSpacing: CGFloat = 4
     }
 
     enum Localization {
@@ -204,6 +226,22 @@ private extension ProductStockDashboardCard {
             value: "Stock levels",
             comment: "Header label on the Stock section on the My Store screen"
         )
+        static func lastUpdatedText(time: String) -> String {
+            let format = NSLocalizedString(
+                "productStockDashboardCard.lastUpdated",
+                value: "Last Updated: %1$@",
+                comment: "Time when the Stock dashboard card was last updated"
+            )
+            return String.localizedStringWithFormat(format, time)
+        }
+        static func refreshFailedText(time: String) -> String {
+            let format = NSLocalizedString(
+                "productStockDashboardCard.refreshFailed",
+                value: "Couldn't refresh · Last Updated: %1$@",
+                comment: "Message on the Stock dashboard card when a refresh fails; includes the last updated time"
+            )
+            return String.localizedStringWithFormat(format, time)
+        }
         static let subtitleSingular = NSLocalizedString(
             "productStockDashboardCard.item.subtitle.singular",
             value: "%1$d item sold last 30 days",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -17,23 +17,49 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
     @Published private(set) var selectedStockType: StockType = .lowStock
     @Published private(set) var analyticsEnabled = true
 
+    var lastUpdatedTimestamp: String {
+        guard let lastSuccessfulRefresh else {
+            return ""
+        }
+        let formatter = lastSuccessfulRefresh.isSameDay(as: currentDate()) ?
+            DateFormatter.timeFormatter :
+            DateFormatter.dateAndTimeFormatter
+        return formatter.string(from: lastSuccessfulRefresh)
+    }
+
+    var isShowingStaleData: Bool {
+        syncingError != nil && reports.isNotEmpty
+    }
+
     let siteID: Int64
     private let stores: StoresManager
     private let analytics: Analytics
+    private let currentDate: () -> Date
 
     /// In-memory list of loaded reports by product IDs.
     private var savedReports: [Int64: ProductReport] = [:]
+    private var lastSuccessfulRefresh: Date?
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         currentDate: @escaping () -> Date = Date.init) {
         self.siteID = siteID
         self.analytics = analytics
         self.stores = stores
+        self.currentDate = currentDate
 
         Task { @MainActor in
             selectedStockType = await loadLastSelectedStockType()
         }
+    }
+
+    @MainActor
+    func reloadDataIfNeeded(forceRefresh: Bool = false) async {
+        guard forceRefresh || shouldRefreshData else {
+            return
+        }
+        await reloadData()
     }
 
     @MainActor
@@ -50,6 +76,7 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
             .sorted { ($0.stockQuantity ?? 0) < ($1.stockQuantity ?? 0) }
 
             analyticsEnabled = true
+            lastSuccessfulRefresh = currentDate()
             analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .stock))
         } catch {
             switch error {
@@ -69,6 +96,11 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
         onDismiss?()
     }
 
+    @MainActor
+    func onProductDetailDismissed() async {
+        await reloadData()
+    }
+
     func updateStockType(_ type: StockType) {
         selectedStockType = type
         stores.dispatch(AppSettingsAction.setLastSelectedStockType(siteID: siteID, type: type.rawValue))
@@ -79,6 +111,13 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
 }
 
 private extension ProductStockDashboardCardViewModel {
+    var shouldRefreshData: Bool {
+        guard let lastSuccessfulRefresh else {
+            return true
+        }
+        return currentDate().timeIntervalSince(lastSuccessfulRefresh) >= Constants.refreshInterval
+    }
+
     @MainActor
     func loadLastSelectedStockType() async -> StockType {
         await withCheckedContinuation { continuation in
@@ -249,5 +288,6 @@ private extension ProductStockDashboardCardViewModel {
         static let pageNumber = 1
         static let maxItemCount = 3
         static let dayInSeconds: TimeInterval = 86400
+        static let refreshInterval: TimeInterval = 5 * 60
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
@@ -74,6 +74,144 @@ final class ProductStockDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_reloadDataIfNeeded_does_not_fetch_when_last_refresh_is_fresh() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let now = Date()
+        let viewModel = ProductStockDashboardCardViewModel(siteID: 123, stores: stores, currentDate: { now })
+        var stockFetchCount = 0
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .fetchStockReport(_, _, _, _, _, completion) = action {
+                stockFetchCount += 1
+                completion(.success([]))
+            }
+        }
+        await viewModel.reloadData()
+
+        // When
+        await viewModel.reloadDataIfNeeded()
+
+        // Then
+        XCTAssertEqual(stockFetchCount, 1)
+    }
+
+    @MainActor
+    func test_reloadDataIfNeeded_fetches_when_last_refresh_is_stale() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var now = Date()
+        let viewModel = ProductStockDashboardCardViewModel(siteID: 123, stores: stores, currentDate: { now })
+        var stockFetchCount = 0
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .fetchStockReport(_, _, _, _, _, completion) = action {
+                stockFetchCount += 1
+                completion(.success([]))
+            }
+        }
+        await viewModel.reloadData()
+        now.addTimeInterval(5 * 60)
+
+        // When
+        await viewModel.reloadDataIfNeeded()
+
+        // Then
+        XCTAssertEqual(stockFetchCount, 2)
+    }
+
+    @MainActor
+    func test_reloadDataIfNeeded_fetches_when_force_refresh_is_true() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductStockDashboardCardViewModel(siteID: 123, stores: stores)
+        var stockFetchCount = 0
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .fetchStockReport(_, _, _, _, _, completion) = action {
+                stockFetchCount += 1
+                completion(.success([]))
+            }
+        }
+        await viewModel.reloadData()
+
+        // When
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
+
+        // Then
+        XCTAssertEqual(stockFetchCount, 2)
+    }
+
+    @MainActor
+    func test_onProductDetailDismissed_fetches_when_last_refresh_is_fresh() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductStockDashboardCardViewModel(siteID: 123, stores: stores)
+        var stockFetchCount = 0
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .fetchStockReport(_, _, _, _, _, completion) = action {
+                stockFetchCount += 1
+                completion(.success([]))
+            }
+        }
+        await viewModel.reloadData()
+
+        // When
+        await viewModel.onProductDetailDismissed()
+
+        // Then
+        XCTAssertEqual(stockFetchCount, 2)
+    }
+
+    @MainActor
+    func test_reloadData_when_refresh_succeeds_then_updates_lastUpdatedTimestamp() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let now = Date()
+        let viewModel = ProductStockDashboardCardViewModel(siteID: 123, stores: stores, currentDate: { now })
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let .fetchStockReport(_, _, _, _, _, completion) = action {
+                completion(.success([]))
+            }
+        }
+
+        // When
+        await viewModel.reloadData()
+
+        // Then
+        XCTAssertFalse(viewModel.lastUpdatedTimestamp.isEmpty)
+    }
+
+    @MainActor
+    func test_reloadData_when_refresh_fails_then_preserves_reports_and_marks_them_as_stale() async {
+        // Given
+        let siteID: Int64 = 123
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductStockDashboardCardViewModel(siteID: siteID, stores: stores)
+        let product = ProductStock.fake().copy(siteID: siteID, productID: 32)
+        let report = ProductReport.fake().copy(productID: product.productID)
+        let refreshError = NSError(domain: "test", code: 500)
+        var shouldFail = false
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .fetchStockReport(_, _, _, _, _, completion):
+                shouldFail ? completion(.failure(refreshError)) : completion(.success([product]))
+            case let .fetchProductReports(_, _, _, _, _, _, _, _, _, completion):
+                completion(.success([report]))
+            default:
+                break
+            }
+        }
+        await viewModel.reloadData()
+        shouldFail = true
+
+        // When
+        await viewModel.reloadData()
+
+        // Then
+        XCTAssertEqual(viewModel.reports, [report])
+        XCTAssertTrue(viewModel.isShowingStaleData)
+        XCTAssertFalse(viewModel.lastUpdatedTimestamp.isEmpty)
+    }
+
+    @MainActor
     func test_reloadData_updates_missing_parent_ids_for_variation_reports() async {
         // Given
         let siteID: Int64 = 123


### PR DESCRIPTION
Closes WOOMOB-3830

## Description
The dashboard stock card previously only updated on a pull to refresh, or changing the filter. Edits to the products inside the app, and stock changes from sales on the web or other phones would not be reflected automatically.

This PR makes the stock card update alongside other performance-related cards, though on a 5-minute cadence rather than 30-minutes to help people react to low stock issues quickly. It also refreshes after returning from product details.

The card now shows its last successful update time. If a refresh fails after data has loaded, it keeps the existing stock rows visible and marks them as stale instead of replacing useful data with a full error state.

## Test Steps (optional)
1. Open the dashboard with the Stock card enabled and wait for it to load.
2. Open a product from the Stock card, edit its stock so that it would show in out of stock, low stock, or backordered. Save, and dismiss product details. Use whichever stock issue is the current filter on the card.
3. Confirm the Stock card refreshes and shows the updated stock information and a Last Updated timestamp.
4. Pull to refresh and confirm the Stock card refreshes immediately.
5. With existing Stock data visible, make a refresh fail and confirm the rows remain visible with a Couldn't refresh message.

## Screenshots

https://github.com/user-attachments/assets/b134e528-532c-4b6b-a3b7-b06dff4f8ba2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.