### PR TITLE
[WOOMOB-3456] Keep performance stats visible without revenue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.5
 -----
+- [*] Dashboard: Performance stats now remain visible when the selected dates have no revenue. [https://github.com/woocommerce/woocommerce-ios/pull/17717]
 - [*] Google Ads: Fixed the dashboard campaign card failing to show existing campaign performance data. [https://github.com/woocommerce/woocommerce-ios/pull/17706]
 - [*] POS: Fixed the barcode scanner setup test not recognizing scans on phones. [https://github.com/woocommerce/woocommerce-ios/pull/17702]
 - [*] Dashboard: Fixed the Stock card not refreshing after product edits or when its data becomes stale. [https://github.com/woocommerce/woocommerce-ios/pull/17707]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -193,8 +193,8 @@ private extension StorePerformanceView {
 
     @ViewBuilder
     var statsView: some View {
-        if viewModel.hasRevenue {
-            VStack(spacing: Layout.padding) {
+        VStack(spacing: Layout.padding) {
+            if viewModel.hasRevenue {
                 VStack(spacing: Layout.contentVerticalSpacing) {
                     if let selectedDateText = viewModel.selectedDateText {
                         Text(selectedDateText)
@@ -207,26 +207,32 @@ private extension StorePerformanceView {
                         .largeTitleStyle()
                         .accessibilityIdentifier("revenue-value")
                 }
-
-                HStack(alignment: .bottom) {
-                    Group {
-                        ordersStatsItemView
-                            .frame(maxWidth: .infinity)
-
-                        statsItemView(title: Localization.visitors,
-                                      value: viewModel.visitorStatsText,
-                                      redactMode: .withIcon)
-                        .frame(maxWidth: .infinity)
-
-                        statsItemView(title: Localization.conversion,
-                                      value: viewModel.conversionStatsText,
-                                      redactMode: .withoutIcon)
-                        .frame(maxWidth: .infinity)
-                    }
-                }
             }
-        } else {
-            emptyStatsView
+
+            statsItemsView
+
+            if !viewModel.hasRevenue {
+                emptyStatsView
+            }
+        }
+    }
+
+    var statsItemsView: some View {
+        HStack(alignment: .bottom) {
+            Group {
+                ordersStatsItemView
+                    .frame(maxWidth: .infinity)
+
+                statsItemView(title: Localization.visitors,
+                              value: viewModel.visitorStatsText,
+                              redactMode: .withIcon)
+                .frame(maxWidth: .infinity)
+
+                statsItemView(title: Localization.conversion,
+                              value: viewModel.conversionStatsText,
+                              redactMode: .withoutIcon)
+                .frame(maxWidth: .infinity)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
WOOMOB-3456

When the selected range has no revenue, the Performance card currently replaces all metrics with the empty state, hiding useful visitor data.

This keeps the Orders, Visitors, and Conversion row visible above the existing empty-state illustration and message. The revenue total and chart remain hidden when there is no revenue.

## Test Steps
1. Launch the app with a store that has no revenue for Today.
2. Open the dashboard and scroll to the Performance card.
3. Confirm Orders, Visitors, and Conversion appear above the empty-state illustration and "No revenue for selected dates" message.
4. Select a date range with revenue and confirm the existing revenue total, metrics, and chart layout remains unchanged.

## Screenshots

https://github.com/user-attachments/assets/c21fd694-88f4-426a-a89d-cd551270de01


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
