### PR TITLE
[WOOMOB-3800] Add cookie-nonce authentication endpoint trust boundary

### DIFF
--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationEndpoints.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationEndpoints.swift
@@ -55,7 +55,7 @@ public struct CookieNonceAuthenticationEndpoints: Equatable, Sendable {
         WordPressLoginHTMLVerifier(html: html).isAuthenticatedDashboard
     }
 
-    public func loginErrorMessage(in html: String) -> String? {
+    func loginErrorMessage(in html: String) -> String? {
         WordPressLoginHTMLVerifier(html: html).loginErrorMessage
     }
 
@@ -92,7 +92,7 @@ public struct CookieNonceAuthenticationEndpoints: Equatable, Sendable {
     }
 
     /// Recognizes any structurally exact same-site WordPress REST nonce endpoint.
-    public func isNonceEndpoint(_ candidate: URL) -> Bool {
+    func isNonceEndpoint(_ candidate: URL) -> Bool {
         guard candidate.fragment == nil,
               let components = try? Self.trustedComponents(candidate, relativeTo: siteURL) else {
             return false

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationEndpoints.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationEndpoints.swift
@@ -109,6 +109,19 @@ public struct CookieNonceAuthenticationEndpoints: Equatable, Sendable {
         }
         return normalized == expected
     }
+
+    /// Validates a credential response redirect without promoting its target to a request URL.
+    ///
+    /// Some login integrations redirect to a structurally valid custom nonce endpoint or the configured admin base
+    /// instead of honoring the requested nonce URL. Callers must still fetch the internally derived nonce URL rather
+    /// than follow or promote this transaction-local redirect.
+    public func isExpectedCredentialRedirect(location: String, from previousURL: URL, afterLoginAt finalLoginURL: URL) -> Bool {
+        guard let candidate = try? resolveRedirect(location: location, from: previousURL) else {
+            return false
+        }
+        return isNonceEndpoint(candidate) ||
+            isExpectedAdminBaseURL(candidate, afterLoginAt: finalLoginURL)
+    }
 }
 
 public extension CookieNonceAuthenticationEndpoints {

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationEndpoints.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationEndpoints.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+/// Normalized, same-site endpoints trusted by the cookie-nonce authentication flow.
+///
+/// `loginEntryURL` is durable configuration. A form submission URL is transaction-local and is
+/// returned separately by `verifiedLoginFormSubmissionURL(in:documentURL:)`.
+public struct CookieNonceAuthenticationEndpoints: Equatable, Sendable {
+    public static let maximumRedirectCount = 3
+
+    public let siteURL: URL
+    public let loginEntryURL: URL
+    public let adminBaseURL: URL
+
+    public init(siteURL: URL, loginEntryURL: URL? = nil, adminBaseURL: URL? = nil) throws {
+        let siteURL = try Self.normalized(siteURL, kind: .site)
+        let loginEntryURL = loginEntryURL ?? siteURL.appendingPathComponent("wp-login.php")
+        let adminBaseURL = adminBaseURL ?? siteURL.appendingPathComponent("wp-admin", isDirectory: true)
+        self.siteURL = siteURL
+        self.loginEntryURL = try Self.normalized(loginEntryURL, relativeTo: siteURL, kind: .login)
+        self.adminBaseURL = try Self.normalized(adminBaseURL, relativeTo: siteURL, kind: .admin)
+    }
+
+    /// Resolves a redirect relative to the response URL and enforces the same-site policy.
+    public func resolveRedirect(location: String, from previousURL: URL) throws -> URL {
+        let previousURL = try Self.normalized(previousURL, relativeTo: siteURL, kind: .login)
+        let location = location.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard location.isEmpty == false, let candidate = URL(string: location, relativeTo: previousURL)?.absoluteURL else {
+            throw ValidationError.invalidURL
+        }
+        return try validatedTransactionURL(candidate, after: previousURL)
+    }
+
+    /// Resolves a transaction-local form action without changing the configured login entry.
+    func resolveFormAction(_ action: String?, documentURL: URL) throws -> URL {
+        let documentURL = try Self.normalized(documentURL, relativeTo: siteURL, kind: .login)
+        let action = action?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard action.isEmpty == false else {
+            return documentURL
+        }
+        guard let candidate = URL(string: action, relativeTo: documentURL)?.absoluteURL else {
+            throw ValidationError.invalidURL
+        }
+        return try validatedTransactionURL(candidate, after: documentURL)
+    }
+
+    /// Returns the submission URL only for one rendered, eligible WordPress credential form.
+    public func verifiedLoginFormSubmissionURL(in html: String, documentURL: URL) throws -> URL? {
+        guard let form = WordPressLoginHTMLVerifier(html: html).verifiedLoginForm() else {
+            return nil
+        }
+        return try resolveFormAction(form.action, documentURL: documentURL)
+    }
+
+    public func isAuthenticatedDashboardHTML(_ html: String) -> Bool {
+        WordPressLoginHTMLVerifier(html: html).isAuthenticatedDashboard
+    }
+
+    public func loginErrorMessage(in html: String) -> String? {
+        WordPressLoginHTMLVerifier(html: html).loginErrorMessage
+    }
+
+    /// The admin base after a validated login transaction, including default-port HTTP-to-HTTPS promotion.
+    public func derivedAdminBaseURL(afterLoginAt finalLoginURL: URL? = nil) throws -> URL {
+        let loginURL: URL
+        if let finalLoginURL {
+            loginURL = try validatedTransactionURL(finalLoginURL, after: loginEntryURL)
+        } else {
+            loginURL = loginEntryURL
+        }
+        return try promotedAdminBaseURL(for: loginURL)
+    }
+
+    public func nonceURL(afterLoginAt finalLoginURL: URL? = nil) throws -> URL {
+        let endpoint = try derivedAdminBaseURL(afterLoginAt: finalLoginURL).appendingPathComponent("admin-ajax.php")
+        guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            throw ValidationError.invalidURL
+        }
+        components.percentEncodedQuery = "action=rest-nonce"
+        guard let url = components.url else {
+            throw ValidationError.invalidURL
+        }
+        return url
+    }
+
+    public func isExpectedAdminBaseURL(_ candidate: URL, afterLoginAt finalLoginURL: URL? = nil) -> Bool {
+        guard candidate.fragment == nil,
+              let normalized = try? Self.normalized(candidate, relativeTo: siteURL, kind: .admin),
+              let expected = try? derivedAdminBaseURL(afterLoginAt: finalLoginURL) else {
+            return false
+        }
+        return normalized == expected
+    }
+
+    /// Recognizes any structurally exact same-site WordPress REST nonce endpoint.
+    public func isNonceEndpoint(_ candidate: URL) -> Bool {
+        guard candidate.fragment == nil,
+              let components = try? Self.trustedComponents(candidate, relativeTo: siteURL) else {
+            return false
+        }
+        return components.percentEncodedPath.hasSuffix("/admin-ajax.php") &&
+            components.percentEncodedQuery == "action=rest-nonce"
+    }
+
+    public func isExpectedNonceURL(_ candidate: URL, afterLoginAt finalLoginURL: URL? = nil) -> Bool {
+        guard isNonceEndpoint(candidate),
+              let normalized = try? Self.normalized(candidate, relativeTo: siteURL, kind: .login),
+              let expected = try? nonceURL(afterLoginAt: finalLoginURL) else {
+            return false
+        }
+        return normalized == expected
+    }
+}
+
+public extension CookieNonceAuthenticationEndpoints {
+    enum ValidationError: Error, Equatable, Sendable {
+        case invalidURL
+        case unsupportedScheme
+        case missingHost
+        case userInfoNotAllowed
+        case queryNotAllowed
+        case originMismatch
+        case insecureDowngrade
+    }
+}
+
+private extension CookieNonceAuthenticationEndpoints {
+    enum EndpointKind {
+        case site
+        case login
+        case admin
+    }
+
+    static func normalized(_ url: URL, relativeTo siteURL: URL? = nil, kind: EndpointKind) throws -> URL {
+        var components = try trustedComponents(url, relativeTo: siteURL)
+        if kind != .login, components.query != nil {
+            throw ValidationError.queryNotAllowed
+        }
+        components.fragment = nil
+        if components.port == components.defaultPort {
+            components.port = nil
+        }
+        if kind == .site {
+            components.percentEncodedPath = components.percentEncodedPath.trimmingTrailingSlashes
+            if components.percentEncodedPath == "/" {
+                components.percentEncodedPath = ""
+            }
+        } else if kind == .admin {
+            var path = components.percentEncodedPath.trimmingTrailingSlashes
+            if path.lowercased().hasSuffix("/index.php") {
+                path.removeLast("/index.php".count)
+            }
+            components.percentEncodedPath = (path == "/" ? "" : path.trimmingTrailingSlashes) + "/"
+        }
+        guard let normalized = components.url else {
+            throw ValidationError.invalidURL
+        }
+        return normalized
+    }
+
+    static func trustedComponents(_ url: URL, relativeTo siteURL: URL?) throws -> URLComponents {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw ValidationError.invalidURL
+        }
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+        guard components.scheme == "http" || components.scheme == "https" else {
+            throw ValidationError.unsupportedScheme
+        }
+        guard components.host?.isEmpty == false else {
+            throw ValidationError.missingHost
+        }
+        guard components.user == nil, components.password == nil else {
+            throw ValidationError.userInfoNotAllowed
+        }
+        if let siteURL {
+            try validateOrigin(components, siteURL: siteURL)
+        }
+        return components
+    }
+
+    static func validateOrigin(_ candidate: URLComponents, siteURL: URL) throws {
+        guard let site = URLComponents(url: siteURL, resolvingAgainstBaseURL: false) else {
+            throw ValidationError.invalidURL
+        }
+        guard candidate.host?.lowercased() == site.host?.lowercased() else {
+            throw ValidationError.originMismatch
+        }
+        if candidate.scheme == site.scheme, candidate.effectivePort == site.effectivePort {
+            return
+        }
+        guard site.scheme == "http", site.effectivePort == 80,
+              candidate.scheme == "https", candidate.effectivePort == 443 else {
+            throw ValidationError.originMismatch
+        }
+    }
+
+    func validatedTransactionURL(_ candidate: URL, after previousURL: URL) throws -> URL {
+        let normalized = try Self.normalized(candidate, relativeTo: siteURL, kind: .login)
+        if previousURL.scheme == "https", normalized.scheme != "https" {
+            throw ValidationError.insecureDowngrade
+        }
+        return normalized
+    }
+
+    func promotedAdminBaseURL(for loginURL: URL) throws -> URL {
+        guard adminBaseURL.scheme == "http", loginURL.scheme == "https",
+              URLComponents(url: adminBaseURL, resolvingAgainstBaseURL: false)?.effectivePort == 80,
+              URLComponents(url: loginURL, resolvingAgainstBaseURL: false)?.effectivePort == 443,
+              var components = URLComponents(url: adminBaseURL, resolvingAgainstBaseURL: false) else {
+            return adminBaseURL
+        }
+        components.scheme = "https"
+        components.port = nil
+        guard let url = components.url else {
+            throw ValidationError.invalidURL
+        }
+        return url
+    }
+}
+
+private extension URLComponents {
+    var defaultPort: Int? {
+        if scheme == "http" {
+            return 80
+        }
+        if scheme == "https" {
+            return 443
+        }
+        return nil
+    }
+
+    var effectivePort: Int? {
+        port ?? defaultPort
+    }
+}
+
+private extension String {
+    var trimmingTrailingSlashes: String {
+        var result = self
+        while result.count > 1, result.hasSuffix("/") {
+            result.removeLast()
+        }
+        return result
+    }
+}

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationRules.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationRules.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+public enum CookieNonceAuthenticationFailure: Error, Equatable, Sendable {
+    case basicAuthenticationRequired
+    case invalidCredentials
+    case loginFailed(message: String)
+    case inaccessibleLoginPage
+    case inaccessibleAdminPage
+    case invalidResponse
+    case unacceptableStatusCode(Int)
+}
+
+public enum CookieNonceAuthenticationResponseStage: Equatable, Sendable {
+    case preflight
+    case credentials
+    case dashboard
+    case nonce
+}
+
+/// Pure request and response rules shared by the URLSession and Alamofire adapters.
+public enum CookieNonceAuthenticationRules {
+    public static func failure(
+        statusCode: Int,
+        authenticateHeader: String?,
+        locationHeader: String?,
+        stage: CookieNonceAuthenticationResponseStage
+    ) -> CookieNonceAuthenticationFailure? {
+        if containsBasicAuthentication(statusCode: statusCode, authenticateHeader: authenticateHeader) {
+            return .basicAuthenticationRequired
+        }
+        switch statusCode {
+        case 200..<300:
+            return nil
+        case 300..<400:
+            switch stage {
+            case .preflight, .credentials, .dashboard:
+                return locationHeader?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? nil : .invalidResponse
+            case .nonce:
+                return .invalidResponse
+            }
+        case 404, 410:
+            switch stage {
+            case .preflight:
+                return .inaccessibleLoginPage
+            case .credentials:
+                return .unacceptableStatusCode(statusCode)
+            case .dashboard, .nonce:
+                return .inaccessibleAdminPage
+            }
+        default:
+            return .unacceptableStatusCode(statusCode)
+        }
+    }
+
+    public static func isRedirect(statusCode: Int) -> Bool {
+        (300..<400).contains(statusCode)
+    }
+
+    public static func credentialBody(username: String, password: String, redirectTo: URL) -> Data? {
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "log", value: username),
+            URLQueryItem(name: "pwd", value: password),
+            URLQueryItem(name: "rememberme", value: "true"),
+            URLQueryItem(name: "redirect_to", value: redirectTo.absoluteString)
+        ]
+        let characterSet = CharacterSet(charactersIn: "+").inverted
+        return components.percentEncodedQuery?
+            .addingPercentEncoding(withAllowedCharacters: characterSet)?
+            .data(using: .utf8)
+    }
+
+    public static func credentialFailure(
+        in html: String,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ) -> CookieNonceAuthenticationFailure {
+        let errorMessage = endpoints.loginErrorMessage(in: html)
+        if errorMessage?.localizedCaseInsensitiveContains("captcha") == true {
+            return .invalidResponse
+        }
+        if html.contains("document.querySelector('form').classList.add('shake')") {
+            return .invalidCredentials
+        }
+        if let errorMessage {
+            return .loginFailed(message: errorMessage)
+        }
+        return .invalidResponse
+    }
+
+    public static func validatedNonce(from data: Data) -> String? {
+        guard let nonce = String(data: data, encoding: .utf8), nonce.unicodeScalars.count >= 2,
+              nonce.unicodeScalars.allSatisfy(\.isASCIILetterOrNumber) else {
+            return nil
+        }
+        return nonce
+    }
+
+    public static func containsBasicAuthentication(statusCode: Int, authenticateHeader: String?) -> Bool {
+        guard statusCode == 401, let authenticateHeader else {
+            return false
+        }
+        return authenticationChallenges(in: authenticateHeader).contains { challenge in
+            challenge.split(whereSeparator: \.isWhitespace).first?.lowercased() == "basic"
+        }
+    }
+
+    private static func authenticationChallenges(in header: String) -> [Substring] {
+        var challenges = [Substring]()
+        var start = header.startIndex
+        var index = start
+        var isInsideQuotes = false
+        var isEscaping = false
+
+        while index < header.endIndex {
+            let character = header[index]
+            if isEscaping {
+                isEscaping = false
+            } else if character == "\\", isInsideQuotes {
+                isEscaping = true
+            } else if character == "\"" {
+                isInsideQuotes.toggle()
+            } else if character == ",", isInsideQuotes == false {
+                challenges.append(header[start..<index].trimmingWhitespace)
+                start = header.index(after: index)
+            }
+            index = header.index(after: index)
+        }
+        challenges.append(header[start..<header.endIndex].trimmingWhitespace)
+        return challenges
+    }
+}
+
+private extension Substring {
+    var trimmingWhitespace: Substring {
+        let start = firstIndex(where: { $0.isWhitespace == false }) ?? endIndex
+        let end = lastIndex(where: { $0.isWhitespace == false }).map(index(after:)) ?? endIndex
+        return self[start..<end]
+    }
+}
+
+private extension Unicode.Scalar {
+    var isASCIILetterOrNumber: Bool {
+        (48...57).contains(value) || (65...90).contains(value) || (97...122).contains(value)
+    }
+}

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationRules.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationRules.swift
@@ -31,7 +31,7 @@ public enum CookieNonceAuthenticationRules {
         switch statusCode {
         case 200..<300:
             return nil
-        case 300..<400:
+        case 300...303, 307, 308:
             switch stage {
             case .preflight, .credentials, .dashboard:
                 return locationHeader?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? nil : .invalidResponse
@@ -53,7 +53,7 @@ public enum CookieNonceAuthenticationRules {
     }
 
     public static func isRedirect(statusCode: Int) -> Bool {
-        (300..<400).contains(statusCode)
+        (300...303).contains(statusCode) || (307...308).contains(statusCode)
     }
 
     public static func credentialBody(username: String, password: String, redirectTo: URL) -> Data? {
@@ -99,13 +99,18 @@ public enum CookieNonceAuthenticationRules {
         guard statusCode == 401, let authenticateHeader else {
             return false
         }
-        return authenticationChallenges(in: authenticateHeader).contains { challenge in
-            challenge.split(whereSeparator: \.isWhitespace).first?.lowercased() == "basic"
+        return authenticationSegments(in: authenticateHeader).contains { segment in
+            let parts = segment.split(maxSplits: 1, whereSeparator: \.isWhitespace)
+            guard parts.first?.lowercased() == "basic" else {
+                return false
+            }
+            // `Basic = value` continues the preceding challenge's parameters.
+            return parts.count == 1 || parts[1].first != "="
         }
     }
 
-    private static func authenticationChallenges(in header: String) -> [Substring] {
-        var challenges = [Substring]()
+    private static func authenticationSegments(in header: String) -> [Substring] {
+        var segments = [Substring]()
         var start = header.startIndex
         var index = start
         var isInsideQuotes = false
@@ -120,13 +125,13 @@ public enum CookieNonceAuthenticationRules {
             } else if character == "\"" {
                 isInsideQuotes.toggle()
             } else if character == ",", isInsideQuotes == false {
-                challenges.append(header[start..<index].trimmingWhitespace)
+                segments.append(header[start..<index].trimmingWhitespace)
                 start = header.index(after: index)
             }
             index = header.index(after: index)
         }
-        challenges.append(header[start..<header.endIndex].trimmingWhitespace)
-        return challenges
+        segments.append(header[start..<header.endIndex].trimmingWhitespace)
+        return segments
     }
 }
 

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationRules.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticationRules.swift
@@ -75,8 +75,8 @@ public enum CookieNonceAuthenticationRules {
         endpoints: CookieNonceAuthenticationEndpoints
     ) -> CookieNonceAuthenticationFailure {
         let errorMessage = endpoints.loginErrorMessage(in: html)
-        if errorMessage?.localizedCaseInsensitiveContains("captcha") == true {
-            return .invalidResponse
+        if let errorMessage, errorMessage.localizedCaseInsensitiveContains("captcha") {
+            return .loginFailed(message: errorMessage)
         }
         if html.contains("document.querySelector('form').classList.add('shake')") {
             return .invalidCredentials
@@ -95,7 +95,7 @@ public enum CookieNonceAuthenticationRules {
         return nonce
     }
 
-    public static func containsBasicAuthentication(statusCode: Int, authenticateHeader: String?) -> Bool {
+    static func containsBasicAuthentication(statusCode: Int, authenticateHeader: String?) -> Bool {
         guard statusCode == 401, let authenticateHeader else {
             return false
         }

--- a/Modules/Sources/NetworkingCore/CookieNonce/WordPressLoginHTMLVerifier.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/WordPressLoginHTMLVerifier.swift
@@ -1,0 +1,149 @@
+import Foundation
+import HTMLParser
+
+/// Internal DOM-based verifier; callers use the stateless façade on `CookieNonceAuthenticationEndpoints`.
+struct WordPressLoginHTMLVerifier {
+    struct LoginForm {
+        let action: String?
+    }
+
+    private let html: String
+    private let root: ElementNode
+
+    init(html: String) {
+        self.html = html
+        root = HTMLParser().parse(html)
+    }
+
+    func verifiedLoginForm() -> LoginForm? {
+        guard hasSafeStructure else {
+            return nil
+        }
+        let forms = renderedElements(in: root).compactMap { element -> LoginForm? in
+            guard element.name.lowercased() == "form" else {
+                return nil
+            }
+            return verifiedLoginForm(in: element)
+        }
+        guard forms.count == 1 else {
+            return nil
+        }
+        return forms.first
+    }
+
+    func verifiedLoginForm(in form: ElementNode) -> LoginForm? {
+        guard form.value(of: "id") == "loginform", form.value(of: "name") == "loginform",
+              form.value(of: "method")?.lowercased() == "post" else {
+            return nil
+        }
+        let inputs = formInputs(in: form).filter(\.isEligible)
+        let loginInputs = inputs.filter { $0.value(of: "name") == "log" }
+        let passwordInputs = inputs.filter { $0.value(of: "name") == "pwd" }
+        guard loginInputs.count == 1, passwordInputs.count == 1,
+              let loginInput = loginInputs.first, let passwordInput = passwordInputs.first,
+              loginInput.isCredential(name: "log", id: "user_login", type: "text"),
+              passwordInput.isCredential(name: "pwd", id: "user_pass", type: "password") else {
+            return nil
+        }
+        return LoginForm(action: form.value(of: "action")?.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    var isAuthenticatedDashboard: Bool {
+        let elements = renderedElements(in: root)
+        let dashboardBody = elements.contains { element in
+            guard element.name.lowercased() == "body" else {
+                return false
+            }
+            let classes = Set((element.value(of: "class") ?? "").split(whereSeparator: \.isWhitespace).map { $0.lowercased() })
+            return classes.isSuperset(of: ["wp-admin", "index-php"])
+        }
+        return dashboardBody && elements.contains { $0.value(of: "id") == "dashboard-widgets-wrap" }
+    }
+
+    var loginErrorMessage: String? {
+        guard let error = renderedElements(in: root).first(where: { $0.value(of: "id") == "login_error" }) else {
+            return nil
+        }
+        let message = renderedText(in: error).split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        return message.isEmpty ? nil : message
+    }
+}
+
+private extension WordPressLoginHTMLVerifier {
+    static let nonRendered = Set(["script", "style", "template", "textarea", "title", "iframe", "noembed", "noframes", "xmp", "svg", "math"])
+    static let nonRenderedPattern = "script|style|template|textarea|title|iframe|noembed|noframes|xmp|svg|math"
+
+    var hasSafeStructure: Bool {
+        guard let withoutComments = removing("<!--[\\s\\S]*?-->", from: html),
+              let stripped = removing("<(\(Self.nonRenderedPattern))\\b[^>]*>[\\s\\S]*?</\\1\\s*>", from: withoutComments),
+              let leftovers = matches("<!--|-->|<\\s*/?\\s*(\(Self.nonRenderedPattern))\\b", in: stripped),
+              let formTags = matches("<\\s*/?\\s*form\\b", in: stripped),
+              let formRegions = matches("<form\\b[^>]*>[\\s\\S]*?</form\\s*>", in: stripped),
+              leftovers == 0, formTags == 2 * formRegions else {
+            return false
+        }
+        return true
+    }
+
+    func removing(_ pattern: String, from value: String) -> String? {
+        guard let expression = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+        return expression.stringByReplacingMatches(in: value, range: NSRange(value.startIndex..., in: value), withTemplate: "")
+    }
+
+    func matches(_ pattern: String, in value: String) -> Int? {
+        guard let expression = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+        return expression.numberOfMatches(in: value, range: NSRange(value.startIndex..., in: value))
+    }
+
+    func renderedElements(in root: ElementNode) -> [ElementNode] {
+        root.children.flatMap { renderedElements(in: $0) }
+    }
+
+    func renderedElements(in node: Node) -> [ElementNode] {
+        guard let element = node as? ElementNode,
+              Self.nonRendered.contains(element.name.lowercased()) == false else {
+            return []
+        }
+        return [element] + element.children.flatMap { renderedElements(in: $0) }
+    }
+
+    func formInputs(in form: ElementNode) -> [ElementNode] {
+        form.children.flatMap { node -> [ElementNode] in
+            guard let element = node as? ElementNode, Self.nonRendered.contains(element.name.lowercased()) == false,
+                  element.name.lowercased() != "form" else {
+                return []
+            }
+            return (element.name.lowercased() == "input" ? [element] : []) + formInputs(in: element)
+        }
+    }
+
+    func renderedText(in node: Node) -> String {
+        if let text = node as? TextNode {
+            return text.contents
+        }
+        guard let element = node as? ElementNode,
+              Self.nonRendered.contains(element.name.lowercased()) == false,
+              element.name.lowercased() != "a" else {
+            return ""
+        }
+        return element.children.map(renderedText(in:)).joined(separator: " ")
+    }
+}
+
+private extension ElementNode {
+    func value(of attributeName: String) -> String? {
+        attribute(named: attributeName)?.value.toString()
+    }
+
+    var isEligible: Bool {
+        attribute(named: "disabled") == nil && attribute(named: "form") == nil
+    }
+
+    func isCredential(name: String, id: String, type: String) -> Bool {
+        value(of: "name") == name && value(of: "id") == id && value(of: "type")?.lowercased() == type
+    }
+}

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationEndpointsTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationEndpointsTests.swift
@@ -208,6 +208,108 @@ struct CookieNonceAuthenticationEndpointsTests {
         #expect(error == .insecureDowngrade)
     }
 
+    @Test(arguments: [
+        "https://example.com/private-admin/",
+        "https://example.com/private-admin",
+        "https://example.com/private-admin/index.php",
+        "https://example.com/private-admin/admin-ajax.php?action=rest-nonce",
+        "https://example.com/hidden-admin/admin-ajax.php?action=rest-nonce"
+    ])
+    func test_expected_credential_redirect_accepts_exact_configured_admin_or_structural_nonce(location: String) throws {
+        // Given
+        let submissionURL = try url("https://example.com/custom-submit")
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: url("https://example.com"),
+            loginEntryURL: submissionURL,
+            adminBaseURL: url("https://example.com/private-admin/")
+        )
+
+        // When
+        let isExpected = endpoints.isExpectedCredentialRedirect(
+            location: location,
+            from: submissionURL,
+            afterLoginAt: submissionURL
+        )
+
+        // Then
+        #expect(isExpected)
+    }
+
+    @Test(arguments: [
+        (
+            "https://example.com",
+            "https://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "https://attacker.example/private-admin/"
+        ),
+        (
+            "https://example.com",
+            "https://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "https://user:secret@example.com/private-admin/"
+        ),
+        (
+            "https://example.com",
+            "https://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "https://example.com:8443/private-admin/"
+        ),
+        (
+            "http://example.com",
+            "http://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "http://example.com/private-admin/"
+        ),
+        (
+            "https://example.com",
+            "https://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "https://example.com/private-admin/?page=dashboard"
+        ),
+        (
+            "https://example.com",
+            "https://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "https://example.com/other-admin/"
+        ),
+        (
+            "https://example.com",
+            "https://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "https://example.com/private-admin/admin-ajax.php?action=rest-nonce&extra=1"
+        ),
+        (
+            "https://example.com",
+            "https://example.com/private-admin/",
+            "https://example.com/custom-submit",
+            "https://example.com/hidden-admin/admin-ajax.php?action=wrong-action"
+        )
+    ])
+    func test_expected_credential_redirect_rejects_unsafe_or_inexact_destination(
+        site: String,
+        admin: String,
+        login: String,
+        location: String
+    ) throws {
+        // Given
+        let submissionURL = try url(login)
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: url(site),
+            loginEntryURL: submissionURL,
+            adminBaseURL: url(admin)
+        )
+
+        // When
+        let isExpected = endpoints.isExpectedCredentialRedirect(
+            location: location,
+            from: submissionURL,
+            afterLoginAt: submissionURL
+        )
+
+        // Then
+        #expect(isExpected == false)
+    }
+
     @Test func test_form_action_is_transaction_local_and_does_not_replace_the_login_entry() throws {
         // Given
         let entryURL = try url("https://example.com/custom-entry?durable=1")

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationEndpointsTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationEndpointsTests.swift
@@ -438,17 +438,6 @@ struct CookieNonceAuthenticationEndpointsTests {
         // Then
         #expect(isExpected == false)
     }
-
-    @Test func test_redirect_limit_matches_android() {
-        // Given
-        let androidRedirectLimit = 3
-
-        // When
-        let redirectLimit = CookieNonceAuthenticationEndpoints.maximumRedirectCount
-
-        // Then
-        #expect(redirectLimit == androidRedirectLimit)
-    }
 }
 
 private extension CookieNonceAuthenticationEndpointsTests {

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationEndpointsTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationEndpointsTests.swift
@@ -1,0 +1,374 @@
+import Foundation
+import Testing
+@testable import NetworkingCore
+
+struct CookieNonceAuthenticationEndpointsTests {
+    typealias ValidationError = CookieNonceAuthenticationEndpoints.ValidationError
+
+    @Test func test_configured_endpoints_are_canonically_normalized() throws {
+        // Given
+        let siteURL = try url("HTTPS://EXAMPLE.COM:443/shop///#identity")
+        let loginEntryURL = try url("https://example.com/shop/secret-login?key=value#form")
+        let adminBaseURL = try url("https://example.com/shop/secret-admin/INDEX.PHP//#admin")
+
+        // When
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: loginEntryURL,
+            adminBaseURL: adminBaseURL
+        )
+
+        // Then
+        #expect(endpoints.siteURL.absoluteString == "https://example.com/shop")
+        #expect(endpoints.loginEntryURL.absoluteString == "https://example.com/shop/secret-login?key=value")
+        #expect(endpoints.adminBaseURL.absoluteString == "https://example.com/shop/secret-admin/")
+    }
+
+    @Test func test_percent_encoded_path_identity_is_preserved_during_normalization() throws {
+        // Given
+        let siteURL = try url("https://example.com/store%2Fbranch/")
+        let adminBaseURL = try url("https://example.com/hidden%2Findex.php/")
+
+        // When
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL, adminBaseURL: adminBaseURL)
+
+        // Then
+        #expect(endpoints.siteURL.absoluteString == "https://example.com/store%2Fbranch")
+        #expect(endpoints.loginEntryURL.absoluteString == "https://example.com/store%2Fbranch/wp-login.php")
+        #expect(endpoints.adminBaseURL.absoluteString == "https://example.com/hidden%2Findex.php/")
+    }
+
+    @Test func test_default_endpoints_preserve_the_canonical_subdirectory() throws {
+        // Given
+        let siteURL = try url("https://example.com/store/")
+
+        // When
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+
+        // Then
+        #expect(endpoints.siteURL.absoluteString == "https://example.com/store")
+        #expect(endpoints.loginEntryURL.absoluteString == "https://example.com/store/wp-login.php")
+        #expect(endpoints.adminBaseURL.absoluteString == "https://example.com/store/wp-admin/")
+        #expect(try endpoints.nonceURL().absoluteString == "https://example.com/store/wp-admin/admin-ajax.php?action=rest-nonce")
+    }
+
+    @Test(arguments: [
+        ("ftp://example.com", "https://example.com/login", "https://example.com/admin/", ValidationError.unsupportedScheme),
+        ("https://user:secret@example.com", "https://example.com/login", "https://example.com/admin/", .userInfoNotAllowed),
+        ("https://example.com?identity=other", "https://example.com/login", "https://example.com/admin/", .queryNotAllowed),
+        ("https://example.com", "https://other.example/login", "https://example.com/admin/", .originMismatch),
+        ("https://example.com", "https://user:secret@example.com/login", "https://example.com/admin/", .userInfoNotAllowed),
+        ("https://example.com", "http://example.com/login", "https://example.com/admin/", .originMismatch),
+        ("https://example.com", "https://example.com:8443/login", "https://example.com/admin/", .originMismatch),
+        ("https://example.com", "https://example.com/login", "https://other.example/admin/", .originMismatch),
+        ("https://example.com", "https://example.com/login", "https://example.com/admin/?redirect=1", .queryNotAllowed)
+    ])
+    func test_unsafe_configured_endpoint_is_rejected(
+        site: String,
+        login: String,
+        admin: String,
+        expectedError: ValidationError
+    ) throws {
+        // Given
+        let siteURL = try url(site)
+        let loginEntryURL = try url(login)
+        let adminBaseURL = try url(admin)
+
+        // When
+        let error = validationError {
+            try CookieNonceAuthenticationEndpoints(
+                siteURL: siteURL,
+                loginEntryURL: loginEntryURL,
+                adminBaseURL: adminBaseURL
+            )
+        }
+
+        // Then
+        #expect(error == expectedError)
+    }
+
+    @Test func test_relative_url_with_base_is_not_intrinsically_absolute() throws {
+        // Given
+        let baseURL = try url("https://example.com/root/")
+        let relativeURL = try #require(URL(string: "login", relativeTo: baseURL))
+        let siteURL = try url("https://example.com")
+
+        // When
+        let siteError = validationError { try CookieNonceAuthenticationEndpoints(siteURL: relativeURL) }
+        let loginError = validationError {
+            try CookieNonceAuthenticationEndpoints(siteURL: siteURL, loginEntryURL: relativeURL)
+        }
+
+        // Then
+        #expect(relativeURL.baseURL == baseURL)
+        #expect(siteError == .unsupportedScheme)
+        #expect(loginError == .unsupportedScheme)
+    }
+
+    @Test func test_default_effective_ports_are_equivalent_and_removed() throws {
+        // Given
+        let siteURL = try url("https://example.com:443/")
+        let loginEntryURL = try url("https://EXAMPLE.COM/login")
+
+        // When
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL, loginEntryURL: loginEntryURL)
+
+        // Then
+        #expect(endpoints.siteURL.absoluteString == "https://example.com")
+        #expect(endpoints.loginEntryURL.absoluteString == "https://example.com/login")
+    }
+
+    @Test func test_http_to_https_promotion_is_limited_to_default_effective_ports() throws {
+        // Given
+        let secureLogin = try url("https://example.com:443/login")
+        let defaultSite = try url("http://example.com:80")
+        let customPortSite = try url("http://example.com:8080")
+
+        // When
+        let promoted = try CookieNonceAuthenticationEndpoints(siteURL: defaultSite, loginEntryURL: secureLogin)
+        let error = validationError {
+            try CookieNonceAuthenticationEndpoints(siteURL: customPortSite, loginEntryURL: secureLogin)
+        }
+
+        // Then
+        #expect(promoted.loginEntryURL.absoluteString == "https://example.com/login")
+        #expect(try promoted.derivedAdminBaseURL().absoluteString == "https://example.com/wp-admin/")
+        #expect(error == .originMismatch)
+    }
+
+    @Test func test_untrusted_final_login_url_cannot_influence_admin_promotion() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("http://example.com"))
+        let attackerURL = try url("https://attacker.example/login")
+
+        // When
+        let error = validationError { try endpoints.derivedAdminBaseURL(afterLoginAt: attackerURL) }
+
+        // Then
+        #expect(error == .originMismatch)
+        #expect(endpoints.adminBaseURL.absoluteString == "http://example.com/wp-admin/")
+    }
+
+    @Test func test_https_login_entry_cannot_finish_at_http_when_deriving_admin_base() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: url("http://example.com"),
+            loginEntryURL: url("https://example.com/wp-login.php")
+        )
+        let finalLoginURL = try url("http://example.com/wp-login.php")
+
+        // When
+        let error = validationError { try endpoints.derivedAdminBaseURL(afterLoginAt: finalLoginURL) }
+
+        // Then
+        #expect(error == .insecureDowngrade)
+    }
+
+    @Test func test_redirect_location_is_resolved_relative_to_the_previous_url() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com/store"))
+        let previousURL = try url("https://example.com/store/login/step")
+
+        // When
+        let redirectURL = try endpoints.resolveRedirect(location: " ../finish?flow=login#ignored ", from: previousURL)
+
+        // Then
+        #expect(redirectURL.absoluteString == "https://example.com/store/finish?flow=login")
+    }
+
+    @Test(arguments: [
+        ("//attacker.example/collect", ValidationError.originMismatch),
+        ("https://user:secret@example.com/collect", .userInfoNotAllowed),
+        ("https://example.com:8443/collect", .originMismatch),
+        ("ftp://example.com/collect", .unsupportedScheme)
+    ])
+    func test_unsafe_redirect_location_is_rejected(location: String, expectedError: ValidationError) throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let previousURL = try url("https://example.com/login")
+
+        // When
+        let error = validationError { try endpoints.resolveRedirect(location: location, from: previousURL) }
+
+        // Then
+        #expect(error == expectedError)
+    }
+
+    @Test func test_https_redirect_cannot_downgrade_to_http() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("http://example.com"))
+        let previousURL = try url("https://example.com/login")
+
+        // When
+        let error = validationError {
+            try endpoints.resolveRedirect(location: "http://example.com/login", from: previousURL)
+        }
+
+        // Then
+        #expect(error == .insecureDowngrade)
+    }
+
+    @Test func test_form_action_is_transaction_local_and_does_not_replace_the_login_entry() throws {
+        // Given
+        let entryURL = try url("https://example.com/custom-entry?durable=1")
+        let documentURL = try url("https://example.com/login/final-page")
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"), loginEntryURL: entryURL)
+
+        // When
+        let submissionURL = try endpoints.resolveFormAction("../authenticate?transaction=1#ignored", documentURL: documentURL)
+
+        // Then
+        #expect(submissionURL.absoluteString == "https://example.com/authenticate?transaction=1")
+        #expect(endpoints.loginEntryURL == entryURL)
+    }
+
+    @Test func test_empty_form_action_uses_the_final_document_url() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let documentURL = try url("https://example.com/final-login?attempt=1#ignored")
+
+        // When
+        let submissionURL = try endpoints.resolveFormAction("   ", documentURL: documentURL)
+
+        // Then
+        #expect(submissionURL.absoluteString == "https://example.com/final-login?attempt=1")
+    }
+
+    @Test(arguments: [
+        ("https://example.com", "https://example.com/login", "https://attacker.example/collect", ValidationError.originMismatch),
+        ("https://example.com", "https://example.com/login", "https://user:secret@example.com/collect", .userInfoNotAllowed),
+        ("http://example.com", "https://example.com/login", "http://example.com/collect", .insecureDowngrade),
+        ("https://example.com", "https://example.com/login", "https://example.com:8443/collect", .originMismatch)
+    ])
+    func test_eligible_form_with_unsafe_action_never_returns_submission_url(
+        site: String,
+        document: String,
+        action: String,
+        expectedError: ValidationError
+    ) throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url(site))
+        let html = loginForm(action: action)
+        let documentURL = try url(document)
+
+        // When
+        let error = validationError {
+            try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: documentURL)
+        }
+
+        // Then
+        #expect(error == expectedError)
+    }
+
+    @Test func test_admin_and_nonce_destinations_are_derived_and_matched_exactly() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: url("http://example.com"),
+            adminBaseURL: url("http://example.com/hidden-admin/index.php")
+        )
+        let secureLogin = try endpoints.resolveRedirect(
+            location: "https://example.com/custom-login",
+            from: url("http://example.com/wp-login.php")
+        )
+        let adminURL = try url("https://example.com/hidden-admin/")
+        let nonceURL = try url("https://example.com/hidden-admin/admin-ajax.php?action=rest-nonce")
+
+        // When
+        let derivedAdminURL = try endpoints.derivedAdminBaseURL(afterLoginAt: secureLogin)
+        let derivedNonceURL = try endpoints.nonceURL(afterLoginAt: secureLogin)
+
+        // Then
+        #expect(derivedAdminURL == adminURL)
+        #expect(derivedNonceURL == nonceURL)
+        #expect(endpoints.isExpectedAdminBaseURL(adminURL, afterLoginAt: secureLogin))
+        #expect(endpoints.isExpectedNonceURL(nonceURL, afterLoginAt: secureLogin))
+    }
+
+    @Test func test_nonce_classifier_accepts_exact_same_site_endpoint_at_another_admin_path() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let recoveredNonceURL = try url("https://example.com/custom-admin/admin-ajax.php?action=rest-nonce")
+
+        // When
+        let isNonceEndpoint = endpoints.isNonceEndpoint(recoveredNonceURL)
+        let isConfiguredNonceEndpoint = endpoints.isExpectedNonceURL(recoveredNonceURL)
+
+        // Then
+        #expect(isNonceEndpoint)
+        #expect(isConfiguredNonceEndpoint == false)
+    }
+
+    @Test(arguments: [
+        "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce&extra=1",
+        "https://example.com/wp-admin/admin-ajax.php?action=rest%2Dnonce",
+        "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce#fragment",
+        "https://example.com/wp-admin/admin-ajax.php/?action=rest-nonce",
+        "https://example.com/wp-admin/not-admin-ajax.php?action=rest-nonce",
+        "https://attacker.example/wp-admin/admin-ajax.php?action=rest-nonce"
+    ])
+    func test_mutated_nonce_endpoint_is_not_recognized(_ candidate: String) throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let candidateURL = try url(candidate)
+
+        // When
+        let isNonceEndpoint = endpoints.isNonceEndpoint(candidateURL)
+
+        // Then
+        #expect(isNonceEndpoint == false)
+        #expect(endpoints.isExpectedNonceURL(candidateURL) == false)
+    }
+
+    @Test(arguments: [
+        "https://example.com/wp-admin/?page=dashboard",
+        "https://example.com/wp-admin/#fragment",
+        "https://example.com/other-admin/",
+        "https://attacker.example/wp-admin/"
+    ])
+    func test_mutated_admin_destination_does_not_match(_ candidate: String) throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let candidateURL = try url(candidate)
+
+        // When
+        let isExpected = endpoints.isExpectedAdminBaseURL(candidateURL)
+
+        // Then
+        #expect(isExpected == false)
+    }
+
+    @Test func test_redirect_limit_matches_android() {
+        // Given
+        let androidRedirectLimit = 3
+
+        // When
+        let redirectLimit = CookieNonceAuthenticationEndpoints.maximumRedirectCount
+
+        // Then
+        #expect(redirectLimit == androidRedirectLimit)
+    }
+}
+
+private extension CookieNonceAuthenticationEndpointsTests {
+    func url(_ value: String) throws -> URL {
+        try #require(URL(string: value))
+    }
+
+    func validationError<T>(from operation: () throws -> T) -> ValidationError? {
+        do {
+            _ = try operation()
+            return nil
+        } catch let error as ValidationError {
+            return error
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+            return nil
+        }
+    }
+
+    func loginForm(action: String) -> String {
+        "<form id=\"loginform\" name=\"loginform\" method=\"post\" action=\"\(action)\">" +
+            "<input name=\"log\" id=\"user_login\" type=\"text\">" +
+            "<input name=\"pwd\" id=\"user_pass\" type=\"password\"></form>"
+    }
+}

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationRulesTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationRulesTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import NetworkingCore
+
+struct CookieNonceAuthenticationRulesTests {
+    typealias Failure = CookieNonceAuthenticationFailure
+    typealias Stage = CookieNonceAuthenticationResponseStage
+
+    @Test(arguments: responseCases)
+    func test_response_classification_matches_shared_trace(_ trace: ResponseTrace) {
+        // Given
+        let response = trace
+
+        // When
+        let failure = CookieNonceAuthenticationRules.failure(
+            statusCode: response.statusCode,
+            authenticateHeader: response.authenticate,
+            locationHeader: response.location,
+            stage: response.stage
+        )
+
+        // Then
+        #expect(failure == response.expectedFailure)
+    }
+
+    @Test func test_basic_authentication_requires_basic_challenge_scheme() {
+        // Given
+        let misleadingHeader = "Digest realm=\"basic users\""
+        let mixedHeader = "Bearer realm=\"api\", Basic realm=\"store\""
+
+        // When
+        let misleadingResult = CookieNonceAuthenticationRules.containsBasicAuthentication(
+            statusCode: 401,
+            authenticateHeader: misleadingHeader
+        )
+        let mixedResult = CookieNonceAuthenticationRules.containsBasicAuthentication(
+            statusCode: 401,
+            authenticateHeader: mixedHeader
+        )
+
+        // Then
+        #expect(misleadingResult == false)
+        #expect(mixedResult)
+    }
+
+    @Test func test_basic_authentication_ignores_decoys_inside_quoted_digest_realm() {
+        // Given
+        let quotedDecoyHeader = "Digest realm=\"store, Basic realm=decoy\""
+        let escapedQuoteDecoyHeader = "Digest realm=\"store\\\", Basic realm=decoy\""
+
+        // When
+        let quotedDecoyResult = CookieNonceAuthenticationRules.containsBasicAuthentication(
+            statusCode: 401,
+            authenticateHeader: quotedDecoyHeader
+        )
+        let escapedQuoteDecoyResult = CookieNonceAuthenticationRules.containsBasicAuthentication(
+            statusCode: 401,
+            authenticateHeader: escapedQuoteDecoyHeader
+        )
+
+        // Then
+        #expect(quotedDecoyResult == false)
+        #expect(escapedQuoteDecoyResult == false)
+    }
+
+    @Test func test_credential_body_encodes_reserved_characters_and_policy_nonce_url() throws {
+        // Given
+        let nonceURL = try #require(URL(string: "https://example.com/hidden-admin/admin-ajax.php?action=rest-nonce"))
+
+        // When
+        let body = CookieNonceAuthenticationRules.credentialBody(
+            username: "user+name",
+            password: "password *+/$&=2+é",
+            redirectTo: nonceURL
+        )
+        let value = try #require(body.flatMap { String(data: $0, encoding: .utf8) })
+
+        // Then
+        #expect(value.contains("log=user%2Bname"))
+        #expect(value.contains("pwd=password%20*%2B/$%26%3D2%2B%C3%A9"))
+        #expect(value.contains("rememberme=true"))
+        #expect(value.contains("redirect_to=https://example.com/hidden-admin/admin-ajax.php?action%3Drest-nonce"))
+    }
+
+    @Test(arguments: ["ab", "ABC123", "0a9Z"])
+    func test_valid_nonce_is_returned_unchanged(_ value: String) {
+        // Given
+        let data = Data(value.utf8)
+
+        // When
+        let nonce = CookieNonceAuthenticationRules.validatedNonce(from: data)
+
+        // Then
+        #expect(nonce == value)
+    }
+
+    @Test(arguments: ["", "a", "a-b", "nonce\n", "é2"])
+    func test_mutated_nonce_is_rejected(_ value: String) {
+        // Given
+        let data = Data(value.utf8)
+
+        // When
+        let nonce = CookieNonceAuthenticationRules.validatedNonce(from: data)
+
+        // Then
+        #expect(nonce == nil)
+    }
+
+    @Test func test_credential_failure_preserves_rendered_server_error_message() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: #require(URL(string: "https://example.com"))
+        )
+        let html = "<div id=\"login_error\">Incorrect password</div>"
+
+        // When
+        let failure = CookieNonceAuthenticationRules.credentialFailure(
+            in: html,
+            endpoints: endpoints
+        )
+
+        // Then
+        #expect(failure == .loginFailed(message: "Incorrect password"))
+    }
+
+    @Test func test_credential_failure_requires_wordpress_shake_marker_for_invalid_credentials() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: #require(URL(string: "https://example.com"))
+        )
+        let html = "<div id=\"login_error\">Incorrect password</div>" +
+            "<script>document.querySelector('form').classList.add('shake')</script>"
+
+        // When
+        let failure = CookieNonceAuthenticationRules.credentialFailure(in: html, endpoints: endpoints)
+
+        // Then
+        #expect(failure == .invalidCredentials)
+    }
+
+    @Test func test_credential_failure_rejects_captcha_even_with_shake_marker() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: #require(URL(string: "https://example.com"))
+        )
+        let html = "<div id=\"login_error\">Complete the CAPTCHA</div>" +
+            "<script>document.querySelector('form').classList.add('shake')</script>"
+
+        // When
+        let failure = CookieNonceAuthenticationRules.credentialFailure(in: html, endpoints: endpoints)
+
+        // Then
+        #expect(failure == .invalidResponse)
+    }
+}
+
+extension CookieNonceAuthenticationRulesTests {
+    struct ResponseTrace: CustomTestStringConvertible, Sendable {
+        let statusCode: Int
+        let authenticate: String?
+        let location: String?
+        let stage: Stage
+        let expectedFailure: Failure?
+
+        var testDescription: String {
+            "\(stage)-\(statusCode)-\(expectedFailure.map(String.init(describing:)) ?? "accepted")"
+        }
+    }
+
+    static let responseCases = [
+        ResponseTrace(statusCode: 200, authenticate: nil, location: nil, stage: .preflight, expectedFailure: nil),
+        ResponseTrace(statusCode: 302, authenticate: nil, location: "/login", stage: .preflight, expectedFailure: nil),
+        ResponseTrace(statusCode: 302, authenticate: nil, location: nil, stage: .preflight, expectedFailure: .invalidResponse),
+        ResponseTrace(statusCode: 302, authenticate: nil, location: "/admin/", stage: .credentials, expectedFailure: nil),
+        ResponseTrace(statusCode: 302, authenticate: nil, location: "/login", stage: .dashboard, expectedFailure: nil),
+        ResponseTrace(statusCode: 302, authenticate: nil, location: "/nonce", stage: .nonce, expectedFailure: .invalidResponse),
+        ResponseTrace(statusCode: 401, authenticate: "Basic realm=\"store\"", location: nil, stage: .preflight, expectedFailure: .basicAuthenticationRequired),
+        ResponseTrace(statusCode: 404, authenticate: nil, location: nil, stage: .preflight, expectedFailure: .inaccessibleLoginPage),
+        ResponseTrace(statusCode: 404, authenticate: nil, location: nil, stage: .credentials, expectedFailure: .unacceptableStatusCode(404)),
+        ResponseTrace(statusCode: 404, authenticate: nil, location: nil, stage: .nonce, expectedFailure: .inaccessibleAdminPage),
+        ResponseTrace(statusCode: 410, authenticate: nil, location: nil, stage: .preflight, expectedFailure: .inaccessibleLoginPage),
+        ResponseTrace(statusCode: 410, authenticate: nil, location: nil, stage: .credentials, expectedFailure: .unacceptableStatusCode(410)),
+        ResponseTrace(statusCode: 410, authenticate: nil, location: nil, stage: .dashboard, expectedFailure: .inaccessibleAdminPage),
+        ResponseTrace(statusCode: 429, authenticate: nil, location: nil, stage: .nonce, expectedFailure: .unacceptableStatusCode(429))
+    ]
+}

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationRulesTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationRulesTests.swift
@@ -43,10 +43,11 @@ struct CookieNonceAuthenticationRulesTests {
         #expect(mixedResult)
     }
 
-    @Test func test_basic_authentication_ignores_decoys_inside_quoted_digest_realm() {
+    @Test func test_basic_authentication_ignores_digest_decoys() {
         // Given
         let quotedDecoyHeader = "Digest realm=\"store, Basic realm=decoy\""
         let escapedQuoteDecoyHeader = "Digest realm=\"store\\\", Basic realm=decoy\""
+        let parameterDecoyHeader = "Digest realm=\"store\", Basic = \"decoy\""
 
         // When
         let quotedDecoyResult = CookieNonceAuthenticationRules.containsBasicAuthentication(
@@ -57,10 +58,26 @@ struct CookieNonceAuthenticationRulesTests {
             statusCode: 401,
             authenticateHeader: escapedQuoteDecoyHeader
         )
+        let parameterDecoyResult = CookieNonceAuthenticationRules.containsBasicAuthentication(
+            statusCode: 401,
+            authenticateHeader: parameterDecoyHeader
+        )
 
         // Then
         #expect(quotedDecoyResult == false)
         #expect(escapedQuoteDecoyResult == false)
+        #expect(parameterDecoyResult == false)
+    }
+
+    @Test(arguments: [304, 305, 306, 309, 399])
+    func test_non_redirect_3xx_status_is_rejected(_ statusCode: Int) {
+        // Given a non-redirect 3xx status code
+
+        // When
+        let isRedirect = CookieNonceAuthenticationRules.isRedirect(statusCode: statusCode)
+
+        // Then
+        #expect(isRedirect == false)
     }
 
     @Test func test_credential_body_encodes_reserved_characters_and_policy_nonce_url() throws {
@@ -174,6 +191,7 @@ extension CookieNonceAuthenticationRulesTests {
         ResponseTrace(statusCode: 302, authenticate: nil, location: "/admin/", stage: .credentials, expectedFailure: nil),
         ResponseTrace(statusCode: 302, authenticate: nil, location: "/login", stage: .dashboard, expectedFailure: nil),
         ResponseTrace(statusCode: 302, authenticate: nil, location: "/nonce", stage: .nonce, expectedFailure: .invalidResponse),
+        ResponseTrace(statusCode: 304, authenticate: nil, location: "/admin/", stage: .credentials, expectedFailure: .unacceptableStatusCode(304)),
         ResponseTrace(statusCode: 401, authenticate: "Basic realm=\"store\"", location: nil, stage: .preflight, expectedFailure: .basicAuthenticationRequired),
         ResponseTrace(statusCode: 404, authenticate: nil, location: nil, stage: .preflight, expectedFailure: .inaccessibleLoginPage),
         ResponseTrace(statusCode: 404, authenticate: nil, location: nil, stage: .credentials, expectedFailure: .unacceptableStatusCode(404)),

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationRulesTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticationRulesTests.swift
@@ -155,7 +155,7 @@ struct CookieNonceAuthenticationRulesTests {
         #expect(failure == .invalidCredentials)
     }
 
-    @Test func test_credential_failure_rejects_captcha_even_with_shake_marker() throws {
+    @Test func test_credential_failure_preserves_captcha_message_even_with_shake_marker() throws {
         // Given
         let endpoints = try CookieNonceAuthenticationEndpoints(
             siteURL: #require(URL(string: "https://example.com"))
@@ -167,7 +167,7 @@ struct CookieNonceAuthenticationRulesTests {
         let failure = CookieNonceAuthenticationRules.credentialFailure(in: html, endpoints: endpoints)
 
         // Then
-        #expect(failure == .invalidResponse)
+        #expect(failure == .loginFailed(message: "Complete the CAPTCHA"))
     }
 }
 

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/WordPressLoginHTMLVerifierTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/WordPressLoginHTMLVerifierTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import NetworkingCore
+
+struct WordPressLoginHTMLVerifierTests {
+    @Test func test_eligible_wordpress_form_resolves_its_html_decoded_action() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let html = Self.loginForm(action: "../session?mode=login&amp;source=app")
+        let documentURL = try url("https://example.com/account/final-login")
+
+        // When
+        let submissionURL = try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: documentURL)
+
+        // Then
+        #expect(submissionURL?.absoluteString == "https://example.com/session?mode=login&source=app")
+    }
+
+    @Test func test_closed_comment_and_script_decoys_do_not_create_form_ambiguity() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let decoys = "<!--\(Self.loginForm(action: "https://attacker.example"))-->" +
+            "<script>\(Self.loginForm(action: "https://attacker.example"))</script>"
+        let html = decoys + Self.loginForm(action: "/authenticate")
+
+        // When
+        let submissionURL = try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: url("https://example.com/login"))
+
+        // Then
+        #expect(submissionURL?.absoluteString == "https://example.com/authenticate")
+    }
+
+    @Test(arguments: invalidMarkup)
+    func test_ineligible_or_structurally_unsafe_markup_is_rejected(_ html: String) throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+
+        // When
+        let submissionURL = try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: url("https://example.com/login"))
+
+        // Then
+        #expect(submissionURL == nil)
+    }
+
+    @Test func test_unrelated_form_with_one_credential_marker_does_not_create_ambiguity() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let unrelatedForm = "<form method=\"post\"><input name=\"log\"></form>"
+        let html = unrelatedForm + Self.loginForm(action: "/authenticate")
+
+        // When
+        let submissionURL = try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: url("https://example.com/login"))
+
+        // Then
+        #expect(submissionURL?.absoluteString == "https://example.com/authenticate")
+    }
+
+    @Test func test_multiple_fully_eligible_wordpress_forms_are_rejected_as_ambiguous() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let html = Self.loginForm(action: "/first") + Self.loginForm(action: "/second")
+
+        // When
+        let submissionURL = try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: url("https://example.com/login"))
+
+        // Then
+        #expect(submissionURL == nil)
+    }
+
+    @Test func test_quoted_attribute_content_and_html_entities_are_accepted() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let html = Self.loginForm(action: "/authenticate?mode=login&amp;source=app").replacingOccurrences(
+            of: "method=\"POST\"",
+            with: "method=\"POST\" data-note=\" name method action\""
+        )
+
+        // When
+        let submissionURL = try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: url("https://example.com/login"))
+
+        // Then
+        #expect(submissionURL?.absoluteString == "https://example.com/authenticate?mode=login&source=app")
+    }
+
+    @Test func test_authenticated_dashboard_requires_body_classes_and_dashboard_container() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let dashboard = "<body class=\"wp-core-ui INDEX-PHP wp-admin\"><div id=\"dashboard-widgets-wrap\"></div></body>"
+        let missingClass = "<body class=\"wp-admin\"><div id=\"dashboard-widgets-wrap\"></div></body>"
+        let scriptDecoy = "<body class=\"wp-admin index-php\"><script><div id=\"dashboard-widgets-wrap\"></div></script></body>"
+
+        // When
+        let isDashboard = endpoints.isAuthenticatedDashboardHTML(dashboard)
+
+        // Then
+        #expect(isDashboard)
+        #expect(endpoints.isAuthenticatedDashboardHTML(missingClass) == false)
+        #expect(endpoints.isAuthenticatedDashboardHTML(scriptDecoy) == false)
+    }
+
+    @Test func test_authenticated_dashboard_allows_ordinary_well_formed_forms() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let html = "<body class=\"wp-admin index-php\"><form role=\"search\" action=\"/search?name=log&amp;method=post\">" +
+            "<input aria-label=\"Search\" name=\"s\"></form><div id=\"dashboard-widgets-wrap\"></div></body>"
+
+        // When
+        let isDashboard = endpoints.isAuthenticatedDashboardHTML(html)
+
+        // Then
+        #expect(isDashboard)
+    }
+
+    @Test func test_authenticated_dashboard_ignores_unrelated_unbalanced_form() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let html = "<body class=\"wp-admin index-php\"><form><input name=\"search\">" +
+            "<div id=\"dashboard-widgets-wrap\"></div></body>"
+
+        // When
+        let isDashboard = endpoints.isAuthenticatedDashboardHTML(html)
+
+        // Then
+        #expect(isDashboard)
+    }
+
+    @Test func test_login_error_message_excludes_non_rendered_and_anchor_content() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
+        let html = "<div id=\"login_error\"><strong>Error:</strong> Too many attempts. " +
+            "<a href=\"/help\">Get help</a><script>hidden</script></div>"
+
+        // When
+        let message = endpoints.loginErrorMessage(in: html)
+
+        // Then
+        #expect(message == "Error: Too many attempts.")
+    }
+}
+
+private extension WordPressLoginHTMLVerifierTests {
+    static func loginForm(action: String?) -> String {
+        let action = action.map { " action=\"\($0)\"" } ?? ""
+        return "<form id=\"loginform\" name=\"loginform\" method=\"POST\"\(action)>" +
+            "<input type=\"text\" name=\"log\" id=\"user_login\">" +
+            "<input type=\"password\" name=\"pwd\" id=\"user_pass\"></form>"
+    }
+
+    static let invalidMarkup = [
+        loginForm(action: nil).replacingOccurrences(of: " name=\"loginform\"", with: ""),
+        loginForm(action: nil).replacingOccurrences(of: " id=\"loginform\"", with: ""),
+        loginForm(action: nil).replacingOccurrences(of: "method=\"POST\"", with: "method=\"GET\""),
+        loginForm(action: nil).replacingOccurrences(of: "id=\"user_login\"", with: "id=\"wrong\""),
+        loginForm(action: nil).replacingOccurrences(of: "type=\"text\"", with: "type=\"email\""),
+        loginForm(action: nil).replacingOccurrences(of: "id=\"user_pass\"", with: "id=\"wrong\""),
+        loginForm(action: nil).replacingOccurrences(of: "type=\"password\"", with: "type=\"text\""),
+        loginForm(action: nil).replacingOccurrences(of: "name=\"log\"", with: "name=\"log\" disabled"),
+        loginForm(action: nil).replacingOccurrences(of: "name=\"pwd\"", with: "name=\"pwd\" form=\"other\""),
+        loginForm(action: nil).replacingOccurrences(
+            of: "<input type=\"password\"",
+            with: "<input name=\"log\" id=\"decoy\" type=\"text\"><input type=\"password\""
+        ),
+        loginForm(action: nil).replacingOccurrences(of: "</form>", with: ""),
+        "<script>\(loginForm(action: nil))",
+        "<!--\(loginForm(action: nil))",
+        "</form>\(loginForm(action: nil))",
+        "<form id=\"loginform\" name=\"loginform\" method=\"post\"><form>" +
+            "<input name=\"log\" id=\"user_login\" type=\"text\">" +
+            "<input name=\"pwd\" id=\"user_pass\" type=\"password\"></form></form>"
+    ]
+
+    func url(_ value: String) throws -> URL {
+        try #require(URL(string: value))
+    }
+}

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/WordPressLoginHTMLVerifierTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/WordPressLoginHTMLVerifierTests.swift
@@ -98,32 +98,6 @@ struct WordPressLoginHTMLVerifierTests {
         #expect(endpoints.isAuthenticatedDashboardHTML(scriptDecoy) == false)
     }
 
-    @Test func test_authenticated_dashboard_allows_ordinary_well_formed_forms() throws {
-        // Given
-        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
-        let html = "<body class=\"wp-admin index-php\"><form role=\"search\" action=\"/search?name=log&amp;method=post\">" +
-            "<input aria-label=\"Search\" name=\"s\"></form><div id=\"dashboard-widgets-wrap\"></div></body>"
-
-        // When
-        let isDashboard = endpoints.isAuthenticatedDashboardHTML(html)
-
-        // Then
-        #expect(isDashboard)
-    }
-
-    @Test func test_authenticated_dashboard_ignores_unrelated_unbalanced_form() throws {
-        // Given
-        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))
-        let html = "<body class=\"wp-admin index-php\"><form><input name=\"search\">" +
-            "<div id=\"dashboard-widgets-wrap\"></div></body>"
-
-        // When
-        let isDashboard = endpoints.isAuthenticatedDashboardHTML(html)
-
-        // Then
-        #expect(isDashboard)
-    }
-
     @Test func test_login_error_message_excludes_non_rendered_and_anchor_content() throws {
         // Given
         let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: url("https://example.com"))


### PR DESCRIPTION
Part of: WOOMOB-3800

## Description

> [!NOTE]
> **About 59% of the raw diff is tests:** 818 lines (`+818/-0`), primarily security-focused endpoint and HTML-verification scenarios.
>
> Production is 557 raw lines (`+557/-0`), or 486 lines under the Danger test/comment/blank exclusions (`+486/-0`). Keeping the endpoint policy, verifier, and shared rules together preserves one reviewable authentication trust boundary.

### Why
WordPress security plugins can move `wp-login.php` and `wp-admin` to custom paths. WooCommerce iOS currently assumes the standard paths when it verifies site credentials, creates or regenerates an Application Password, and authenticates some WebViews. Stores using relocated endpoints therefore cannot complete native authentication.

Allowing configuration to influence where credentials are submitted is security-sensitive. Both existing iOS authentication transports—the interactive URLSession flow and the runtime Alamofire flow—need one shared definition of which endpoints, redirects, form actions, and nonce destinations are trusted. Implementing those decisions separately would invite behavior and security drift.

### Why this is the first PR
This PR establishes that shared trust boundary before either transport consumes it. It intentionally adds no production call sites, so merging it does not change app behavior. Reviewers can assess the URL and HTML trust rules independently before later PRs send credentials through them.

### How
Add three NetworkingCore components:

- `CookieNonceAuthenticationEndpoints` normalizes the canonical site, login entry, and admin base; enforces same-origin/effective-port rules; rejects userinfo and HTTPS downgrades; derives the nonce URL; and validates safe redirects.
- `WordPressLoginHTMLVerifier` accepts exactly one eligible WordPress login form, resolves its action against the verified document URL, recognizes an authenticated dashboard, and extracts login errors.
- `CookieNonceAuthenticationRules` centralizes status handling, Basic Authentication detection, credential-body encoding, authentication failure classification, and nonce validation for both later transports.

### Credential redirects
Some plugins redirect a successful credential POST to the configured admin base or a valid nonce endpoint. `isExpectedCredentialRedirect` accepts those targets only as evidence that login succeeded and returns `Bool`—not a URL. Later consumers discard the raw redirect and issue a clean GET to the nonce URL derived from validated configuration.

`resolveRedirect` remains public because later app-target consumers need the same redirect policy. Form actions stay behind the internal `resolveFormAction` plus `verifiedLoginFormSubmissionURL` boundary.

### Stack
This is PR 1 of 6:

1. Endpoint trust boundary and shared rules (this PR)
2. Interactive authentication transport
3. Runtime authentication transport
4. Endpoint persistence
5. Site and authenticated WebView consumers
6. Inline endpoint recovery

## Test Steps

N/A — this PR adds no production call sites or user-facing behavior. Manual verification begins when the trust boundary is adopted by the authentication transports in the following PRs.

## Screenshots
N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No entry in this PR because it has no production callers; the final user-facing PR will add it.
