### PR TITLE
[WOOMOB-3800] Secure runtime cookie-nonce authentication

### DIFF
--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -66,6 +66,10 @@ public final class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     ///
     private let authenticationType: AuthenticationType
 
+    /// Resolved cookie-nonce endpoints used by WordPress.org authentication.
+    ///
+    let authenticationEndpoints: CookieNonceAuthenticationEndpoints?
+
     /// To generate and delete application password
     ///
     private let network: Network
@@ -91,11 +95,14 @@ public final class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
                 storage: ApplicationPasswordStorageType? = nil,
                 rootCache: RESTAPIRootCaching = WordPressRESTAPIRootCache.shared) {
         self.authenticationType = type
+        self.authenticationEndpoints = nil
         self.storage = storage ?? ApplicationPasswordStorage(keychain: Keychain(service: WooConstants.keychainServiceName))
         self.network = network
         self.applicationPasswordName = passwordName ?? Self.createPasswordName()
 
-        if case .wporg(_, _, let siteAddress) = type, !(network is AlamofireNetwork) {
+        if case .wporg(_, _, let siteAddress) = type,
+           !(network is AlamofireNetwork),
+           rootCache.root(for: siteAddress) == nil {
             self.discoveryTask = Task {
                 guard rootCache.root(for: siteAddress) == nil else { return }
                 _ = await WordPressAPIDiscovery().resolveRESTAPIRootURL(for: siteAddress)
@@ -109,16 +116,35 @@ public final class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     public init(username: String,
                 password: String,
                 siteAddress: String,
+                authenticationEndpoints: CookieNonceAuthenticationEndpoints? = nil,
                 network: Network? = nil,
                 storage: ApplicationPasswordStorageType? = nil,
                 rootCache: RESTAPIRootCaching = WordPressRESTAPIRootCache.shared) throws {
+        let defaultEndpoints: CookieNonceAuthenticationEndpoints
+        do {
+            guard let siteURL = URL(string: siteAddress) else {
+                throw ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress
+            }
+            defaultEndpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+        } catch {
+            DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteAddress)")
+            throw ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress
+        }
+
+        self.authenticationEndpoints = authenticationEndpoints ?? defaultEndpoints
+        guard let resolvedEndpoints = self.authenticationEndpoints,
+              resolvedEndpoints.siteURL == defaultEndpoints.siteURL else {
+            DDLogWarn("⚠️ Cookie nonce authentication endpoints do not match site \(siteAddress)")
+            throw ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress
+        }
+
         self.authenticationType = .wporg(username: username, password: password, siteAddress: siteAddress)
         self.storage = storage ?? ApplicationPasswordStorage(keychain: Keychain(service: WooConstants.keychainServiceName))
         self.applicationPasswordName = Self.createPasswordName()
 
         if let network {
             self.network = network
-            if network is AlamofireNetwork {
+            if network is AlamofireNetwork || rootCache.root(for: siteAddress) != nil {
                 self.discoveryTask = nil
             } else {
                 self.discoveryTask = Task {
@@ -127,20 +153,18 @@ public final class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
                 }
             }
         } else {
-            guard let loginURL = URL(string: siteAddress + Constants.loginPath),
-                  let adminURL = URL(string: siteAddress + Constants.adminPath) else {
-                DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteAddress)")
-                throw ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress
-            }
             // Prepares the authenticator with username and password
             let config = CookieNonceAuthenticatorConfiguration(username: username,
                                                                password: password,
-                                                               loginURL: loginURL,
-                                                               adminURL: adminURL)
+                                                               endpoints: resolvedEndpoints)
             self.network = WordPressOrgNetwork(configuration: config, siteAddress: siteAddress)
-            self.discoveryTask = Task {
-                guard rootCache.root(for: siteAddress) == nil else { return }
-                _ = await WordPressAPIDiscovery().resolveRESTAPIRootURL(for: siteAddress)
+            if rootCache.root(for: siteAddress) == nil {
+                self.discoveryTask = Task {
+                    guard rootCache.root(for: siteAddress) == nil else { return }
+                    _ = await WordPressAPIDiscovery().resolveRESTAPIRootURL(for: siteAddress)
+                }
+            } else {
+                self.discoveryTask = nil
             }
         }
     }
@@ -409,8 +433,6 @@ private extension DefaultApplicationPasswordUseCase {
     }
 
     enum Constants {
-        static let loginPath = "/wp-login.php"
-        static let adminPath = "/wp-admin/"
         static let editValue = "edit"
     }
 }

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -100,13 +100,8 @@ public final class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
         self.network = network
         self.applicationPasswordName = passwordName ?? Self.createPasswordName()
 
-        if case .wporg(_, _, let siteAddress) = type,
-           !(network is AlamofireNetwork),
-           rootCache.root(for: siteAddress) == nil {
-            self.discoveryTask = Task {
-                guard rootCache.root(for: siteAddress) == nil else { return }
-                _ = await WordPressAPIDiscovery().resolveRESTAPIRootURL(for: siteAddress)
-            }
+        if case .wporg(_, _, let siteAddress) = type, !(network is AlamofireNetwork) {
+            self.discoveryTask = Self.makeDiscoveryTask(for: siteAddress, rootCache: rootCache)
         } else {
             self.discoveryTask = nil
         }
@@ -131,41 +126,40 @@ public final class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
             throw ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress
         }
 
-        self.authenticationEndpoints = authenticationEndpoints ?? defaultEndpoints
-        guard let resolvedEndpoints = self.authenticationEndpoints,
-              resolvedEndpoints.siteURL == defaultEndpoints.siteURL else {
+        let resolvedEndpoints = authenticationEndpoints ?? defaultEndpoints
+        guard resolvedEndpoints.siteURL == defaultEndpoints.siteURL else {
             DDLogWarn("⚠️ Cookie nonce authentication endpoints do not match site \(siteAddress)")
             throw ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress
         }
 
+        self.authenticationEndpoints = resolvedEndpoints
         self.authenticationType = .wporg(username: username, password: password, siteAddress: siteAddress)
         self.storage = storage ?? ApplicationPasswordStorage(keychain: Keychain(service: WooConstants.keychainServiceName))
         self.applicationPasswordName = Self.createPasswordName()
 
         if let network {
             self.network = network
-            if network is AlamofireNetwork || rootCache.root(for: siteAddress) != nil {
-                self.discoveryTask = nil
-            } else {
-                self.discoveryTask = Task {
-                    guard rootCache.root(for: siteAddress) == nil else { return }
-                    _ = await WordPressAPIDiscovery().resolveRESTAPIRootURL(for: siteAddress)
-                }
-            }
+            self.discoveryTask = network is AlamofireNetwork ? nil : Self.makeDiscoveryTask(for: siteAddress, rootCache: rootCache)
         } else {
             // Prepares the authenticator with username and password
             let config = CookieNonceAuthenticatorConfiguration(username: username,
                                                                password: password,
                                                                endpoints: resolvedEndpoints)
             self.network = WordPressOrgNetwork(configuration: config, siteAddress: siteAddress)
-            if rootCache.root(for: siteAddress) == nil {
-                self.discoveryTask = Task {
-                    guard rootCache.root(for: siteAddress) == nil else { return }
-                    _ = await WordPressAPIDiscovery().resolveRESTAPIRootURL(for: siteAddress)
-                }
-            } else {
-                self.discoveryTask = nil
-            }
+            self.discoveryTask = Self.makeDiscoveryTask(for: siteAddress, rootCache: rootCache)
+        }
+    }
+
+    /// Eagerly resolves the REST API root URL unless it is already cached.
+    ///
+    private static func makeDiscoveryTask(for siteAddress: String, rootCache: RESTAPIRootCaching) -> Task<Void, Never>? {
+        guard rootCache.root(for: siteAddress) == nil else {
+            return nil
+        }
+        return Task {
+            // The root may have been cached between this task being created and started.
+            guard rootCache.root(for: siteAddress) == nil else { return }
+            _ = await WordPressAPIDiscovery().resolveRESTAPIRootURL(for: siteAddress)
         }
     }
 

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -96,6 +96,7 @@ final class CookieNonceAuthenticator: RequestInterceptor {
         let sourceConfiguration = session.sessionConfiguration
         let configuration = sourceConfiguration.copy() as? URLSessionConfiguration ?? .ephemeral
         configuration.httpCookieStorage = sourceConfiguration.httpCookieStorage
+        configuration.urlCredentialStorage = nil
         configuration.protocolClasses = []
         return configuration
     }

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -3,7 +3,9 @@ import Foundation
 
 /// An authenticator to handle cookie-nonce authentication.
 /// This differs from WordPressKit's version by handling the nonce retrieval as a separate request
-/// instead of a redirect from the login request - to fix issues with Pressable sites.
+/// instead of following the login redirect - to fix issues with Pressable sites. Credential responses
+/// may redirect to the expected nonce or configured admin base, but nonce retrieval always uses the
+/// independently derived nonce URL.
 ///
 /// This authenticator uses Ajax nonce retrieval method by default
 /// since we are not supporting sites with WP versions earlier than 5.6.0.
@@ -12,14 +14,28 @@ final class CookieNonceAuthenticator: RequestInterceptor {
     private let username: String
     private let password: String
     private let loginURL: URL
-    private let adminURL: URL
+    private let endpoints: CookieNonceAuthenticationEndpoints
+    private let authenticationSessionFactory: @Sendable (Session) -> Session
     private let state = CookieNonceAuthenticatorState()
 
-    init(configuration: CookieNonceAuthenticatorConfiguration) {
+    convenience init(configuration: CookieNonceAuthenticatorConfiguration) {
+        self.init(
+            configuration: configuration,
+            authenticationSessionFactory: { session in
+                Self.makeAuthenticationSession(from: session)
+            }
+        )
+    }
+
+    init(
+        configuration: CookieNonceAuthenticatorConfiguration,
+        authenticationSessionFactory: @escaping @Sendable (Session) -> Session
+    ) {
         self.username = configuration.username
         self.password = configuration.password
-        self.loginURL = configuration.loginURL
-        self.adminURL = configuration.adminURL
+        self.loginURL = configuration.endpoints.loginEntryURL
+        self.endpoints = configuration.endpoints
+        self.authenticationSessionFactory = authenticationSessionFactory
     }
 
     // MARK: Request Adapter
@@ -53,67 +69,192 @@ final class CookieNonceAuthenticator: RequestInterceptor {
     }
 
     enum Error: Swift.Error {
-        case invalidNewPostURL
+        case authenticationFailed(CookieNonceAuthenticationFailure)
         case postLoginFailed(Swift.Error)
-        case missingNonce
-        case unknown(Swift.Error)
+    }
+
+    private enum PreflightResult {
+        case credentials(URL)
+        case authenticated(URL)
+    }
+
+    func authenticate(session: Session) async throws -> String {
+        let authenticationSession = authenticationSessionFactory(session)
+        let preflightResult = try await preflight(session: authenticationSession, endpoints: endpoints)
+        let loginURL: URL
+        let nonceURL: URL
+        switch preflightResult {
+        case .credentials(let submissionURL):
+            loginURL = submissionURL
+            nonceURL = try await handleSiteCredentialLogin(
+                submissionURL: submissionURL,
+                session: authenticationSession,
+                endpoints: endpoints
+            )
+        case .authenticated(let documentURL):
+            loginURL = documentURL
+            nonceURL = try endpointValue { try endpoints.nonceURL(afterLoginAt: documentURL) }
+        }
+        return try await retrieveNonce(
+            at: nonceURL,
+            afterLoginAt: loginURL,
+            session: authenticationSession,
+            endpoints: endpoints
+        )
+    }
+
+    static func authenticationSessionConfiguration(from session: Session) -> URLSessionConfiguration {
+        let sourceConfiguration = session.sessionConfiguration
+        let configuration = sourceConfiguration.copy() as? URLSessionConfiguration ?? .ephemeral
+        configuration.httpCookieStorage = sourceConfiguration.httpCookieStorage
+        configuration.protocolClasses = []
+        return configuration
     }
 }
 
 // MARK: Private helpers
 private extension CookieNonceAuthenticator {
 
+    static func makeAuthenticationSession(from session: Session) -> Session {
+        Session(
+            configuration: authenticationSessionConfiguration(from: session),
+            redirectHandler: Redirector.doNotFollow
+        )
+    }
+
     func startLoginSequence(session: Session) {
         DDLogInfo("Starting Cookie+Nonce login sequence for \(loginURL)")
-        guard let nonceRetrievalURL = buildNonceRequestURL(base: adminURL),
-              let nonceRequest = try? URLRequest(url: nonceRetrievalURL, method: .get) else {
-            return invalidateLoginSequence(error: .invalidNewPostURL)
-        }
         Task(priority: .medium) {
             do {
-                try await handleSiteCredentialLogin(session: session)
-                let page = try await handleNonceRetrieval(request: nonceRequest, session: session)
-                guard let nonce = readNonceFromAjaxAction(html: page) else {
-                    throw CookieNonceAuthenticator.Error.missingNonce
-                }
+                let nonce = try await authenticate(session: session)
                 self.state.nonce = nonce
                 successfulLoginSequence()
             } catch let error as CookieNonceAuthenticator.Error {
                 invalidateLoginSequence(error: error)
             } catch {
-                DDLogError("⛔️ Cookie nonce authenticator failed with uncaught error: \(error)")
-                invalidateLoginSequence(error: .unknown(error))
+                invalidateLoginSequence(error: .postLoginFailed(error))
             }
         }
     }
 
-    func handleSiteCredentialLogin(session: Session) async throws {
-        let request = authenticatedRequest()
-        return try await withCheckedThrowingContinuation { continuation in
+    private func preflight(session: Session, endpoints: CookieNonceAuthenticationEndpoints) async throws -> PreflightResult {
+        var requestURL = endpoints.loginEntryURL
+        var redirectCount = 0
+        while true {
+            let response = try await load(getRequest(url: requestURL), session: session)
+            try validate(response.http, stage: .preflight)
+            if CookieNonceAuthenticationRules.isRedirect(statusCode: response.http.statusCode) {
+                guard redirectCount < CookieNonceAuthenticationEndpoints.maximumRedirectCount,
+                      let location = response.http.value(forHTTPHeaderField: "Location") else {
+                    throw Error.authenticationFailed(.invalidResponse)
+                }
+                requestURL = try endpointValue {
+                    try endpoints.resolveRedirect(location: location, from: response.http.url ?? requestURL)
+                }
+                redirectCount += 1
+                continue
+            }
+            let documentURL = response.http.url ?? requestURL
+            guard let html = String(data: response.data, encoding: .utf8) else {
+                throw Error.authenticationFailed(.invalidResponse)
+            }
+            if endpoints.isAuthenticatedDashboardHTML(html) {
+                return .authenticated(documentURL)
+            }
+            guard let submissionURL = try endpointValue({
+                      try endpoints.verifiedLoginFormSubmissionURL(in: html, documentURL: documentURL)
+                  }) else {
+                throw Error.authenticationFailed(.invalidResponse)
+            }
+            return .credentials(submissionURL)
+        }
+    }
+
+    func handleSiteCredentialLogin(
+        submissionURL: URL,
+        session: Session,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ) async throws -> URL {
+        let nonceURL = try endpointValue { try endpoints.nonceURL(afterLoginAt: submissionURL) }
+        let request = try authenticatedRequest(submissionURL: submissionURL, nonceURL: nonceURL)
+        let response = try await load(request, session: session)
+        try validate(response.http, stage: .credentials)
+        if CookieNonceAuthenticationRules.isRedirect(statusCode: response.http.statusCode) {
+            guard let location = response.http.value(forHTTPHeaderField: "Location"),
+                  let responseURL = response.http.url,
+                  endpoints.isExpectedCredentialRedirect(
+                    location: location,
+                    from: responseURL,
+                    afterLoginAt: submissionURL
+                  ) else {
+                throw Error.authenticationFailed(.invalidResponse)
+            }
+            return nonceURL
+        }
+        guard let html = String(data: response.data, encoding: .utf8) else {
+            throw Error.authenticationFailed(.invalidResponse)
+        }
+        throw Error.authenticationFailed(
+            CookieNonceAuthenticationRules.credentialFailure(
+                in: html,
+                endpoints: endpoints
+            )
+        )
+    }
+
+    func retrieveNonce(
+        at nonceURL: URL,
+        afterLoginAt loginURL: URL,
+        session: Session,
+        endpoints: CookieNonceAuthenticationEndpoints
+    ) async throws -> String {
+        let response = try await load(getRequest(url: nonceURL), session: session)
+        try validate(response.http, stage: .nonce)
+        guard let responseURL = response.http.url,
+              endpoints.isExpectedNonceURL(responseURL, afterLoginAt: loginURL),
+              let nonce = CookieNonceAuthenticationRules.validatedNonce(from: response.data) else {
+            throw Error.authenticationFailed(.invalidResponse)
+        }
+        return nonce
+    }
+
+    func load(_ request: URLRequest, session: Session) async throws -> (data: Data, http: HTTPURLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
             session.request(request)
-                .validate()
                 .response { response in
                     if let error = response.error {
-                        continuation.resume(throwing: CookieNonceAuthenticator.Error.postLoginFailed(error))
+                        continuation.resume(throwing: error)
+                    } else if let http = response.response {
+                        continuation.resume(returning: (response.data ?? Data(), http))
                     } else {
-                        continuation.resume(returning: ())
+                        continuation.resume(throwing: Error.authenticationFailed(.invalidResponse))
                     }
                 }
         }
     }
 
-    func handleNonceRetrieval(request: URLRequest, session: Session) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation -> Void in
-            session.request(request)
-                .validate()
-                .responseString { response in
-                    switch response.result {
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-                    case .success(let page):
-                        continuation.resume(returning: page)
-                    }
-                }
+    func validate(_ response: HTTPURLResponse, stage: CookieNonceAuthenticationResponseStage) throws {
+        if let failure = CookieNonceAuthenticationRules.failure(
+            statusCode: response.statusCode,
+            authenticateHeader: response.value(forHTTPHeaderField: "WWW-Authenticate"),
+            locationHeader: response.value(forHTTPHeaderField: "Location"),
+            stage: stage
+        ) {
+            throw Error.authenticationFailed(failure)
+        }
+    }
+
+    func getRequest(url: URL) -> URLRequest {
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 8)
+        request.httpMethod = HTTPMethod.get.rawValue
+        return request
+    }
+
+    func endpointValue<T>(_ operation: () throws -> T) throws -> T {
+        do {
+            return try operation()
+        } catch {
+            throw Error.authenticationFailed(.invalidResponse)
         }
     }
 
@@ -124,11 +265,9 @@ private extension CookieNonceAuthenticator {
     }
 
     func invalidateLoginSequence(error: Error) {
-        let allowRetry = switch error {
-        case .postLoginFailed, .unknown:
-            true
-        case .invalidNewPostURL, .missingNonce:
-            false
+        var allowRetry = false
+        if case .postLoginFailed(let originalError) = error {
+            allowRetry = Self.isOfflineError(originalError)
         }
         state.invalidate(allowRetry: allowRetry)
         DDLogInfo("Aborting Cookie+Nonce login sequence for \(loginURL)")
@@ -141,14 +280,6 @@ private extension CookieNonceAuthenticator {
         pendingCompletions.forEach { completion in
             completion(result)
         }
-    }
-
-    func readNonceFromAjaxAction(html: String) -> String? {
-        html.isEmpty ? nil : html
-    }
-
-    func buildNonceRequestURL(base: URL) -> URL? {
-        URL(string: "admin-ajax.php?action=rest-nonce", relativeTo: base)
     }
 }
 
@@ -211,23 +342,26 @@ fileprivate extension CookieNonceAuthenticator {
 
 // MARK: Public helpers
 extension CookieNonceAuthenticator {
-    func authenticatedRequest() -> URLRequest {
-        var request = URLRequest(url: loginURL)
+    static func isOfflineError(_ error: Swift.Error) -> Bool {
+        if case .sessionTaskFailed(let underlyingError) = error as? AFError {
+            return isOfflineError(underlyingError)
+        }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorNotConnectedToInternet
+    }
 
-        request.httpMethod = "POST"
+    func authenticatedRequest(submissionURL: URL, nonceURL: URL) throws -> URLRequest {
+        guard let body = CookieNonceAuthenticationRules.credentialBody(
+            username: username,
+            password: password,
+            redirectTo: nonceURL
+        ) else {
+            throw Error.authenticationFailed(.invalidResponse)
+        }
+        var request = URLRequest(url: submissionURL)
+        request.httpMethod = HTTPMethod.post.rawValue
+        request.httpBody = body
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-
-        var parameters = [URLQueryItem]()
-        parameters.append(URLQueryItem(name: "log", value: username))
-        parameters.append(URLQueryItem(name: "pwd", value: password))
-        parameters.append(URLQueryItem(name: "rememberme", value: "true"))
-        var components = URLComponents()
-        components.queryItems = parameters
-
-        /// `percentEncodedQuery` creates a validly escaped URL query component, but
-        /// doesn't encode the '+'. Percent encodes '+' to avoid this ambiguity.
-        let characterSet = CharacterSet(charactersIn: "+").inverted
-        request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSet)?.data(using: .utf8)
         return request
     }
 }

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -235,7 +235,7 @@ private extension CookieNonceAuthenticator {
     }
 
     func getRequest(url: URL) -> URLRequest {
-        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 8)
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         request.httpMethod = HTTPMethod.get.rawValue
         return request
     }

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -13,7 +13,6 @@ import Foundation
 final class CookieNonceAuthenticator: RequestInterceptor {
     private let username: String
     private let password: String
-    private let loginURL: URL
     private let endpoints: CookieNonceAuthenticationEndpoints
     private let authenticationSessionFactory: @Sendable (Session) -> Session
     private let state = CookieNonceAuthenticatorState()
@@ -33,7 +32,6 @@ final class CookieNonceAuthenticator: RequestInterceptor {
     ) {
         self.username = configuration.username
         self.password = configuration.password
-        self.loginURL = configuration.endpoints.loginEntryURL
         self.endpoints = configuration.endpoints
         self.authenticationSessionFactory = authenticationSessionFactory
     }
@@ -55,7 +53,7 @@ final class CookieNonceAuthenticator: RequestInterceptor {
             // Only retry once
             request.retryCount == 0,
             // And don't retry the login request
-            request.request?.url != loginURL,
+            request.request?.url != endpoints.loginEntryURL,
             // Only retry because of failed authorization
             case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = error as? AFError
         else {
@@ -80,27 +78,18 @@ final class CookieNonceAuthenticator: RequestInterceptor {
 
     func authenticate(session: Session) async throws -> String {
         let authenticationSession = authenticationSessionFactory(session)
-        let preflightResult = try await preflight(session: authenticationSession, endpoints: endpoints)
-        let loginURL: URL
+        let preflightResult = try await preflight(session: authenticationSession)
+        let finalLoginURL: URL
         let nonceURL: URL
         switch preflightResult {
         case .credentials(let submissionURL):
-            loginURL = submissionURL
-            nonceURL = try await handleSiteCredentialLogin(
-                submissionURL: submissionURL,
-                session: authenticationSession,
-                endpoints: endpoints
-            )
+            finalLoginURL = submissionURL
+            nonceURL = try await handleSiteCredentialLogin(submissionURL: submissionURL, session: authenticationSession)
         case .authenticated(let documentURL):
-            loginURL = documentURL
+            finalLoginURL = documentURL
             nonceURL = try endpointValue { try endpoints.nonceURL(afterLoginAt: documentURL) }
         }
-        return try await retrieveNonce(
-            at: nonceURL,
-            afterLoginAt: loginURL,
-            session: authenticationSession,
-            endpoints: endpoints
-        )
+        return try await retrieveNonce(at: nonceURL, afterLoginAt: finalLoginURL, session: authenticationSession)
     }
 
     static func authenticationSessionConfiguration(from session: Session) -> URLSessionConfiguration {
@@ -123,7 +112,7 @@ private extension CookieNonceAuthenticator {
     }
 
     func startLoginSequence(session: Session) {
-        DDLogInfo("Starting Cookie+Nonce login sequence for \(loginURL)")
+        DDLogInfo("Starting Cookie+Nonce login sequence for \(endpoints.loginEntryURL)")
         Task(priority: .medium) {
             do {
                 let nonce = try await authenticate(session: session)
@@ -137,7 +126,7 @@ private extension CookieNonceAuthenticator {
         }
     }
 
-    private func preflight(session: Session, endpoints: CookieNonceAuthenticationEndpoints) async throws -> PreflightResult {
+    private func preflight(session: Session) async throws -> PreflightResult {
         var requestURL = endpoints.loginEntryURL
         var redirectCount = 0
         while true {
@@ -170,11 +159,7 @@ private extension CookieNonceAuthenticator {
         }
     }
 
-    func handleSiteCredentialLogin(
-        submissionURL: URL,
-        session: Session,
-        endpoints: CookieNonceAuthenticationEndpoints
-    ) async throws -> URL {
+    func handleSiteCredentialLogin(submissionURL: URL, session: Session) async throws -> URL {
         let nonceURL = try endpointValue { try endpoints.nonceURL(afterLoginAt: submissionURL) }
         let request = try authenticatedRequest(submissionURL: submissionURL, nonceURL: nonceURL)
         let response = try await load(request, session: session)
@@ -202,16 +187,11 @@ private extension CookieNonceAuthenticator {
         )
     }
 
-    func retrieveNonce(
-        at nonceURL: URL,
-        afterLoginAt loginURL: URL,
-        session: Session,
-        endpoints: CookieNonceAuthenticationEndpoints
-    ) async throws -> String {
+    func retrieveNonce(at nonceURL: URL, afterLoginAt finalLoginURL: URL, session: Session) async throws -> String {
         let response = try await load(getRequest(url: nonceURL), session: session)
         try validate(response.http, stage: .nonce)
         guard let responseURL = response.http.url,
-              endpoints.isExpectedNonceURL(responseURL, afterLoginAt: loginURL),
+              endpoints.isExpectedNonceURL(responseURL, afterLoginAt: finalLoginURL),
               let nonce = CookieNonceAuthenticationRules.validatedNonce(from: response.data) else {
             throw Error.authenticationFailed(.invalidResponse)
         }
@@ -259,7 +239,7 @@ private extension CookieNonceAuthenticator {
     }
 
     func successfulLoginSequence() {
-        DDLogInfo("Completed Cookie+Nonce login sequence for \(loginURL)")
+        DDLogInfo("Completed Cookie+Nonce login sequence for \(endpoints.loginEntryURL)")
         state.resetAfterSuccess()
         completeRequests(true)
     }
@@ -270,7 +250,7 @@ private extension CookieNonceAuthenticator {
             allowRetry = Self.isOfflineError(originalError)
         }
         state.invalidate(allowRetry: allowRetry)
-        DDLogInfo("Aborting Cookie+Nonce login sequence for \(loginURL)")
+        DDLogInfo("Aborting Cookie+Nonce login sequence for \(endpoints.loginEntryURL)")
         completeRequests(false)
     }
 

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -144,9 +144,7 @@ private extension CookieNonceAuthenticator {
                 continue
             }
             let documentURL = response.http.url ?? requestURL
-            guard let html = String(data: response.data, encoding: .utf8) else {
-                throw Error.authenticationFailed(.invalidResponse)
-            }
+            let html = try decodeHTML(response)
             if endpoints.isAuthenticatedDashboardHTML(html) {
                 return .authenticated(documentURL)
             }
@@ -176,9 +174,7 @@ private extension CookieNonceAuthenticator {
             }
             return nonceURL
         }
-        guard let html = String(data: response.data, encoding: .utf8) else {
-            throw Error.authenticationFailed(.invalidResponse)
-        }
+        let html = try decodeHTML(response)
         throw Error.authenticationFailed(
             CookieNonceAuthenticationRules.credentialFailure(
                 in: html,
@@ -210,6 +206,19 @@ private extension CookieNonceAuthenticator {
                         continuation.resume(throwing: Error.authenticationFailed(.invalidResponse))
                     }
                 }
+        }
+    }
+
+    func decodeHTML(_ response: (data: Data, http: HTTPURLResponse)) throws -> String {
+        do {
+            return try StringResponseSerializer().serialize(
+                request: nil,
+                response: response.http,
+                data: response.data,
+                error: nil
+            )
+        } catch {
+            throw Error.authenticationFailed(.invalidResponse)
         }
     }
 
@@ -245,6 +254,7 @@ private extension CookieNonceAuthenticator {
     }
 
     func invalidateLoginSequence(error: Error) {
+        DDLogError("⛔️ Cookie nonce authentication failed for \(endpoints.loginEntryURL): \(error)")
         var allowRetry = false
         if case .postLoginFailed(let originalError) = error {
             allowRetry = Self.isOfflineError(originalError)

--- a/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
@@ -7,14 +7,12 @@ import Foundation
 public struct CookieNonceAuthenticatorConfiguration {
     let username: String
     let password: String
-    let loginURL: URL
-    let adminURL: URL
+    let endpoints: CookieNonceAuthenticationEndpoints
 
-    public init(username: String, password: String, loginURL: URL, adminURL: URL) {
+    public init(username: String, password: String, endpoints: CookieNonceAuthenticationEndpoints) {
         self.username = username
         self.password = password
-        self.loginURL = loginURL
-        self.adminURL = adminURL
+        self.endpoints = endpoints
     }
 }
 

--- a/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
@@ -25,9 +25,7 @@ public final class WordPressOrgNetwork: Network {
     private let requestConverter: RequestConverter
 
     private lazy var alamofireSession: Alamofire.Session = {
-        let configuration = URLSessionConfiguration.default
-        configuration.httpCookieStorage = URLSessionConfiguration.ephemeral.httpCookieStorage
-        return makeSession(configuration: configuration)
+        makeSession(configuration: .default)
     }()
 
     public var session: URLSession { alamofireSession.session }

--- a/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
@@ -25,7 +25,9 @@ public final class WordPressOrgNetwork: Network {
     private let requestConverter: RequestConverter
 
     private lazy var alamofireSession: Alamofire.Session = {
-        makeSession(configuration: .default)
+        let configuration = URLSessionConfiguration.default
+        configuration.httpCookieStorage = URLSessionConfiguration.ephemeral.httpCookieStorage
+        return makeSession(configuration: configuration)
     }()
 
     public var session: URLSession { alamofireSession.session }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -26,6 +26,7 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         sourceConfiguration.timeoutIntervalForRequest = 17
         sourceConfiguration.protocolClasses = [CookieNonceAuthenticationURLProtocol.self]
         sourceConfiguration.httpCookieStorage = cookieStorage
+        sourceConfiguration.urlCredentialStorage = URLCredentialStorage.shared
         let sourceSession = Session(configuration: sourceConfiguration)
 
         // When
@@ -34,11 +35,13 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         // Then
         XCTAssertTrue(configuration.protocolClasses?.isEmpty == true)
         XCTAssertTrue(configuration.httpCookieStorage === cookieStorage)
+        XCTAssertNil(configuration.urlCredentialStorage)
         XCTAssertEqual(configuration.timeoutIntervalForRequest, 17)
         XCTAssertEqual(
             sourceSession.sessionConfiguration.protocolClasses?.map { ObjectIdentifier($0) },
             [ObjectIdentifier(CookieNonceAuthenticationURLProtocol.self)]
         )
+        XCTAssertTrue(sourceSession.sessionConfiguration.urlCredentialStorage === URLCredentialStorage.shared)
     }
 
     func test_wordpress_org_network_uses_cookie_storage_isolated_from_shared_and_other_networks() throws {
@@ -520,6 +523,71 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         XCTAssertTrue(trace.successfulProtectedCookie?.contains(scenario.loginCookie) == true)
     }
 
+    func test_wordpress_org_network_when_preflight_requires_Basic_auth_then_does_not_use_cached_credential_or_post_site_credentials() async throws {
+        // Given
+        let cachedCredential = CookieNonceLoopbackScenario.BasicCredential(
+            username: "cached-user",
+            password: "cached-password",
+            realm: "cached-credential-\(UUID().uuidString)"
+        )
+        let scenario = CookieNonceLoopbackScenario(
+            requiredInitialProtectedRequests: 1,
+            preflightBasicCredential: cachedCredential
+        )
+        let server = try CookieNonceLoopbackServer(handler: scenario.response)
+        defer { server.stop() }
+        let siteURL = server.siteURL
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
+            adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+        )
+        let network = WordPressOrgNetwork(
+            configuration: CookieNonceAuthenticatorConfiguration(
+                username: sampleUser,
+                password: samplePassword,
+                endpoints: endpoints
+            ),
+            siteAddress: siteURL.absoluteString
+        )
+        let credentialStorage = try XCTUnwrap(network.session.configuration.urlCredentialStorage)
+        let protectionSpace = URLProtectionSpace(
+            host: try XCTUnwrap(siteURL.host),
+            port: try XCTUnwrap(siteURL.port),
+            protocol: siteURL.scheme,
+            realm: cachedCredential.realm,
+            authenticationMethod: NSURLAuthenticationMethodHTTPBasic
+        )
+        let credential = URLCredential(
+            user: cachedCredential.username,
+            password: cachedCredential.password,
+            persistence: .forSession
+        )
+        credentialStorage.setDefaultCredential(credential, for: protectionSpace)
+        defer { credentialStorage.remove(credential, for: protectionSpace) }
+        XCTAssertTrue(credentialStorage === URLCredentialStorage.shared)
+        XCTAssertEqual(credentialStorage.defaultCredential(for: protectionSpace)?.user, cachedCredential.username)
+        let request = URLRequest(url: siteURL.appendingPathComponent("wp-json/protected"))
+
+        // When
+        do {
+            _ = try await network.responseData(for: request)
+            XCTFail("Expected the protected request to remain unauthorized")
+        } catch {
+            guard case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = error as? AFError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        // Then
+        let trace = scenario.trace
+        XCTAssertEqual(trace.protectedRequestCount, 1)
+        XCTAssertEqual(trace.loginEntryRequestCount, 2)
+        XCTAssertNil(trace.loginEntryAuthorizationHeader)
+        XCTAssertEqual(trace.credentialRequestCount, 0)
+        XCTAssertEqual(trace.nonceRequestCount, 0)
+    }
+
     func test_wordpress_org_network_when_credentials_redirect_to_admin_base_then_fetches_nonce_without_following_redirect() async throws {
         // Given
         let scenario = CookieNonceLoopbackScenario(
@@ -842,9 +910,21 @@ private extension NSLock {
 }
 
 private final class CookieNonceLoopbackScenario: @unchecked Sendable {
+    struct BasicCredential {
+        let username: String
+        let password: String
+        let realm: String
+
+        var authorizationHeader: String {
+            let value = Data("\(username):\(password)".utf8).base64EncodedString()
+            return "Basic \(value)"
+        }
+    }
+
     struct Trace {
         let protectedRequestCount: Int
         let loginEntryRequestCount: Int
+        let loginEntryAuthorizationHeader: String?
         let credentialRequestCount: Int
         let nonceRequestCount: Int
         let successfulProtectedRequestCount: Int
@@ -859,6 +939,7 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
     private let lock = NSLock()
     private let token = UUID().uuidString
     private let requiredInitialProtectedRequests: Int
+    private let preflightBasicCredential: BasicCredential?
     private let credentialRedirectStatusCode: Int?
     private let credentialRedirectsToAdminBase: Bool
     private let protectedMethod: String
@@ -866,6 +947,7 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
     private let successfulProtectedBody: Data
     private var protectedRequestCount = 0
     private var loginEntryRequestCount = 0
+    private var loginEntryAuthorizationHeader: String?
     private var credentialRequestCount = 0
     private var nonceRequestCount = 0
     private var successfulProtectedRequestCount = 0
@@ -878,6 +960,7 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
 
     init(
         requiredInitialProtectedRequests: Int,
+        preflightBasicCredential: BasicCredential? = nil,
         credentialRedirectStatusCode: Int? = nil,
         credentialRedirectsToAdminBase: Bool = false,
         protectedMethod: String = "GET",
@@ -885,6 +968,7 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
         successfulProtectedBody: Data = Data("success".utf8)
     ) {
         self.requiredInitialProtectedRequests = requiredInitialProtectedRequests
+        self.preflightBasicCredential = preflightBasicCredential
         self.credentialRedirectStatusCode = credentialRedirectStatusCode
         self.credentialRedirectsToAdminBase = credentialRedirectsToAdminBase
         self.protectedMethod = protectedMethod
@@ -900,6 +984,7 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
             Trace(
                 protectedRequestCount: protectedRequestCount,
                 loginEntryRequestCount: loginEntryRequestCount,
+                loginEntryAuthorizationHeader: loginEntryAuthorizationHeader,
                 credentialRequestCount: credentialRequestCount,
                 nonceRequestCount: nonceRequestCount,
                 successfulProtectedRequestCount: successfulProtectedRequestCount,
@@ -920,7 +1005,17 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
         switch (request.method, request.target) {
         case ("GET", "/custom-entry"):
             waitForInitialProtectedRequests()
-            lock.withTestLock { loginEntryRequestCount += 1 }
+            lock.withTestLock {
+                loginEntryRequestCount += 1
+                loginEntryAuthorizationHeader = request.headers["authorization"]
+            }
+            if let preflightBasicCredential,
+               request.headers["authorization"] != preflightBasicCredential.authorizationHeader {
+                return .init(
+                    statusCode: 401,
+                    headers: ["WWW-Authenticate": "Basic realm=\"\(preflightBasicCredential.realm)\""]
+                )
+            }
             return .init(
                 statusCode: 200,
                 headers: ["Set-Cookie": "\(preflightCookie); Path=/"],

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -1,34 +1,75 @@
 import Alamofire
-import TestKit
+import Network
 import XCTest
 @testable import Networking
 @testable import NetworkingCore
 
+@MainActor
 final class CookieNonceAuthenticatorTests: XCTestCase {
 
     private let loginURL = URL(string: "https://example.com/wp-login.php")!
     private let adminURL = URL(string: "https://example.com/wp-admin/")!
+    private let siteURL = URL(string: "https://example.com")!
     private let apiRequest = URLRequest(url: URL(string: "https://example.com/wp-json/")!)
     private let sampleUser = "user123"
     private let samplePassword = "password *+/$&=2+é"
 
+    override func tearDown() {
+        CookieNonceAuthenticationURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func test_authentication_session_configuration_when_source_has_protocol_classes_then_clears_them_and_preserves_cookie_storage() {
+        // Given
+        let sourceConfiguration = URLSessionConfiguration.ephemeral
+        let cookieStorage = HTTPCookieStorage()
+        sourceConfiguration.timeoutIntervalForRequest = 17
+        sourceConfiguration.protocolClasses = [CookieNonceAuthenticationURLProtocol.self]
+        sourceConfiguration.httpCookieStorage = cookieStorage
+        let sourceSession = Session(configuration: sourceConfiguration)
+
+        // When
+        let configuration = CookieNonceAuthenticator.authenticationSessionConfiguration(from: sourceSession)
+
+        // Then
+        XCTAssertTrue(configuration.protocolClasses?.isEmpty == true)
+        XCTAssertTrue(configuration.httpCookieStorage === cookieStorage)
+        XCTAssertEqual(configuration.timeoutIntervalForRequest, 17)
+        XCTAssertEqual(
+            sourceSession.sessionConfiguration.protocolClasses?.map { ObjectIdentifier($0) },
+            [ObjectIdentifier(CookieNonceAuthenticationURLProtocol.self)]
+        )
+    }
+
     func test_cookie_nonce_authenticator_encode_parameters_correctly() throws {
         // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: loginURL,
+            adminBaseURL: adminURL
+        )
         let config = CookieNonceAuthenticatorConfiguration(username: sampleUser,
                                                            password: samplePassword,
-                                                           loginURL: loginURL,
-                                                           adminURL: adminURL)
+                                                           endpoints: endpoints)
         let authenticator = CookieNonceAuthenticator(configuration: config)
 
 
-        let generatedBodyAsData = try XCTUnwrap(authenticator.authenticatedRequest().urlRequest?.httpBody)
+        let nonceURL = try endpoints.nonceURL()
+        let generatedBodyAsData = try XCTUnwrap(
+            authenticator.authenticatedRequest(submissionURL: loginURL, nonceURL: nonceURL).httpBody
+        )
         let generatedBodyAsString = try XCTUnwrap(String(data: generatedBodyAsData, encoding: .utf8))
         let generatedBodyParameters = generatedBodyAsString.split(separator: Character("&"))
 
         // When
         /// Expected parameters with encoded data
         ///
-        let expectedParameters = ["log": "user123", "pwd": "password%20*%2B/$%26%3D2%2B%C3%A9", "rememberme": "true"]
+        let expectedParameters = [
+            "log": "user123",
+            "pwd": "password%20*%2B/$%26%3D2%2B%C3%A9",
+            "rememberme": "true",
+            "redirect_to": "https://example.com/wp-admin/admin-ajax.php?action%3Drest-nonce"
+        ]
 
         // Then
         /// Note: As of iOS 12 the parameters were being serialized at random positions. That's *why* this test is a bit extra complex!
@@ -42,77 +83,981 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         }
     }
 
-    // MARK: - Login sequence failure handling (WOOMOB-3866)
-
-    func test_request_when_login_POST_fails_with_401_then_request_completes_with_original_error() throws {
+    func test_authenticated_request_when_form_action_differs_then_posts_transaction_locally() throws {
         // Given
-        // A host that responds with HTTP 401 to the wp-login.php POST
-        // (instead of the standard WordPress 200 + re-rendered login form).
-        let session = makeSessionWithMockURLProtocol(interceptor: makeAuthenticator())
-        MockURLProtocol.Mocks.mockResponse(["error": "unauthorized"], statusCode: 401, for: apiRequest)
-        MockURLProtocol.Mocks.mockResponse(["error": "captcha_required"], statusCode: 401, for: URLRequest(url: loginURL))
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: loginURL,
+            adminBaseURL: adminURL
+        )
+        let config = CookieNonceAuthenticatorConfiguration(
+            username: sampleUser,
+            password: samplePassword,
+            endpoints: endpoints
+        )
+        let authenticator = CookieNonceAuthenticator(configuration: config)
+        let formAction = try XCTUnwrap(URL(string: "https://example.com/custom-login-handler"))
 
         // When
-        let error: Error? = waitFor { promise in
-            session.request(self.apiRequest)
-                .validate()
-                .response { response in
-                    promise(response.error)
-                }
-        }
+        let nonceURL = try XCTUnwrap(URL(string: "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+        let request = try authenticator.authenticatedRequest(submissionURL: formAction, nonceURL: nonceURL)
 
         // Then
-        let afError = try XCTUnwrap(error as? AFError)
-        guard case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = afError else {
-            return XCTFail("Expected a 401 validation error, got \(afError)")
+        XCTAssertEqual(request.url, formAction)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+    }
+
+    func test_authenticate_when_form_action_differs_then_posts_credentials_and_gets_exact_nonce() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let submissionURL = try XCTUnwrap(URL(string: "https://example.com/custom-submit"))
+        let nonceURL = try XCTUnwrap(URL(string: "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            data: Data(loginForm(action: "/custom-submit").utf8)
+        )
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "POST",
+            url: submissionURL,
+            statusCode: 302,
+            headers: ["Location": nonceURL.absoluteString]
+        )
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: nonceURL, data: Data("freshnonce".utf8))
+
+        // When
+        let nonce = try await authenticator.authenticate(session: makeSession())
+
+        // Then
+        XCTAssertEqual(nonce, "freshnonce")
+        let requests = CookieNonceAuthenticationURLProtocol.receivedRequests
+        XCTAssertEqual(requests.compactMap(\.httpMethod), ["GET", "POST", "GET"])
+        XCTAssertEqual(requests.compactMap(\.url), [loginURL, submissionURL, nonceURL])
+        let bodyData = try XCTUnwrap(requests[1].httpBody)
+        let body = try XCTUnwrap(String(data: bodyData, encoding: .utf8))
+        XCTAssertTrue(body.contains("redirect_to=https://example.com/wp-admin/admin-ajax.php?action%3Drest-nonce"))
+    }
+
+    func test_authenticate_when_credential_redirect_is_exact_admin_base_then_gets_exact_nonce_without_requesting_redirect_target() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let submissionURL = try XCTUnwrap(URL(string: "https://example.com/custom-submit"))
+        let nonceURL = try XCTUnwrap(URL(string: "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            data: Data(loginForm(action: submissionURL.absoluteString).utf8)
+        )
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "POST",
+            url: submissionURL,
+            statusCode: 302,
+            headers: ["Location": adminURL.absoluteString]
+        )
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: nonceURL, data: Data("freshnonce".utf8))
+
+        // When
+        let nonce = try await authenticator.authenticate(session: makeSession())
+
+        // Then
+        XCTAssertEqual(nonce, "freshnonce")
+        let requests = CookieNonceAuthenticationURLProtocol.receivedRequests
+        XCTAssertEqual(requests.compactMap(\.httpMethod), ["GET", "POST", "GET"])
+        XCTAssertEqual(requests.compactMap(\.url), [loginURL, submissionURL, nonceURL])
+        XCTAssertEqual(requests.filter { $0.httpMethod == "POST" }.count, 1)
+        XCTAssertFalse(requests.contains { $0.url == adminURL })
+        XCTAssertNil(requests.last?.httpBody)
+        XCTAssertNil(requests.last?.httpBodyStream)
+    }
+
+    func test_authenticate_when_credential_redirect_is_custom_nonce_then_gets_configured_nonce_and_reports_admin_not_found() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let submissionURL = try XCTUnwrap(URL(string: "https://example.com/custom-submit"))
+        let redirectedNonceURL = try XCTUnwrap(URL(string: "https://example.com/hidden-admin/admin-ajax.php?action=rest-nonce"))
+        let configuredNonceURL = try XCTUnwrap(URL(string: "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            data: Data(loginForm(action: submissionURL.absoluteString).utf8)
+        )
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "POST",
+            url: submissionURL,
+            statusCode: 302,
+            headers: ["Location": redirectedNonceURL.absoluteString]
+        )
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: configuredNonceURL, statusCode: 404)
+
+        // When / Then
+        do {
+            _ = try await authenticator.authenticate(session: makeSession())
+            XCTFail("Expected the configured nonce endpoint to report admin not found")
+        } catch CookieNonceAuthenticator.Error.authenticationFailed(.inaccessibleAdminPage) {
+            let requests = CookieNonceAuthenticationURLProtocol.receivedRequests
+            XCTAssertEqual(requests.compactMap(\.httpMethod), ["GET", "POST", "GET"])
+            XCTAssertEqual(requests.compactMap(\.url), [loginURL, submissionURL, configuredNonceURL])
+            XCTAssertFalse(requests.contains { $0.url == redirectedNonceURL })
+            XCTAssertEqual(requests.last?.httpMethod, "GET")
+            XCTAssertNil(requests.last?.httpBody)
+            XCTAssertNil(requests.last?.httpBodyStream)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
-    func test_request_when_login_sequence_previously_failed_with_unexpected_error_then_subsequent_request_completes() throws {
+    func test_authenticate_when_credential_redirect_is_unrelated_same_site_admin_then_rejects_without_requesting_target_or_nonce() async throws {
         // Given
-        // A first request has already gone through a login sequence whose wp-login.php POST
-        // failed with an unexpected 401. Before the fix, this left the authenticator stuck in
-        // the authenticating state, so any subsequent 401 request would hang forever.
-        let session = makeSessionWithMockURLProtocol(interceptor: makeAuthenticator())
-        MockURLProtocol.Mocks.mockResponse(["error": "unauthorized"], statusCode: 401, for: apiRequest)
-        MockURLProtocol.Mocks.mockResponse(["error": "captcha_required"], statusCode: 401, for: URLRequest(url: loginURL))
-        _ = waitFor { promise in
-            session.request(self.apiRequest)
-                .validate()
-                .response { response in
-                    promise(response.error)
-                }
+        let authenticator = try stubbedAuthenticator()
+        let submissionURL = try XCTUnwrap(URL(string: "https://example.com/custom-submit"))
+        let unrelatedAdminURL = try XCTUnwrap(URL(string: "https://example.com/other-admin/"))
+        let nonceURL = try XCTUnwrap(URL(string: "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            data: Data(loginForm(action: submissionURL.absoluteString).utf8)
+        )
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "POST",
+            url: submissionURL,
+            statusCode: 302,
+            headers: ["Location": unrelatedAdminURL.absoluteString]
+        )
+
+        // When / Then
+        do {
+            _ = try await authenticator.authenticate(session: makeSession())
+            XCTFail("Expected an unrelated same-site admin redirect to be rejected")
+        } catch CookieNonceAuthenticator.Error.authenticationFailed(.invalidResponse) {
+            let requests = CookieNonceAuthenticationURLProtocol.receivedRequests
+            XCTAssertEqual(requests.compactMap(\.httpMethod), ["GET", "POST"])
+            XCTAssertEqual(requests.compactMap(\.url), [loginURL, submissionURL])
+            XCTAssertEqual(requests.filter { $0.httpMethod == "POST" }.count, 1)
+            XCTAssertFalse(requests.contains { $0.url == unrelatedAdminURL })
+            XCTAssertFalse(requests.contains { $0.url == nonceURL })
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_authenticate_when_preflight_is_authenticated_dashboard_then_skips_credentials_and_gets_fresh_nonce() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let nonceURL = try XCTUnwrap(URL(string: "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+        let dashboard = "<body class=\"wp-core-ui index-php wp-admin\"><div id=\"dashboard-widgets-wrap\"></div></body>"
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            data: Data(dashboard.utf8)
+        )
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: nonceURL, data: Data("freshnonce".utf8))
+
+        // When
+        let nonce = try await authenticator.authenticate(session: makeSession())
+
+        // Then
+        XCTAssertEqual(nonce, "freshnonce")
+        let requests = CookieNonceAuthenticationURLProtocol.receivedRequests
+        XCTAssertEqual(requests.compactMap(\.httpMethod), ["GET", "GET"])
+        XCTAssertEqual(requests.compactMap(\.url), [loginURL, nonceURL])
+    }
+
+    func test_authenticate_when_preflight_has_fourth_redirect_then_rejects_without_contacting_target() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let redirectURLs = try (1...4).map { index in
+            try XCTUnwrap(URL(string: "https://example.com/login-step-\(index)"))
+        }
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            statusCode: 302,
+            headers: ["Location": redirectURLs[0].absoluteString]
+        )
+        for index in 0..<3 {
+            CookieNonceAuthenticationURLProtocol.stub(
+                method: "GET",
+                url: redirectURLs[index],
+                statusCode: 302,
+                headers: ["Location": redirectURLs[index + 1].absoluteString]
+            )
         }
 
         // When
-        let error: Error? = waitFor { promise in
-            session.request(self.apiRequest)
-                .validate()
-                .response { response in
-                    promise(response.error)
-                }
+        do {
+            _ = try await authenticator.authenticate(session: makeSession())
+            XCTFail("Expected the fourth redirect to be rejected")
+        } catch CookieNonceAuthenticator.Error.authenticationFailed(.invalidResponse) {
+            // Then
+            XCTAssertEqual(
+                CookieNonceAuthenticationURLProtocol.receivedRequests.compactMap(\.url),
+                [loginURL] + Array(redirectURLs.prefix(3))
+            )
+            XCTAssertFalse(CookieNonceAuthenticationURLProtocol.receivedRequests.contains { $0.url == redirectURLs[3] })
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
+    }
+
+    func test_authenticate_when_form_action_is_cross_origin_then_rejects_without_contacting_target() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let targetURL = try XCTUnwrap(URL(string: "https://attacker.example/collect"))
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            data: Data(loginForm(action: targetURL.absoluteString).utf8)
+        )
+
+        // When / Then
+        do {
+            _ = try await authenticator.authenticate(session: makeSession())
+            XCTFail("Expected a cross-origin form action to be rejected")
+        } catch CookieNonceAuthenticator.Error.authenticationFailed(.invalidResponse) {
+            XCTAssertEqual(CookieNonceAuthenticationURLProtocol.receivedRequests.compactMap(\.url), [loginURL])
+            XCTAssertFalse(CookieNonceAuthenticationURLProtocol.receivedRequests.contains { $0.url == targetURL })
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_authenticate_when_preflight_has_exactly_three_redirects_then_completes_custom_entry_and_admin_trace() async throws {
+        // Given
+        let customEntryURL = try XCTUnwrap(URL(string: "https://example.com/custom-entry"))
+        let customAdminURL = try XCTUnwrap(URL(string: "https://example.com/private-admin/"))
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: customEntryURL,
+            adminBaseURL: customAdminURL
+        )
+        let authenticator = try stubbedAuthenticator(
+            configuration: CookieNonceAuthenticatorConfiguration(
+                username: sampleUser,
+                password: samplePassword,
+                endpoints: endpoints
+            )
+        )
+        let redirectURLs = try (1...3).map { index in
+            try XCTUnwrap(URL(string: "https://example.com/entry-step-\(index)"))
+        }
+        let submissionURL = try XCTUnwrap(URL(string: "https://example.com/custom-submit"))
+        let nonceURL = try XCTUnwrap(URL(string: "https://example.com/private-admin/admin-ajax.php?action=rest-nonce"))
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: customEntryURL, statusCode: 302, headers: ["Location": redirectURLs[0].absoluteString])
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: redirectURLs[0], statusCode: 302, headers: ["Location": redirectURLs[1].absoluteString])
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: redirectURLs[1], statusCode: 302, headers: ["Location": redirectURLs[2].absoluteString])
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: redirectURLs[2], data: Data(loginForm(action: submissionURL.absoluteString).utf8))
+        CookieNonceAuthenticationURLProtocol.stub(method: "POST", url: submissionURL, statusCode: 302, headers: ["Location": nonceURL.absoluteString])
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: nonceURL, data: Data("freshnonce".utf8))
+
+        // When
+        let nonce = try await authenticator.authenticate(session: makeSession())
 
         // Then
-        let afError = try XCTUnwrap(error as? AFError)
-        guard case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = afError else {
-            return XCTFail("Expected a 401 validation error, got \(afError)")
+        XCTAssertEqual(nonce, "freshnonce")
+        XCTAssertEqual(
+            CookieNonceAuthenticationURLProtocol.receivedRequests.compactMap(\.url),
+            [customEntryURL] + redirectURLs + [submissionURL, nonceURL]
+        )
+    }
+
+    func test_authenticate_when_credential_response_is_404_or_410_then_reports_unacceptable_status() async throws {
+        for statusCode in [404, 410] {
+            // Given
+            CookieNonceAuthenticationURLProtocol.reset()
+            let authenticator = try stubbedAuthenticator()
+            CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: loginURL, data: Data(loginForm(action: "/wp-login.php").utf8))
+            CookieNonceAuthenticationURLProtocol.stub(method: "POST", url: loginURL, statusCode: statusCode)
+
+            // When / Then
+            do {
+                _ = try await authenticator.authenticate(session: makeSession())
+                XCTFail("Expected status \(statusCode) to fail")
+            } catch CookieNonceAuthenticator.Error.authenticationFailed(.unacceptableStatusCode(let actualStatusCode)) {
+                XCTAssertEqual(actualStatusCode, statusCode)
+            } catch {
+                XCTFail("Unexpected error for status \(statusCode): \(error)")
+            }
+        }
+    }
+
+    func test_offline_error_recognizes_alamofire_session_task_wrapper() {
+        // Given
+        let error = AFError.sessionTaskFailed(error: URLError(.notConnectedToInternet))
+
+        // Then
+        XCTAssertTrue(CookieNonceAuthenticator.isOfflineError(error))
+        XCTAssertFalse(CookieNonceAuthenticator.isOfflineError(AFError.sessionTaskFailed(error: URLError(.timedOut))))
+    }
+
+    func test_wordpress_org_network_when_protected_request_is_unauthorized_then_authenticates_and_retries_with_nonce_and_cookies() async throws {
+        // Given
+        let scenario = CookieNonceLoopbackScenario(requiredInitialProtectedRequests: 1)
+        let server = try CookieNonceLoopbackServer(handler: scenario.response)
+        defer { server.stop() }
+        let siteURL = server.siteURL
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
+            adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+        )
+        let network = WordPressOrgNetwork(
+            configuration: CookieNonceAuthenticatorConfiguration(
+                username: sampleUser,
+                password: samplePassword,
+                endpoints: endpoints
+            ),
+            siteAddress: siteURL.absoluteString
+        )
+        let request = URLRequest(url: siteURL.appendingPathComponent("wp-json/protected"))
+
+        // When
+        let data = try await network.responseData(for: request)
+
+        // Then
+        XCTAssertEqual(String(data: data, encoding: .utf8), "success")
+        let trace = scenario.trace
+        XCTAssertEqual(trace.protectedRequestCount, 2)
+        XCTAssertEqual(trace.loginEntryRequestCount, 1)
+        XCTAssertEqual(trace.credentialRequestCount, 1)
+        XCTAssertEqual(trace.nonceRequestCount, 1)
+        XCTAssertEqual(trace.successfulProtectedRequestCount, 1)
+        XCTAssertTrue(trace.credentialCookie?.contains(scenario.preflightCookie) == true)
+        XCTAssertTrue(trace.nonceCookie?.contains(scenario.loginCookie) == true)
+        XCTAssertEqual(trace.successfulProtectedNonce, "freshnonce")
+        XCTAssertTrue(trace.successfulProtectedCookie?.contains(scenario.loginCookie) == true)
+    }
+
+    func test_wordpress_org_network_when_credentials_redirect_to_admin_base_then_fetches_nonce_without_following_redirect() async throws {
+        // Given
+        let scenario = CookieNonceLoopbackScenario(
+            requiredInitialProtectedRequests: 1,
+            credentialRedirectsToAdminBase: true
+        )
+        let server = try CookieNonceLoopbackServer(handler: scenario.response)
+        defer { server.stop() }
+        let siteURL = server.siteURL
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
+            adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+        )
+        let network = WordPressOrgNetwork(
+            configuration: CookieNonceAuthenticatorConfiguration(
+                username: sampleUser,
+                password: samplePassword,
+                endpoints: endpoints
+            ),
+            siteAddress: siteURL.absoluteString
+        )
+        let request = URLRequest(url: siteURL.appendingPathComponent("wp-json/protected"))
+
+        // When
+        let data = try await network.responseData(for: request)
+
+        // Then
+        XCTAssertEqual(String(data: data, encoding: .utf8), "success")
+        let trace = scenario.trace
+        XCTAssertEqual(trace.protectedRequestCount, 2)
+        XCTAssertEqual(trace.loginEntryRequestCount, 1)
+        XCTAssertEqual(trace.credentialRequestCount, 1)
+        XCTAssertEqual(trace.adminBaseRequestCount, 0)
+        XCTAssertEqual(trace.nonceRequestCount, 1)
+        XCTAssertEqual(trace.successfulProtectedRequestCount, 1)
+        XCTAssertTrue(trace.credentialCookie?.contains(scenario.preflightCookie) == true)
+        XCTAssertTrue(trace.nonceCookie?.contains(scenario.loginCookie) == true)
+        XCTAssertEqual(trace.successfulProtectedNonce, "freshnonce")
+        XCTAssertTrue(trace.successfulProtectedCookie?.contains(scenario.loginCookie) == true)
+    }
+
+    func test_default_application_password_use_case_with_custom_endpoints_authenticates_and_maps_password() async throws {
+        // Given
+        let passwordUUID = "8ef68e6b-4670-4cfd-8ca0-456e616bcd5e"
+        let generatedPassword = "generated-password"
+        let responseBody = Data(#"{"uuid":"\#(passwordUUID)","password":"\#(generatedPassword)"}"#.utf8)
+        let scenario = CookieNonceLoopbackScenario(
+            requiredInitialProtectedRequests: 1,
+            protectedMethod: "POST",
+            protectedTarget: "/wp-json/wp/v2/users/me/application-passwords",
+            successfulProtectedBody: responseBody
+        )
+        let server = try CookieNonceLoopbackServer(handler: scenario.response)
+        defer { server.stop() }
+        let siteURL = server.siteURL
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
+            adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+        )
+        let storage = MockApplicationPasswordStorage()
+        let sut = try DefaultApplicationPasswordUseCase(
+            username: sampleUser,
+            password: samplePassword,
+            siteAddress: siteURL.absoluteString,
+            authenticationEndpoints: endpoints,
+            storage: storage,
+            rootCache: MockRESTAPIRootCache(
+                stubbedRoot: siteURL.appendingPathComponent("wp-json", isDirectory: true).absoluteString
+            )
+        )
+
+        // When
+        let password = try await sut.generateNewPassword()
+
+        // Then
+        XCTAssertEqual(password.wpOrgUsername, sampleUser)
+        XCTAssertEqual(password.password.secretValue, generatedPassword)
+        XCTAssertEqual(password.uuid, passwordUUID)
+        XCTAssertEqual(storage.applicationPassword, password)
+        let trace = scenario.trace
+        XCTAssertEqual(trace.protectedRequestCount, 2)
+        XCTAssertEqual(trace.loginEntryRequestCount, 1)
+        XCTAssertEqual(trace.credentialRequestCount, 1)
+        XCTAssertEqual(trace.nonceRequestCount, 1)
+        XCTAssertEqual(trace.successfulProtectedRequestCount, 1)
+        XCTAssertTrue(trace.credentialCookie?.contains(scenario.preflightCookie) == true)
+        XCTAssertTrue(trace.nonceCookie?.contains(scenario.loginCookie) == true)
+        XCTAssertEqual(trace.successfulProtectedNonce, "freshnonce")
+        XCTAssertTrue(trace.successfulProtectedCookie?.contains(scenario.loginCookie) == true)
+    }
+
+    func test_wordpress_org_network_when_protected_requests_are_concurrent_then_coalesces_authentication_and_retries_all() async throws {
+        // Given
+        let scenario = CookieNonceLoopbackScenario(requiredInitialProtectedRequests: 2)
+        let server = try CookieNonceLoopbackServer(handler: scenario.response)
+        defer { server.stop() }
+        let siteURL = server.siteURL
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
+            adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+        )
+        let network = WordPressOrgNetwork(
+            configuration: CookieNonceAuthenticatorConfiguration(
+                username: sampleUser,
+                password: samplePassword,
+                endpoints: endpoints
+            ),
+            siteAddress: siteURL.absoluteString
+        )
+        let request = URLRequest(url: siteURL.appendingPathComponent("wp-json/protected"))
+
+        // When
+        async let firstResponse = responseData(for: request, using: network)
+        async let secondResponse = responseData(for: request, using: network)
+        let responses = try await (firstResponse, secondResponse)
+
+        // Then
+        XCTAssertEqual(
+            [responses.0, responses.1].compactMap { String(data: $0, encoding: .utf8) },
+            ["success", "success"]
+        )
+        let trace = scenario.trace
+        XCTAssertEqual(trace.protectedRequestCount, 4)
+        XCTAssertEqual(trace.loginEntryRequestCount, 1)
+        XCTAssertEqual(trace.credentialRequestCount, 1)
+        XCTAssertEqual(trace.nonceRequestCount, 1)
+        XCTAssertEqual(trace.successfulProtectedRequestCount, 2)
+    }
+
+    func test_wordpress_org_network_when_credentials_receive_307_or_308_then_does_not_contact_redirect_target() async throws {
+        for statusCode in [307, 308] {
+            // Given
+            let scenario = CookieNonceLoopbackScenario(
+                requiredInitialProtectedRequests: 1,
+                credentialRedirectStatusCode: statusCode
+            )
+            let server = try CookieNonceLoopbackServer(handler: scenario.response)
+            let siteURL = server.siteURL
+            let endpoints = try CookieNonceAuthenticationEndpoints(
+                siteURL: siteURL,
+                loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
+                adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+            )
+            let network = WordPressOrgNetwork(
+                configuration: CookieNonceAuthenticatorConfiguration(
+                    username: sampleUser,
+                    password: samplePassword,
+                    endpoints: endpoints
+                ),
+                siteAddress: siteURL.absoluteString
+            )
+            let request = URLRequest(url: siteURL.appendingPathComponent("wp-json/protected"))
+
+            // When
+            do {
+                _ = try await network.responseData(for: request)
+                XCTFail("Expected credential redirect \(statusCode) to fail")
+            } catch {
+                // Expected: the credential redirect is not the exact nonce target.
+            }
+
+            // Then
+            let trace = scenario.trace
+            XCTAssertEqual(trace.loginEntryRequestCount, 1)
+            XCTAssertEqual(trace.credentialRequestCount, 1)
+            XCTAssertEqual(trace.redirectTargetRequestCount, 0)
+            XCTAssertEqual(trace.nonceRequestCount, 0)
+            server.stop()
         }
     }
 }
 
 private extension CookieNonceAuthenticatorTests {
-    func makeAuthenticator() -> CookieNonceAuthenticator {
-        let config = CookieNonceAuthenticatorConfiguration(username: sampleUser,
-                                                           password: samplePassword,
-                                                           loginURL: loginURL,
-                                                           adminURL: adminURL)
-        return CookieNonceAuthenticator(configuration: config)
+    func configuration() throws -> CookieNonceAuthenticatorConfiguration {
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: loginURL,
+            adminBaseURL: adminURL
+        )
+        return CookieNonceAuthenticatorConfiguration(
+            username: sampleUser,
+            password: samplePassword,
+            endpoints: endpoints
+        )
     }
 
-    func makeSessionWithMockURLProtocol(interceptor: RequestInterceptor) -> Session {
-        let configuration = URLSessionConfiguration.default
-        configuration.protocolClasses = [MockURLProtocol.self]
-        return Session(configuration: configuration, interceptor: interceptor)
+    func makeSession() -> Session {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CookieNonceAuthenticationURLProtocol.self]
+        configuration.httpCookieStorage = HTTPCookieStorage()
+        configuration.httpShouldSetCookies = true
+        return Session(configuration: configuration)
+    }
+
+    func stubbedAuthenticator(
+        configuration: CookieNonceAuthenticatorConfiguration? = nil
+    ) throws -> CookieNonceAuthenticator {
+        let configuration = try configuration ?? self.configuration()
+        return CookieNonceAuthenticator(
+            configuration: configuration,
+            authenticationSessionFactory: { _ in
+                let configuration = URLSessionConfiguration.ephemeral
+                configuration.protocolClasses = [CookieNonceAuthenticationURLProtocol.self]
+                configuration.httpCookieStorage = HTTPCookieStorage()
+                configuration.httpShouldSetCookies = true
+                return Session(configuration: configuration, redirectHandler: Redirector.doNotFollow)
+            }
+        )
+    }
+
+    func loginForm(action: String) -> String {
+        "<form id=\"loginform\" name=\"loginform\" method=\"post\" action=\"\(action)\">" +
+            "<input name=\"log\" id=\"user_login\" type=\"text\">" +
+            "<input name=\"pwd\" id=\"user_pass\" type=\"password\"></form>"
+    }
+
+    func responseData(for request: URLRequest, using network: WordPressOrgNetwork) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            network.responseData(for: request) { (result: Result<Data, Swift.Error>) in
+                continuation.resume(with: result)
+            }
+        }
+    }
+}
+
+private final class CookieNonceAuthenticationURLProtocol: URLProtocol {
+    struct Stub {
+        let statusCode: Int
+        let headers: [String: String]
+        let data: Data
+    }
+
+    private static let lock = NSLock()
+    private static var stubs: [String: Stub] = [:]
+    private static var requests: [URLRequest] = []
+
+    static var receivedRequests: [URLRequest] {
+        lock.withTestLock { requests }
+    }
+
+    static func stub(method: String, url: URL, statusCode: Int = 200, headers: [String: String] = [:], data: Data = Data()) {
+        lock.withTestLock {
+            stubs[key(method: method, url: url)] = Stub(statusCode: statusCode, headers: headers, data: data)
+        }
+    }
+
+    static func reset() {
+        lock.withTestLock {
+            stubs.removeAll()
+            requests.removeAll()
+        }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        let stub = Self.lock.withTestLock { () -> Stub? in
+            Self.requests.append(Self.recordableRequest(from: request))
+            return Self.stubs[Self.key(method: request.httpMethod ?? "GET", url: url)]
+        }
+        guard let stub,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: stub.statusCode,
+                  httpVersion: nil,
+                  headerFields: stub.headers
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func key(method: String, url: URL) -> String {
+        "\(method) \(url.absoluteString)"
+    }
+
+    private static func recordableRequest(from request: URLRequest) -> URLRequest {
+        guard request.httpBody == nil, let stream = request.httpBodyStream else {
+            return request
+        }
+        stream.open()
+        defer { stream.close() }
+        var body = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            body.append(contentsOf: buffer.prefix(count))
+        }
+        var recordedRequest = request
+        recordedRequest.httpBody = body
+        return recordedRequest
+    }
+}
+
+private extension NSLock {
+    func withTestLock<T>(_ operation: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return operation()
+    }
+}
+
+private final class CookieNonceLoopbackScenario: @unchecked Sendable {
+    struct Trace {
+        let protectedRequestCount: Int
+        let loginEntryRequestCount: Int
+        let credentialRequestCount: Int
+        let nonceRequestCount: Int
+        let successfulProtectedRequestCount: Int
+        let credentialCookie: String?
+        let nonceCookie: String?
+        let successfulProtectedNonce: String?
+        let successfulProtectedCookie: String?
+        let redirectTargetRequestCount: Int
+        let adminBaseRequestCount: Int
+    }
+
+    private let lock = NSLock()
+    private let token = UUID().uuidString
+    private let requiredInitialProtectedRequests: Int
+    private let credentialRedirectStatusCode: Int?
+    private let credentialRedirectsToAdminBase: Bool
+    private let protectedMethod: String
+    private let protectedTarget: String
+    private let successfulProtectedBody: Data
+    private var protectedRequestCount = 0
+    private var loginEntryRequestCount = 0
+    private var credentialRequestCount = 0
+    private var nonceRequestCount = 0
+    private var successfulProtectedRequestCount = 0
+    private var credentialCookie: String?
+    private var nonceCookie: String?
+    private var successfulProtectedNonce: String?
+    private var successfulProtectedCookie: String?
+    private var redirectTargetRequestCount = 0
+    private var adminBaseRequestCount = 0
+
+    init(
+        requiredInitialProtectedRequests: Int,
+        credentialRedirectStatusCode: Int? = nil,
+        credentialRedirectsToAdminBase: Bool = false,
+        protectedMethod: String = "GET",
+        protectedTarget: String = "/wp-json/protected",
+        successfulProtectedBody: Data = Data("success".utf8)
+    ) {
+        self.requiredInitialProtectedRequests = requiredInitialProtectedRequests
+        self.credentialRedirectStatusCode = credentialRedirectStatusCode
+        self.credentialRedirectsToAdminBase = credentialRedirectsToAdminBase
+        self.protectedMethod = protectedMethod
+        self.protectedTarget = protectedTarget
+        self.successfulProtectedBody = successfulProtectedBody
+    }
+
+    var preflightCookie: String { "preflight=\(token)" }
+    var loginCookie: String { "wordpress_logged_in=\(token)" }
+
+    var trace: Trace {
+        lock.withTestLock {
+            Trace(
+                protectedRequestCount: protectedRequestCount,
+                loginEntryRequestCount: loginEntryRequestCount,
+                credentialRequestCount: credentialRequestCount,
+                nonceRequestCount: nonceRequestCount,
+                successfulProtectedRequestCount: successfulProtectedRequestCount,
+                credentialCookie: credentialCookie,
+                nonceCookie: nonceCookie,
+                successfulProtectedNonce: successfulProtectedNonce,
+                successfulProtectedCookie: successfulProtectedCookie,
+                redirectTargetRequestCount: redirectTargetRequestCount,
+                adminBaseRequestCount: adminBaseRequestCount
+            )
+        }
+    }
+
+    func response(to request: CookieNonceLoopbackServer.Request) -> CookieNonceLoopbackServer.Response {
+        if request.method == protectedMethod, request.target == protectedTarget {
+            return protectedResponse(to: request)
+        }
+        switch (request.method, request.target) {
+        case ("GET", "/custom-entry"):
+            waitForInitialProtectedRequests()
+            lock.withTestLock { loginEntryRequestCount += 1 }
+            return .init(
+                statusCode: 200,
+                headers: ["Set-Cookie": "\(preflightCookie); Path=/"],
+                body: Data(loginForm.utf8)
+            )
+        case ("POST", "/custom-submit"):
+            lock.withTestLock {
+                credentialRequestCount += 1
+                credentialCookie = request.headers["cookie"]
+            }
+            guard request.headers["cookie"]?.contains(preflightCookie) == true else {
+                return .init(statusCode: 403)
+            }
+            if let credentialRedirectStatusCode {
+                return .init(
+                    statusCode: credentialRedirectStatusCode,
+                    headers: ["Location": "/body-preserving-target"]
+                )
+            }
+            return .init(
+                statusCode: 302,
+                headers: [
+                    "Location": credentialRedirectsToAdminBase ?
+                        "/private-admin/" : "/private-admin/admin-ajax.php?action=rest-nonce",
+                    "Set-Cookie": "\(loginCookie); Path=/"
+                ]
+            )
+        case ("GET", "/private-admin/"):
+            lock.withTestLock { adminBaseRequestCount += 1 }
+            return .init(statusCode: 200)
+        case ("GET", "/private-admin/admin-ajax.php?action=rest-nonce"):
+            lock.withTestLock {
+                nonceRequestCount += 1
+                nonceCookie = request.headers["cookie"]
+            }
+            guard request.headers["cookie"]?.contains(loginCookie) == true else {
+                return .init(statusCode: 403)
+            }
+            return .init(statusCode: 200, body: Data("freshnonce".utf8))
+        case (_, "/body-preserving-target"):
+            lock.withTestLock { redirectTargetRequestCount += 1 }
+            return .init(statusCode: 200)
+        default:
+            return .init(statusCode: 404)
+        }
+    }
+
+    private func protectedResponse(to request: CookieNonceLoopbackServer.Request) -> CookieNonceLoopbackServer.Response {
+        let isAuthenticated = request.headers["x-wp-nonce"] == "freshnonce" &&
+            request.headers["cookie"]?.contains(loginCookie) == true
+        lock.withTestLock {
+            protectedRequestCount += 1
+            if isAuthenticated {
+                successfulProtectedRequestCount += 1
+                successfulProtectedNonce = request.headers["x-wp-nonce"]
+                successfulProtectedCookie = request.headers["cookie"]
+            }
+        }
+        return isAuthenticated ? .init(statusCode: 200, body: successfulProtectedBody) : .init(statusCode: 401)
+    }
+
+    private func waitForInitialProtectedRequests() {
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if lock.withTestLock({ protectedRequestCount >= requiredInitialProtectedRequests }) {
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+    }
+
+    private var loginForm: String {
+        "<form id=\"loginform\" name=\"loginform\" method=\"post\" action=\"/custom-submit\">" +
+            "<input name=\"log\" id=\"user_login\" type=\"text\">" +
+            "<input name=\"pwd\" id=\"user_pass\" type=\"password\"></form>"
+    }
+}
+
+private final class CookieNonceLoopbackServer: @unchecked Sendable {
+    struct Request {
+        let method: String
+        let target: String
+        let headers: [String: String]
+        let body: Data
+    }
+
+    struct Response {
+        let statusCode: Int
+        let headers: [String: String]
+        let body: Data
+
+        init(statusCode: Int, headers: [String: String] = [:], body: Data = Data()) {
+            self.statusCode = statusCode
+            self.headers = headers
+            self.body = body
+        }
+    }
+
+    private let listener: NWListener
+    private let handler: (Request) -> Response
+    private let queue = DispatchQueue(label: "com.woocommerce.tests.cookie-nonce-loopback-listener")
+    private var listeningPort: NWEndpoint.Port?
+
+    var siteURL: URL {
+        guard let listeningPort,
+              let url = URL(string: "http://127.0.0.1:\(listeningPort.rawValue)") else {
+            // A server without its listener-assigned port cannot produce any valid test request URL.
+            preconditionFailure("Loopback server is not listening")
+        }
+        return url
+    }
+
+    init(handler: @escaping (Request) -> Response) throws {
+        let listener = try NWListener(using: .tcp, on: .any)
+        self.listener = listener
+        self.handler = handler
+
+        let ready = DispatchSemaphore(value: 0)
+        let stateLock = NSLock()
+        var startupError: Swift.Error?
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                ready.signal()
+            case .failed(let error):
+                stateLock.withTestLock { startupError = error }
+                ready.signal()
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection)
+        }
+        listener.start(queue: queue)
+        guard ready.wait(timeout: .now() + 5) == .success,
+              stateLock.withTestLock({ startupError == nil }),
+              let port = listener.port else {
+            listener.cancel()
+            throw startupError ?? URLError(.cannotConnectToHost)
+        }
+        self.listeningPort = port
+    }
+
+    func stop() {
+        listener.cancel()
+    }
+
+    private func handle(_ connection: NWConnection) {
+        connection.start(queue: .global(qos: .userInitiated))
+        receive(on: connection, accumulatedData: Data())
+    }
+
+    private func receive(on connection: NWConnection, accumulatedData: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self] data, _, isComplete, error in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            var accumulatedData = accumulatedData
+            accumulatedData.append(data ?? Data())
+            if let request = Self.parseRequest(from: accumulatedData) {
+                send(handler(request), on: connection)
+            } else if isComplete || error != nil {
+                connection.cancel()
+            } else {
+                receive(on: connection, accumulatedData: accumulatedData)
+            }
+        }
+    }
+
+    private func send(_ response: Response, on connection: NWConnection) {
+        let reason = Self.reason(for: response.statusCode)
+        var headerLines = [
+            "HTTP/1.1 \(response.statusCode) \(reason)",
+            "Content-Length: \(response.body.count)",
+            "Connection: close"
+        ]
+        headerLines.append(contentsOf: response.headers.map { "\($0.key): \($0.value)" })
+        var data = Data((headerLines.joined(separator: "\r\n") + "\r\n\r\n").utf8)
+        data.append(response.body)
+        connection.send(content: data, completion: .contentProcessed { _ in connection.cancel() })
+    }
+
+    private static func parseRequest(from data: Data) -> Request? {
+        let separator = Data("\r\n\r\n".utf8)
+        guard let headerRange = data.range(of: separator),
+              let headerText = String(data: data[..<headerRange.lowerBound], encoding: .utf8) else {
+            return nil
+        }
+        let lines = headerText.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            return nil
+        }
+        let requestParts = requestLine.split(separator: " ")
+        guard requestParts.count >= 2 else {
+            return nil
+        }
+        let headers = Dictionary(uniqueKeysWithValues: lines.dropFirst().compactMap { line -> (String, String)? in
+            guard let separatorIndex = line.firstIndex(of: ":") else {
+                return nil
+            }
+            let name = String(line[..<separatorIndex]).lowercased()
+            let value = String(line[line.index(after: separatorIndex)...]).trimmingCharacters(in: .whitespaces)
+            return (name, value)
+        })
+        let contentLength = Int(headers["content-length"] ?? "0") ?? 0
+        let bodyStart = headerRange.upperBound
+        guard data.count >= bodyStart + contentLength else {
+            return nil
+        }
+        return Request(
+            method: String(requestParts[0]),
+            target: String(requestParts[1]),
+            headers: headers,
+            body: data.subdata(in: bodyStart..<(bodyStart + contentLength))
+        )
+    }
+
+    private static func reason(for statusCode: Int) -> String {
+        switch statusCode {
+        case 200: "OK"
+        case 302: "Found"
+        case 307: "Temporary Redirect"
+        case 308: "Permanent Redirect"
+        case 401: "Unauthorized"
+        case 403: "Forbidden"
+        case 404: "Not Found"
+        default: "Response"
+        }
     }
 }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -4,6 +4,8 @@ import XCTest
 @testable import Networking
 @testable import NetworkingCore
 
+private let cookieNonceLoopbackCookiePrefix = "woocommerce_cookie_nonce_test_"
+
 @MainActor
 final class CookieNonceAuthenticatorTests: XCTestCase {
 
@@ -16,6 +18,9 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
 
     override func tearDown() {
         CookieNonceAuthenticationURLProtocol.reset()
+        HTTPCookieStorage.shared.cookies?
+            .filter { $0.name.hasPrefix(cookieNonceLoopbackCookiePrefix) }
+            .forEach { HTTPCookieStorage.shared.deleteCookie($0) }
         super.tearDown()
     }
 
@@ -44,17 +49,8 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         XCTAssertTrue(sourceSession.sessionConfiguration.urlCredentialStorage === URLCredentialStorage.shared)
     }
 
-    func test_wordpress_org_network_uses_cookie_storage_isolated_from_shared_and_other_networks() throws {
+    func test_wordpress_org_network_uses_shared_cookie_storage() throws {
         // Given
-        let cookieName = "stale-wordpress-session-\(UUID().uuidString)"
-        let staleCookie = try XCTUnwrap(HTTPCookie(properties: [
-            .domain: "example.com",
-            .path: "/",
-            .name: cookieName,
-            .value: "wrong-user"
-        ]))
-        HTTPCookieStorage.shared.setCookie(staleCookie)
-        defer { HTTPCookieStorage.shared.deleteCookie(staleCookie) }
         let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
         let configuration = CookieNonceAuthenticatorConfiguration(
             username: sampleUser,
@@ -69,10 +65,8 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         let secondStorage = try XCTUnwrap(secondNetwork.session.configuration.httpCookieStorage)
 
         // Then
-        XCTAssertFalse(firstStorage === HTTPCookieStorage.shared)
-        XCTAssertFalse(firstStorage === secondStorage)
-        XCTAssertFalse(firstStorage.cookies(for: siteURL)?.contains { $0.name == cookieName } == true)
-        XCTAssertTrue(HTTPCookieStorage.shared.cookies(for: siteURL)?.contains { $0.name == cookieName } == true)
+        XCTAssertTrue(firstStorage === HTTPCookieStorage.shared)
+        XCTAssertTrue(firstStorage === secondStorage)
     }
 
     func test_cookie_nonce_authenticator_encode_parameters_correctly() throws {
@@ -168,6 +162,11 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         let requests = CookieNonceAuthenticationURLProtocol.receivedRequests
         XCTAssertEqual(requests.compactMap(\.httpMethod), ["GET", "POST", "GET"])
         XCTAssertEqual(requests.compactMap(\.url), [loginURL, submissionURL, nonceURL])
+        let defaultTimeoutInterval = URLRequest(url: loginURL).timeoutInterval
+        XCTAssertEqual(
+            requests.filter { $0.httpMethod == "GET" }.map(\.timeoutInterval),
+            [defaultTimeoutInterval, defaultTimeoutInterval]
+        )
         let bodyData = try XCTUnwrap(requests[1].httpBody)
         let body = try XCTUnwrap(String(data: bodyData, encoding: .utf8))
         XCTAssertTrue(body.contains("redirect_to=https://example.com/wp-admin/admin-ajax.php?action%3Drest-nonce"))
@@ -521,6 +520,40 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         XCTAssertTrue(trace.nonceCookie?.contains(scenario.loginCookie) == true)
         XCTAssertEqual(trace.successfulProtectedNonce, "freshnonce")
         XCTAssertTrue(trace.successfulProtectedCookie?.contains(scenario.loginCookie) == true)
+    }
+
+    func test_wordpress_org_network_when_second_network_uses_authenticated_shared_cookie_then_does_not_post_credentials_again() async throws {
+        // Given
+        let scenario = CookieNonceLoopbackScenario(requiredInitialProtectedRequests: 1)
+        let server = try CookieNonceLoopbackServer(handler: scenario.response)
+        defer { server.stop() }
+        let siteURL = server.siteURL
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
+            adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+        )
+        let configuration = CookieNonceAuthenticatorConfiguration(
+            username: sampleUser,
+            password: samplePassword,
+            endpoints: endpoints
+        )
+        let firstNetwork = WordPressOrgNetwork(configuration: configuration, siteAddress: siteURL.absoluteString)
+        let secondNetwork = WordPressOrgNetwork(configuration: configuration, siteAddress: siteURL.absoluteString)
+        let request = URLRequest(url: siteURL.appendingPathComponent("wp-json/protected"))
+
+        // When
+        let firstData = try await firstNetwork.responseData(for: request)
+        let secondData = try await secondNetwork.responseData(for: request)
+
+        // Then
+        XCTAssertEqual(String(data: firstData, encoding: .utf8), "success")
+        XCTAssertEqual(String(data: secondData, encoding: .utf8), "success")
+        let trace = scenario.trace
+        XCTAssertEqual(trace.loginEntryRequestCount, 2)
+        XCTAssertEqual(trace.credentialRequestCount, 1)
+        XCTAssertEqual(trace.nonceRequestCount, 2)
+        XCTAssertEqual(trace.successfulProtectedRequestCount, 2)
     }
 
     func test_wordpress_org_network_when_preflight_requires_Basic_auth_then_does_not_use_cached_credential_or_post_site_credentials() async throws {
@@ -976,8 +1009,8 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
         self.successfulProtectedBody = successfulProtectedBody
     }
 
-    var preflightCookie: String { "preflight=\(token)" }
-    var loginCookie: String { "wordpress_logged_in=\(token)" }
+    var preflightCookie: String { "\(cookieNonceLoopbackCookiePrefix)preflight_\(token)=present" }
+    var loginCookie: String { "\(cookieNonceLoopbackCookiePrefix)logged_in_\(token)=present" }
 
     var trace: Trace {
         lock.withTestLock {
@@ -1008,6 +1041,9 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
             lock.withTestLock {
                 loginEntryRequestCount += 1
                 loginEntryAuthorizationHeader = request.headers["authorization"]
+            }
+            if request.headers["cookie"]?.contains(loginCookie) == true {
+                return .init(statusCode: 200, body: Data(authenticatedDashboard.utf8))
             }
             if let preflightBasicCredential,
                request.headers["authorization"] != preflightBasicCredential.authorizationHeader {
@@ -1091,6 +1127,10 @@ private final class CookieNonceLoopbackScenario: @unchecked Sendable {
         "<form id=\"loginform\" name=\"loginform\" method=\"post\" action=\"/custom-submit\">" +
             "<input name=\"log\" id=\"user_login\" type=\"text\">" +
             "<input name=\"pwd\" id=\"user_pass\" type=\"password\"></form>"
+    }
+
+    private var authenticatedDashboard: String {
+        "<body class=\"wp-core-ui index-php wp-admin\"><div id=\"dashboard-widgets-wrap\"></div></body>"
     }
 }
 

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -663,24 +663,20 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         XCTAssertTrue(trace.successfulProtectedCookie?.contains(scenario.loginCookie) == true)
     }
 
-    func test_default_application_password_use_case_with_custom_endpoints_authenticates_and_maps_password() async throws {
+    func test_default_application_password_use_case_with_custom_endpoints_retains_them_and_maps_password() async throws {
         // Given
         let passwordUUID = "8ef68e6b-4670-4cfd-8ca0-456e616bcd5e"
-        let generatedPassword = "generated-password"
-        let responseBody = Data(#"{"uuid":"\#(passwordUUID)","password":"\#(generatedPassword)"}"#.utf8)
-        let scenario = CookieNonceLoopbackScenario(
-            requiredInitialProtectedRequests: 1,
-            protectedMethod: "POST",
-            protectedTarget: "/wp-json/wp/v2/users/me/application-passwords",
-            successfulProtectedBody: responseBody
-        )
-        let server = try CookieNonceLoopbackServer(handler: scenario.response)
-        defer { server.stop() }
-        let siteURL = server.siteURL
+        let generatedPassword = "passwordvalue"
+        let siteURL = try XCTUnwrap(URL(string: "https://example.com"))
         let endpoints = try CookieNonceAuthenticationEndpoints(
             siteURL: siteURL,
             loginEntryURL: siteURL.appendingPathComponent("custom-entry"),
             adminBaseURL: siteURL.appendingPathComponent("private-admin", isDirectory: true)
+        )
+        let network = MockNetwork()
+        network.simulateResponse(
+            requestUrlSuffix: "users/me/application-passwords",
+            filename: "generate-application-password-using-wporg-creds-success"
         )
         let storage = MockApplicationPasswordStorage()
         let sut = try DefaultApplicationPasswordUseCase(
@@ -688,6 +684,7 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
             password: samplePassword,
             siteAddress: siteURL.absoluteString,
             authenticationEndpoints: endpoints,
+            network: network,
             storage: storage,
             rootCache: MockRESTAPIRootCache(
                 stubbedRoot: siteURL.appendingPathComponent("wp-json", isDirectory: true).absoluteString
@@ -702,16 +699,7 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         XCTAssertEqual(password.password.secretValue, generatedPassword)
         XCTAssertEqual(password.uuid, passwordUUID)
         XCTAssertEqual(storage.applicationPassword, password)
-        let trace = scenario.trace
-        XCTAssertEqual(trace.protectedRequestCount, 2)
-        XCTAssertEqual(trace.loginEntryRequestCount, 1)
-        XCTAssertEqual(trace.credentialRequestCount, 1)
-        XCTAssertEqual(trace.nonceRequestCount, 1)
-        XCTAssertEqual(trace.successfulProtectedRequestCount, 1)
-        XCTAssertTrue(trace.credentialCookie?.contains(scenario.preflightCookie) == true)
-        XCTAssertTrue(trace.nonceCookie?.contains(scenario.loginCookie) == true)
-        XCTAssertEqual(trace.successfulProtectedNonce, "freshnonce")
-        XCTAssertTrue(trace.successfulProtectedCookie?.contains(scenario.loginCookie) == true)
+        XCTAssertEqual(sut.authenticationEndpoints, endpoints)
     }
 
     func test_wordpress_org_network_when_protected_requests_are_concurrent_then_coalesces_authentication_and_retries_all() async throws {

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -41,6 +41,37 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         )
     }
 
+    func test_wordpress_org_network_uses_cookie_storage_isolated_from_shared_and_other_networks() throws {
+        // Given
+        let cookieName = "stale-wordpress-session-\(UUID().uuidString)"
+        let staleCookie = try XCTUnwrap(HTTPCookie(properties: [
+            .domain: "example.com",
+            .path: "/",
+            .name: cookieName,
+            .value: "wrong-user"
+        ]))
+        HTTPCookieStorage.shared.setCookie(staleCookie)
+        defer { HTTPCookieStorage.shared.deleteCookie(staleCookie) }
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+        let configuration = CookieNonceAuthenticatorConfiguration(
+            username: sampleUser,
+            password: samplePassword,
+            endpoints: endpoints
+        )
+
+        // When
+        let firstNetwork = WordPressOrgNetwork(configuration: configuration, siteAddress: siteURL.absoluteString)
+        let secondNetwork = WordPressOrgNetwork(configuration: configuration, siteAddress: siteURL.absoluteString)
+        let firstStorage = try XCTUnwrap(firstNetwork.session.configuration.httpCookieStorage)
+        let secondStorage = try XCTUnwrap(secondNetwork.session.configuration.httpCookieStorage)
+
+        // Then
+        XCTAssertFalse(firstStorage === HTTPCookieStorage.shared)
+        XCTAssertFalse(firstStorage === secondStorage)
+        XCTAssertFalse(firstStorage.cookies(for: siteURL)?.contains { $0.name == cookieName } == true)
+        XCTAssertTrue(HTTPCookieStorage.shared.cookies(for: siteURL)?.contains { $0.name == cookieName } == true)
+    }
+
     func test_cookie_nonce_authenticator_encode_parameters_correctly() throws {
         // Given
         let endpoints = try CookieNonceAuthenticationEndpoints(
@@ -261,6 +292,67 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         let requests = CookieNonceAuthenticationURLProtocol.receivedRequests
         XCTAssertEqual(requests.compactMap(\.httpMethod), ["GET", "GET"])
         XCTAssertEqual(requests.compactMap(\.url), [loginURL, nonceURL])
+    }
+
+    func test_authenticate_when_preflight_uses_iso_8859_1_then_decodes_login_form() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let submissionURL = try XCTUnwrap(URL(string: "https://example.com/custom-submit"))
+        let nonceURL = try XCTUnwrap(URL(string: "https://example.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+        let html = loginForm(action: submissionURL.absoluteString) + "<p>café</p>"
+        let data = try XCTUnwrap(html.data(using: .isoLatin1))
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            headers: ["Content-Type": "text/html; charset=iso-8859-1"],
+            data: data
+        )
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "POST",
+            url: submissionURL,
+            statusCode: 302,
+            headers: ["Location": nonceURL.absoluteString]
+        )
+        CookieNonceAuthenticationURLProtocol.stub(method: "GET", url: nonceURL, data: Data("freshnonce".utf8))
+
+        // When
+        let nonce = try await authenticator.authenticate(session: makeSession())
+
+        // Then
+        XCTAssertEqual(nonce, "freshnonce")
+        XCTAssertEqual(
+            CookieNonceAuthenticationURLProtocol.receivedRequests.compactMap(\.url),
+            [loginURL, submissionURL, nonceURL]
+        )
+    }
+
+    func test_authenticate_when_credential_failure_uses_iso_8859_1_then_classifies_response() async throws {
+        // Given
+        let authenticator = try stubbedAuthenticator()
+        let html = "<div id=\"login_error\">Mot de passe incorrect : café</div>" +
+            "<script>document.querySelector('form').classList.add('shake')</script>"
+        let data = try XCTUnwrap(html.data(using: .isoLatin1))
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "GET",
+            url: loginURL,
+            data: Data(loginForm(action: "/wp-login.php").utf8)
+        )
+        CookieNonceAuthenticationURLProtocol.stub(
+            method: "POST",
+            url: loginURL,
+            headers: ["Content-Type": "text/html; charset=iso-8859-1"],
+            data: data
+        )
+
+        // When / Then
+        do {
+            _ = try await authenticator.authenticate(session: makeSession())
+            XCTFail("Expected invalid credentials")
+        } catch CookieNonceAuthenticator.Error.authenticationFailed(.invalidCredentials) {
+            XCTAssertEqual(CookieNonceAuthenticationURLProtocol.receivedRequests.compactMap(\.url), [loginURL, loginURL])
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     func test_authenticate_when_preflight_has_fourth_redirect_then_rejects_without_contacting_target() async throws {

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
@@ -6,6 +6,7 @@ import KeychainAccess
 
 /// DefaultApplicationPasswordUseCase Unit Tests
 ///
+@MainActor
 final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
     /// Mock Network: Allows us to inject predefined responses!
     ///
@@ -199,5 +200,27 @@ final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertNil(storage.applicationPassword)
+    }
+
+    func test_wporg_initializer_with_mismatched_endpoint_site_throws() throws {
+        // Given
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: XCTUnwrap(URL(string: "https://other.example"))
+        )
+
+        // When / Then
+        XCTAssertThrowsError(
+            try DefaultApplicationPasswordUseCase(
+                username: "demo",
+                password: "password",
+                siteAddress: "https://test.com",
+                authenticationEndpoints: endpoints,
+                network: network
+            )
+        ) { error in
+            guard case ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -29,6 +29,16 @@ class AuthenticationManager: Authentication {
         _ authenticationEndpoints: CookieNonceAuthenticationEndpoints?
     ) throws -> ApplicationPasswordUseCase
 
+    static let defaultApplicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory = {
+        username, password, siteAddress, authenticationEndpoints in
+        try DefaultApplicationPasswordUseCase(
+            username: username,
+            password: password,
+            siteAddress: siteAddress,
+            authenticationEndpoints: authenticationEndpoints
+        )
+    }
+
     var displayAuthenticatorIfLoggedOut: (() -> UINavigationController?)?
 
     /// Store Picker Coordinator
@@ -87,15 +97,8 @@ class AuthenticationManager: Authentication {
          switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil,
          userDefaults: UserDefaults = .standard,
          qrLoginAvailability: QRLoginAvailabilityProvider = QRLoginAvailability(),
-         applicationPasswordUseCaseFactory: @escaping ApplicationPasswordUseCaseFactory = {
-             username, password, siteAddress, authenticationEndpoints in
-             try DefaultApplicationPasswordUseCase(
-                 username: username,
-                 password: password,
-                 siteAddress: siteAddress,
-                 authenticationEndpoints: authenticationEndpoints
-             )
-         }) {
+         applicationPasswordUseCaseFactory: @escaping ApplicationPasswordUseCaseFactory
+             = AuthenticationManager.defaultApplicationPasswordUseCaseFactory) {
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics
@@ -818,7 +821,10 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         let webView = SFSafariViewController(url: url)
         navigationController.present(webView, animated: true)
     }
+}
 
+// MARK: - Application password
+extension AuthenticationManager {
     func makeApplicationPasswordUseCase(for credentials: WordPressOrgCredentials) throws -> ApplicationPasswordUseCase {
         try applicationPasswordUseCaseFactory(
             credentials.username,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -22,6 +22,11 @@ import struct NetworkingCore.WordPressAPIDiscovery
 /// Encapsulates all of the interactions with the WordPress Authenticator
 ///
 class AuthenticationManager: Authentication {
+    typealias SiteCredentialLoginUseCaseFactory = (
+        _ siteURL: String,
+        _ authenticationEndpoints: CookieNonceAuthenticationEndpoints?
+    ) -> SiteCredentialLoginProtocol
+
     typealias ApplicationPasswordUseCaseFactory = (
         _ username: String,
         _ password: String,
@@ -37,6 +42,10 @@ class AuthenticationManager: Authentication {
             siteAddress: siteAddress,
             authenticationEndpoints: authenticationEndpoints
         )
+    }
+
+    static let defaultSiteCredentialLoginUseCaseFactory: SiteCredentialLoginUseCaseFactory = { siteURL, authenticationEndpoints in
+        SiteCredentialLoginUseCase(siteURL: siteURL, endpoints: authenticationEndpoints)
     }
 
     var displayAuthenticatorIfLoggedOut: (() -> UINavigationController?)?
@@ -75,7 +84,7 @@ class AuthenticationManager: Authentication {
     private var postSiteCredentialLoginChecker: PostSiteCredentialLoginChecker?
 
     /// Keeps a reference to the use case
-    private var siteCredentialLoginUseCase: SiteCredentialLoginUseCase?
+    private var siteCredentialLoginUseCase: SiteCredentialLoginProtocol?
 
     /// Keeps a reference to the QR-login coordinator while the flow is active.
     private var qrLoginCoordinator: QRLoginCoordinator?
@@ -88,6 +97,10 @@ class AuthenticationManager: Authentication {
 
     private let userDefaults: UserDefaults
 
+    private let runtimeCookieJar: HTTPCookieStorage
+
+    private let siteCredentialLoginUseCaseFactory: SiteCredentialLoginUseCaseFactory
+
     private let applicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory
 
     init(stores: StoresManager = ServiceLocator.stores,
@@ -97,6 +110,9 @@ class AuthenticationManager: Authentication {
          switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil,
          userDefaults: UserDefaults = .standard,
          qrLoginAvailability: QRLoginAvailabilityProvider = QRLoginAvailability(),
+         runtimeCookieJar: HTTPCookieStorage = .shared,
+         siteCredentialLoginUseCaseFactory: @escaping SiteCredentialLoginUseCaseFactory
+             = AuthenticationManager.defaultSiteCredentialLoginUseCaseFactory,
          applicationPasswordUseCaseFactory: @escaping ApplicationPasswordUseCaseFactory
              = AuthenticationManager.defaultApplicationPasswordUseCaseFactory) {
         self.stores = stores
@@ -106,6 +122,8 @@ class AuthenticationManager: Authentication {
         self.switchStoreUseCase = switchStoreUseCase
         self.userDefaults = userDefaults
         self.qrLoginAvailability = qrLoginAvailability
+        self.runtimeCookieJar = runtimeCookieJar
+        self.siteCredentialLoginUseCaseFactory = siteCredentialLoginUseCaseFactory
         self.applicationPasswordUseCaseFactory = applicationPasswordUseCaseFactory
     }
 
@@ -561,7 +579,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping  (Error, Bool) -> Void) {
-        let useCase = SiteCredentialLoginUseCase(siteURL: credentials.siteURL)
+        let useCase = siteCredentialLoginUseCaseFactory(credentials.siteURL, credentials.authenticationEndpoints)
         useCase.setupHandlers(onLoginSuccess: onSuccess, onLoginFailure: { [weak self] error in
             guard let self else { return }
             onLoading(false)
@@ -826,7 +844,10 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 // MARK: - Application password
 extension AuthenticationManager {
     func makeApplicationPasswordUseCase(for credentials: WordPressOrgCredentials) throws -> ApplicationPasswordUseCase {
-        try applicationPasswordUseCaseFactory(
+        if let siteURL = URL(string: credentials.siteURL) {
+            runtimeCookieJar.removeCookies(forHostOf: siteURL)
+        }
+        return try applicationPasswordUseCaseFactory(
             credentials.username,
             credentials.password,
             credentials.siteURL,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -13,6 +13,7 @@ import protocol Storage.StorageManagerType
 import protocol Networking.ApplicationPasswordUseCase
 import class Networking.OneTimeApplicationPasswordUseCase
 import class Networking.DefaultApplicationPasswordUseCase
+import struct NetworkingCore.CookieNonceAuthenticationEndpoints
 import protocol Experiments.ABTestVariationProvider
 import protocol WooFoundation.Analytics
 import struct Experiments.CachedABTestVariationProvider
@@ -21,6 +22,13 @@ import struct NetworkingCore.WordPressAPIDiscovery
 /// Encapsulates all of the interactions with the WordPress Authenticator
 ///
 class AuthenticationManager: Authentication {
+    typealias ApplicationPasswordUseCaseFactory = (
+        _ username: String,
+        _ password: String,
+        _ siteAddress: String,
+        _ authenticationEndpoints: CookieNonceAuthenticationEndpoints?
+    ) throws -> ApplicationPasswordUseCase
+
     var displayAuthenticatorIfLoggedOut: (() -> UINavigationController?)?
 
     /// Store Picker Coordinator
@@ -70,13 +78,24 @@ class AuthenticationManager: Authentication {
 
     private let userDefaults: UserDefaults
 
+    private let applicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory
+
     init(stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
          abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider(),
          switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil,
          userDefaults: UserDefaults = .standard,
-         qrLoginAvailability: QRLoginAvailabilityProvider = QRLoginAvailability()) {
+         qrLoginAvailability: QRLoginAvailabilityProvider = QRLoginAvailability(),
+         applicationPasswordUseCaseFactory: @escaping ApplicationPasswordUseCaseFactory = {
+             username, password, siteAddress, authenticationEndpoints in
+             try DefaultApplicationPasswordUseCase(
+                 username: username,
+                 password: password,
+                 siteAddress: siteAddress,
+                 authenticationEndpoints: authenticationEndpoints
+             )
+         }) {
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics
@@ -84,6 +103,7 @@ class AuthenticationManager: Authentication {
         self.switchStoreUseCase = switchStoreUseCase
         self.userDefaults = userDefaults
         self.qrLoginAvailability = qrLoginAvailability
+        self.applicationPasswordUseCaseFactory = applicationPasswordUseCaseFactory
     }
 
     /// Initializes the WordPress Authenticator.
@@ -798,6 +818,15 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         let webView = SFSafariViewController(url: url)
         navigationController.present(webView, animated: true)
     }
+
+    func makeApplicationPasswordUseCase(for credentials: WordPressOrgCredentials) throws -> ApplicationPasswordUseCase {
+        try applicationPasswordUseCaseFactory(
+            credentials.username,
+            credentials.password,
+            credentials.siteURL,
+            credentials.authenticationEndpoints
+        )
+    }
 }
 
 // MARK: - Private helpers
@@ -992,12 +1021,13 @@ private extension AuthenticationManager {
     func didAuthenticateUser(to siteURL: String,
                              with siteCredentials: WordPressOrgCredentials,
                              in navigationController: UINavigationController) {
-        guard let useCase = try? DefaultApplicationPasswordUseCase(
-            username: siteCredentials.username,
-            password: siteCredentials.password,
-            siteAddress: siteCredentials.siteURL
-        ) else {
-            return assertionFailure("⛔️ Error creating application password use case")
+        let useCase: ApplicationPasswordUseCase
+        do {
+            useCase = try makeApplicationPasswordUseCase(for: siteCredentials)
+        } catch {
+            // Authenticated credentials without a constructible canonical site cannot safely enter the eligibility flow.
+            assertionFailure("⛔️ Error creating application password use case")
+            return
         }
         checkSiteCredentialLogin(to: siteURL, with: useCase, in: navigationController, previousViewController: nil)
     }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -140,7 +140,21 @@ private extension SiteCredentialLoginViewModel {
 
     func clearCookies(for siteURL: String) {
         guard let url = URL(string: siteURL) else { return }
-        cookieJar.cookies(for: url)?.forEach { cookieJar.deleteCookie($0) }
+        cookieJar.removeCookies(forHostOf: url)
+    }
+}
+
+extension HTTPCookieStorage {
+    func removeCookies(forHostOf url: URL) {
+        guard let siteHost = url.host?.lowercased() else { return }
+        cookies?.forEach { cookie in
+            let cookieDomain = cookie.domain
+                .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+                .lowercased()
+            if siteHost == cookieDomain || siteHost.hasSuffix(".\(cookieDomain)") {
+                deleteCookie(cookie)
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -75,13 +75,11 @@ private extension SiteCredentialLoginViewModel {
     }
 
     func handleCookieAuthentication() {
-        guard let canonicalSiteURL = URL(string: siteURL) else {
-            DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteURL)")
-            isLoggingIn = false
-            return
-        }
         let endpoints: CookieNonceAuthenticationEndpoints
         do {
+            guard let canonicalSiteURL = URL(string: siteURL) else {
+                throw CookieNonceAuthenticationEndpoints.ValidationError.invalidURL
+            }
             endpoints = try CookieNonceAuthenticationEndpoints(siteURL: canonicalSiteURL)
         } catch {
             DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteURL)")

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -4,6 +4,7 @@ import WordPressAuthenticator
 import enum Alamofire.AFError
 import struct Networking.CookieNonceAuthenticatorConfiguration
 import class Networking.WordPressOrgNetwork
+import struct NetworkingCore.CookieNonceAuthenticationEndpoints
 import protocol WooFoundation.Analytics
 
 /// View model for `SiteCredentialLoginView`.
@@ -74,8 +75,15 @@ private extension SiteCredentialLoginViewModel {
     }
 
     func handleCookieAuthentication() {
-        guard let loginURL = URL(string: siteURL + Constants.loginPath),
-              let adminURL = URL(string: siteURL + Constants.adminPath) else {
+        guard let canonicalSiteURL = URL(string: siteURL) else {
+            DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteURL)")
+            isLoggingIn = false
+            return
+        }
+        let endpoints: CookieNonceAuthenticationEndpoints
+        do {
+            endpoints = try CookieNonceAuthenticationEndpoints(siteURL: canonicalSiteURL)
+        } catch {
             DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteURL)")
             isLoggingIn = false
             return
@@ -87,8 +95,7 @@ private extension SiteCredentialLoginViewModel {
         // Prepares the authenticator with username and password
         let config = CookieNonceAuthenticatorConfiguration(username: username,
                                                            password: password,
-                                                           loginURL: loginURL,
-                                                           adminURL: adminURL)
+                                                           endpoints: endpoints)
         let network = WordPressOrgNetwork(configuration: config, siteAddress: siteURL)
         let authenticationAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
         stores.dispatch(authenticationAction)
@@ -146,10 +153,5 @@ extension SiteCredentialLoginViewModel {
             comment: "An error message shown during login when the username or password is incorrect."
         )
         static let genericFailure = NSLocalizedString("Login failed. Please try again.", comment: "A generic error during site credential login")
-    }
-
-    enum Constants {
-        static let loginPath = "/wp-login.php"
-        static let adminPath = "/wp-admin/"
     }
 }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -144,20 +144,6 @@ private extension SiteCredentialLoginViewModel {
     }
 }
 
-extension HTTPCookieStorage {
-    func removeCookies(forHostOf url: URL) {
-        guard let siteHost = url.host?.lowercased() else { return }
-        cookies?.forEach { cookie in
-            let cookieDomain = cookie.domain
-                .trimmingCharacters(in: CharacterSet(charactersIn: "."))
-                .lowercased()
-            if siteHost == cookieDomain || siteHost.hasSuffix(".\(cookieDomain)") {
-                deleteCookie(cookie)
-            }
-        }
-    }
-}
-
 extension SiteCredentialLoginViewModel {
     enum Localization {
         static let wrongCredentials = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
+++ b/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressAuthenticator
 import struct NetworkingCore.CookieNonceAuthenticationEndpoints
 
-/// Extension to create cookie nonce authenticator from WP.org credentials.
+/// Authentication endpoints and URL strings derived from WP.org credentials.
 ///
 extension WordPressOrgCredentials {
     var loginURL: String {

--- a/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
+++ b/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
@@ -19,20 +19,14 @@ extension WordPressOrgCredentials {
         guard let adminURL = defaultAuthenticationEndpoints?.adminBaseURL.absoluteString else {
             return siteURL
         }
-        return adminURL.hasSuffix("/") ? String(adminURL.dropLast()) : adminURL
+        return adminURL.removingSuffix("/")
     }
 
     /// Validated, canonical endpoints supplied by site discovery, or safe defaults when options are absent.
     var authenticationEndpoints: CookieNonceAuthenticationEndpoints? {
         do {
-            guard let canonicalSiteURL = URL(string: siteURL) else {
-                return nil
-            }
-            return try CookieNonceAuthenticationEndpoints(
-                siteURL: canonicalSiteURL,
-                loginEntryURL: try configuredURL(for: .loginURL),
-                adminBaseURL: try configuredURL(for: .adminURL)
-            )
+            return makeAuthenticationEndpoints(loginEntryURL: try configuredURL(for: .loginURL),
+                                               adminBaseURL: try configuredURL(for: .adminURL))
         } catch {
             return nil
         }
@@ -43,22 +37,27 @@ extension WordPressOrgCredentials {
 //
 private extension WordPressOrgCredentials {
     var defaultAuthenticationEndpoints: CookieNonceAuthenticationEndpoints? {
+        makeAuthenticationEndpoints()
+    }
+
+    func makeAuthenticationEndpoints(loginEntryURL: URL? = nil, adminBaseURL: URL? = nil) -> CookieNonceAuthenticationEndpoints? {
+        guard let canonicalSiteURL = URL(string: siteURL) else {
+            return nil
+        }
         do {
-            guard let canonicalSiteURL = URL(string: siteURL) else {
-                return nil
-            }
-            return try CookieNonceAuthenticationEndpoints(siteURL: canonicalSiteURL)
+            return try CookieNonceAuthenticationEndpoints(siteURL: canonicalSiteURL,
+                                                          loginEntryURL: loginEntryURL,
+                                                          adminBaseURL: adminBaseURL)
         } catch {
             return nil
         }
     }
 
     func configuredURL(for key: Key) throws -> URL? {
-        guard let option = options[key.rawValue] else {
+        guard options[key.rawValue] != nil else {
             return nil
         }
-        guard let container = option as? [String: Any],
-              let value = container[Key.value.rawValue] as? String,
+        guard let value = optionValue(for: key.rawValue) as? String,
               value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
               let url = URL(string: value) else {
             throw EndpointOptionError.invalidValue

--- a/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
+++ b/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
@@ -1,37 +1,71 @@
 import Foundation
 import WordPressAuthenticator
-import struct Networking.CookieNonceAuthenticatorConfiguration
+import struct NetworkingCore.CookieNonceAuthenticationEndpoints
 
 /// Extension to create cookie nonce authenticator from WP.org credentials.
 ///
 extension WordPressOrgCredentials {
     var loginURL: String {
-        let value = optionValue(for: Key.loginURL.rawValue) as? String
-        return value ?? siteURL + Strings.loginPath
+        if let value = optionValue(for: Key.loginURL.rawValue) as? String {
+            return value
+        }
+        return defaultAuthenticationEndpoints?.loginEntryURL.absoluteString ?? siteURL
     }
 
     var adminURL: String {
-        let value = optionValue(for: Key.adminURL.rawValue) as? String
-        return value ?? siteURL + Strings.adminPath
+        if let value = optionValue(for: Key.adminURL.rawValue) as? String {
+            return value
+        }
+        guard let adminURL = defaultAuthenticationEndpoints?.adminBaseURL.absoluteString else {
+            return siteURL
+        }
+        return adminURL.hasSuffix("/") ? String(adminURL.dropLast()) : adminURL
     }
 
-    /// Returns a cookie nonce authenticator configuration based on the current credentials
-    ///
-    func makeCookieNonceAuthenticatorConfig() -> CookieNonceAuthenticatorConfiguration? {
-        guard let loginURL = URL(string: loginURL),
-              let adminURL = URL(string: adminURL) else {
+    /// Validated, canonical endpoints supplied by site discovery, or safe defaults when options are absent.
+    var authenticationEndpoints: CookieNonceAuthenticationEndpoints? {
+        do {
+            guard let canonicalSiteURL = URL(string: siteURL) else {
+                return nil
+            }
+            return try CookieNonceAuthenticationEndpoints(
+                siteURL: canonicalSiteURL,
+                loginEntryURL: try configuredURL(for: .loginURL),
+                adminBaseURL: try configuredURL(for: .adminURL)
+            )
+        } catch {
             return nil
         }
-        return CookieNonceAuthenticatorConfiguration(username: username,
-                                                     password: password,
-                                                     loginURL: loginURL,
-                                                     adminURL: adminURL)
     }
 }
 
 // MARK: - Private helpers
 //
 private extension WordPressOrgCredentials {
+    var defaultAuthenticationEndpoints: CookieNonceAuthenticationEndpoints? {
+        do {
+            guard let canonicalSiteURL = URL(string: siteURL) else {
+                return nil
+            }
+            return try CookieNonceAuthenticationEndpoints(siteURL: canonicalSiteURL)
+        } catch {
+            return nil
+        }
+    }
+
+    func configuredURL(for key: Key) throws -> URL? {
+        guard let option = options[key.rawValue] else {
+            return nil
+        }
+        guard let container = option as? [String: Any],
+              let value = container[Key.value.rawValue] as? String,
+              value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
+              let url = URL(string: value) else {
+            throw EndpointOptionError.invalidValue
+        }
+        return url
+    }
+
     /// Returns value for an option given a key.
     ///
     func optionValue(for key: String) -> Any? {
@@ -41,9 +75,8 @@ private extension WordPressOrgCredentials {
 }
 
 private extension WordPressOrgCredentials {
-    enum Strings {
-        static let loginPath = "/wp-login.php"
-        static let adminPath = "/wp-admin"
+    enum EndpointOptionError: Error {
+        case invalidValue
     }
 
     /// Key for getting value from `options`.

--- a/WooCommerce/Classes/Extensions/HTTPCookieStorage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/HTTPCookieStorage+Woo.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension HTTPCookieStorage {
+    func removeCookies(forHostOf url: URL) {
+        guard let siteHost = url.host?.lowercased() else { return }
+        cookies?.forEach { cookie in
+            let cookieDomain = cookie.domain
+                .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+                .lowercased()
+            if siteHost == cookieDomain || siteHost.hasSuffix(".\(cookieDomain)") {
+                deleteCookie(cookie)
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -1,5 +1,7 @@
 import TestKit
 import XCTest
+@testable import Networking
+@testable import NetworkingCore
 import WordPressAuthenticator
 import Yosemite
 import YosemiteTestHelpers
@@ -56,6 +58,86 @@ final class AuthenticationManagerTests: XCTestCase {
 
         // Then
         XCTAssertFalse(canHandle)
+    }
+
+    func test_application_password_factory_receives_custom_endpoints_from_wordpress_org_credentials() throws {
+        // Given
+        let apiRoot = "https://example.com/wp-json/"
+        WordPressRESTAPIRootCache.shared.setRoot(apiRoot, for: "https://example.com")
+        defer { WordPressRESTAPIRootCache.shared.removeRoot(apiRoot, for: "https://example.com") }
+        let credentials = WordPressOrgCredentials(
+            username: "merchant",
+            password: "password",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            options: [
+                "login_url": ["value": "https://example.com/custom-login"],
+                "admin_url": ["value": "https://example.com/custom-admin"]
+            ]
+        )
+        var capturedUsername: String?
+        var capturedPassword: String?
+        var capturedSiteAddress: String?
+        var capturedEndpoints: CookieNonceAuthenticationEndpoints?
+        let manager = AuthenticationManager(
+            applicationPasswordUseCaseFactory: { username, password, siteAddress, endpoints in
+                capturedUsername = username
+                capturedPassword = password
+                capturedSiteAddress = siteAddress
+                capturedEndpoints = endpoints
+                return MockAuthenticationManagerApplicationPasswordUseCase()
+            }
+        )
+
+        // When
+        _ = try manager.makeApplicationPasswordUseCase(for: credentials)
+
+        // Then
+        XCTAssertEqual(capturedUsername, "merchant")
+        XCTAssertEqual(capturedPassword, "password")
+        XCTAssertEqual(capturedSiteAddress, "https://example.com")
+        XCTAssertEqual(capturedEndpoints?.siteURL.absoluteString, "https://example.com")
+        XCTAssertEqual(capturedEndpoints?.loginEntryURL.absoluteString, "https://example.com/custom-login")
+        XCTAssertEqual(capturedEndpoints?.adminBaseURL.absoluteString, "https://example.com/custom-admin/")
+
+        let productionUseCase = try XCTUnwrap(
+            AuthenticationManager().makeApplicationPasswordUseCase(for: credentials) as? DefaultApplicationPasswordUseCase
+        )
+        XCTAssertEqual(productionUseCase.authenticationEndpoints?.siteURL.absoluteString, "https://example.com")
+        XCTAssertEqual(productionUseCase.authenticationEndpoints?.loginEntryURL.absoluteString, "https://example.com/custom-login")
+        XCTAssertEqual(productionUseCase.authenticationEndpoints?.adminBaseURL.absoluteString, "https://example.com/custom-admin/")
+    }
+
+    func test_application_password_factory_receives_nil_endpoints_when_credential_options_are_malformed() throws {
+        // Given
+        let apiRoot = "https://example.com/wp-json/"
+        WordPressRESTAPIRootCache.shared.setRoot(apiRoot, for: "https://example.com")
+        defer { WordPressRESTAPIRootCache.shared.removeRoot(apiRoot, for: "https://example.com") }
+        let credentials = WordPressOrgCredentials(
+            username: "merchant",
+            password: "password",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            options: ["login_url": ["value": ":// malformed"]]
+        )
+        var capturedEndpoints: CookieNonceAuthenticationEndpoints?
+        let manager = AuthenticationManager(
+            applicationPasswordUseCaseFactory: { _, _, _, endpoints in
+                capturedEndpoints = endpoints
+                return MockAuthenticationManagerApplicationPasswordUseCase()
+            }
+        )
+
+        // When
+        _ = try manager.makeApplicationPasswordUseCase(for: credentials)
+
+        // Then
+        XCTAssertNil(capturedEndpoints)
+
+        let productionUseCase = try XCTUnwrap(
+            AuthenticationManager().makeApplicationPasswordUseCase(for: credentials) as? DefaultApplicationPasswordUseCase
+        )
+        XCTAssertEqual(productionUseCase.authenticationEndpoints?.siteURL.absoluteString, "https://example.com")
+        XCTAssertEqual(productionUseCase.authenticationEndpoints?.loginEntryURL.absoluteString, "https://example.com/wp-login.php")
+        XCTAssertEqual(productionUseCase.authenticationEndpoints?.adminBaseURL.absoluteString, "https://example.com/wp-admin/")
     }
 
     /// We don't allow sites that do not have SSL. We provide a custom error UI for this.
@@ -650,4 +732,15 @@ private extension AuthenticationManagerTests {
                                       "isWordPressDotCom": isWordPressCom,
                                       "isCommerceGarden": isCommerceGarden])
     }
+}
+
+private final class MockAuthenticationManagerApplicationPasswordUseCase: ApplicationPasswordUseCase {
+    var applicationPassword: ApplicationPassword? { nil }
+    var canRegenerateApplicationPassword: Bool { true }
+
+    func generateNewPassword() async throws -> ApplicationPassword {
+        throw ApplicationPasswordUseCaseError.notSupported
+    }
+
+    func deletePassword(locally: Bool) async throws {}
 }

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -107,6 +107,45 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual(productionUseCase.authenticationEndpoints?.adminBaseURL.absoluteString, "https://example.com/custom-admin/")
     }
 
+    func test_site_credential_login_factory_receives_custom_endpoints_from_wordpress_org_credentials() {
+        // Given
+        let credentials = WordPressOrgCredentials(
+            username: "merchant",
+            password: "password",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            options: [
+                "login_url": ["value": "https://example.com/custom-login"],
+                "admin_url": ["value": "https://example.com/custom-admin"]
+            ]
+        )
+        let mockUseCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var capturedSiteURL: String?
+        var capturedEndpoints: CookieNonceAuthenticationEndpoints?
+        let manager = AuthenticationManager(
+            siteCredentialLoginUseCaseFactory: { siteURL, endpoints in
+                capturedSiteURL = siteURL
+                capturedEndpoints = endpoints
+                return mockUseCase
+            }
+        )
+
+        // When
+        manager.handleSiteCredentialLogin(
+            credentials: credentials,
+            onLoading: { _ in },
+            onSuccess: {},
+            onFailure: { _, _ in }
+        )
+
+        // Then
+        XCTAssertEqual(capturedSiteURL, "https://example.com")
+        XCTAssertEqual(capturedEndpoints?.siteURL.absoluteString, "https://example.com")
+        XCTAssertEqual(capturedEndpoints?.loginEntryURL.absoluteString, "https://example.com/custom-login")
+        XCTAssertEqual(capturedEndpoints?.adminBaseURL.absoluteString, "https://example.com/custom-admin/")
+        XCTAssertEqual(mockUseCase.receivedUsername, "merchant")
+        XCTAssertEqual(mockUseCase.receivedPassword, "password")
+    }
+
     func test_application_password_factory_receives_nil_endpoints_when_credential_options_are_malformed() throws {
         // Given
         let apiRoot = "https://example.com/wp-json/"
@@ -138,6 +177,47 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual(productionUseCase.authenticationEndpoints?.siteURL.absoluteString, "https://example.com")
         XCTAssertEqual(productionUseCase.authenticationEndpoints?.loginEntryURL.absoluteString, "https://example.com/wp-login.php")
         XCTAssertEqual(productionUseCase.authenticationEndpoints?.adminBaseURL.absoluteString, "https://example.com/wp-admin/")
+    }
+
+    func test_application_password_factory_when_credentials_are_fresh_then_clears_site_cookies_before_construction() throws {
+        // Given
+        let runtimeCookieJar = MockCookieJar()
+        let siteCookie = try XCTUnwrap(HTTPCookie(properties: [
+            .domain: ".example.com",
+            .path: "/",
+            .secure: true,
+            .name: "wordpress_logged_in_stale",
+            .value: "wrong-user"
+        ]))
+        let unrelatedCookie = try XCTUnwrap(HTTPCookie(properties: [
+            .domain: "unrelated.test",
+            .path: "/",
+            .name: "unrelated-session",
+            .value: "preserve"
+        ]))
+        runtimeCookieJar.setCookie(siteCookie)
+        runtimeCookieJar.setCookie(unrelatedCookie)
+        let credentials = WordPressOrgCredentials(
+            username: "merchant",
+            password: "password",
+            xmlrpc: "http://shop.example.com/xmlrpc.php",
+            options: [:]
+        )
+        var cookieNamesDuringConstruction = Set<String>()
+        let manager = AuthenticationManager(
+            runtimeCookieJar: runtimeCookieJar,
+            applicationPasswordUseCaseFactory: { _, _, _, _ in
+                cookieNamesDuringConstruction = Set(runtimeCookieJar.cookies?.map(\.name) ?? [])
+                return MockAuthenticationManagerApplicationPasswordUseCase()
+            }
+        )
+
+        // When
+        _ = try manager.makeApplicationPasswordUseCase(for: credentials)
+
+        // Then
+        XCTAssertFalse(cookieNamesDuringConstruction.contains(siteCookie.name))
+        XCTAssertTrue(cookieNamesDuringConstruction.contains(unrelatedCookie.name))
     }
 
     /// We don't allow sites that do not have SSL. We provide a custom error UI for this.
@@ -743,4 +823,17 @@ private final class MockAuthenticationManagerApplicationPasswordUseCase: Applica
     }
 
     func deletePassword(locally: Bool) async throws {}
+}
+
+private final class MockAuthenticationManagerSiteCredentialLoginUseCase: SiteCredentialLoginProtocol {
+    private(set) var receivedUsername: String?
+    private(set) var receivedPassword: String?
+
+    func setupHandlers(onLoginSuccess: @escaping () -> Void,
+                       onLoginFailure: @escaping (SiteCredentialLoginError) -> Void) {}
+
+    func handleLogin(username: String, password: String) {
+        receivedUsername = username
+        receivedPassword = password
+    }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
@@ -1,14 +1,16 @@
 import XCTest
+import WebKit
 import WordPressAuthenticator
 @testable import WooCommerce
 
+@MainActor
 final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
 
     private let username = "test"
     private let password = "pwd"
     private let xmlrpc = "https://test.com/xmlrpc.php"
     private let options: [AnyHashable: Any] = [
-        "login_url": ["value": "http://test.com/wp-login.php"],
+        "login_url": ["value": "https://test.com/wp-login.php"],
         "admin_url": ["value": "https://test.com/wp-admin"],
         "software_version": ["value": "5.3.1"]
     ]
@@ -18,7 +20,7 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
 
         // Then
-        assertEqual(credentials.loginURL, "http://test.com/wp-login.php")
+        assertEqual(credentials.loginURL, "https://test.com/wp-login.php")
     }
 
     func test_adminURL_is_correct() {
@@ -29,14 +31,88 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         assertEqual(credentials.adminURL, "https://test.com/wp-admin")
     }
 
-    func test_configuration_is_created_correctly() {
+    func test_authentication_endpoints_reject_https_to_http_downgrade() {
         // Given
+        let options: [AnyHashable: Any] = [
+            "login_url": ["value": "http://test.com/wp-login.php"],
+            "admin_url": ["value": "https://test.com/wp-admin"]
+        ]
         let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
 
-        // When
-        let configuration = credentials.makeCookieNonceAuthenticatorConfig()
+        // Then
+        XCTAssertNil(credentials.authenticationEndpoints)
+    }
+
+    func test_default_endpoints_normalize_trailing_slash_without_double_slashes() {
+        // Given
+        let credentials = WordPressOrgCredentials(
+            username: username,
+            password: password,
+            xmlrpc: "https://test.com//xmlrpc.php",
+            options: [:]
+        )
 
         // Then
-        XCTAssertNotNil(configuration)
+        XCTAssertEqual(credentials.authenticationEndpoints?.loginEntryURL.absoluteString, "https://test.com/wp-login.php")
+        XCTAssertEqual(credentials.authenticationEndpoints?.adminBaseURL.absoluteString, "https://test.com/wp-admin/")
+        XCTAssertEqual(credentials.loginURL, "https://test.com/wp-login.php")
+        XCTAssertEqual(credentials.adminURL, "https://test.com/wp-admin")
+    }
+
+    func test_web_view_authentication_default_redirect_has_exactly_one_admin_path_separator() throws {
+        // Given
+        let credentials = WordPressOrgCredentials(
+            username: username,
+            password: password,
+            xmlrpc: "https://test.com//xmlrpc.php",
+            options: [:]
+        )
+
+        // When
+        let request = try WKWebView().authenticateForWPOrg(with: credentials)
+        let body = try XCTUnwrap(request.httpBody)
+        let encodedParameters = try XCTUnwrap(String(data: body, encoding: .utf8))
+        var components = URLComponents()
+        components.percentEncodedQuery = encodedParameters
+        let redirectURL = components.queryItems?.first(where: { $0.name == "redirect_to" })?.value
+
+        // Then
+        XCTAssertEqual(redirectURL, "https://test.com/wp-admin/admin-ajax.php?action=rest-nonce")
+        XCTAssertFalse(redirectURL?.contains("/wp-admin//admin-ajax.php") == true)
+    }
+
+    func test_authentication_endpoints_accept_custom_same_site_options() {
+        // Given
+        let options: [AnyHashable: Any] = [
+            "login_url": ["value": "https://test.com/custom-entry"],
+            "admin_url": ["value": "https://test.com/private-admin"]
+        ]
+        let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
+
+        // Then
+        XCTAssertEqual(credentials.authenticationEndpoints?.loginEntryURL.absoluteString, "https://test.com/custom-entry")
+        XCTAssertEqual(credentials.authenticationEndpoints?.adminBaseURL.absoluteString, "https://test.com/private-admin/")
+    }
+
+    func test_authentication_endpoints_reject_cross_origin_option() {
+        // Given
+        let options: [AnyHashable: Any] = [
+            "login_url": ["value": "https://attacker.example/wp-login.php"]
+        ]
+        let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
+
+        // Then
+        XCTAssertNil(credentials.authenticationEndpoints)
+    }
+
+    func test_authentication_endpoints_reject_malformed_option_string() {
+        // Given
+        let options: [AnyHashable: Any] = [
+            "login_url": ["value": ":// malformed"]
+        ]
+        let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
+
+        // Then
+        XCTAssertNil(credentials.authenticationEndpoints)
     }
 }


### PR DESCRIPTION
## Description

> [!NOTE]
> **About 73% of the raw diff is tests:** 1,231 lines (`+1,222/-9`), primarily security-focused `CookieNonceAuthenticator` scenarios.
>
> Production is 458 raw lines (`+325/-133`), or 415 lines under the Danger test/comment/blank exclusions (`+294/-121`). Keeping the complete runtime authentication transaction together avoids an incomplete intermediate transport.


### Why

PR #17719 secures the interactive URLSession site-credential login, but Application Password creation and regeneration use the separate, existing Alamofire `CookieNonceAuthenticator` transport.

That runtime path still assumes the default login and admin locations unless the endpoints are threaded into it. It must also independently preflight the durable login entry and derive the current transaction-local form action because it cannot reuse PR #17719's private cookies or session.

This brings the PR #17718 trust decisions to runtime authentication while preserving the existing 401 retry and request-coalescing state, rather than introducing a new authentication platform.

### How

- Threads normalized configured/default endpoints through `DefaultApplicationPasswordUseCase`, `SiteCredentialLoginViewModel`, WordPress.org credentials authenticator construction, and `AuthenticationManager` option forwarding.
- Performs a fresh, bounded preflight and verifies the transaction-local form action before posting credentials.
- Uses a dedicated redirect-blocking authentication `Session` without the protected interceptor, while sharing the protected `Session`'s exact `HTTPCookieStorage` so the resulting REST request sees the login cookie.
- Treats credential redirects as evidence only: their raw target is never followed or promoted. The independently derived configured nonce URL is fetched with a clean, bodyless `GET`.
- Preserves the existing one-401, one-retry, and request-coalescing lifecycle.

Explicitly excluded from this PR: persistence; `SessionManager`/`AuthenticatedState`; `Site`/WebView projection; recovery contract/UI; analytics; and release-note behavior.

### Stack context

1. #17718 — endpoint trust boundary and shared rules
2. #17719 — interactive authentication
3. This PR — runtime authentication
4. Persistence
5. `Site`/WebView consumers
6. Recovery contract/UI

## Test Steps

### Manual verification — Application Password creation and regeneration

Prerequisite: Use a real HTTPS self-hosted WooCommerce site with Application Passwords enabled and the standard WordPress login/admin paths.

1. Log out of the app and remove any existing WooCommerce iOS Application Password for the test device from WP Admin.
2. In the app, tap **Log In**, enter the store address, choose **Sign in with store credentials**, and submit valid administrator credentials.
3. Verify login completes, the authenticated store opens, and real Dashboard data loads without an Application Password or authentication error.
4. In WP Admin, verify a new WooCommerce iOS Application Password was created.
5. Without logging out of the app, revoke that Application Password in WP Admin.
6. Refresh an authenticated screen such as Orders.
7. Verify the app remains signed in, the refresh succeeds after regeneration, and a new WooCommerce iOS Application Password appears in WP Admin.

Custom login/admin endpoints are not exposed through the UI at this stack layer; they will be manually verified when endpoint recovery lands.

## Screenshots

N/A — internal authentication transport only.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No entry is included in this internal transport PR; the final user-facing PR in the stack will carry it.
