### PR TITLE
Phone POS: x button miss-alignment on Exit POS only

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -133,6 +133,10 @@ struct PointOfSaleDashboardView: View {
         .animation(.easeInOut, value: viewState == .loading())
         .background(Color.posSurface)
         .navigationBarBackButtonHidden(true)
+        // Applied before the posModal/posRootModal modifiers so only the dashboard content
+        // ignores the iOS 26 container insets — the modal overlay must keep the top safe
+        // area, or full-screen phone modals lay out underneath the status bar.
+        .ignoresSafeArea(dashboardIgnoredSafeAreaRegions)
         .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
             posModel.cancelCardPaymentsOnboarding()
         }) { factory in
@@ -184,7 +188,6 @@ struct PointOfSaleDashboardView: View {
             guard case .eligible = newValue, oldValue != newValue else { return }
             loadItemsWhenEligible()
         }
-        .ignoresSafeArea(dashboardIgnoredSafeAreaRegions)
         .onAppear {
             trackTimeForInitialLoadingState()
             loadItemsWhenEligible()

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct PointOfSaleExitPosAlertView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.posAnalytics) private var analytics
-    @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding private var isPresented: Bool
 
@@ -46,7 +45,7 @@ struct PointOfSaleExitPosAlertView: View {
         }
         .padding(POSPadding.xLarge)
         .background(Color.posSurfaceBright)
-        .frame(width: parentSize.width, height: parentSize.height, alignment: .top)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var regularCloseButton: some View {


### PR DESCRIPTION
Closes WOOMOB-3803 <!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR fixes the `x` modal button being off in exit POS for Phone POS.

It seems that on iOS 26, the modal (and any other `posModal` presented from the dashboard) laid out underneath the status bar on phones, which made the `x` button misaligned next to the battery icon. This is different than the existing Scanner/Printer setup views, which are presented in native full-screen covers with an intact safe area.

**Before:**

<img width="171" height="215" alt="Screenshot 2026-08-14 at 12 52 45" src="https://github.com/user-attachments/assets/a42d315a-1f4c-48d0-b975-77a66a7de380" />


**After:**

(While Phone POS is not supported in iOS18, I was testing in simulator as well and we get the same result)

| iOS18 | iOS26 |
|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-08-14 at 12 44 10" src="https://github.com/user-attachments/assets/3dba6545-48a5-4a80-ac12-482e4f5fdff0" /> | <img width="585" height="1266" alt="My Store 7" src="https://github.com/user-attachments/assets/6596b201-42b2-4d5a-86fe-2f0ca577b907" />| 



## Test Steps
1. Open Phone POS (UK store + iOS26), or white-listed a8c account.
2. Enter and exit POS. The x button should sit below the status bar, at approx the same height Scanner setup and Printer setup (just not so close to the battery icon)
4. On iPad, the exit POS modal should look unchanged.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
