### PR TITLE
[WOOMOB-3800] Verify native site credential endpoints

### DIFF
--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -120,8 +120,9 @@ enum SiteCredentialLoginError: LocalizedError {
 /// - Preflight the configured login entry and verify one eligible WordPress login form.
 /// - Post to that transaction's form action with the exact rest nonce endpoint as the redirect target.
 /// - Prevent the HTTP stack from automatically following that redirect.
-/// - Accept only the expected nonce or configured admin redirect, then ignore it and issue an explicit nonce GET using the same private session.
+/// - Accept only the expected nonce or configured admin redirect as login-success evidence, but never follow it.
 /// - Optionally prove the admin dashboard from its independently derived URL.
+/// - Issue an explicit nonce GET using the same private session.
 /// Ref: pe5sF9-1iQ-p2
 ///
 final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
@@ -352,7 +353,7 @@ private extension SiteCredentialLoginUseCase {
     }
 
     func getRequest(url: URL) -> URLRequest {
-        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 8)
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         request.httpMethod = "GET"
         request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
         return request

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -1,5 +1,9 @@
 import Foundation
 import class Networking.UserAgent
+import enum NetworkingCore.CookieNonceAuthenticationFailure
+import struct NetworkingCore.CookieNonceAuthenticationEndpoints
+import enum NetworkingCore.CookieNonceAuthenticationResponseStage
+import enum NetworkingCore.CookieNonceAuthenticationRules
 import protocol NetworkingCore.URLSessionProtocol
 
 protocol SiteCredentialLoginProtocol {
@@ -113,32 +117,56 @@ enum SiteCredentialLoginError: LocalizedError {
 
 /// This use case handles site credential login without the need to use XMLRPC API.
 /// Steps for login:
-/// - Post to `wp-login.php` with a redirect target for the rest nonce endpoint.
+/// - Preflight the configured login entry and verify one eligible WordPress login form.
+/// - Post to that transaction's form action with the exact rest nonce endpoint as the redirect target.
 /// - Prevent the HTTP stack from automatically following that redirect.
-/// - Validate the redirect target and then issue an explicit nonce GET using the same cookie store.
+/// - Accept only the expected nonce or configured admin redirect, then ignore it and issue an explicit nonce GET using the same private session.
+/// - Optionally prove the admin dashboard from its independently derived URL.
 /// Ref: pe5sF9-1iQ-p2
 ///
 final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
-    private let siteURL: String
+    private let endpointConfiguration: Result<CookieNonceAuthenticationEndpoints, SiteCredentialLoginError>
     private let cookieJar: HTTPCookieStorage
     private let session: URLSessionProtocol
     private let loginSession: URLSessionProtocol
+    private let ownedTransactionSession: URLSession?
+    private let verifyAdminDashboard: Bool
     private var successHandler: (() -> Void)?
     private var errorHandler: ((SiteCredentialLoginError) -> Void)?
 
     init(siteURL: String,
-         cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared,
+         endpoints configuredEndpoints: CookieNonceAuthenticationEndpoints? = nil,
+         verifyAdminDashboard: Bool = false,
+         cookieJar: HTTPCookieStorage = SiteCredentialLoginUseCase.makePrivateCookieJar(),
          session: URLSessionProtocol? = nil,
          loginSession: URLSessionProtocol? = nil) {
-        self.siteURL = siteURL
+        do {
+            guard let siteURL = URL(string: siteURL) else {
+                throw SiteCredentialLoginError.invalidLoginResponse
+            }
+            let defaultEndpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+            if let configuredEndpoints {
+                guard defaultEndpoints.siteURL == configuredEndpoints.siteURL else {
+                    throw SiteCredentialLoginError.invalidLoginResponse
+                }
+                self.endpointConfiguration = .success(configuredEndpoints)
+            } else {
+                self.endpointConfiguration = .success(defaultEndpoints)
+            }
+        } catch {
+            self.endpointConfiguration = .failure(.invalidLoginResponse)
+        }
         self.cookieJar = cookieJar
-        self.session = session ?? Self.makeSession(cookieJar: cookieJar)
-        self.loginSession = loginSession ?? Self.makeRedirectBlockingSession(cookieJar: cookieJar)
+        let transactionSession = session ?? Self.makeRedirectBlockingSession(cookieJar: cookieJar)
+        self.session = transactionSession
+        self.loginSession = loginSession ?? transactionSession
+        self.ownedTransactionSession = session == nil ? transactionSession as? URLSession : nil
+        self.verifyAdminDashboard = verifyAdminDashboard
         super.init()
     }
 
     deinit {
-        (loginSession as? URLSession)?.finishTasksAndInvalidate()
+        ownedTransactionSession?.finishTasksAndInvalidate()
     }
 
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
@@ -151,13 +179,17 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
         // Old cookies can make the login succeeds even with incorrect credentials
         // So we need to clear all cookies before login.
         clearAllCookies()
-        guard let loginRequest = buildLoginRequest(username: username, password: password) else {
-            DDLogError("⛔️ Error constructing login requests")
-            return
-        }
         Task { @MainActor in
             do {
-                try await startLogin(with: loginRequest)
+                let endpoints: CookieNonceAuthenticationEndpoints
+                switch endpointConfiguration {
+                case .success(let configuredEndpoints):
+                    endpoints = configuredEndpoints
+                case .failure(let error):
+                    DDLogError("⛔️ Error constructing or validating login requests")
+                    throw error
+                }
+                try await startLogin(username: username, password: password, endpoints: endpoints)
                 successHandler?()
             } catch let error as SiteCredentialLoginError {
                 errorHandler?(error)
@@ -177,140 +209,177 @@ private extension SiteCredentialLoginUseCase {
         }
     }
 
-    func startLogin(with loginRequest: URLRequest) async throws {
-        try await detectBasicAuthProbe()
+    func startLogin(
+        username: String,
+        password: String,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ) async throws {
+        let submissionURL = try await preflight(endpoints: endpoints)
+        let nonceURL = try endpointValue { try endpoints.nonceURL(afterLoginAt: submissionURL) }
+        let loginRequest = try credentialRequest(
+            username: username,
+            password: password,
+            submissionURL: submissionURL,
+            nonceURL: nonceURL
+        )
+        let loginResponse = try await load(loginRequest, using: loginSession)
+        try validate(loginResponse.http, stage: .credentials)
 
-        let (data, response): (Data, URLResponse) = try await loginSession.data(for: loginRequest)
+        if CookieNonceAuthenticationRules.isRedirect(statusCode: loginResponse.http.statusCode) {
+            guard let location = loginResponse.http.value(forHTTPHeaderField: "Location"),
+                  let responseURL = loginResponse.http.url,
+                  endpoints.isExpectedCredentialRedirect(
+                    location: location,
+                    from: responseURL,
+                    afterLoginAt: submissionURL
+                  ) else {
+                throw SiteCredentialLoginError.invalidLoginResponse
+            }
+        } else {
+            let html = try decodedHTML(from: loginResponse.data)
+            throw SiteCredentialLoginError(
+                CookieNonceAuthenticationRules.credentialFailure(
+                    in: html,
+                    endpoints: endpoints
+                )
+            )
+        }
 
-        guard let response = response as? HTTPURLResponse else {
+        if verifyAdminDashboard {
+            try await verifyDashboard(afterLoginAt: submissionURL, endpoints: endpoints)
+        }
+        try await retrieveNonce(at: nonceURL, afterLoginAt: submissionURL, endpoints: endpoints)
+    }
+
+    func preflight(endpoints: CookieNonceAuthenticationEndpoints) async throws -> URL {
+        var requestURL = endpoints.loginEntryURL
+        var redirectCount = 0
+        while true {
+            let response = try await load(getRequest(url: requestURL), using: session)
+            try validate(response.http, stage: .preflight)
+            if CookieNonceAuthenticationRules.isRedirect(statusCode: response.http.statusCode) {
+                guard redirectCount < CookieNonceAuthenticationEndpoints.maximumRedirectCount,
+                      let location = response.http.value(forHTTPHeaderField: "Location") else {
+                    throw SiteCredentialLoginError.invalidLoginResponse
+                }
+                requestURL = try endpointValue {
+                    try endpoints.resolveRedirect(location: location, from: response.http.url ?? requestURL)
+                }
+                redirectCount += 1
+                continue
+            }
+            let documentURL = response.http.url ?? requestURL
+            let html = try decodedHTML(from: response.data)
+            guard let submissionURL = try endpointValue({
+                try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: documentURL)
+            }) else {
+                throw SiteCredentialLoginError.invalidLoginResponse
+            }
+            return submissionURL
+        }
+    }
+
+    func retrieveNonce(
+        at nonceURL: URL,
+        afterLoginAt loginURL: URL,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ) async throws {
+        let response = try await load(getRequest(url: nonceURL), using: session)
+        try validate(response.http, stage: .nonce)
+        guard let responseURL = response.http.url,
+              endpoints.isExpectedNonceURL(responseURL, afterLoginAt: loginURL),
+              CookieNonceAuthenticationRules.validatedNonce(from: response.data) != nil else {
             throw SiteCredentialLoginError.invalidLoginResponse
         }
-
-        if response.containsHTTPBasicAuthenticationChallenge {
-            throw SiteCredentialLoginError.basicAuthenticationRequired
-        }
-
-        switch response.statusCode {
-        case 300..<400:
-            guard let nonceRequest = buildNonceRequest(from: response) else {
-                throw SiteCredentialLoginError.invalidLoginResponse
-            }
-            try await retrieveNonce(with: nonceRequest)
-        case 404:
-            throw SiteCredentialLoginError.inaccessibleLoginPage
-        case 200:
-            // 200 for the login URL, which means a failure
-            guard let html = String(data: data, encoding: .utf8) else {
-                throw SiteCredentialLoginError.invalidLoginResponse
-            }
-
-            // Extracts error message from the HTML to determine whether there's an authentication issue
-            // otherwise we'll assume it's an invalid response
-            let errorMessage = html.findLoginErrorMessage() ?? ""
-
-            if html.hasInvalidCredentialsPattern(),
-               !errorMessage.lowercased().contains(Constants.captchaText) {
-                throw SiteCredentialLoginError.invalidCredentials
-            } else {
-                throw SiteCredentialLoginError.invalidLoginResponse
-            }
-        default:
-            throw SiteCredentialLoginError.unacceptableStatusCode(code: response.statusCode)
-        }
     }
 
-    func buildLoginRequest(username: String, password: String) -> URLRequest? {
-        guard let loginURL = URL(string: siteURL + Constants.loginPath) else {
-            return nil
-        }
-
-        let nonceRetrievalPath = siteURL + Constants.adminPath + Constants.wporgNoncePath
-        var request = URLRequest(url: loginURL)
-
-        request.httpMethod = "POST"
-        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
-
-        var parameters = [URLQueryItem]()
-        parameters.append(URLQueryItem(name: "log", value: username))
-        parameters.append(URLQueryItem(name: "pwd", value: password))
-        parameters.append(URLQueryItem(name: "redirect_to", value: nonceRetrievalPath))
-        var components = URLComponents()
-        components.queryItems = parameters
-
-        /// `percentEncodedQuery` creates a validly escaped URL query component, but
-        /// doesn't encode the '+'. Percent encodes '+' to avoid this ambiguity.
-        let characterSet = CharacterSet(charactersIn: "+").inverted
-        request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSet)?.data(using: .utf8)
-        return request
-    }
-
-    func buildNonceRequest(from response: HTTPURLResponse) -> URLRequest? {
-        guard let nonceURL = nonceURL(from: response) else {
-            return nil
-        }
-
-        var request = URLRequest(url: nonceURL)
-        request.httpMethod = "GET"
-        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
-        return request
-    }
-
-    /// Issues a lightweight GET to detect Basic Auth without engaging URLSession auth challenge flow.
-    func detectBasicAuthProbe() async throws {
-        guard let loginURL = URL(string: siteURL + Constants.loginPath) else {
+    func verifyDashboard(afterLoginAt loginURL: URL, endpoints: CookieNonceAuthenticationEndpoints) async throws {
+        var requestURL = try endpointValue { try endpoints.derivedAdminBaseURL(afterLoginAt: loginURL) }
+        var redirectCount = 0
+        while true {
+            let response = try await load(getRequest(url: requestURL), using: session)
+            try validate(response.http, stage: .dashboard)
+            if CookieNonceAuthenticationRules.isRedirect(statusCode: response.http.statusCode) {
+                guard redirectCount < CookieNonceAuthenticationEndpoints.maximumRedirectCount,
+                      let location = response.http.value(forHTTPHeaderField: "Location") else {
+                    throw SiteCredentialLoginError.invalidLoginResponse
+                }
+                requestURL = try endpointValue {
+                    try endpoints.resolveRedirect(location: location, from: response.http.url ?? requestURL)
+                }
+                redirectCount += 1
+                continue
+            }
+            let documentURL = response.http.url ?? requestURL
+            let html = try decodedHTML(from: response.data)
+            guard endpoints.isExpectedAdminBaseURL(documentURL, afterLoginAt: loginURL),
+                  endpoints.isAuthenticatedDashboardHTML(html) else {
+                throw SiteCredentialLoginError(
+                    CookieNonceAuthenticationRules.credentialFailure(
+                        in: html,
+                        endpoints: endpoints
+                    )
+                )
+            }
             return
         }
-        var request = URLRequest(
-            url: loginURL,
-            cachePolicy: .reloadIgnoringLocalCacheData,
-            timeoutInterval: 8
-        )
-        request.httpMethod = "GET"
-        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
-
-        let (_, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse else { return }
-        if http.containsHTTPBasicAuthenticationChallenge {
-            throw SiteCredentialLoginError.basicAuthenticationRequired
-        }
     }
 
-    func retrieveNonce(with request: URLRequest) async throws {
+    func load(_ request: URLRequest, using session: URLSessionProtocol) async throws -> (data: Data, http: HTTPURLResponse) {
         let (data, response) = try await session.data(for: request)
-
         guard let response = response as? HTTPURLResponse else {
             throw SiteCredentialLoginError.invalidLoginResponse
         }
+        return (data, response)
+    }
 
-        if response.containsHTTPBasicAuthenticationChallenge {
-            throw SiteCredentialLoginError.basicAuthenticationRequired
-        }
-
-        switch response.statusCode {
-        case 200:
-            guard let nonceString = String(data: data, encoding: .utf8),
-                  nonceString.isValidNonce() else {
-                throw SiteCredentialLoginError.invalidLoginResponse
-            }
-        case 404:
-            throw SiteCredentialLoginError.inaccessibleAdminPage
-        default:
-            throw SiteCredentialLoginError.unacceptableStatusCode(code: response.statusCode)
+    func validate(_ response: HTTPURLResponse, stage: CookieNonceAuthenticationResponseStage) throws {
+        if let failure = CookieNonceAuthenticationRules.failure(
+            statusCode: response.statusCode,
+            authenticateHeader: response.value(forHTTPHeaderField: "WWW-Authenticate"),
+            locationHeader: response.value(forHTTPHeaderField: "Location"),
+            stage: stage
+        ) {
+            throw SiteCredentialLoginError(failure)
         }
     }
 
-    func nonceURL(from response: HTTPURLResponse) -> URL? {
-        guard let location = response.value(forHTTPHeaderField: "Location"),
-              let resolvedURL = URL(string: location, relativeTo: response.url)?.absoluteURL,
-              resolvedURL.isExpectedRestNonceURL(for: siteURL) else {
-            return nil
+    func credentialRequest(username: String, password: String, submissionURL: URL, nonceURL: URL) throws -> URLRequest {
+        guard let body = CookieNonceAuthenticationRules.credentialBody(
+            username: username,
+            password: password,
+            redirectTo: nonceURL
+        ) else {
+            throw SiteCredentialLoginError.invalidLoginResponse
         }
-        return resolvedURL
+        var request = URLRequest(url: submissionURL)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
+        return request
     }
 
-    static func makeSession(cookieJar: HTTPCookieStorage) -> URLSession {
-        URLSession(configuration: makeSessionConfiguration(cookieJar: cookieJar))
+    func getRequest(url: URL) -> URLRequest {
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 8)
+        request.httpMethod = "GET"
+        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    func decodedHTML(from data: Data) throws -> String {
+        guard let html = String(data: data, encoding: .utf8) else {
+            throw SiteCredentialLoginError.invalidLoginResponse
+        }
+        return html
+    }
+
+    func endpointValue<T>(_ operation: () throws -> T) throws -> T {
+        do {
+            return try operation()
+        } catch {
+            throw SiteCredentialLoginError.invalidLoginResponse
+        }
     }
 
     static func makeRedirectBlockingSession(cookieJar: HTTPCookieStorage) -> URLSession {
@@ -321,11 +390,20 @@ private extension SiteCredentialLoginUseCase {
 }
 
 extension SiteCredentialLoginUseCase {
+    static func makePrivateCookieJar() -> HTTPCookieStorage {
+        if let cookieJar = URLSessionConfiguration.ephemeral.httpCookieStorage,
+           cookieJar !== HTTPCookieStorage.shared {
+            return cookieJar
+        }
+        return HTTPCookieStorage()
+    }
+
     static func makeSessionConfiguration(cookieJar: HTTPCookieStorage,
-                                         baseConfiguration: URLSessionConfiguration = .default) -> URLSessionConfiguration {
+                                         baseConfiguration: URLSessionConfiguration = .ephemeral) -> URLSessionConfiguration {
         let configuration = baseConfiguration
         configuration.httpCookieStorage = cookieJar
         configuration.httpShouldSetCookies = true
+        configuration.httpCookieAcceptPolicy = .always
         // This login flow depends on handling the redirect itself and should not be intercepted by debug URLProtocol handlers.
         configuration.protocolClasses = []
         return configuration
@@ -335,10 +413,6 @@ extension SiteCredentialLoginUseCase {
         static let loginPath = "/wp-login.php"
         static let adminPath = "/wp-admin"
         static let wporgNoncePath = "/admin-ajax.php?action=rest-nonce"
-        static let wporgNonceEndpointPath = adminPath + "/admin-ajax.php"
-        static let restNonceActionParameter = "action"
-        static let restNonceAction = "rest-nonce"
-        static let captchaText = "captcha"
     }
 }
 
@@ -351,146 +425,23 @@ private final class RedirectBlockingURLSessionDelegate: NSObject, URLSessionTask
     }
 }
 
-extension HTTPURLResponse {
-    /// Detects whether the server requires HTTP Basic authentication.
-    ///
-    /// When a site is behind basic auth it responds with a 401 and a `WWW-Authenticate` header containing `Basic`.
-    /// That reliably distinguishes it from a normal WordPress login failure, which returns 200.
-    var containsHTTPBasicAuthenticationChallenge: Bool {
-        guard statusCode == 401 else {
-            return false
+private extension SiteCredentialLoginError {
+    init(_ failure: CookieNonceAuthenticationFailure) {
+        switch failure {
+        case .basicAuthenticationRequired:
+            self = .basicAuthenticationRequired
+        case .invalidCredentials:
+            self = .invalidCredentials
+        case .loginFailed(let message):
+            self = .loginFailed(message: message)
+        case .inaccessibleLoginPage:
+            self = .inaccessibleLoginPage
+        case .inaccessibleAdminPage:
+            self = .inaccessibleAdminPage
+        case .invalidResponse:
+            self = .invalidLoginResponse
+        case .unacceptableStatusCode(let code):
+            self = .unacceptableStatusCode(code: code)
         }
-        return value(forHTTPHeaderField: "WWW-Authenticate")?
-            .localizedCaseInsensitiveContains("basic") == true
-    }
-}
-
-private extension URL {
-    func isExpectedRestNonceURL(for siteURLString: String) -> Bool {
-        guard let resolvedComponents = URLComponents(url: self, resolvingAgainstBaseURL: true),
-              let siteURL = URL(string: siteURLString),
-              let siteComponents = URLComponents(url: siteURL, resolvingAgainstBaseURL: true),
-              resolvedComponents.isRestNonceURL else {
-            return false
-        }
-
-        return resolvedComponents.isOnExpectedSite(as: siteComponents)
-    }
-}
-
-private extension URLComponents {
-    var isRestNonceURL: Bool {
-        let action = queryItems?.first(where: { $0.name == SiteCredentialLoginUseCase.Constants.restNonceActionParameter })?.value
-        return path.hasSuffix(SiteCredentialLoginUseCase.Constants.wporgNonceEndpointPath) &&
-            action == SiteCredentialLoginUseCase.Constants.restNonceAction
-    }
-
-    func isOnExpectedSite(as siteComponents: URLComponents) -> Bool {
-        guard let scheme = scheme?.lowercased(),
-              let siteScheme = siteComponents.scheme?.lowercased(),
-              let host = host?.lowercased(),
-              let siteHost = siteComponents.host?.lowercased() else {
-            return false
-        }
-
-        if scheme == siteScheme {
-            return host == siteHost && effectivePort == siteComponents.effectivePort
-        }
-
-        return isHTTPSUpgrade(from: siteComponents, redirectScheme: scheme, redirectHost: host, siteHost: siteHost)
-    }
-
-    var effectivePort: Int? {
-        if let port {
-            return port
-        }
-
-        switch scheme?.lowercased() {
-        case "http":
-            return 80
-        case "https":
-            return 443
-        default:
-            return nil
-        }
-    }
-
-    func isHTTPSUpgrade(from siteComponents: URLComponents,
-                        redirectScheme: String,
-                        redirectHost: String,
-                        siteHost: String) -> Bool {
-        guard siteComponents.scheme?.lowercased() == "http",
-              redirectScheme == "https",
-              redirectHost == siteHost else {
-            return false
-        }
-
-        let usesDefaultUpgradePorts = (siteComponents.port == nil || siteComponents.port == 80) &&
-            (port == nil || port == 443)
-        return usesDefaultUpgradePorts || siteComponents.port == port
-    }
-}
-
-private extension String {
-    /// Gets contents between HTML tags with regex.
-    ///
-    func findLoginErrorMessage() -> String? {
-        let pattern = "<div[^>]*id=\"login_error\"[^>]*>([\\s\\S]+?)</div>"
-        let urlPattern = "<a href=\".*\">[^~]*?</a>"
-        let regexOptions = NSRegularExpression.Options.caseInsensitive
-        let matchOptions = NSRegularExpression.MatchingOptions(rawValue: UInt(0))
-        do {
-            let regex = try NSRegularExpression(pattern: pattern, options: regexOptions)
-            guard let textCheckingResult = regex.firstMatch(in: self,
-                                                            options: matchOptions,
-                                                            range: NSMakeRange(0, count)) else {
-                return nil
-            }
-            let matchRange = textCheckingResult.range(at: 0)
-            let match = (self as NSString).substring(with: matchRange)
-
-            /// Removes any <a> tag
-            let urlRegex = try NSRegularExpression(pattern: urlPattern, options: regexOptions)
-            let results = urlRegex.matches(in: match,
-                                           options: matchOptions,
-                                           range: NSMakeRange(0, match.count))
-            var urlMatches: [String] = []
-            for result in results {
-                let range = result.range(at: 0)
-                let urlMatch = (match as NSString).substring(with: range)
-                urlMatches.append(urlMatch)
-            }
-            if urlMatches.isNotEmpty {
-                var updatedMatch = match
-                urlMatches.forEach { url in
-                    updatedMatch = updatedMatch.replacingOccurrences(of: url, with: "")
-                }
-                return updatedMatch.strippedHTML.trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return match.strippedHTML.trimmingCharacters(in: .whitespacesAndNewlines)
-        } catch {
-            DDLogError("⚠️" + pattern + "<-- not found in string -->" + self )
-            return nil
-        }
-    }
-
-    /// When logging in with site credentials there is no way to properly tell if an error message is an invalid credentials error.
-    /// However, the server injects this `shake` pattern when an invalid credential error is found.
-    /// For the time being, we will use that pattern as a guess for an invalid credential error message.
-    /// ref: https://github.com/WordPress/WordPress/blob/master/wp-login.php#L65-L67
-    ///
-    func hasInvalidCredentialsPattern() -> Bool {
-        contains("document.querySelector('form').classList.add('shake')")
-    }
-
-    /// Validates if the string matches the expected nonce format.
-    /// A valid nonce should contain at least 2 alphanumeric characters.
-    ///
-    func isValidNonce() -> Bool {
-        guard let regex = try? Regex("^[0-9a-zA-Z]{2,}$") else {
-            DDLogError("⚠️ Invalid regex pattern")
-            return false
-        }
-        return wholeMatch(of: regex) != nil
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -251,32 +251,41 @@ private extension SiteCredentialLoginUseCase {
         try await retrieveNonce(at: nonceURL, afterLoginAt: submissionURL, endpoints: endpoints)
     }
 
-    func preflight(endpoints: CookieNonceAuthenticationEndpoints) async throws -> URL {
-        var requestURL = endpoints.loginEntryURL
+    /// Fetches a document, following only same-site redirects and never more than the shared bound.
+    /// Returns the first non-redirect response, so callers only express their own terminal check.
+    func loadDocument(
+        from startURL: URL,
+        stage: CookieNonceAuthenticationResponseStage,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ) async throws -> (url: URL, html: String) {
+        var requestURL = startURL
         var redirectCount = 0
         while true {
             let response = try await load(getRequest(url: requestURL), using: session)
-            try validate(response.http, stage: .preflight)
-            if CookieNonceAuthenticationRules.isRedirect(statusCode: response.http.statusCode) {
-                guard redirectCount < CookieNonceAuthenticationEndpoints.maximumRedirectCount,
-                      let location = response.http.value(forHTTPHeaderField: "Location") else {
-                    throw SiteCredentialLoginError.invalidLoginResponse
-                }
-                requestURL = try endpointValue {
-                    try endpoints.resolveRedirect(location: location, from: response.http.url ?? requestURL)
-                }
-                redirectCount += 1
-                continue
+            try validate(response.http, stage: stage)
+            guard CookieNonceAuthenticationRules.isRedirect(statusCode: response.http.statusCode) else {
+                let html = try decodedHTML(from: response.data)
+                return (response.http.url ?? requestURL, html)
             }
-            let documentURL = response.http.url ?? requestURL
-            let html = try decodedHTML(from: response.data)
-            guard let submissionURL = try endpointValue({
-                try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: documentURL)
-            }) else {
+            guard redirectCount < CookieNonceAuthenticationEndpoints.maximumRedirectCount,
+                  let location = response.http.value(forHTTPHeaderField: "Location") else {
                 throw SiteCredentialLoginError.invalidLoginResponse
             }
-            return submissionURL
+            requestURL = try endpointValue {
+                try endpoints.resolveRedirect(location: location, from: response.http.url ?? requestURL)
+            }
+            redirectCount += 1
         }
+    }
+
+    func preflight(endpoints: CookieNonceAuthenticationEndpoints) async throws -> URL {
+        let document = try await loadDocument(from: endpoints.loginEntryURL, stage: .preflight, endpoints: endpoints)
+        guard let submissionURL = try endpointValue({
+            try endpoints.verifiedLoginFormSubmissionURL(in: document.html, documentURL: document.url)
+        }) else {
+            throw SiteCredentialLoginError.invalidLoginResponse
+        }
+        return submissionURL
     }
 
     func retrieveNonce(
@@ -294,34 +303,16 @@ private extension SiteCredentialLoginUseCase {
     }
 
     func verifyDashboard(afterLoginAt loginURL: URL, endpoints: CookieNonceAuthenticationEndpoints) async throws {
-        var requestURL = try endpointValue { try endpoints.derivedAdminBaseURL(afterLoginAt: loginURL) }
-        var redirectCount = 0
-        while true {
-            let response = try await load(getRequest(url: requestURL), using: session)
-            try validate(response.http, stage: .dashboard)
-            if CookieNonceAuthenticationRules.isRedirect(statusCode: response.http.statusCode) {
-                guard redirectCount < CookieNonceAuthenticationEndpoints.maximumRedirectCount,
-                      let location = response.http.value(forHTTPHeaderField: "Location") else {
-                    throw SiteCredentialLoginError.invalidLoginResponse
-                }
-                requestURL = try endpointValue {
-                    try endpoints.resolveRedirect(location: location, from: response.http.url ?? requestURL)
-                }
-                redirectCount += 1
-                continue
-            }
-            let documentURL = response.http.url ?? requestURL
-            let html = try decodedHTML(from: response.data)
-            guard endpoints.isExpectedAdminBaseURL(documentURL, afterLoginAt: loginURL),
-                  endpoints.isAuthenticatedDashboardHTML(html) else {
-                throw SiteCredentialLoginError(
-                    CookieNonceAuthenticationRules.credentialFailure(
-                        in: html,
-                        endpoints: endpoints
-                    )
+        let adminBaseURL = try endpointValue { try endpoints.derivedAdminBaseURL(afterLoginAt: loginURL) }
+        let document = try await loadDocument(from: adminBaseURL, stage: .dashboard, endpoints: endpoints)
+        guard endpoints.isExpectedAdminBaseURL(document.url, afterLoginAt: loginURL),
+              endpoints.isAuthenticatedDashboardHTML(document.html) else {
+            throw SiteCredentialLoginError(
+                CookieNonceAuthenticationRules.credentialFailure(
+                    in: document.html,
+                    endpoints: endpoints
                 )
-            }
-            return
+            )
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
@@ -11,7 +11,11 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         // Given
         let cookieJar = MockCookieJar()
         cookieJar.setWordPressComCookie(username: "lalala")
-        let useCase = SiteCredentialLoginUseCase(siteURL: "https://test.com", cookieJar: cookieJar)
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: "https://test.com",
+            cookieJar: cookieJar,
+            session: MockURLSession()
+        )
         // confidence check
         let cookies = try XCTUnwrap(cookieJar.cookies)
         XCTAssertTrue(cookies.isNotEmpty)

--- a/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
@@ -1,7 +1,10 @@
+import Network
 import XCTest
 import class Networking.UserAgent
+import struct NetworkingCore.CookieNonceAuthenticationEndpoints
 @testable import WooCommerce
 
+@MainActor
 final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
     func test_cookieJar_is_cleared_upon_login() throws {
@@ -22,7 +25,7 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
     func test_sessionConfiguration_when_customURLProtocolIsPresent_then_removesProtocolClasses() {
         // Given
-        let cookieJar = MockCookieJar()
+        let cookieJar = SiteCredentialLoginUseCase.makePrivateCookieJar()
         let baseConfiguration = URLSessionConfiguration.default
         baseConfiguration.protocolClasses = [SiteCredentialLoginTestURLProtocol.self]
 
@@ -35,7 +38,53 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         // Then
         XCTAssertTrue(configuration.httpCookieStorage === cookieJar)
         XCTAssertEqual(configuration.httpShouldSetCookies, true)
+        XCTAssertEqual(configuration.httpCookieAcceptPolicy, .always)
         XCTAssertEqual(configuration.protocolClasses?.isEmpty, true)
+    }
+
+    func test_make_private_cookie_jar_returns_non_shared_functional_cookie_storage() throws {
+        // Given
+        let cookieJar = SiteCredentialLoginUseCase.makePrivateCookieJar()
+        let url = try XCTUnwrap(URL(string: "https://private-cookie-storage.test"))
+        let cookie = try XCTUnwrap(HTTPCookie(properties: [
+            .domain: url.host ?? "",
+            .path: "/",
+            .name: "private-cookie-storage-sentinel",
+            .value: "present"
+        ]))
+
+        // When
+        cookieJar.setCookie(cookie)
+
+        // Then
+        XCTAssertFalse(cookieJar === HTTPCookieStorage.shared)
+        XCTAssertTrue(cookieJar.cookies(for: url)?.contains(cookie) == true)
+        cookieJar.deleteCookie(cookie)
+    }
+
+    func test_handle_login_when_only_primary_session_is_injected_then_uses_it_for_the_entire_transaction() async throws {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let submissionURL = siteURL + "/credential-submit"
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm(action: submissionURL).utf8))
+        session.simulateResponse(for: submissionURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: siteURL,
+            cookieJar: MockCookieJar(),
+            session: session
+        )
+
+        // When
+        let result = await performLogin(using: useCase)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(session.receivedRequests.compactMap(\.httpMethod), ["GET", "POST", "GET"])
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL, submissionURL, nonceURL])
     }
 
     func test_handleLogin_when_loginRedirectLocation_is_absoluteSameOrigin_then_nonceRequestSucceeds() async {
@@ -123,10 +172,16 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         let siteURL = "http://test.com"
         let session = MockURLSession()
         let loginSession = MockURLSession()
+        let secureLoginURL = "https://test.com" + SiteCredentialLoginUseCase.Constants.loginPath
         let secureNonceURL = "https://test.com" + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
-        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
-        loginSession.simulateResponse(
+        session.simulateResponse(
             for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": secureLoginURL]
+        )
+        session.simulateResponse(for: secureLoginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(
+            for: secureLoginURL,
             statusCode: 302,
             headerFields: ["Location": secureNonceURL]
         )
@@ -140,16 +195,82 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         XCTAssertEqual(session.receivedRequests.last?.url?.absoluteString, secureNonceURL)
     }
 
-    func test_handleLogin_when_loginRedirectLocation_is_not_restNonce_then_returns_invalidLoginResponse() async {
+    func test_handle_login_when_preflight_has_three_safe_redirects_then_nonce_request_succeeds() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let redirectURLs = (1...3).map { "\(siteURL)/login-step-\($0)" }
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": redirectURLs[0]])
+        session.simulateResponse(for: redirectURLs[0], statusCode: 302, headerFields: ["Location": redirectURLs[1]])
+        session.simulateResponse(for: redirectURLs[1], statusCode: 302, headerFields: ["Location": redirectURLs[2]])
+        session.simulateResponse(for: redirectURLs[2], data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: redirectURLs[2], statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL] + redirectURLs + [nonceURL])
+    }
+
+    func test_handle_login_when_preflight_has_fourth_redirect_then_rejects_without_contacting_target() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let redirectURLs = (1...4).map { "\(siteURL)/login-step-\($0)" }
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": redirectURLs[0]])
+        session.simulateResponse(for: redirectURLs[0], statusCode: 302, headerFields: ["Location": redirectURLs[1]])
+        session.simulateResponse(for: redirectURLs[1], statusCode: 302, headerFields: ["Location": redirectURLs[2]])
+        session.simulateResponse(for: redirectURLs[2], statusCode: 302, headerFields: ["Location": redirectURLs[3]])
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL] + Array(redirectURLs.prefix(3)))
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == redirectURLs[3] })
+        XCTAssertEqual(loginSession.requestCount, 0)
+    }
+
+    func test_handle_login_when_form_action_is_same_site_then_posts_to_transaction_local_action() async throws {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let submissionURL = siteURL + "/custom-submit"
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm(action: "/custom-submit").utf8))
+        loginSession.simulateResponse(for: submissionURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(loginSession.lastRequest?.url?.absoluteString, submissionURL)
+        let bodyData = try XCTUnwrap(loginSession.lastRequest?.httpBody)
+        let body = try XCTUnwrap(String(data: bodyData, encoding: .utf8))
+        XCTAssertTrue(body.contains("redirect_to=https://test.com/wp-admin/admin-ajax.php?action%3Drest-nonce"))
+    }
+
+    func test_handle_login_when_form_action_is_cross_origin_then_rejects_without_posting_credentials() async {
         // Given
         let siteURL = "https://test.com"
         let session = MockURLSession()
         let loginSession = MockURLSession()
-        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
-        loginSession.simulateResponse(
+        session.simulateResponse(
             for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
-            statusCode: 302,
-            headerFields: ["Location": siteURL + SiteCredentialLoginUseCase.Constants.adminPath]
+            data: Data(loginForm(action: "https://attacker.example/collect").utf8)
         )
 
         // When
@@ -157,18 +278,598 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
         // Then
         assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertEqual(loginSession.requestCount, 0)
+    }
+
+    func test_handle_login_when_preflight_requires_basic_authentication_then_returns_basic_authentication_required() async {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 401,
+            headerFields: ["WWW-Authenticate": "Basic realm=\"store\""]
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .basicAuthenticationRequired)
+        XCTAssertEqual(loginSession.requestCount, 0)
+    }
+
+    func test_handle_login_when_credentials_return_login_error_then_preserves_server_message() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        let invalidCredentialsHTML = "<div id=\"login_error\">Incorrect password</div>" + loginForm()
+        loginSession.simulateResponse(for: loginURL, data: Data(invalidCredentialsHTML.utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .loginFailed(message: "Incorrect password"))
+    }
+
+    func test_handle_login_when_credentials_return_wordpress_shake_marker_then_returns_invalid_credentials() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        let invalidCredentialsHTML = "<div id=\"login_error\">Incorrect password</div>" + loginForm() +
+            "<script>document.querySelector('form').classList.add('shake')</script>"
+        loginSession.simulateResponse(for: loginURL, data: Data(invalidCredentialsHTML.utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .invalidCredentials)
+    }
+
+    func test_handle_login_when_injected_endpoints_match_site_then_uses_custom_entry_and_admin_paths() async throws {
+        // Given
+        let siteURL = "https://test.com/shop"
+        let customLoginURL = try XCTUnwrap(URL(string: "https://test.com/private-login"))
+        let customAdminURL = try XCTUnwrap(URL(string: "https://test.com/private-admin/"))
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: XCTUnwrap(URL(string: siteURL)),
+            loginEntryURL: customLoginURL,
+            adminBaseURL: customAdminURL
+        )
+        let nonceURL = "https://test.com/private-admin/admin-ajax.php?action=rest-nonce"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: customLoginURL.absoluteString, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: customLoginURL.absoluteString, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, endpoints: endpoints, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(session.receivedRequests.first?.url, customLoginURL)
+    }
+
+    func test_handle_login_when_injected_endpoints_site_mismatches_initializer_then_rejects_without_request() async throws {
+        // Given
+        let siteURL = "https://test.com"
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: XCTUnwrap(URL(string: "https://other.example")))
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+
+        // When
+        let result = await performLogin(siteURL: siteURL, endpoints: endpoints, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertEqual(session.requestCount, 0)
+        XCTAssertEqual(loginSession.requestCount, 0)
+    }
+
+    func test_handle_login_when_admin_verification_is_enabled_then_follows_safe_redirect_and_requires_dashboard() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let adminURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + "/"
+        let dashboardURL = adminURL + "index.php"
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: adminURL, statusCode: 302, headerFields: ["Location": dashboardURL])
+        let dashboard = "<body class=\"wp-admin index-php\"><div id=\"dashboard-widgets-wrap\"></div></body>"
+        session.simulateResponse(for: dashboardURL, data: Data(dashboard.utf8))
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(
+            siteURL: siteURL,
+            verifyAdminDashboard: true,
+            session: session,
+            loginSession: loginSession
+        )
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(
+            session.receivedRequests.compactMap(\.url?.absoluteString),
+            [loginURL, adminURL, dashboardURL, nonceURL]
+        )
+    }
+
+    func test_handle_login_when_admin_verification_returns_login_form_then_fails_before_nonce_request() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let adminURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + "/"
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        let loginPage = loginForm() + "<script>document.querySelector('form').classList.add('shake')</script>"
+        session.simulateResponse(for: adminURL, data: Data(loginPage.utf8))
+
+        // When
+        let result = await performLogin(
+            siteURL: siteURL,
+            verifyAdminDashboard: true,
+            session: session,
+            loginSession: loginSession
+        )
+
+        // Then
+        assertFailure(result, matches: .invalidCredentials)
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == nonceURL })
+    }
+
+    func test_handle_login_when_admin_verification_finds_dashboard_at_unexpected_path_then_rejects_it() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let adminURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + "/"
+        let unexpectedDashboardURL = siteURL + "/other-admin/"
+        let nonceURL = adminURL + "admin-ajax.php?action=rest-nonce"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: adminURL, statusCode: 302, headerFields: ["Location": unexpectedDashboardURL])
+        let dashboard = "<body class=\"wp-admin index-php\"><div id=\"dashboard-widgets-wrap\"></div></body>"
+        session.simulateResponse(for: unexpectedDashboardURL, data: Data(dashboard.utf8))
+
+        // When
+        let result = await performLogin(
+            siteURL: siteURL,
+            verifyAdminDashboard: true,
+            session: session,
+            loginSession: loginSession
+        )
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == nonceURL })
+    }
+
+    func test_handle_login_when_endpoint_construction_fails_then_completes_asynchronously() async {
+        // Given
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: "not a valid absolute site URL",
+            cookieJar: MockCookieJar(),
+            session: session,
+            loginSession: loginSession
+        )
+        let completion = expectation(description: "Login completion")
+        var isLoading = true
+        var receivedError: SiteCredentialLoginError?
+        useCase.setupHandlers(onLoginSuccess: {
+            XCTFail("Expected endpoint validation to fail")
+            completion.fulfill()
+        }, onLoginFailure: { error in
+            receivedError = error
+            isLoading = false
+            completion.fulfill()
+        })
+
+        // When
+        useCase.handleLogin(username: "username", password: "password")
+
+        // Then
+        XCTAssertTrue(isLoading)
+        XCTAssertNil(receivedError)
+        await fulfillment(of: [completion], timeout: 1)
+        XCTAssertFalse(isLoading)
+        assertError(receivedError, matches: .invalidLoginResponse)
+        XCTAssertEqual(session.requestCount, 0)
+        XCTAssertEqual(loginSession.requestCount, 0)
+    }
+
+    func test_handle_login_when_verified_credential_post_is_missing_then_returns_unacceptable_status_code() async {
+        for statusCode in [404, 410] {
+            // Given
+            let siteURL = "https://test.com"
+            let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+            let session = MockURLSession()
+            let loginSession = MockURLSession()
+            loginSession.simulateResponse(for: loginURL, statusCode: statusCode)
+
+            // When
+            let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+            // Then
+            assertFailure(result, matches: .unacceptableStatusCode(code: statusCode))
+        }
+    }
+
+    func test_handle_login_when_preflight_contains_malformed_or_decoy_markup_then_never_posts_credentials() async {
+        for html in malformedLoginMarkup() {
+            // Given
+            let siteURL = "https://test.com"
+            let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+            let session = MockURLSession()
+            let loginSession = MockURLSession()
+            session.simulateResponse(for: loginURL, data: Data(html.utf8))
+
+            // When
+            let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+            // Then
+            assertFailure(result, matches: .invalidLoginResponse)
+            XCTAssertEqual(loginSession.requestCount, 0, "Unexpected credential POST for markup: \(html)")
+        }
+    }
+
+    func test_handle_login_when_admin_verification_has_three_safe_redirects_then_succeeds() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let adminURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + "/"
+        let redirectURLs = [adminURL + "one", adminURL + "two", adminURL + "index.php"]
+        let nonceURL = adminURL + "admin-ajax.php?action=rest-nonce"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: adminURL, statusCode: 302, headerFields: ["Location": redirectURLs[0]])
+        session.simulateResponse(for: redirectURLs[0], statusCode: 302, headerFields: ["Location": redirectURLs[1]])
+        session.simulateResponse(for: redirectURLs[1], statusCode: 302, headerFields: ["Location": redirectURLs[2]])
+        session.simulateResponse(for: redirectURLs[2], data: Data(authenticatedDashboard().utf8))
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(
+            siteURL: siteURL,
+            verifyAdminDashboard: true,
+            session: session,
+            loginSession: loginSession
+        )
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL, adminURL] + redirectURLs + [nonceURL])
+    }
+
+    func test_handle_login_when_admin_verification_has_fourth_redirect_then_never_contacts_target() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let adminURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + "/"
+        let redirectURLs = (1...4).map { adminURL + "step-\($0)" }
+        let nonceURL = adminURL + "admin-ajax.php?action=rest-nonce"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: adminURL, statusCode: 302, headerFields: ["Location": redirectURLs[0]])
+        session.simulateResponse(for: redirectURLs[0], statusCode: 302, headerFields: ["Location": redirectURLs[1]])
+        session.simulateResponse(for: redirectURLs[1], statusCode: 302, headerFields: ["Location": redirectURLs[2]])
+        session.simulateResponse(for: redirectURLs[2], statusCode: 302, headerFields: ["Location": redirectURLs[3]])
+
+        // When
+        let result = await performLogin(
+            siteURL: siteURL,
+            verifyAdminDashboard: true,
+            session: session,
+            loginSession: loginSession
+        )
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL, adminURL] + Array(redirectURLs.prefix(3)))
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == redirectURLs[3] })
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == nonceURL })
+    }
+
+    func test_handle_login_when_admin_verification_redirect_is_off_origin_then_never_contacts_destination() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let adminURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + "/"
+        let nonceURL = adminURL + "admin-ajax.php?action=rest-nonce"
+        let unsafeDestination = "https://attacker.example/wp-admin/"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: adminURL, statusCode: 302, headerFields: ["Location": unsafeDestination])
+
+        // When
+        let result = await performLogin(
+            siteURL: siteURL,
+            verifyAdminDashboard: true,
+            session: session,
+            loginSession: loginSession
+        )
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == unsafeDestination })
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == nonceURL })
+    }
+
+    func test_handle_login_when_retrieving_nonce_then_follow_up_is_bodyless_get() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        loginSession.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": nonceURL])
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        let nonceRequest = session.receivedRequests.last
+        XCTAssertEqual(nonceRequest?.httpMethod, "GET")
+        XCTAssertNil(nonceRequest?.httpBody)
+        XCTAssertNil(nonceRequest?.httpBodyStream)
+    }
+
+    func test_handle_login_when_called_twice_then_each_attempt_starts_from_durable_entry() async throws {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + "/durable-entry"
+        let redirectedLoginURL = siteURL + "/redirected-login"
+        let submissionURL = siteURL + "/credential-submit"
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: XCTUnwrap(URL(string: siteURL)),
+            loginEntryURL: XCTUnwrap(URL(string: loginURL))
+        )
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, statusCode: 302, headerFields: ["Location": redirectedLoginURL])
+        session.simulateResponse(for: redirectedLoginURL, data: Data(loginForm(action: submissionURL).utf8))
+        loginSession.simulateResponse(for: submissionURL, data: Data("<div id=\"login_error\">Try again</div>".utf8))
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: siteURL,
+            endpoints: endpoints,
+            cookieJar: MockCookieJar(),
+            session: session,
+            loginSession: loginSession
+        )
+
+        // When
+        let firstResult = await performLogin(using: useCase)
+        let secondResult = await performLogin(using: useCase)
+
+        // Then
+        assertFailure(firstResult, matches: .loginFailed(message: "Try again"))
+        assertFailure(secondResult, matches: .loginFailed(message: "Try again"))
+        XCTAssertEqual(
+            session.receivedRequests.compactMap(\.url?.absoluteString),
+            [loginURL, redirectedLoginURL, loginURL, redirectedLoginURL]
+        )
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [submissionURL, submissionURL])
+    }
+
+    func test_handle_login_when_transport_fails_then_preserves_generic_failure() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let transportError = URLError(.notConnectedToInternet)
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateError(for: loginURL, error: transportError)
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        guard case .failure(.genericFailure(let underlyingError)) = result else {
+            return XCTFail("Expected generic transport failure, received \(result)")
+        }
+        XCTAssertEqual((underlyingError as NSError).domain, NSURLErrorDomain)
+        XCTAssertEqual((underlyingError as NSError).code, URLError.notConnectedToInternet.rawValue)
+        XCTAssertEqual(loginSession.requestCount, 0)
+    }
+
+    func test_production_url_loading_keeps_cookies_private_and_carries_them_through_dashboard_and_nonce() async throws {
+        // Given
+        let server = try SiteCredentialLoginLoopbackServer(scenario: .successfulDashboardLogin)
+        defer { server.stop() }
+        let siteURL = try server.siteURL()
+        let sentinel = try XCTUnwrap(HTTPCookie(properties: [
+            .domain: "shared-cookie-sentinel.invalid",
+            .path: "/",
+            .name: "site_credential_login_\(UUID().uuidString)",
+            .value: "preserve"
+        ]))
+        HTTPCookieStorage.shared.setCookie(sentinel)
+        defer { HTTPCookieStorage.shared.deleteCookie(sentinel) }
+        let useCase = SiteCredentialLoginUseCase(siteURL: siteURL.absoluteString, verifyAdminDashboard: true)
+
+        // When
+        let result = await performLogin(using: useCase)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        let requests = server.receivedRequests
+        let credentialRequest = try XCTUnwrap(requests.first { $0.method == "POST" })
+        XCTAssertTrue(credentialRequest.headers["cookie"]?.contains("preflight_cookie=present") == true)
+        let dashboardRequest = try XCTUnwrap(requests.first { $0.path == "/wp-admin/" })
+        XCTAssertTrue(dashboardRequest.headers["cookie"]?.contains("login_cookie=present") == true)
+        let nonceRequest = try XCTUnwrap(requests.first { $0.path == "/wp-admin/admin-ajax.php?action=rest-nonce" })
+        XCTAssertEqual(nonceRequest.method, "GET")
+        XCTAssertTrue(nonceRequest.body.isEmpty)
+        XCTAssertTrue(nonceRequest.headers["cookie"]?.contains("login_cookie=present") == true)
+        let sharedCookies = HTTPCookieStorage.shared.cookies ?? []
+        XCTAssertTrue(sharedCookies.contains { $0.name == sentinel.name })
+        XCTAssertFalse(sharedCookies.contains { cookie in
+            cookie.domain == "127.0.0.1" && ["preflight_cookie", "login_cookie"].contains(cookie.name)
+        })
+    }
+
+    func test_production_url_loading_when_preflight_requires_basic_authentication_then_returns_basic_authentication_required() async throws {
+        // Given
+        let server = try SiteCredentialLoginLoopbackServer(scenario: .basicAuthenticationRequired)
+        defer { server.stop() }
+        let useCase = SiteCredentialLoginUseCase(siteURL: try server.siteURL().absoluteString)
+
+        // When
+        let result = await performLogin(using: useCase)
+
+        // Then
+        assertFailure(result, matches: .basicAuthenticationRequired)
+        let requests = server.receivedRequests
+        XCTAssertFalse(requests.isEmpty)
+        XCTAssertTrue(requests.allSatisfy { $0.method == "GET" })
+        XCTAssertTrue(requests.allSatisfy { $0.path == "/wp-login.php" })
+        XCTAssertTrue(requests.allSatisfy { $0.headers["authorization"] == nil })
+        XCTAssertFalse(requests.contains { $0.method == "POST" })
+    }
+
+    func test_production_url_loading_blocks_body_preserving_non_exact_credential_redirect_target() async throws {
+        // Given
+        let server = try SiteCredentialLoginLoopbackServer(scenario: .bodyPreservingCredentialRedirect)
+        defer { server.stop() }
+        let siteURL = try server.siteURL()
+        let useCase = SiteCredentialLoginUseCase(siteURL: siteURL.absoluteString)
+
+        // When
+        let result = await performLogin(using: useCase)
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+        let credentialRequest = try XCTUnwrap(server.receivedRequests.first { $0.method == "POST" })
+        XCTAssertFalse(credentialRequest.body.isEmpty)
+        XCTAssertFalse(server.receivedRequests.contains { $0.path == "/body-preserving-target" })
+    }
+
+    func test_handle_login_when_credential_redirect_is_exact_admin_base_then_fetches_exact_nonce_without_requesting_redirect_target() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let adminURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + "/"
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL)
+        loginSession.simulateResponse(
+            for: loginURL,
+            statusCode: 302,
+            headerFields: ["Location": adminURL]
+        )
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.httpMethod), ["POST"])
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL, nonceURL])
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == adminURL })
+        XCTAssertEqual(session.receivedRequests.last?.httpMethod, "GET")
+        XCTAssertNil(session.receivedRequests.last?.httpBody)
+        XCTAssertNil(session.receivedRequests.last?.httpBodyStream)
+    }
+
+    func test_handle_login_when_credential_redirect_is_custom_nonce_then_fetches_configured_nonce_and_returns_admin_not_found() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let redirectedNonceURL = siteURL + "/hidden-admin/admin-ajax.php?action=rest-nonce"
+        let configuredNonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath +
+            SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        loginSession.simulateResponse(
+            for: loginURL,
+            statusCode: 302,
+            headerFields: ["Location": redirectedNonceURL]
+        )
+        session.simulateResponse(for: configuredNonceURL, statusCode: 404)
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .inaccessibleAdminPage)
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL, configuredNonceURL])
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == redirectedNonceURL })
+        XCTAssertEqual(session.receivedRequests.last?.httpMethod, "GET")
+        XCTAssertNil(session.receivedRequests.last?.httpBody)
+        XCTAssertNil(session.receivedRequests.last?.httpBodyStream)
+    }
+
+    func test_handle_login_when_credential_redirect_is_unrelated_same_site_admin_then_rejects_without_requesting_target_or_nonce() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let unrelatedAdminURL = siteURL + "/other-admin/"
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL)
+        loginSession.simulateResponse(
+            for: loginURL,
+            statusCode: 302,
+            headerFields: ["Location": unrelatedAdminURL]
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.httpMethod), ["POST"])
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == unrelatedAdminURL })
+        XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == nonceURL })
     }
 
     func test_handleLogin_when_loginRedirectLocation_is_crossOriginRestNonce_then_returns_invalidLoginResponse() async {
         // Given
         let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let unsafeNonceURL = "https://example-attacker.test/wp-admin/admin-ajax.php?action=rest-nonce"
         let session = MockURLSession()
         let loginSession = MockURLSession()
-        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        session.simulateResponse(for: loginURL)
         loginSession.simulateResponse(
-            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            for: loginURL,
             statusCode: 302,
-            headerFields: ["Location": "https://example-attacker.test/wp-admin/admin-ajax.php?action=rest-nonce"]
+            headerFields: ["Location": unsafeNonceURL]
         )
 
         // When
@@ -176,18 +877,22 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
         // Then
         assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
     }
 
     func test_handleLogin_when_loginRedirectLocation_is_sameHostDifferentPortRestNonce_then_returns_invalidLoginResponse() async {
         // Given
         let siteURL = "https://test.com:8080"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let unsafeNonceURL = "https://test.com:9090/wp-admin/admin-ajax.php?action=rest-nonce"
         let session = MockURLSession()
         let loginSession = MockURLSession()
-        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        session.simulateResponse(for: loginURL)
         loginSession.simulateResponse(
-            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            for: loginURL,
             statusCode: 302,
-            headerFields: ["Location": "https://test.com:9090/wp-admin/admin-ajax.php?action=rest-nonce"]
+            headerFields: ["Location": unsafeNonceURL]
         )
 
         // When
@@ -195,6 +900,8 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
         // Then
         assertFailure(result, matches: .invalidLoginResponse)
+        XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
+        XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
     }
 
     func test_handleLogin_when_manualNonceRequest_returns_notFound_then_returns_inaccessibleAdminPage() async {
@@ -242,28 +949,6 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         // Then
         assertFailure(result, matches: .unacceptableStatusCode(code: 429))
     }
-
-    func test_basicAuthenticationChallenge_is_detected_from_response_headers() throws {
-        // Given
-        let response = try XCTUnwrap(makeHTTPURLResponse(
-            statusCode: 401,
-            headers: ["WWW-Authenticate": "Basic realm=\"Restricted Area\""]
-        ))
-
-        // Then
-        XCTAssertTrue(response.containsHTTPBasicAuthenticationChallenge)
-    }
-
-    func test_basicAuthenticationChallenge_returns_false_when_header_is_missing() throws {
-        // Given
-        let response = try XCTUnwrap(makeHTTPURLResponse(
-            statusCode: 401,
-            headers: ["Content-Type": "text/html"]
-        ))
-
-        // Then
-        XCTAssertFalse(response.containsHTTPBasicAuthenticationChallenge)
-    }
 }
 
 private final class SiteCredentialLoginTestURLProtocol: URLProtocol {
@@ -280,18 +965,256 @@ private final class SiteCredentialLoginTestURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
+private final class SiteCredentialLoginLoopbackServer: @unchecked Sendable {
+    enum Scenario: Equatable {
+        case successfulDashboardLogin
+        case bodyPreservingCredentialRedirect
+        case basicAuthenticationRequired
+    }
+
+    struct Request: Sendable {
+        let method: String
+        let path: String
+        let headers: [String: String]
+        let body: Data
+    }
+
+    private struct Response {
+        let status: String
+        let headers: [String: String]
+        let body: Data
+    }
+
+    enum ServerError: Error {
+        case failedToStart
+        case missingPort
+    }
+
+    private let scenario: Scenario
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "com.woocommerce.site-credential-login-test-server")
+    private let readiness = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var didResolveReadiness = false
+    private var startupError: NWError?
+    private var requests = [Request]()
+
+    init(scenario: Scenario) throws {
+        self.scenario = scenario
+        self.listener = try NWListener(using: .tcp, on: .any)
+        listener.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                self?.resolveReadiness()
+            case .failed(let error):
+                self?.resolveReadiness(error: error)
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.accept(connection)
+        }
+        listener.start(queue: queue)
+
+        guard readiness.wait(timeout: .now() + 5) == .success else {
+            listener.cancel()
+            throw ServerError.failedToStart
+        }
+        if startupError != nil {
+            listener.cancel()
+            throw ServerError.failedToStart
+        }
+    }
+
+    var receivedRequests: [Request] {
+        lock.withLock { requests }
+    }
+
+    func siteURL() throws -> URL {
+        guard let port = listener.port?.rawValue,
+              let url = URL(string: "http://127.0.0.1:\(port)") else {
+            throw ServerError.missingPort
+        }
+        return url
+    }
+
+    func stop() {
+        listener.stateUpdateHandler = nil
+        listener.newConnectionHandler = nil
+        listener.cancel()
+        queue.sync {}
+    }
+}
+
+private extension SiteCredentialLoginLoopbackServer {
+    func resolveReadiness(error: NWError? = nil) {
+        let shouldSignal = lock.withLock { () -> Bool in
+            guard didResolveReadiness == false else {
+                return false
+            }
+            didResolveReadiness = true
+            startupError = error
+            return true
+        }
+        if shouldSignal {
+            readiness.signal()
+        }
+    }
+
+    func accept(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        receive(on: connection, accumulatedData: Data())
+    }
+
+    func receive(on connection: NWConnection, accumulatedData: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1_024) { [weak self] data, _, isComplete, error in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            var accumulatedData = accumulatedData
+            if let data {
+                accumulatedData.append(data)
+            }
+            if let requestLength = Self.requestLength(in: accumulatedData), accumulatedData.count >= requestLength {
+                guard let request = Self.parseRequest(from: accumulatedData, length: requestLength) else {
+                    connection.cancel()
+                    return
+                }
+                lock.withLock {
+                    self.requests.append(request)
+                }
+                send(response(for: request), on: connection)
+            } else if error != nil || isComplete {
+                connection.cancel()
+            } else {
+                receive(on: connection, accumulatedData: accumulatedData)
+            }
+        }
+    }
+
+    private func response(for request: Request) -> Response {
+        switch (request.method, request.path) {
+        case ("GET", "/wp-login.php") where scenario == .basicAuthenticationRequired:
+            return Response(
+                status: "401 Unauthorized",
+                headers: ["WWW-Authenticate": "Basic realm=\"site-credential-login-sentinel\""],
+                body: Data()
+            )
+        case ("GET", "/wp-login.php"):
+            return Response(
+                status: "200 OK",
+                headers: ["Content-Type": "text/html", "Set-Cookie": "preflight_cookie=present; Path=/"],
+                body: Data(Self.loginForm.utf8)
+            )
+        case ("POST", "/credential-submit") where scenario == .successfulDashboardLogin:
+            return Response(
+                status: "302 Found",
+                headers: [
+                    "Location": "/wp-admin/admin-ajax.php?action=rest-nonce",
+                    "Set-Cookie": "login_cookie=present; Path=/"
+                ],
+                body: Data()
+            )
+        case ("POST", "/credential-submit"):
+            return Response(
+                status: "307 Temporary Redirect",
+                headers: ["Location": "/body-preserving-target"],
+                body: Data()
+            )
+        case ("GET", "/wp-admin/"):
+            return Response(status: "200 OK", headers: ["Content-Type": "text/html"], body: Data(Self.dashboard.utf8))
+        case ("GET", "/wp-admin/admin-ajax.php?action=rest-nonce"):
+            return Response(status: "200 OK", headers: [:], body: Data("validnonce".utf8))
+        default:
+            return Response(status: "404 Not Found", headers: [:], body: Data())
+        }
+    }
+
+    private func send(_ response: Response, on connection: NWConnection) {
+        var headers = response.headers
+        headers["Content-Length"] = String(response.body.count)
+        headers["Connection"] = "close"
+        let headerLines = headers.map { "\($0.key): \($0.value)" }.joined(separator: "\r\n")
+        var data = Data("HTTP/1.1 \(response.status)\r\n\(headerLines)\r\n\r\n".utf8)
+        data.append(response.body)
+        connection.send(content: data, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    static func requestLength(in data: Data) -> Int? {
+        let separator = Data("\r\n\r\n".utf8)
+        guard let separatorRange = data.range(of: separator),
+              let headers = String(data: data[..<separatorRange.lowerBound], encoding: .utf8) else {
+            return nil
+        }
+        let contentLength = headers.components(separatedBy: "\r\n")
+            .first { $0.lowercased().hasPrefix("content-length:") }
+            .flatMap { Int($0.dropFirst("content-length:".count).trimmingCharacters(in: .whitespaces)) } ?? 0
+        return separatorRange.upperBound + contentLength
+    }
+
+    static func parseRequest(from data: Data, length: Int) -> Request? {
+        let separator = Data("\r\n\r\n".utf8)
+        guard let separatorRange = data.range(of: separator),
+              let headerText = String(data: data[..<separatorRange.lowerBound], encoding: .utf8) else {
+            return nil
+        }
+        let lines = headerText.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            return nil
+        }
+        let requestParts = requestLine.split(separator: " ", maxSplits: 2).map(String.init)
+        guard requestParts.count >= 2 else {
+            return nil
+        }
+        let headers = lines.dropFirst().reduce(into: [String: String]()) { result, line in
+            guard let separatorIndex = line.firstIndex(of: ":") else {
+                return
+            }
+            let name = line[..<separatorIndex].lowercased()
+            let value = line[line.index(after: separatorIndex)...].trimmingCharacters(in: .whitespaces)
+            result[name] = value
+        }
+        let body = data.subdata(in: separatorRange.upperBound..<length)
+        return Request(method: requestParts[0], path: requestParts[1], headers: headers, body: body)
+    }
+
+    static let loginForm = """
+        <form id="loginform" name="loginform" method="post" action="/credential-submit">
+        <input name="log" id="user_login" type="text">
+        <input name="pwd" id="user_pass" type="password">
+        </form>
+        """
+
+    static let dashboard = "<body class=\"wp-admin index-php\"><div id=\"dashboard-widgets-wrap\"></div></body>"
+}
+
 // MARK: - Helpers
 private extension SiteCredentialLoginUseCaseTests {
     func performLogin(siteURL: String,
+                      endpoints: CookieNonceAuthenticationEndpoints? = nil,
+                      verifyAdminDashboard: Bool = false,
                       session: MockURLSession,
                       loginSession: MockURLSession) async -> Result<Void, SiteCredentialLoginError> {
+        if endpoints == nil {
+            configureDefaultLoginForm(siteURL: siteURL, session: session)
+        }
         let useCase = SiteCredentialLoginUseCase(
             siteURL: siteURL,
+            endpoints: endpoints,
+            verifyAdminDashboard: verifyAdminDashboard,
             cookieJar: MockCookieJar(),
             session: session,
             loginSession: loginSession
         )
 
+        return await performLogin(using: useCase)
+    }
+
+    func performLogin(using useCase: SiteCredentialLoginUseCase) async -> Result<Void, SiteCredentialLoginError> {
         return await withCheckedContinuation { continuation in
             useCase.setupHandlers(onLoginSuccess: {
                 continuation.resume(returning: .success(()))
@@ -303,13 +1226,46 @@ private extension SiteCredentialLoginUseCaseTests {
         }
     }
 
-    func makeHTTPURLResponse(statusCode: Int, headers: [String: String]) -> HTTPURLResponse? {
-        HTTPURLResponse(
-            url: URL(string: "https://example.com")!,
-            statusCode: statusCode,
-            httpVersion: nil,
-            headerFields: headers
-        )
+    func configureDefaultLoginForm(siteURL: String, session: MockURLSession) {
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        if let configured = session.responses[loginURL],
+           let response = configured.1 as? HTTPURLResponse,
+           response.statusCode != 200 || configured.0.isEmpty == false {
+            return
+        }
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+    }
+
+    func loginForm(action: String? = nil) -> String {
+        let action = action.map { " action=\"\($0)\"" } ?? ""
+        return "<form id=\"loginform\" name=\"loginform\" method=\"post\"\(action)>" +
+            "<input name=\"log\" id=\"user_login\" type=\"text\">" +
+            "<input name=\"pwd\" id=\"user_pass\" type=\"password\"></form>"
+    }
+
+    func malformedLoginMarkup() -> [String] {
+        let form = loginForm()
+        return [
+            form.replacingOccurrences(of: " name=\"loginform\"", with: ""),
+            form.replacingOccurrences(of: "method=\"post\"", with: "method=\"get\""),
+            form.replacingOccurrences(of: "type=\"password\"", with: "type=\"hidden\""),
+            form + form,
+            "<script>\(form)</script>"
+        ]
+    }
+
+    func authenticatedDashboard() -> String {
+        "<body class=\"wp-admin index-php\"><div id=\"dashboard-widgets-wrap\"></div></body>"
+    }
+
+    func assertError(_ actualError: SiteCredentialLoginError?,
+                     matches expectedError: SiteCredentialLoginError,
+                     file: StaticString = #filePath,
+                     line: UInt = #line) {
+        guard let actualError else {
+            return XCTFail("Expected an error", file: file, line: line)
+        }
+        assertFailure(.failure(actualError), matches: expectedError, file: file, line: line)
     }
 
     func assertFailure(_ result: Result<Void, SiteCredentialLoginError>,
@@ -323,10 +1279,15 @@ private extension SiteCredentialLoginUseCaseTests {
 
         switch (actualError, expectedError) {
         case (.invalidLoginResponse, .invalidLoginResponse),
-             (.inaccessibleAdminPage, .inaccessibleAdminPage):
+             (.inaccessibleAdminPage, .inaccessibleAdminPage),
+             (.inaccessibleLoginPage, .inaccessibleLoginPage),
+             (.basicAuthenticationRequired, .basicAuthenticationRequired),
+             (.invalidCredentials, .invalidCredentials):
             break
         case let (.unacceptableStatusCode(actualCode), .unacceptableStatusCode(expectedCode)):
             XCTAssertEqual(actualCode, expectedCode, file: file, line: line)
+        case let (.loginFailed(actualMessage), .loginFailed(expectedMessage)):
+            XCTAssertEqual(actualMessage, expectedMessage, file: file, line: line)
         default:
             XCTFail("Unexpected error: \(actualError)", file: file, line: line)
         }

--- a/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
@@ -147,6 +147,8 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
             session.receivedRequests.last?.value(forHTTPHeaderField: "User-Agent"),
             UserAgent.defaultUserAgent
         )
+        let defaultTimeoutInterval = URLRequest(url: try XCTUnwrap(URL(string: siteURL))).timeoutInterval
+        XCTAssertEqual(session.receivedRequests.map(\.timeoutInterval), [defaultTimeoutInterval, defaultTimeoutInterval])
     }
 
     func test_handleLogin_when_loginRedirectLocation_is_subdirectoryRestNonce_then_nonceRequestSucceeds() async {


### PR DESCRIPTION
Part of: WOOMOB-3800

## Description

> [!NOTE]
> **About 70% of the raw diff is tests and test support:** 1,055 lines (`+1,011/-44`), primarily security-focused `SiteCredentialLoginUseCase` scenarios and local transport support.
>
> Production is 461 raw lines (`+202/-259`), or 403 lines under the Danger test/comment/blank exclusions (`+192/-211`)—above the 300-line guideline. Keeping the complete interactive authentication transaction together avoids an unsafe, unreleasable intermediate transport.

### Why

The interactive direct-site login on trunk posts credentials to a constructed default `wp-login.php` URL and expects a specific redirect. It therefore cannot authenticate stores whose security plugins relocate the login or admin paths.

Once those endpoints become configurable, the app must not post credentials until the login page, redirects, rendered form, and final form action have all been verified under the shared policy introduced by PR #17718. This PR adapts only the existing `URLSession` interactive transport, before any persistence, runtime, or UI producer arrives.

### Why separate PR

This is a security-sensitive replacement of one complete live authentication transaction. Keeping it separate makes the policy-to-transport boundary reviewable and ensures this PR is safe to merge and release even if later stack entries never land.

### How

- Preflight the configured or default login entry with at most three same-site, policy-validated redirects.
- Verify exactly one WordPress login form, resolve its form action transaction-locally, and reject an unsafe action before any credential POST.
- Use one redirect-blocking `URLSession` with a functional private cookie jar and `.always` cookie acceptance for the preflight, credential POST, optional dashboard proof, and nonce request; invalidate only the session this transaction owns.
- Map Basic Auth challenges, invalid credentials, CAPTCHA responses, server errors, and unexpected statuses to existing response behavior.
- Preserve the existing default-path API and callback behavior.

### Security-sensitive redirect behavior

Credential POST redirects are never followed. Only the configured admin URL or a structurally valid nonce redirect counts as success evidence. The raw `Location` value is discarded, and the transaction issues a clean, bodyless GET to the policy-derived configured nonce URL. Dashboard proof remains optional.

This PR deliberately contains no PR3 runtime Alamofire work, persistence, Site/WebView changes, recovery UI, analytics, or release note.

### Stack context

1. #17718 — trust boundary and shared rules
2. This PR — interactive authentication
3. Runtime authentication
4. Persistence
5. Site/WebView
6. Recovery contract and UI


## Test Steps

### Manual regression — standard site-credential login

Prerequisite: Use a real HTTPS self-hosted WooCommerce site with Application Passwords enabled and the standard WordPress login/admin paths.

1. Launch the PR2 build while logged out.
2. Tap **Log In**, enter the store address, and choose **Sign in with store credentials**.
3. Enter valid administrator credentials and submit.
4. Verify the credentials screen completes without a login or unexpected-response error.
5. Verify the app reaches the authenticated store and real Dashboard data loads.

Custom login/admin endpoints are not exposed through the UI at this stack layer; they will be manually verified when endpoint recovery lands.

## Screenshots

N/A — this PR changes the authentication transport only and adds no UI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release note is needed because this stack entry adds no custom-endpoint producer or UI.


