### PR TITLE
[WOOMOB-3800] Recover moved site credential endpoints

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -48,7 +48,6 @@
 - [*] Google Ads: Fixed the dashboard campaign card failing to show existing campaign performance data. [https://github.com/woocommerce/woocommerce-ios/pull/17706]
 - [*] POS: Fixed the barcode scanner setup test not recognizing scans on phones. [https://github.com/woocommerce/woocommerce-ios/pull/17702]
 - [*] Dashboard: Fixed the Stock card not refreshing after product edits or when its data becomes stale. [https://github.com/woocommerce/woocommerce-ios/pull/17707]
-- [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing.
 - [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
 - [*] Orders: Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin. [https://github.com/woocommerce/woocommerce-ios/pull/17691]
 - [*] Orders: Fixed Custom Fields and refunded-product rows becoming centered after scrolling order details. [https://github.com/woocommerce/woocommerce-ios/pull/17689]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.7
 -----
 - [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax. [https://github.com/woocommerce/woocommerce-ios/pull/17827]
+- [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
 
 
 25.6
@@ -48,7 +49,6 @@
 - [*] Google Ads: Fixed the dashboard campaign card failing to show existing campaign performance data. [https://github.com/woocommerce/woocommerce-ios/pull/17706]
 - [*] POS: Fixed the barcode scanner setup test not recognizing scans on phones. [https://github.com/woocommerce/woocommerce-ios/pull/17702]
 - [*] Dashboard: Fixed the Stock card not refreshing after product edits or when its data becomes stale. [https://github.com/woocommerce/woocommerce-ios/pull/17707]
-- [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
 - [*] Orders: Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin. [https://github.com/woocommerce/woocommerce-ios/pull/17691]
 - [*] Orders: Fixed Custom Fields and refunded-product rows becoming centered after scrolling order details. [https://github.com/woocommerce/woocommerce-ios/pull/17689]
 - [*] In-Person Payments: Fixed the Manage Card Reader sheet truncating its Learn More text on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17690]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -48,6 +48,7 @@
 - [*] Google Ads: Fixed the dashboard campaign card failing to show existing campaign performance data. [https://github.com/woocommerce/woocommerce-ios/pull/17706]
 - [*] POS: Fixed the barcode scanner setup test not recognizing scans on phones. [https://github.com/woocommerce/woocommerce-ios/pull/17702]
 - [*] Dashboard: Fixed the Stock card not refreshing after product edits or when its data becomes stale. [https://github.com/woocommerce/woocommerce-ios/pull/17707]
+- [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing.
 - [*] Orders: Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin. [https://github.com/woocommerce/woocommerce-ios/pull/17691]
 - [*] Orders: Fixed Custom Fields and refunded-product rows becoming centered after scrolling order details. [https://github.com/woocommerce/woocommerce-ios/pull/17689]
 - [*] In-Person Payments: Fixed the Manage Card Reader sheet truncating its Learn More text on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17690]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -49,6 +49,7 @@
 - [*] POS: Fixed the barcode scanner setup test not recognizing scans on phones. [https://github.com/woocommerce/woocommerce-ios/pull/17702]
 - [*] Dashboard: Fixed the Stock card not refreshing after product edits or when its data becomes stale. [https://github.com/woocommerce/woocommerce-ios/pull/17707]
 - [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing.
+- [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
 - [*] Orders: Refunding an order paid with a gift card is now blocked in the app with a prompt to refund from your store admin. [https://github.com/woocommerce/woocommerce-ios/pull/17691]
 - [*] Orders: Fixed Custom Fields and refunded-product rows becoming centered after scrolling order details. [https://github.com/woocommerce/woocommerce-ios/pull/17689]
 - [*] In-Person Payments: Fixed the Manage Card Reader sheet truncating its Learn More text on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17690]

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -1299,7 +1299,7 @@ private extension AuthenticationManager {
         }()
         let defaultAction = shouldEnableWebFlow ? { [weak self] in
             guard let self else { return }
-            presentAppPasswordTutorial(error: error, invalidLoginPageDetected: false, for: siteURL, in: viewController)
+            presentApplicationPasswordWebView(for: siteURL, in: viewController)
         } : nil
         presentSiteCredentialLoginErrorAlert(
             message: (error as NSError).localizedDescription,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -653,11 +653,11 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             guard let self, let viewController else { return }
             presentApplicationPasswordWebView(for: siteURL, in: viewController)
         } : nil
-        let alert = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
+        presentSiteCredentialLoginErrorAlert(
             message: error.localizedDescription,
-            defaultAction: browserAction
+            defaultAction: browserAction,
+            in: viewController
         )
-        viewController.present(alert, animated: true)
     }
 
     func handleSiteCredentialLoginFailure(error: Error,
@@ -1287,12 +1287,28 @@ private extension AuthenticationManager {
             guard let self else { return }
             presentApplicationPasswordWebView(for: siteURL, in: viewController)
         } : nil
-        let alertController = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
+        presentSiteCredentialLoginErrorAlert(
             message: (error as NSError).localizedDescription,
+            defaultAction: defaultAction,
+            in: viewController
+        )
+    }
+
+    /// Presents the site credential failure using the authenticator's centered, dimmed alert treatment.
+    ///
+    /// Without the custom presentation configuration, UIKit presents the alert as a page sheet on iOS 26.
+    private func presentSiteCredentialLoginErrorAlert(message: String,
+                                                      defaultAction: (() -> Void)?,
+                                                      in viewController: UIViewController) {
+        let alert = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
+            message: message,
             defaultAction: defaultAction
         )
-
-        viewController.present(alertController, animated: true)
+        if let transitioningDelegate = viewController as? UIViewControllerTransitioningDelegate {
+            alert.modalPresentationStyle = .custom
+            alert.transitioningDelegate = transitioningDelegate
+        }
+        viewController.present(alert, animated: true)
     }
 
     /// Presents app password site login using a web view.

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -643,7 +643,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     }
 
     func presentSiteCredentialBrowserAlternative(for siteURL: String, in viewController: UIViewController) {
-        presentApplicationPasswordWebView(for: siteURL, in: viewController)
+        presentAppPasswordTutorial(error: SiteCredentialLoginError.inaccessibleLoginPage, for: siteURL, in: viewController)
     }
 
     /// Presents the failure without ever navigating to the browser flow on its own. The browser alternative
@@ -655,7 +655,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                            in viewController: UIViewController) {
         let browserAction: (() -> Void)? = offersBrowserAlternative ? { [weak self, weak viewController] in
             guard let self, let viewController else { return }
-            presentApplicationPasswordWebView(for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } : nil
         presentSiteCredentialLoginErrorAlert(
             message: error.localizedDescription,
@@ -1289,7 +1289,7 @@ private extension AuthenticationManager {
         }()
         let defaultAction = shouldEnableWebFlow ? { [weak self] in
             guard let self else { return }
-            presentApplicationPasswordWebView(for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } : nil
         presentSiteCredentialLoginErrorAlert(
             message: (error as NSError).localizedDescription,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -23,11 +23,12 @@ import struct NetworkingCore.WordPressAPIDiscovery
 class AuthenticationManager: Authentication {
     typealias SiteCredentialLoginUseCaseFactory = (
         _ siteURL: String,
-        _ authenticationEndpoints: CookieNonceAuthenticationEndpoints?
+        _ endpoints: CookieNonceAuthenticationEndpoints?,
+        _ verifyAdminDashboard: Bool
     ) -> SiteCredentialLoginProtocol
 
-    static let defaultSiteCredentialLoginUseCaseFactory: SiteCredentialLoginUseCaseFactory = { siteURL, authenticationEndpoints in
-        SiteCredentialLoginUseCase(siteURL: siteURL, endpoints: authenticationEndpoints)
+    static let defaultSiteCredentialLoginUseCaseFactory: SiteCredentialLoginUseCaseFactory = { siteURL, endpoints, verifyAdminDashboard in
+        SiteCredentialLoginUseCase(siteURL: siteURL, endpoints: endpoints, verifyAdminDashboard: verifyAdminDashboard)
     }
 
     var displayAuthenticatorIfLoggedOut: (() -> UINavigationController?)?
@@ -93,9 +94,9 @@ class AuthenticationManager: Authentication {
          userDefaults: UserDefaults = .standard,
          qrLoginAvailability: QRLoginAvailabilityProvider = QRLoginAvailability(),
          runtimeCookieJar: HTTPCookieStorage = .shared,
+         applicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory = .init(),
          siteCredentialLoginUseCaseFactory: @escaping SiteCredentialLoginUseCaseFactory
-             = AuthenticationManager.defaultSiteCredentialLoginUseCaseFactory,
-         applicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory = .init()) {
+             = AuthenticationManager.defaultSiteCredentialLoginUseCaseFactory) {
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics
@@ -560,25 +561,103 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping  (Error, Bool) -> Void) {
-        let useCase = siteCredentialLoginUseCaseFactory(credentials.siteURL, credentials.authenticationEndpoints)
-        useCase.setupHandlers(onLoginSuccess: onSuccess, onLoginFailure: { [weak self] error in
+        let useCase = siteCredentialLoginUseCaseFactory(
+            credentials.siteURL,
+            credentials.authenticationEndpoints,
+            false
+        )
+        useCase.setupHandlers(onLoginSuccess: onSuccess, onLoginFailure: { [weak self] error, _ in
             guard let self else { return }
             onLoading(false)
             onFailure(error, false)
-            let challengeType: String? = {
-                if case .basicAuthenticationRequired = error {
-                    return "basic_auth"
-                }
-                return nil
-            }()
-            self.analytics.track(event: .Login.siteCredentialFailed(step: .authentication,
-                                                                    error: error.underlyingError,
-                                                                    challengeType: challengeType))
+            self.trackSiteCredentialLoginFailure(error)
         })
         self.siteCredentialLoginUseCase = useCase
 
         useCase.handleLogin(username: credentials.username, password: credentials.password)
         onLoading(true)
+    }
+
+    /// Authenticates site credentials against explicitly configured endpoints, asking the merchant where
+    /// the sign-in page or the dashboard lives when the standard addresses do not work.
+    ///
+    func authenticateSiteCredentials(credentials: WordPressOrgCredentials,
+                                     loginURL: String?,
+                                     adminURL: String?,
+                                     endpointUnderVerification: SiteCredentialRecoveryEndpoint?,
+                                     onLoading: @escaping (Bool) -> Void,
+                                     onSuccess: @escaping (WordPressOrgCredentials) -> Void,
+                                     onRecovery: @escaping (SiteCredentialRecovery) -> Void,
+                                     onFailure: @escaping (Error, Bool, String?) -> Void) {
+        let endpoints: CookieNonceAuthenticationEndpoints
+        do {
+            endpoints = try siteCredentialRecoveryEndpoints(
+                siteURL: credentials.siteURL,
+                loginURL: loginURL,
+                adminURL: adminURL
+            )
+        } catch let error as SiteCredentialRecoveryValidationError {
+            onRecovery(error.recovery)
+            return
+        } catch {
+            onFailure(SiteCredentialLoginError.invalidLoginResponse, false, nil)
+            return
+        }
+
+        let useCase = siteCredentialLoginUseCaseFactory(
+            credentials.siteURL,
+            endpoints,
+            endpointUnderVerification == .admin
+        )
+        useCase.setupHandlers(onLoginSuccess: {
+            onLoading(false)
+            onSuccess(credentials.replacingAuthenticationEndpoints(with: endpoints))
+        }, onLoginFailure: { [weak self] error, loginEntryVerified in
+            onLoading(false)
+            let normalizedLoginURL = endpoints.loginEntryURL.absoluteString
+            let normalizedAdminURL = endpoints.adminBaseURL.absoluteString
+            switch error {
+            case .inaccessibleLoginPage where endpointUnderVerification != .admin:
+                let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .login ? .notFound : nil
+                onRecovery(.login(draftURL: normalizedLoginURL, error: inlineError))
+            case .invalidLoginResponse where endpointUnderVerification == .login && loginEntryVerified == false:
+                onRecovery(.login(draftURL: normalizedLoginURL, error: .notFound))
+            case .inaccessibleAdminPage where loginEntryVerified:
+                let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .admin ? .notFound : nil
+                onRecovery(.admin(verifiedLoginURL: normalizedLoginURL,
+                                  draftURL: normalizedAdminURL,
+                                  error: inlineError))
+            default:
+                let incorrectCredentials = if case .invalidCredentials = error { true } else { false }
+                onFailure(error, incorrectCredentials, loginEntryVerified ? normalizedLoginURL : nil)
+            }
+            self?.trackSiteCredentialLoginFailure(error)
+        })
+        siteCredentialLoginUseCase = useCase
+        onLoading(true)
+        useCase.handleLogin(username: credentials.username, password: credentials.password)
+    }
+
+    func presentSiteCredentialBrowserAlternative(for siteURL: String, in viewController: UIViewController) {
+        presentApplicationPasswordWebView(for: siteURL, in: viewController)
+    }
+
+    /// Presents the failure without ever navigating to the browser flow on its own. The browser alternative
+    /// is only ever offered as a button the merchant has to tap.
+    ///
+    func presentSiteCredentialLoginFailure(error: Error,
+                                           offersBrowserAlternative: Bool,
+                                           for siteURL: String,
+                                           in viewController: UIViewController) {
+        let browserAction: (() -> Void)? = offersBrowserAlternative ? { [weak self, weak viewController] in
+            guard let self, let viewController else { return }
+            presentApplicationPasswordWebView(for: siteURL, in: viewController)
+        } : nil
+        let alert = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
+            message: error.localizedDescription,
+            defaultAction: browserAction
+        )
+        viewController.present(alert, animated: true)
     }
 
     func handleSiteCredentialLoginFailure(error: Error,
@@ -846,8 +925,84 @@ extension AuthenticationManager {
     }
 }
 
+/// Signals that a candidate endpoint was rejected locally, before any request was made.
+///
+private struct SiteCredentialRecoveryValidationError: Error {
+    let recovery: SiteCredentialRecovery
+}
+
 // MARK: - Private helpers
 private extension AuthenticationManager {
+
+    /// Builds normalized, same-site endpoints from the addresses the merchant supplied so far.
+    ///
+    /// Throws `SiteCredentialRecoveryValidationError` when a supplied address cannot be used, so the caller
+    /// can ask for it again instead of starting a doomed login.
+    ///
+    func siteCredentialRecoveryEndpoints(siteURL: String,
+                                         loginURL: String?,
+                                         adminURL: String?) throws -> CookieNonceAuthenticationEndpoints {
+        guard let canonicalURL = URL(string: siteURL) else {
+            throw SiteCredentialLoginError.invalidLoginResponse
+        }
+        var endpoints = try CookieNonceAuthenticationEndpoints(siteURL: canonicalURL)
+        if let loginURL {
+            guard let url = URL(string: loginURL), url.scheme != nil, url.host != nil else {
+                throw recoveryValidation(.login, .invalidURL, loginURL, endpoints)
+            }
+            do {
+                endpoints = try CookieNonceAuthenticationEndpoints(siteURL: endpoints.siteURL, loginEntryURL: url)
+            } catch let error as CookieNonceAuthenticationEndpoints.ValidationError {
+                throw recoveryValidation(.login, recoveryError(error), loginURL, endpoints)
+            }
+        }
+        if let adminURL {
+            guard let url = URL(string: adminURL), url.scheme != nil, url.host != nil else {
+                throw recoveryValidation(.admin, .invalidURL, adminURL, endpoints)
+            }
+            do {
+                endpoints = try CookieNonceAuthenticationEndpoints(
+                    siteURL: endpoints.siteURL,
+                    loginEntryURL: endpoints.loginEntryURL,
+                    adminBaseURL: url
+                )
+            } catch let error as CookieNonceAuthenticationEndpoints.ValidationError {
+                throw recoveryValidation(.admin, recoveryError(error), adminURL, endpoints)
+            }
+        }
+        return endpoints
+    }
+
+    func recoveryError(_ error: CookieNonceAuthenticationEndpoints.ValidationError) -> SiteCredentialRecoveryError {
+        switch error {
+        case .invalidURL, .unsupportedScheme, .missingHost:
+            .invalidURL
+        case .userInfoNotAllowed, .queryNotAllowed, .originMismatch, .insecureDowngrade:
+            .differentSite
+        }
+    }
+
+    func recoveryValidation(_ endpoint: SiteCredentialRecoveryEndpoint,
+                            _ error: SiteCredentialRecoveryError,
+                            _ draftURL: String,
+                            _ endpoints: CookieNonceAuthenticationEndpoints) -> SiteCredentialRecoveryValidationError {
+        let recovery: SiteCredentialRecovery = switch endpoint {
+        case .login: .login(draftURL: draftURL, error: error)
+        case .admin: .admin(verifiedLoginURL: endpoints.loginEntryURL.absoluteString, draftURL: draftURL, error: error)
+        }
+        return SiteCredentialRecoveryValidationError(recovery: recovery)
+    }
+
+    func trackSiteCredentialLoginFailure(_ error: SiteCredentialLoginError) {
+        let challengeType: String? = if case .basicAuthenticationRequired = error {
+            "basic_auth"
+        } else {
+            nil
+        }
+        analytics.track(event: .Login.siteCredentialFailed(step: .authentication,
+                                                           error: error.underlyingError,
+                                                           challengeType: challengeType))
+    }
 
     func getAvailableStores() async -> [Site] {
         let storePickerViewModel = StorePickerViewModel(configuration: .switchingStores,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -620,9 +620,11 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             case .inaccessibleLoginPage where endpointUnderVerification != .admin:
                 let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .login ? .notFound : nil
                 onRecovery(.login(draftURL: normalizedLoginURL, error: inlineError))
+                self?.analytics.track(event: .ApplicationPasswordAuthorization.invalidLoginPageDetected())
             case .invalidLoginResponse where endpointUnderVerification != .admin && loginEntryVerified == false:
                 let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .login ? .notFound : nil
                 onRecovery(.login(draftURL: normalizedLoginURL, error: inlineError))
+                self?.analytics.track(event: .ApplicationPasswordAuthorization.invalidLoginPageDetected())
             case .inaccessibleAdminPage where loginEntryVerified:
                 let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .admin ? .notFound : nil
                 onRecovery(.admin(verifiedLoginURL: normalizedLoginURL,
@@ -643,12 +645,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     }
 
     func presentSiteCredentialBrowserAlternative(for siteURL: String, in viewController: UIViewController) {
-        presentAppPasswordTutorial(
-            error: SiteCredentialLoginError.inaccessibleLoginPage,
-            invalidLoginPageDetected: false,
-            for: siteURL,
-            in: viewController
-        )
+        presentAppPasswordTutorial(error: SiteCredentialLoginError.inaccessibleLoginPage, for: siteURL, in: viewController)
     }
 
     /// Presents the failure without ever navigating to the browser flow on its own. The browser alternative
@@ -660,7 +657,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                            in viewController: UIViewController) {
         let browserAction: (() -> Void)? = offersBrowserAlternative ? { [weak self, weak viewController] in
             guard let self, let viewController else { return }
-            presentAppPasswordTutorial(error: error, invalidLoginPageDetected: false, for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } : nil
         presentSiteCredentialLoginErrorAlert(
             message: error.localizedDescription,
@@ -687,7 +684,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         // Show the tutorial immediately if it's obvious that the error can be solved by the app password flow.
         if isAppPasswordAuthError {
-            presentAppPasswordTutorial(error: error, invalidLoginPageDetected: true, for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } else {
             presentAppPasswordAlert(error: error, for: siteURL, in: viewController)
         }
@@ -1259,10 +1256,7 @@ private extension AuthenticationManager {
 
     /// Presents Application Passwords tutorial before redirecting user to the site login using a web view.
     ///
-    private func presentAppPasswordTutorial(error: Error,
-                                            invalidLoginPageDetected: Bool,
-                                            for siteURL: String,
-                                            in viewController: UIViewController) {
+    private func presentAppPasswordTutorial(error: Error, for siteURL: String, in viewController: UIViewController) {
         let tutorialVC = ApplicationPasswordTutorialViewController(error: error)
         tutorialVC.continueButtonTapped = { [weak self] in
             self?.presentApplicationPasswordWebView(for: siteURL, in: viewController)
@@ -1279,10 +1273,6 @@ private extension AuthenticationManager {
             }
         }
         viewController.show(tutorialVC, sender: viewController)
-
-        if invalidLoginPageDetected {
-            analytics.track(event: .ApplicationPasswordAuthorization.invalidLoginPageDetected())
-        }
     }
 
     /// Presents login error alert before redirecting user to the site login using a web view.

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -634,8 +634,8 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                           incorrectCredentials,
                           loginEntryVerified ? normalizedLoginURL : nil,
                           offersBrowserAlternative)
+                self?.trackSiteCredentialLoginFailure(error)
             }
-            self?.trackSiteCredentialLoginFailure(error)
         })
         siteCredentialLoginUseCase = useCase
         onLoading(true)
@@ -643,7 +643,12 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     }
 
     func presentSiteCredentialBrowserAlternative(for siteURL: String, in viewController: UIViewController) {
-        presentAppPasswordTutorial(error: SiteCredentialLoginError.inaccessibleLoginPage, for: siteURL, in: viewController)
+        presentAppPasswordTutorial(
+            error: SiteCredentialLoginError.inaccessibleLoginPage,
+            invalidLoginPageDetected: false,
+            for: siteURL,
+            in: viewController
+        )
     }
 
     /// Presents the failure without ever navigating to the browser flow on its own. The browser alternative
@@ -655,7 +660,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                            in viewController: UIViewController) {
         let browserAction: (() -> Void)? = offersBrowserAlternative ? { [weak self, weak viewController] in
             guard let self, let viewController else { return }
-            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, invalidLoginPageDetected: false, for: siteURL, in: viewController)
         } : nil
         presentSiteCredentialLoginErrorAlert(
             message: error.localizedDescription,
@@ -682,7 +687,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         // Show the tutorial immediately if it's obvious that the error can be solved by the app password flow.
         if isAppPasswordAuthError {
-            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, invalidLoginPageDetected: true, for: siteURL, in: viewController)
         } else {
             presentAppPasswordAlert(error: error, for: siteURL, in: viewController)
         }
@@ -1254,7 +1259,10 @@ private extension AuthenticationManager {
 
     /// Presents Application Passwords tutorial before redirecting user to the site login using a web view.
     ///
-    private func presentAppPasswordTutorial(error: Error, for siteURL: String, in viewController: UIViewController) {
+    private func presentAppPasswordTutorial(error: Error,
+                                            invalidLoginPageDetected: Bool,
+                                            for siteURL: String,
+                                            in viewController: UIViewController) {
         let tutorialVC = ApplicationPasswordTutorialViewController(error: error)
         tutorialVC.continueButtonTapped = { [weak self] in
             self?.presentApplicationPasswordWebView(for: siteURL, in: viewController)
@@ -1272,7 +1280,9 @@ private extension AuthenticationManager {
         }
         viewController.show(tutorialVC, sender: viewController)
 
-        analytics.track(event: .ApplicationPasswordAuthorization.invalidLoginPageDetected())
+        if invalidLoginPageDetected {
+            analytics.track(event: .ApplicationPasswordAuthorization.invalidLoginPageDetected())
+        }
     }
 
     /// Presents login error alert before redirecting user to the site login using a web view.
@@ -1289,7 +1299,7 @@ private extension AuthenticationManager {
         }()
         let defaultAction = shouldEnableWebFlow ? { [weak self] in
             guard let self else { return }
-            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, invalidLoginPageDetected: false, for: siteURL, in: viewController)
         } : nil
         presentSiteCredentialLoginErrorAlert(
             message: (error as NSError).localizedDescription,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -620,8 +620,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             case .inaccessibleLoginPage where endpointUnderVerification != .admin:
                 let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .login ? .notFound : nil
                 onRecovery(.login(draftURL: normalizedLoginURL, error: inlineError))
-            case .invalidLoginResponse where endpointUnderVerification == .login && loginEntryVerified == false:
-                onRecovery(.login(draftURL: normalizedLoginURL, error: .notFound))
+            case .invalidLoginResponse where endpointUnderVerification != .admin && loginEntryVerified == false:
+                let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .login ? .notFound : nil
+                onRecovery(.login(draftURL: normalizedLoginURL, error: inlineError))
             case .inaccessibleAdminPage where loginEntryVerified:
                 let inlineError: SiteCredentialRecoveryError? = endpointUnderVerification == .admin ? .notFound : nil
                 onRecovery(.admin(verifiedLoginURL: normalizedLoginURL,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -566,7 +566,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             credentials.authenticationEndpoints,
             false
         )
-        useCase.setupHandlers(onLoginSuccess: onSuccess, onLoginFailure: { [weak self] error, _ in
+        useCase.setupHandlers(onLoginSuccess: onSuccess, onLoginFailure: { [weak self] error, _, _ in
             guard let self else { return }
             onLoading(false)
             onFailure(error, false)
@@ -588,7 +588,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                      onLoading: @escaping (Bool) -> Void,
                                      onSuccess: @escaping (WordPressOrgCredentials) -> Void,
                                      onRecovery: @escaping (SiteCredentialRecovery) -> Void,
-                                     onFailure: @escaping (Error, Bool, String?) -> Void) {
+                                     onFailure: @escaping (Error, Bool, String?, Bool) -> Void) {
         let endpoints: CookieNonceAuthenticationEndpoints
         do {
             endpoints = try siteCredentialRecoveryEndpoints(
@@ -600,7 +600,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             onRecovery(error.recovery)
             return
         } catch {
-            onFailure(SiteCredentialLoginError.invalidLoginResponse, false, nil)
+            onFailure(SiteCredentialLoginError.invalidLoginResponse, false, nil, false)
             return
         }
 
@@ -612,7 +612,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         useCase.setupHandlers(onLoginSuccess: {
             onLoading(false)
             onSuccess(credentials.replacingAuthenticationEndpoints(with: endpoints))
-        }, onLoginFailure: { [weak self] error, loginEntryVerified in
+        }, onLoginFailure: { [weak self] error, loginEntryVerified, offersBrowserAlternative in
             onLoading(false)
             let normalizedLoginURL = endpoints.loginEntryURL.absoluteString
             let normalizedAdminURL = endpoints.adminBaseURL.absoluteString
@@ -629,7 +629,10 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                   error: inlineError))
             default:
                 let incorrectCredentials = if case .invalidCredentials = error { true } else { false }
-                onFailure(error, incorrectCredentials, loginEntryVerified ? normalizedLoginURL : nil)
+                onFailure(error,
+                          incorrectCredentials,
+                          loginEntryVerified ? normalizedLoginURL : nil,
+                          offersBrowserAlternative)
             }
             self?.trackSiteCredentialLoginFailure(error)
         })

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -8,9 +8,10 @@ import protocol NetworkingCore.URLSessionProtocol
 
 protocol SiteCredentialLoginProtocol {
     /// - Parameter onLoginFailure: called with the failure and whether the configured login entry was proven
-    ///   to render one eligible WordPress login form before the failure occurred.
+    ///   to render one eligible WordPress login form before the failure occurred, plus whether the failure
+    ///   came from the credential response and can plausibly be solved by browser authentication.
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
-                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool) -> Void)
+                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool, Bool) -> Void)
 
     func handleLogin(username: String, password: String)
 }
@@ -87,6 +88,22 @@ enum SiteCredentialLoginError: LocalizedError {
         underlyingError.localizedDescription
     }
 
+    func offersBrowserAlternative(at stage: CookieNonceAuthenticationResponseStage) -> Bool {
+        guard stage == .credentials else {
+            return false
+        }
+        switch self {
+        case .invalidCredentials, .invalidLoginResponse, .loginFailed:
+            return true
+        case .basicAuthenticationRequired,
+             .inaccessibleLoginPage,
+             .inaccessibleAdminPage,
+             .unacceptableStatusCode,
+             .genericFailure:
+            return false
+        }
+    }
+
     private enum Localization {
         static let inaccessibleLoginPage = NSLocalizedString(
             "Unable to login because we cannot identify your store's login URL.",
@@ -135,7 +152,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     private let ownedTransactionSession: URLSession?
     private let verifyAdminDashboard: Bool
     private var successHandler: (() -> Void)?
-    private var errorHandler: ((SiteCredentialLoginError, Bool) -> Void)?
+    private var errorHandler: ((SiteCredentialLoginError, Bool, Bool) -> Void)?
 
     init(siteURL: String,
          endpoints configuredEndpoints: CookieNonceAuthenticationEndpoints? = nil,
@@ -173,7 +190,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     }
 
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
-                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool) -> Void) {
+                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool, Bool) -> Void) {
         self.successHandler = onLoginSuccess
         self.errorHandler = onLoginFailure
     }
@@ -184,6 +201,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
         clearAllCookies()
         Task { @MainActor in
             var loginEntryVerified = false
+            var responseStage = CookieNonceAuthenticationResponseStage.preflight
             do {
                 let endpoints: CookieNonceAuthenticationEndpoints
                 switch endpointConfiguration {
@@ -193,14 +211,18 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
                     DDLogError("⛔️ Error constructing or validating login requests")
                     throw error
                 }
-                try await startLogin(username: username, password: password, endpoints: endpoints) {
-                    loginEntryVerified = true
-                }
+                try await startLogin(
+                    username: username,
+                    password: password,
+                    endpoints: endpoints,
+                    onLoginEntryVerified: { loginEntryVerified = true },
+                    onResponseStageChanged: { responseStage = $0 }
+                )
                 successHandler?()
             } catch let error as SiteCredentialLoginError {
-                errorHandler?(error, loginEntryVerified)
+                errorHandler?(error, loginEntryVerified, error.offersBrowserAlternative(at: responseStage))
             } catch {
-                errorHandler?(.genericFailure(underlyingError: error as NSError), loginEntryVerified)
+                errorHandler?(.genericFailure(underlyingError: error as NSError), loginEntryVerified, false)
             }
         }
     }
@@ -219,7 +241,8 @@ private extension SiteCredentialLoginUseCase {
         username: String,
         password: String,
         endpoints: CookieNonceAuthenticationEndpoints,
-        onLoginEntryVerified: () -> Void
+        onLoginEntryVerified: () -> Void,
+        onResponseStageChanged: (CookieNonceAuthenticationResponseStage) -> Void
     ) async throws {
         let submissionURL = try await preflight(endpoints: endpoints)
         onLoginEntryVerified()
@@ -230,6 +253,7 @@ private extension SiteCredentialLoginUseCase {
             submissionURL: submissionURL,
             nonceURL: nonceURL
         )
+        onResponseStageChanged(.credentials)
         let loginResponse = try await load(loginRequest, using: loginSession)
         try validate(loginResponse.http, stage: .credentials)
 
@@ -254,8 +278,10 @@ private extension SiteCredentialLoginUseCase {
         }
 
         if verifyAdminDashboard {
+            onResponseStageChanged(.dashboard)
             try await verifyDashboard(afterLoginAt: submissionURL, endpoints: endpoints)
         }
+        onResponseStageChanged(.nonce)
         try await retrieveNonce(at: nonceURL, afterLoginAt: submissionURL, endpoints: endpoints)
     }
 

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -7,8 +7,10 @@ import enum NetworkingCore.CookieNonceAuthenticationRules
 import protocol NetworkingCore.URLSessionProtocol
 
 protocol SiteCredentialLoginProtocol {
+    /// - Parameter onLoginFailure: called with the failure and whether the configured login entry was proven
+    ///   to render one eligible WordPress login form before the failure occurred.
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
-                       onLoginFailure: @escaping (SiteCredentialLoginError) -> Void)
+                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool) -> Void)
 
     func handleLogin(username: String, password: String)
 }
@@ -133,7 +135,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     private let ownedTransactionSession: URLSession?
     private let verifyAdminDashboard: Bool
     private var successHandler: (() -> Void)?
-    private var errorHandler: ((SiteCredentialLoginError) -> Void)?
+    private var errorHandler: ((SiteCredentialLoginError, Bool) -> Void)?
 
     init(siteURL: String,
          endpoints configuredEndpoints: CookieNonceAuthenticationEndpoints? = nil,
@@ -171,7 +173,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     }
 
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
-                       onLoginFailure: @escaping (SiteCredentialLoginError) -> Void) {
+                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool) -> Void) {
         self.successHandler = onLoginSuccess
         self.errorHandler = onLoginFailure
     }
@@ -181,6 +183,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
         // So we need to clear all cookies before login.
         clearAllCookies()
         Task { @MainActor in
+            var loginEntryVerified = false
             do {
                 let endpoints: CookieNonceAuthenticationEndpoints
                 switch endpointConfiguration {
@@ -190,12 +193,14 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
                     DDLogError("⛔️ Error constructing or validating login requests")
                     throw error
                 }
-                try await startLogin(username: username, password: password, endpoints: endpoints)
+                try await startLogin(username: username, password: password, endpoints: endpoints) {
+                    loginEntryVerified = true
+                }
                 successHandler?()
             } catch let error as SiteCredentialLoginError {
-                errorHandler?(error)
+                errorHandler?(error, loginEntryVerified)
             } catch {
-                errorHandler?(.genericFailure(underlyingError: error as NSError))
+                errorHandler?(.genericFailure(underlyingError: error as NSError), loginEntryVerified)
             }
         }
     }
@@ -213,9 +218,11 @@ private extension SiteCredentialLoginUseCase {
     func startLogin(
         username: String,
         password: String,
-        endpoints: CookieNonceAuthenticationEndpoints
+        endpoints: CookieNonceAuthenticationEndpoints,
+        onLoginEntryVerified: () -> Void
     ) async throws {
         let submissionURL = try await preflight(endpoints: endpoints)
+        onLoginEntryVerified()
         let nonceURL = try endpointValue { try endpoints.nonceURL(afterLoginAt: submissionURL) }
         let loginRequest = try credentialRequest(
             username: username,

--- a/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
+++ b/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
@@ -5,6 +5,27 @@ import Yosemite
 /// Authentication endpoints and URL strings derived from WP.org credentials.
 ///
 extension WordPressOrgCredentials {
+    /// Records verified endpoints on the credentials, keeping only the ones that differ from the site's defaults.
+    ///
+    /// Only normalized, verified configuration is carried. Transaction-local values such as a form action or a
+    /// redirect target must never reach here.
+    ///
+    func replacingAuthenticationEndpoints(with endpoints: CookieNonceAuthenticationEndpoints) -> WordPressOrgCredentials {
+        guard let defaults = try? CookieNonceAuthenticationEndpoints(siteURL: endpoints.siteURL) else {
+            return self
+        }
+        var updatedOptions = options
+        updatedOptions.removeValue(forKey: Key.loginURL.rawValue)
+        updatedOptions.removeValue(forKey: Key.adminURL.rawValue)
+        if endpoints.loginEntryURL != defaults.loginEntryURL {
+            updatedOptions[Key.loginURL.rawValue] = [Key.value.rawValue: endpoints.loginEntryURL.absoluteString]
+        }
+        if endpoints.adminBaseURL != defaults.adminBaseURL {
+            updatedOptions[Key.adminURL.rawValue] = [Key.value.rawValue: endpoints.adminBaseURL.absoluteString]
+        }
+        return WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: updatedOptions)
+    }
+
     var loginURL: String {
         if let value = optionValue(for: Key.loginURL.rawValue) as? String {
             return value

--- a/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
+++ b/WooCommerce/Classes/Authentication/WordPressOrgCredentials+Authenticator.swift
@@ -11,8 +11,17 @@ extension WordPressOrgCredentials {
     /// redirect target must never reach here.
     ///
     func replacingAuthenticationEndpoints(with endpoints: CookieNonceAuthenticationEndpoints) -> WordPressOrgCredentials {
-        guard let defaults = try? CookieNonceAuthenticationEndpoints(siteURL: endpoints.siteURL) else {
-            return self
+        let defaults: CookieNonceAuthenticationEndpoints
+        do {
+            defaults = try CookieNonceAuthenticationEndpoints(siteURL: endpoints.siteURL)
+        } catch {
+            // The supplied endpoints already validated their canonical site URL, so this indicates an invariant violation.
+            DDLogError("⛔️ Failed to derive default authentication endpoints from verified endpoints: \(error)")
+            ServiceLocator.crashLogging.logError(error)
+            var updatedOptions = options
+            updatedOptions[Key.loginURL.rawValue] = [Key.value.rawValue: endpoints.loginEntryURL.absoluteString]
+            updatedOptions[Key.adminURL.rawValue] = [Key.value.rawValue: endpoints.adminBaseURL.absoluteString]
+            return WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: updatedOptions)
         }
         var updatedOptions = options
         updatedOptions.removeValue(forKey: Key.loginURL.rawValue)

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -115,7 +115,7 @@ final class AuthenticationManagerTests: XCTestCase {
         var capturedSiteURL: String?
         var capturedEndpoints: CookieNonceAuthenticationEndpoints?
         let manager = AuthenticationManager(
-            siteCredentialLoginUseCaseFactory: { siteURL, endpoints in
+            siteCredentialLoginUseCaseFactory: { siteURL, endpoints, _ in
                 capturedSiteURL = siteURL
                 capturedEndpoints = endpoints
                 return mockUseCase
@@ -917,9 +917,298 @@ final class AuthenticationManagerTests: XCTestCase {
             XCTAssertEqual(switchStoreUseCase.destinationStoreIDs, [])
         })
     }
+
+    func test_authenticate_site_credentials_when_login_url_is_cross_site_then_recovers_without_starting_login() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let manager = AuthenticationManager(
+            analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+            siteCredentialLoginUseCaseFactory: { _, _, _ in
+                XCTFail("Login must not start for a locally rejected endpoint")
+                return MockAuthenticationManagerSiteCredentialLoginUseCase()
+            }
+        )
+        var loading = [Bool]()
+        var recovery: SiteCredentialRecovery?
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: "https://attacker.example/wp-login.php",
+            adminURL: nil,
+            endpointUnderVerification: .login,
+            onLoading: { loading.append($0) },
+            onSuccess: { _ in XCTFail("Expected endpoint recovery") },
+            onRecovery: { recovery = $0 },
+            onFailure: { _, _, _ in XCTFail("Expected endpoint recovery") }
+        )
+
+        // Then
+        XCTAssertEqual(
+            recovery,
+            .login(draftURL: "https://attacker.example/wp-login.php", error: .differentSite)
+        )
+        XCTAssertTrue(loading.isEmpty)
+        XCTAssertTrue(analyticsProvider.receivedEvents.isEmpty)
+    }
+
+    func test_authenticate_site_credentials_when_default_login_is_missing_then_prefills_normalized_url_after_loading_starts() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var events = [String]()
+        useCase.onHandleLogin = { events.append("handle") }
+        var verifyAdminDashboard: Bool?
+        var recovery: SiteCredentialRecovery?
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, verifyAdmin in
+            verifyAdminDashboard = verifyAdmin
+            return useCase
+        })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: .login,
+            onLoading: { events.append("loading:\($0)") },
+            onSuccess: { _ in XCTFail("Expected endpoint recovery") },
+            onRecovery: {
+                recovery = $0
+                events.append("recovery")
+            },
+            onFailure: { _, _, _ in XCTFail("Expected endpoint recovery") }
+        )
+        useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: false)
+
+        // Then
+        XCTAssertEqual(verifyAdminDashboard, false)
+        XCTAssertEqual(useCase.receivedUsername, "merchant")
+        XCTAssertEqual(useCase.receivedPassword, "password")
+        XCTAssertEqual(recovery, .login(draftURL: "https://example.com/wp-login.php", error: .notFound))
+        XCTAssertEqual(events, ["loading:true", "handle", "loading:false", "recovery"])
+    }
+
+    func test_authenticate_site_credentials_when_login_retry_has_invalid_unverified_response_then_recovers_not_found() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var recovery: SiteCredentialRecovery?
+        var didFail = false
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: "https://example.com/custom-login",
+            adminURL: nil,
+            endpointUnderVerification: .login,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected recovery") },
+            onRecovery: { recovery = $0 },
+            onFailure: { _, _, _ in didFail = true }
+        )
+        useCase.fail(with: .invalidLoginResponse, loginEntryVerified: false)
+
+        // Then
+        XCTAssertEqual(
+            recovery,
+            .login(draftURL: "https://example.com/custom-login", error: .notFound)
+        )
+        XCTAssertFalse(didFail)
+    }
+
+    func test_authenticate_site_credentials_when_admin_is_missing_after_verified_custom_login_then_recovers_admin() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var endpoints: CookieNonceAuthenticationEndpoints?
+        var verifyAdminDashboard: Bool?
+        var recovery: SiteCredentialRecovery?
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, receivedEndpoints, verifyAdmin in
+            endpoints = receivedEndpoints
+            verifyAdminDashboard = verifyAdmin
+            return useCase
+        })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: "https://example.com/custom-login#fragment",
+            adminURL: nil,
+            endpointUnderVerification: .login,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected endpoint recovery") },
+            onRecovery: { recovery = $0 },
+            onFailure: { _, _, _ in XCTFail("Expected endpoint recovery") }
+        )
+        useCase.fail(with: .inaccessibleAdminPage, loginEntryVerified: true)
+
+        // Then
+        XCTAssertEqual(endpoints?.loginEntryURL.absoluteString, "https://example.com/custom-login")
+        XCTAssertEqual(verifyAdminDashboard, false)
+        XCTAssertEqual(
+            recovery,
+            .admin(
+                verifiedLoginURL: "https://example.com/custom-login",
+                draftURL: "https://example.com/wp-admin/",
+                error: nil
+            )
+        )
+    }
+
+    func test_authenticate_site_credentials_when_admin_retry_hits_login_failure_then_routes_to_ordinary_failure() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var verifyAdminDashboard: Bool?
+        var receivedError: Error?
+        var incorrectCredentials: Bool?
+        var verifiedLoginURL: String?
+        var didRecover = false
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, verifyAdmin in
+            verifyAdminDashboard = verifyAdmin
+            return useCase
+        })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: "https://example.com/custom-login",
+            adminURL: "https://example.com/private-admin",
+            endpointUnderVerification: .admin,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected failure") },
+            onRecovery: { _ in didRecover = true },
+            onFailure: {
+                receivedError = $0
+                incorrectCredentials = $1
+                verifiedLoginURL = $2
+            }
+        )
+        useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: true)
+
+        // Then
+        XCTAssertEqual(verifyAdminDashboard, true)
+        if case .inaccessibleLoginPage? = receivedError as? SiteCredentialLoginError {} else {
+            XCTFail("Expected inaccessible login page failure")
+        }
+        XCTAssertEqual(incorrectCredentials, false)
+        XCTAssertEqual(verifiedLoginURL, "https://example.com/custom-login")
+        XCTAssertFalse(didRecover)
+    }
+
+    func test_authenticate_site_credentials_when_admin_is_inaccessible_before_login_verification_then_does_not_recover_or_promote_login() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var receivedError: Error?
+        var incorrectCredentials: Bool?
+        var verifiedLoginURL: String?
+        var didRecover = false
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected failure") },
+            onRecovery: { _ in didRecover = true },
+            onFailure: {
+                receivedError = $0
+                incorrectCredentials = $1
+                verifiedLoginURL = $2
+            }
+        )
+        useCase.fail(with: .inaccessibleAdminPage, loginEntryVerified: false)
+
+        // Then
+        if case .inaccessibleAdminPage? = receivedError as? SiteCredentialLoginError {} else {
+            XCTFail("Expected inaccessible admin page failure")
+        }
+        XCTAssertEqual(incorrectCredentials, false)
+        XCTAssertNil(verifiedLoginURL)
+        XCTAssertFalse(didRecover)
+    }
+
+    func test_authenticate_site_credentials_when_verified_credentials_are_invalid_then_marks_incorrect_and_preserves_login_url() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var incorrectCredentials: Bool?
+        var verifiedLoginURL: String?
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: "https://example.com/custom-login",
+            adminURL: nil,
+            endpointUnderVerification: .login,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected failure") },
+            onRecovery: { _ in XCTFail("Expected ordinary failure") },
+            onFailure: {
+                incorrectCredentials = $1
+                verifiedLoginURL = $2
+            }
+        )
+        useCase.fail(with: .invalidCredentials, loginEntryVerified: true)
+
+        // Then
+        XCTAssertEqual(incorrectCredentials, true)
+        XCTAssertEqual(verifiedLoginURL, "https://example.com/custom-login")
+    }
+
+    func test_authenticate_site_credentials_when_custom_or_standard_login_succeeds_then_persists_only_nondefault_endpoints() throws {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var receivedCredentials: WordPressOrgCredentials?
+        var loading = [Bool]()
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+        let credentials = siteCredentials(options: [
+            "login_url": ["value": "https://example.com/stale-login"],
+            "admin_url": ["value": "https://example.com/stale-admin"],
+            "unrelated": ["value": "preserved"]
+        ])
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: credentials,
+            loginURL: "https://example.com/custom-login#fragment",
+            adminURL: "https://example.com/wp-admin/",
+            endpointUnderVerification: .admin,
+            onLoading: { loading.append($0) },
+            onSuccess: { receivedCredentials = $0 },
+            onRecovery: { _ in XCTFail("Expected success") },
+            onFailure: { _, _, _ in XCTFail("Expected success") }
+        )
+        useCase.succeed()
+
+        // Then
+        let options = try XCTUnwrap(receivedCredentials?.options)
+        XCTAssertEqual((options["login_url"] as? [String: String])?["value"], "https://example.com/custom-login")
+        XCTAssertNil(options["admin_url"])
+        XCTAssertEqual((options["unrelated"] as? [String: String])?["value"], "preserved")
+        XCTAssertEqual(loading, [true, false])
+
+        let defaultEndpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: XCTUnwrap(URL(string: "https://example.com"))
+        )
+        let defaultOptions = credentials.replacingAuthenticationEndpoints(with: defaultEndpoints).options
+        XCTAssertNil(defaultOptions["login_url"])
+        XCTAssertNil(defaultOptions["admin_url"])
+        XCTAssertEqual((defaultOptions["unrelated"] as? [String: String])?["value"], "preserved")
+    }
 }
 
 private extension AuthenticationManagerTests {
+    func siteCredentials(options: [AnyHashable: Any] = [:]) -> WordPressOrgCredentials {
+        WordPressOrgCredentials(
+            username: "merchant",
+            password: "password",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            options: options
+        )
+    }
+
     func siteInfo(url: String = "https://test.com",
                   exists: Bool = false,
                   hasWordPress: Bool = false,
@@ -939,6 +1228,34 @@ private extension AuthenticationManagerTests {
     }
 }
 
+private final class MockAuthenticationManagerSiteCredentialLoginUseCase: SiteCredentialLoginProtocol {
+    var onHandleLogin: (() -> Void)?
+    private(set) var receivedUsername: String?
+    private(set) var receivedPassword: String?
+    private var successHandler: (() -> Void)?
+    private var failureHandler: ((SiteCredentialLoginError, Bool) -> Void)?
+
+    func setupHandlers(onLoginSuccess: @escaping () -> Void,
+                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool) -> Void) {
+        successHandler = onLoginSuccess
+        failureHandler = onLoginFailure
+    }
+
+    func handleLogin(username: String, password: String) {
+        receivedUsername = username
+        receivedPassword = password
+        onHandleLogin?()
+    }
+
+    func succeed() {
+        successHandler?()
+    }
+
+    func fail(with error: SiteCredentialLoginError, loginEntryVerified: Bool) {
+        failureHandler?(error, loginEntryVerified)
+    }
+}
+
 private final class MockAuthenticationManagerApplicationPasswordUseCase: ApplicationPasswordUseCase {
     let applicationPassword: ApplicationPassword?
     var canRegenerateApplicationPassword: Bool { true }
@@ -952,17 +1269,4 @@ private final class MockAuthenticationManagerApplicationPasswordUseCase: Applica
     }
 
     func deletePassword(locally: Bool) async throws {}
-}
-
-private final class MockAuthenticationManagerSiteCredentialLoginUseCase: SiteCredentialLoginProtocol {
-    private(set) var receivedUsername: String?
-    private(set) var receivedPassword: String?
-
-    func setupHandlers(onLoginSuccess: @escaping () -> Void,
-                       onLoginFailure: @escaping (SiteCredentialLoginError) -> Void) {}
-
-    func handleLogin(username: String, password: String) {
-        receivedUsername = username
-        receivedPassword = password
-    }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -1172,6 +1172,19 @@ final class AuthenticationManagerTests: XCTestCase {
         try assertCenteredFancyAlertPresented(by: presenter)
     }
 
+    func test_present_site_credential_browser_alternative_presents_application_password_tutorial() {
+        // Given
+        let presenter = UIViewController()
+        navigationController.setViewControllers([presenter], animated: false)
+        let manager = AuthenticationManager()
+
+        // When
+        manager.presentSiteCredentialBrowserAlternative(for: "https://example.com", in: presenter)
+
+        // Then
+        XCTAssertTrue(navigationController.topViewController is ApplicationPasswordTutorialViewController)
+    }
+
     func test_legacy_site_credential_login_failure_presents_centered_fancy_alert() throws {
         // Given
         let presenter = SiteCredentialAlertPresenter()

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -953,6 +953,58 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertTrue(analyticsProvider.receivedEvents.isEmpty)
     }
 
+    func test_authenticate_site_credentials_when_network_failure_surfaces_recovery_then_does_not_track_login_failure() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        let manager = AuthenticationManager(
+            analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+            siteCredentialLoginUseCaseFactory: { _, _, _ in useCase }
+        )
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected endpoint recovery") },
+            onRecovery: { _ in },
+            onFailure: { _, _, _, _ in XCTFail("Expected endpoint recovery") }
+        )
+        useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: false)
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsFailed.rawValue))
+    }
+
+    func test_authenticate_site_credentials_when_genuine_failure_occurs_then_tracks_login_failure() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        let manager = AuthenticationManager(
+            analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+            siteCredentialLoginUseCaseFactory: { _, _, _ in useCase }
+        )
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected failure") },
+            onRecovery: { _ in XCTFail("Expected failure") },
+            onFailure: { _, _, _, _ in }
+        )
+        useCase.fail(with: .invalidCredentials, loginEntryVerified: true)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsFailed.rawValue))
+    }
+
     func test_authenticate_site_credentials_when_login_retry_is_missing_then_recovers_not_found_after_loading_starts() {
         // Given
         let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
@@ -1172,17 +1224,38 @@ final class AuthenticationManagerTests: XCTestCase {
         try assertCenteredFancyAlertPresented(by: presenter)
     }
 
-    func test_present_site_credential_browser_alternative_presents_application_password_tutorial() {
+    func test_present_site_credential_browser_alternative_presents_tutorial_without_tracking_invalid_login_page() {
         // Given
         let presenter = UIViewController()
         navigationController.setViewControllers([presenter], animated: false)
-        let manager = AuthenticationManager()
+        let analyticsProvider = MockAnalyticsProvider()
+        let manager = AuthenticationManager(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
 
         // When
         manager.presentSiteCredentialBrowserAlternative(for: "https://example.com", in: presenter)
 
         // Then
         XCTAssertTrue(navigationController.topViewController is ApplicationPasswordTutorialViewController)
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue))
+    }
+
+    func test_handle_site_credential_login_failure_when_invalid_login_page_is_detected_then_tracks_detection() {
+        // Given
+        let presenter = UIViewController()
+        navigationController.setViewControllers([presenter], animated: false)
+        let analyticsProvider = MockAnalyticsProvider()
+        let manager = AuthenticationManager(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+
+        // When
+        manager.handleSiteCredentialLoginFailure(
+            error: SiteCredentialLoginError.inaccessibleLoginPage,
+            for: "https://example.com",
+            in: presenter
+        )
+
+        // Then
+        XCTAssertTrue(navigationController.topViewController is ApplicationPasswordTutorialViewController)
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue))
     }
 
     func test_legacy_site_credential_login_failure_presents_centered_fancy_alert() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -953,7 +953,7 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertTrue(analyticsProvider.receivedEvents.isEmpty)
     }
 
-    func test_authenticate_site_credentials_when_default_login_is_missing_then_prefills_normalized_url_after_loading_starts() {
+    func test_authenticate_site_credentials_when_login_retry_is_missing_then_recovers_not_found_after_loading_starts() {
         // Given
         let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
         var events = [String]()
@@ -968,7 +968,7 @@ final class AuthenticationManagerTests: XCTestCase {
         // When
         manager.authenticateSiteCredentials(
             credentials: siteCredentials(),
-            loginURL: nil,
+            loginURL: "https://example.com/custom-login",
             adminURL: nil,
             endpointUnderVerification: .login,
             onLoading: { events.append("loading:\($0)") },
@@ -985,7 +985,7 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual(verifyAdminDashboard, false)
         XCTAssertEqual(useCase.receivedUsername, "merchant")
         XCTAssertEqual(useCase.receivedPassword, "password")
-        XCTAssertEqual(recovery, .login(draftURL: "https://example.com/wp-login.php", error: .notFound))
+        XCTAssertEqual(recovery, .login(draftURL: "https://example.com/custom-login", error: .notFound))
         XCTAssertEqual(events, ["loading:true", "handle", "loading:false", "recovery"])
     }
 
@@ -1013,6 +1013,34 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual(
             recovery,
             .login(draftURL: "https://example.com/custom-login", error: .notFound)
+        )
+        XCTAssertFalse(didFail)
+    }
+
+    func test_authenticate_site_credentials_when_initial_login_has_invalid_unverified_response_then_recovers_without_error() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var recovery: SiteCredentialRecovery?
+        var didFail = false
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected recovery") },
+            onRecovery: { recovery = $0 },
+            onFailure: { _, _, _, _ in didFail = true }
+        )
+        useCase.fail(with: .invalidLoginResponse, loginEntryVerified: false)
+
+        // Then
+        XCTAssertEqual(
+            recovery,
+            .login(draftURL: "https://example.com/wp-login.php", error: nil)
         )
         XCTAssertFalse(didFail)
     }
@@ -1055,7 +1083,7 @@ final class AuthenticationManagerTests: XCTestCase {
         )
     }
 
-    func test_authenticate_site_credentials_when_admin_retry_hits_login_failure_then_routes_to_ordinary_failure() {
+    func test_authenticate_site_credentials_when_admin_retry_login_preflight_fails_then_routes_to_ordinary_failure() {
         // Given
         let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
         var verifyAdminDashboard: Bool?
@@ -1083,47 +1111,12 @@ final class AuthenticationManagerTests: XCTestCase {
                 verifiedLoginURL = loginURL
             }
         )
-        useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: true)
+        useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: false)
 
         // Then
         XCTAssertEqual(verifyAdminDashboard, true)
         if case .inaccessibleLoginPage? = receivedError as? SiteCredentialLoginError {} else {
             XCTFail("Expected inaccessible login page failure")
-        }
-        XCTAssertEqual(incorrectCredentials, false)
-        XCTAssertEqual(verifiedLoginURL, "https://example.com/custom-login")
-        XCTAssertFalse(didRecover)
-    }
-
-    func test_authenticate_site_credentials_when_admin_is_inaccessible_before_login_verification_then_does_not_recover_or_promote_login() {
-        // Given
-        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
-        var receivedError: Error?
-        var incorrectCredentials: Bool?
-        var verifiedLoginURL: String?
-        var didRecover = false
-        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
-
-        // When
-        manager.authenticateSiteCredentials(
-            credentials: siteCredentials(),
-            loginURL: nil,
-            adminURL: nil,
-            endpointUnderVerification: nil,
-            onLoading: { _ in },
-            onSuccess: { _ in XCTFail("Expected failure") },
-            onRecovery: { _ in didRecover = true },
-            onFailure: { error, isIncorrectCredentials, loginURL, _ in
-                receivedError = error
-                incorrectCredentials = isIncorrectCredentials
-                verifiedLoginURL = loginURL
-            }
-        )
-        useCase.fail(with: .inaccessibleAdminPage, loginEntryVerified: false)
-
-        // Then
-        if case .inaccessibleAdminPage? = receivedError as? SiteCredentialLoginError {} else {
-            XCTFail("Expected inaccessible admin page failure")
         }
         XCTAssertEqual(incorrectCredentials, false)
         XCTAssertNil(verifiedLoginURL)

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -941,7 +941,7 @@ final class AuthenticationManagerTests: XCTestCase {
             onLoading: { loading.append($0) },
             onSuccess: { _ in XCTFail("Expected endpoint recovery") },
             onRecovery: { recovery = $0 },
-            onFailure: { _, _, _ in XCTFail("Expected endpoint recovery") }
+            onFailure: { _, _, _, _ in XCTFail("Expected endpoint recovery") }
         )
 
         // Then
@@ -977,7 +977,7 @@ final class AuthenticationManagerTests: XCTestCase {
                 recovery = $0
                 events.append("recovery")
             },
-            onFailure: { _, _, _ in XCTFail("Expected endpoint recovery") }
+            onFailure: { _, _, _, _ in XCTFail("Expected endpoint recovery") }
         )
         useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: false)
 
@@ -1005,7 +1005,7 @@ final class AuthenticationManagerTests: XCTestCase {
             onLoading: { _ in },
             onSuccess: { _ in XCTFail("Expected recovery") },
             onRecovery: { recovery = $0 },
-            onFailure: { _, _, _ in didFail = true }
+            onFailure: { _, _, _, _ in didFail = true }
         )
         useCase.fail(with: .invalidLoginResponse, loginEntryVerified: false)
 
@@ -1038,7 +1038,7 @@ final class AuthenticationManagerTests: XCTestCase {
             onLoading: { _ in },
             onSuccess: { _ in XCTFail("Expected endpoint recovery") },
             onRecovery: { recovery = $0 },
-            onFailure: { _, _, _ in XCTFail("Expected endpoint recovery") }
+            onFailure: { _, _, _, _ in XCTFail("Expected endpoint recovery") }
         )
         useCase.fail(with: .inaccessibleAdminPage, loginEntryVerified: true)
 
@@ -1077,10 +1077,10 @@ final class AuthenticationManagerTests: XCTestCase {
             onLoading: { _ in },
             onSuccess: { _ in XCTFail("Expected failure") },
             onRecovery: { _ in didRecover = true },
-            onFailure: {
-                receivedError = $0
-                incorrectCredentials = $1
-                verifiedLoginURL = $2
+            onFailure: { error, isIncorrectCredentials, loginURL, _ in
+                receivedError = error
+                incorrectCredentials = isIncorrectCredentials
+                verifiedLoginURL = loginURL
             }
         )
         useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: true)
@@ -1113,10 +1113,10 @@ final class AuthenticationManagerTests: XCTestCase {
             onLoading: { _ in },
             onSuccess: { _ in XCTFail("Expected failure") },
             onRecovery: { _ in didRecover = true },
-            onFailure: {
-                receivedError = $0
-                incorrectCredentials = $1
-                verifiedLoginURL = $2
+            onFailure: { error, isIncorrectCredentials, loginURL, _ in
+                receivedError = error
+                incorrectCredentials = isIncorrectCredentials
+                verifiedLoginURL = loginURL
             }
         )
         useCase.fail(with: .inaccessibleAdminPage, loginEntryVerified: false)
@@ -1135,6 +1135,7 @@ final class AuthenticationManagerTests: XCTestCase {
         let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
         var incorrectCredentials: Bool?
         var verifiedLoginURL: String?
+        var offersBrowserAlternative: Bool?
         let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
 
         // When
@@ -1149,13 +1150,15 @@ final class AuthenticationManagerTests: XCTestCase {
             onFailure: {
                 incorrectCredentials = $1
                 verifiedLoginURL = $2
+                offersBrowserAlternative = $3
             }
         )
-        useCase.fail(with: .invalidCredentials, loginEntryVerified: true)
+        useCase.fail(with: .invalidCredentials, loginEntryVerified: true, offersBrowserAlternative: true)
 
         // Then
         XCTAssertEqual(incorrectCredentials, true)
         XCTAssertEqual(verifiedLoginURL, "https://example.com/custom-login")
+        XCTAssertEqual(offersBrowserAlternative, true)
     }
 
     func test_present_site_credential_login_failure_presents_centered_fancy_alert() throws {
@@ -1214,7 +1217,7 @@ final class AuthenticationManagerTests: XCTestCase {
             onLoading: { loading.append($0) },
             onSuccess: { receivedCredentials = $0 },
             onRecovery: { _ in XCTFail("Expected success") },
-            onFailure: { _, _, _ in XCTFail("Expected success") }
+            onFailure: { _, _, _, _ in XCTFail("Expected success") }
         )
         useCase.succeed()
 
@@ -1284,10 +1287,10 @@ private final class MockAuthenticationManagerSiteCredentialLoginUseCase: SiteCre
     private(set) var receivedUsername: String?
     private(set) var receivedPassword: String?
     private var successHandler: (() -> Void)?
-    private var failureHandler: ((SiteCredentialLoginError, Bool) -> Void)?
+    private var failureHandler: ((SiteCredentialLoginError, Bool, Bool) -> Void)?
 
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
-                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool) -> Void) {
+                       onLoginFailure: @escaping (SiteCredentialLoginError, Bool, Bool) -> Void) {
         successHandler = onLoginSuccess
         failureHandler = onLoginFailure
     }
@@ -1302,8 +1305,10 @@ private final class MockAuthenticationManagerSiteCredentialLoginUseCase: SiteCre
         successHandler?()
     }
 
-    func fail(with error: SiteCredentialLoginError, loginEntryVerified: Bool) {
-        failureHandler?(error, loginEntryVerified)
+    func fail(with error: SiteCredentialLoginError,
+              loginEntryVerified: Bool,
+              offersBrowserAlternative: Bool = false) {
+        failureHandler?(error, loginEntryVerified, offersBrowserAlternative)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import Networking
 @testable import NetworkingCore
 import WordPressAuthenticator
+import WordPressUI
 import Yosemite
 import YosemiteTestHelpers
 @testable import WooCommerce
@@ -1157,6 +1158,41 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual(verifiedLoginURL, "https://example.com/custom-login")
     }
 
+    func test_present_site_credential_login_failure_presents_centered_fancy_alert() throws {
+        // Given
+        let presenter = SiteCredentialAlertPresenter()
+        navigationController.setViewControllers([presenter], animated: false)
+        let manager = AuthenticationManager()
+
+        // When
+        manager.presentSiteCredentialLoginFailure(
+            error: SiteCredentialLoginError.invalidCredentials,
+            offersBrowserAlternative: false,
+            for: "https://example.com",
+            in: presenter
+        )
+
+        // Then
+        try assertCenteredFancyAlertPresented(by: presenter)
+    }
+
+    func test_legacy_site_credential_login_failure_presents_centered_fancy_alert() throws {
+        // Given
+        let presenter = SiteCredentialAlertPresenter()
+        navigationController.setViewControllers([presenter], animated: false)
+        let manager = AuthenticationManager()
+
+        // When
+        manager.handleSiteCredentialLoginFailure(
+            error: SiteCredentialLoginError.invalidCredentials,
+            for: "https://example.com",
+            in: presenter
+        )
+
+        // Then
+        try assertCenteredFancyAlertPresented(by: presenter)
+    }
+
     func test_authenticate_site_credentials_when_custom_or_standard_login_succeeds_then_persists_only_nondefault_endpoints() throws {
         // Given
         let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
@@ -1200,6 +1236,13 @@ final class AuthenticationManagerTests: XCTestCase {
 }
 
 private extension AuthenticationManagerTests {
+    func assertCenteredFancyAlertPresented(by presenter: SiteCredentialAlertPresenter) throws {
+        let alert = try XCTUnwrap(presenter.presentedViewController as? FancyAlertViewController)
+        XCTAssertEqual(alert.modalPresentationStyle, .custom)
+        XCTAssertTrue(alert.transitioningDelegate === presenter)
+        XCTAssertTrue(alert.presentationController is FancyAlertPresentationController)
+    }
+
     func siteCredentials(options: [AnyHashable: Any] = [:]) -> WordPressOrgCredentials {
         WordPressOrgCredentials(
             username: "merchant",
@@ -1225,6 +1268,14 @@ private extension AuthenticationManagerTests {
                                       "isJetpackConnected": isJetpackConnected,
                                       "isWordPressDotCom": isWordPressCom,
                                       "isCommerceGarden": isCommerceGarden])
+    }
+}
+
+private final class SiteCredentialAlertPresenter: UIViewController, UIViewControllerTransitioningDelegate {
+    func presentationController(forPresented presented: UIViewController,
+                                presenting: UIViewController?,
+                                source: UIViewController) -> UIPresentationController? {
+        FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -1224,7 +1224,87 @@ final class AuthenticationManagerTests: XCTestCase {
         try assertCenteredFancyAlertPresented(by: presenter)
     }
 
-    func test_present_site_credential_browser_alternative_presents_tutorial_without_tracking_invalid_login_page() {
+    func test_authenticate_site_credentials_when_login_recovery_is_requested_then_tracks_invalid_login_page_detected() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        let analyticsProvider = MockAnalyticsProvider()
+        let manager = AuthenticationManager(analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+                                            siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected endpoint recovery") },
+            onRecovery: { _ in },
+            onFailure: { _, _, _, _ in XCTFail("Expected endpoint recovery") }
+        )
+        useCase.fail(with: .inaccessibleLoginPage, loginEntryVerified: false)
+
+        // Then
+        XCTAssertEqual(
+            analyticsProvider.receivedEvents.filter { $0 == WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue }.count,
+            1
+        )
+    }
+
+    func test_authenticate_site_credentials_when_unverified_response_recovers_login_then_tracks_invalid_login_page_detected() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        let analyticsProvider = MockAnalyticsProvider()
+        let manager = AuthenticationManager(analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+                                            siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: "https://example.com/custom-login",
+            adminURL: nil,
+            endpointUnderVerification: .login,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected endpoint recovery") },
+            onRecovery: { _ in },
+            onFailure: { _, _, _, _ in XCTFail("Expected endpoint recovery") }
+        )
+        useCase.fail(with: .invalidLoginResponse, loginEntryVerified: false)
+
+        // Then
+        XCTAssertEqual(
+            analyticsProvider.receivedEvents.filter { $0 == WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue }.count,
+            1
+        )
+    }
+
+    func test_authenticate_site_credentials_when_admin_recovery_is_requested_then_does_not_track_invalid_login_page_detected() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        let analyticsProvider = MockAnalyticsProvider()
+        let manager = AuthenticationManager(analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+                                            siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected endpoint recovery") },
+            onRecovery: { _ in },
+            onFailure: { _, _, _, _ in XCTFail("Expected endpoint recovery") }
+        )
+        useCase.fail(with: .inaccessibleAdminPage, loginEntryVerified: true)
+
+        // Then
+        XCTAssertFalse(
+            analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue)
+        )
+    }
+
+    func test_present_site_credential_browser_alternative_presents_tutorial_without_tracking_detection() {
         // Given
         let presenter = UIViewController()
         navigationController.setViewControllers([presenter], animated: false)
@@ -1239,7 +1319,7 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue))
     }
 
-    func test_handle_site_credential_login_failure_when_invalid_login_page_is_detected_then_tracks_detection() {
+    func test_handle_site_credential_login_failure_when_login_page_is_inaccessible_then_presents_tutorial_without_tracking_detection() {
         // Given
         let presenter = UIViewController()
         navigationController.setViewControllers([presenter], animated: false)
@@ -1255,7 +1335,7 @@ final class AuthenticationManagerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(navigationController.topViewController is ApplicationPasswordTutorialViewController)
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue))
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.loginSiteCredentialsInvalidLoginPageDetected.rawValue))
     }
 
     func test_legacy_site_credential_login_failure_presents_centered_fancy_alert() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
@@ -2,6 +2,7 @@ import Network
 import XCTest
 import class Networking.UserAgent
 import struct NetworkingCore.CookieNonceAuthenticationEndpoints
+import enum NetworkingCore.CookieNonceAuthenticationResponseStage
 @testable import WooCommerce
 
 @MainActor
@@ -304,11 +305,13 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         )
         let completion = expectation(description: "Login failure")
         var loginEntryVerified: Bool?
+        var offersBrowserAlternative: Bool?
         useCase.setupHandlers(onLoginSuccess: {
             XCTFail("Expected preflight failure")
             completion.fulfill()
-        }, onLoginFailure: { _, verified in
+        }, onLoginFailure: { _, verified, offersBrowser in
             loginEntryVerified = verified
+            offersBrowserAlternative = offersBrowser
             completion.fulfill()
         })
 
@@ -318,6 +321,7 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertEqual(loginEntryVerified, false)
+        XCTAssertEqual(offersBrowserAlternative, false)
         XCTAssertEqual(loginSession.requestCount, 0)
     }
 
@@ -338,11 +342,13 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         )
         let completion = expectation(description: "Login failure")
         var loginEntryVerified: Bool?
+        var offersBrowserAlternative: Bool?
         useCase.setupHandlers(onLoginSuccess: {
             XCTFail("Expected credential failure")
             completion.fulfill()
-        }, onLoginFailure: { _, verified in
+        }, onLoginFailure: { _, verified, offersBrowser in
             loginEntryVerified = verified
+            offersBrowserAlternative = offersBrowser
             completion.fulfill()
         })
 
@@ -352,6 +358,7 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertEqual(loginEntryVerified, true)
+        XCTAssertEqual(offersBrowserAlternative, true)
     }
 
     func test_handle_login_when_preflight_requires_basic_authentication_then_returns_basic_authentication_required() async {
@@ -384,10 +391,11 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         loginSession.simulateResponse(for: loginURL, data: Data(invalidCredentialsHTML.utf8))
 
         // When
-        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+        let outcome = await performLoginWithVerification(siteURL: siteURL, session: session, loginSession: loginSession)
 
         // Then
-        assertFailure(result, matches: .loginFailed(message: "Incorrect password"))
+        assertFailure(outcome.result, matches: .loginFailed(message: "Incorrect password"))
+        XCTAssertEqual(outcome.offersBrowserAlternative, true)
     }
 
     func test_handle_login_when_credentials_return_wordpress_shake_marker_then_returns_invalid_credentials() async {
@@ -495,15 +503,16 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         session.simulateResponse(for: adminURL, data: Data(loginPage.utf8))
 
         // When
-        let result = await performLogin(
-            siteURL: siteURL,
+        let outcome = await performLoginWithVerification(
             verifyAdminDashboard: true,
+            siteURL: siteURL,
             session: session,
             loginSession: loginSession
         )
 
         // Then
-        assertFailure(result, matches: .invalidCredentials)
+        assertFailure(outcome.result, matches: .invalidCredentials)
+        XCTAssertEqual(outcome.offersBrowserAlternative, false)
         XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == nonceURL })
     }
 
@@ -551,7 +560,7 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         useCase.setupHandlers(onLoginSuccess: {
             XCTFail("Expected endpoint validation to fail")
             completion.fulfill()
-        }, onLoginFailure: { error, _ in
+        }, onLoginFailure: { error, _, _ in
             receivedError = error
             isLoading = false
             completion.fulfill()
@@ -925,10 +934,11 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         )
 
         // When
-        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+        let outcome = await performLoginWithVerification(siteURL: siteURL, session: session, loginSession: loginSession)
 
         // Then
-        assertFailure(result, matches: .invalidLoginResponse)
+        assertFailure(outcome.result, matches: .invalidLoginResponse)
+        XCTAssertEqual(outcome.offersBrowserAlternative, true)
         XCTAssertEqual(loginSession.receivedRequests.compactMap(\.httpMethod), ["POST"])
         XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
         XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
@@ -957,6 +967,31 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         assertFailure(result, matches: .invalidLoginResponse)
         XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
         XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
+    }
+
+    func test_browser_alternative_is_limited_to_credential_response_login_failures() {
+        let eligibleErrors: [SiteCredentialLoginError] = [
+            .invalidCredentials,
+            .invalidLoginResponse,
+            .loginFailed(message: "Captcha required")
+        ]
+        for error in eligibleErrors {
+            XCTAssertTrue(error.offersBrowserAlternative(at: .credentials))
+            XCTAssertFalse(error.offersBrowserAlternative(at: .preflight))
+            XCTAssertFalse(error.offersBrowserAlternative(at: .dashboard))
+            XCTAssertFalse(error.offersBrowserAlternative(at: .nonce))
+        }
+
+        let ineligibleErrors: [SiteCredentialLoginError] = [
+            .basicAuthenticationRequired,
+            .inaccessibleLoginPage,
+            .inaccessibleAdminPage,
+            .unacceptableStatusCode(code: 500),
+            .genericFailure(underlyingError: URLError(.notConnectedToInternet))
+        ]
+        for error in ineligibleErrors {
+            XCTAssertFalse(error.offersBrowserAlternative(at: .credentials))
+        }
     }
 
     func test_handleLogin_when_loginRedirectLocation_is_sameHostDifferentPortRestNonce_then_returns_invalidLoginResponse() async {
@@ -1296,6 +1331,7 @@ private extension SiteCredentialLoginUseCaseTests {
     struct LoginOutcome {
         let result: Result<Void, SiteCredentialLoginError>
         let loginEntryVerified: Bool?
+        let offersBrowserAlternative: Bool?
     }
 
     func performLoginWithVerification(endpoints: CookieNonceAuthenticationEndpoints? = nil,
@@ -1325,10 +1361,18 @@ private extension SiteCredentialLoginUseCaseTests {
     func performLoginWithVerification(using useCase: SiteCredentialLoginUseCase) async -> LoginOutcome {
         return await withCheckedContinuation { continuation in
             useCase.setupHandlers(onLoginSuccess: {
-                continuation.resume(returning: LoginOutcome(result: .success(()), loginEntryVerified: nil))
-            }, onLoginFailure: { error, loginEntryVerified in
+                continuation.resume(returning: LoginOutcome(
+                    result: .success(()),
+                    loginEntryVerified: nil,
+                    offersBrowserAlternative: nil
+                ))
+            }, onLoginFailure: { error, loginEntryVerified, offersBrowserAlternative in
                 continuation.resume(
-                    returning: LoginOutcome(result: .failure(error), loginEntryVerified: loginEntryVerified)
+                    returning: LoginOutcome(
+                        result: .failure(error),
+                        loginEntryVerified: loginEntryVerified,
+                        offersBrowserAlternative: offersBrowserAlternative
+                    )
                 )
             })
 

--- a/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
@@ -287,6 +287,73 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         XCTAssertEqual(loginSession.requestCount, 0)
     }
 
+    func test_handle_login_when_preflight_fails_then_reports_login_entry_as_unverified() async {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 404
+        )
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: siteURL,
+            cookieJar: MockCookieJar(),
+            session: session,
+            loginSession: loginSession
+        )
+        let completion = expectation(description: "Login failure")
+        var loginEntryVerified: Bool?
+        useCase.setupHandlers(onLoginSuccess: {
+            XCTFail("Expected preflight failure")
+            completion.fulfill()
+        }, onLoginFailure: { _, verified in
+            loginEntryVerified = verified
+            completion.fulfill()
+        })
+
+        // When
+        useCase.handleLogin(username: "test", password: "secret")
+        await fulfillment(of: [completion], timeout: 1)
+
+        // Then
+        XCTAssertEqual(loginEntryVerified, false)
+        XCTAssertEqual(loginSession.requestCount, 0)
+    }
+
+    func test_handle_login_when_credentials_fail_after_preflight_then_reports_login_entry_as_verified() async {
+        // Given
+        let siteURL = "https://test.com"
+        let loginURL = siteURL + SiteCredentialLoginUseCase.Constants.loginPath
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: loginURL, data: Data(loginForm().utf8))
+        let invalidCredentialsHTML = loginForm() + "<script>document.querySelector('form').classList.add('shake')</script>"
+        loginSession.simulateResponse(for: loginURL, data: Data(invalidCredentialsHTML.utf8))
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: siteURL,
+            cookieJar: MockCookieJar(),
+            session: session,
+            loginSession: loginSession
+        )
+        let completion = expectation(description: "Login failure")
+        var loginEntryVerified: Bool?
+        useCase.setupHandlers(onLoginSuccess: {
+            XCTFail("Expected credential failure")
+            completion.fulfill()
+        }, onLoginFailure: { _, verified in
+            loginEntryVerified = verified
+            completion.fulfill()
+        })
+
+        // When
+        useCase.handleLogin(username: "test", password: "secret")
+        await fulfillment(of: [completion], timeout: 1)
+
+        // Then
+        XCTAssertEqual(loginEntryVerified, true)
+    }
+
     func test_handle_login_when_preflight_requires_basic_authentication_then_returns_basic_authentication_required() async {
         // Given
         let siteURL = "https://test.com"
@@ -484,7 +551,7 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         useCase.setupHandlers(onLoginSuccess: {
             XCTFail("Expected endpoint validation to fail")
             completion.fulfill()
-        }, onLoginFailure: { error in
+        }, onLoginFailure: { error, _ in
             receivedError = error
             isLoading = false
             completion.fulfill()
@@ -825,10 +892,15 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         session.simulateResponse(for: configuredNonceURL, statusCode: 404)
 
         // When
-        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+        let outcome = await performLoginWithVerification(
+            siteURL: siteURL,
+            session: session,
+            loginSession: loginSession
+        )
 
         // Then
-        assertFailure(result, matches: .inaccessibleAdminPage)
+        assertFailure(outcome.result, matches: .inaccessibleAdminPage)
+        XCTAssertEqual(outcome.loginEntryVerified, true)
         XCTAssertEqual(loginSession.receivedRequests.compactMap(\.url?.absoluteString), [loginURL])
         XCTAssertEqual(session.receivedRequests.compactMap(\.url?.absoluteString), [loginURL, configuredNonceURL])
         XCTAssertFalse(session.receivedRequests.contains { $0.url?.absoluteString == redirectedNonceURL })
@@ -1220,12 +1292,44 @@ private extension SiteCredentialLoginUseCaseTests {
         return await performLogin(using: useCase)
     }
 
+    /// The login result plus, on failure, whether the configured login entry had already been verified.
+    struct LoginOutcome {
+        let result: Result<Void, SiteCredentialLoginError>
+        let loginEntryVerified: Bool?
+    }
+
+    func performLoginWithVerification(endpoints: CookieNonceAuthenticationEndpoints? = nil,
+                                      verifyAdminDashboard: Bool = false,
+                                      siteURL: String,
+                                      session: MockURLSession,
+                                      loginSession: MockURLSession) async -> LoginOutcome {
+        if endpoints == nil {
+            configureDefaultLoginForm(siteURL: siteURL, session: session)
+        }
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: siteURL,
+            endpoints: endpoints,
+            verifyAdminDashboard: verifyAdminDashboard,
+            cookieJar: MockCookieJar(),
+            session: session,
+            loginSession: loginSession
+        )
+
+        return await performLoginWithVerification(using: useCase)
+    }
+
     func performLogin(using useCase: SiteCredentialLoginUseCase) async -> Result<Void, SiteCredentialLoginError> {
+        await performLoginWithVerification(using: useCase).result
+    }
+
+    func performLoginWithVerification(using useCase: SiteCredentialLoginUseCase) async -> LoginOutcome {
         return await withCheckedContinuation { continuation in
             useCase.setupHandlers(onLoginSuccess: {
-                continuation.resume(returning: .success(()))
-            }, onLoginFailure: { error in
-                continuation.resume(returning: .failure(error))
+                continuation.resume(returning: LoginOutcome(result: .success(()), loginEntryVerified: nil))
+            }, onLoginFailure: { error, loginEntryVerified in
+                continuation.resume(
+                    returning: LoginOutcome(result: .failure(error), loginEntryVerified: loginEntryVerified)
+                )
             })
 
             useCase.handleLogin(username: "test", password: "secret")

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -171,7 +171,8 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///     - onSuccess: the block to finish the login flow, carrying credentials that record the verified endpoints.
     ///     - onRecovery: the block asking the merchant to supply an endpoint address.
     ///     - onFailure: the block to trigger error handling. The closure accepts an error, a boolean indicating if the
-    ///       login failed with incorrect credentials, and the verified login entry address when one is already known.
+    ///       login failed with incorrect credentials, the verified login entry address when one is already known,
+    ///       and whether browser authentication could plausibly solve this credential-response failure.
     ///
     func authenticateSiteCredentials(credentials: WordPressOrgCredentials,
                                      loginURL: String?,
@@ -180,7 +181,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
                                      onLoading: @escaping (Bool) -> Void,
                                      onSuccess: @escaping (WordPressOrgCredentials) -> Void,
                                      onRecovery: @escaping (SiteCredentialRecovery) -> Void,
-                                     onFailure: @escaping (Error, Bool, String?) -> Void)
+                                     onFailure: @escaping (Error, Bool, String?, Bool) -> Void)
 
     /// Signals to the Host App that the merchant explicitly asked to authenticate with a browser instead.
     ///
@@ -287,13 +288,13 @@ public extension WordPressAuthenticatorDelegate {
                                      onLoading: @escaping (Bool) -> Void,
                                      onSuccess: @escaping (WordPressOrgCredentials) -> Void,
                                      onRecovery: @escaping (SiteCredentialRecovery) -> Void,
-                                     onFailure: @escaping (Error, Bool, String?) -> Void) {
+                                     onFailure: @escaping (Error, Bool, String?, Bool) -> Void) {
         handleSiteCredentialLogin(
             credentials: credentials,
             onLoading: onLoading,
             onSuccess: { onSuccess(credentials) },
             onFailure: { error, incorrectCredentials in
-                onFailure(error, incorrectCredentials, nil)
+                onFailure(error, incorrectCredentials, nil, false)
             }
         )
     }

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -1,3 +1,28 @@
+/// The authentication endpoint a site credential login attempt is currently trying to establish.
+///
+public enum SiteCredentialRecoveryEndpoint: Equatable {
+    case login
+    case admin
+}
+
+/// Why a candidate endpoint entered by the merchant could not be used.
+///
+public enum SiteCredentialRecoveryError: Equatable {
+    case invalidURL
+    case differentSite
+    case notFound
+}
+
+/// A request for the merchant to confirm where one of the site's authentication endpoints lives.
+///
+/// `draftURL` is the address to prefill. The `admin` case also carries the already verified login
+/// entry so it survives the second round trip.
+///
+public enum SiteCredentialRecovery: Equatable {
+    case login(draftURL: String, error: SiteCredentialRecoveryError?)
+    case admin(verifiedLoginURL: String, draftURL: String, error: SiteCredentialRecoveryError?)
+}
+
 // MARK: - WordPressAuthenticator Delegate Protocol
 //
 public protocol WordPressAuthenticatorDelegate: AnyObject {
@@ -132,6 +157,53 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error, Bool) -> Void)
 
+    /// Asks the Host App to authenticate site credentials against explicitly configured endpoints.
+    ///
+    /// This is the endpoint-aware counterpart of `handleSiteCredentialLogin`. It lets the Host App ask the merchant
+    /// where the sign-in page or the dashboard lives when they are not at the standard addresses.
+    ///
+    /// - Parameters:
+    ///     - credentials: WordPress.org credentials submitted in the site credentials form.
+    ///     - loginURL: the login entry address to use, or `nil` to use the standard one.
+    ///     - adminURL: the admin base address to use, or `nil` to use the standard one.
+    ///     - endpointUnderVerification: the endpoint this attempt is trying to confirm, or `nil` for an ordinary attempt.
+    ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
+    ///     - onSuccess: the block to finish the login flow, carrying credentials that record the verified endpoints.
+    ///     - onRecovery: the block asking the merchant to supply an endpoint address.
+    ///     - onFailure: the block to trigger error handling. The closure accepts an error, a boolean indicating if the
+    ///       login failed with incorrect credentials, and the verified login entry address when one is already known.
+    ///
+    func authenticateSiteCredentials(credentials: WordPressOrgCredentials,
+                                     loginURL: String?,
+                                     adminURL: String?,
+                                     endpointUnderVerification: SiteCredentialRecoveryEndpoint?,
+                                     onLoading: @escaping (Bool) -> Void,
+                                     onSuccess: @escaping (WordPressOrgCredentials) -> Void,
+                                     onRecovery: @escaping (SiteCredentialRecovery) -> Void,
+                                     onFailure: @escaping (Error, Bool, String?) -> Void)
+
+    /// Signals to the Host App that the merchant explicitly asked to authenticate with a browser instead.
+    ///
+    /// - Parameters:
+    ///     - siteURL: The site URL being authenticated.
+    ///     - viewController: the view controller containing the site credential input.
+    ///
+    func presentSiteCredentialBrowserAlternative(for siteURL: String, in viewController: UIViewController)
+
+    /// Signals to the Host App to handle an error for site credential login, stating whether a browser
+    /// alternative may still be offered to the merchant.
+    ///
+    /// - Parameters:
+    ///     - error: The site credential login failure.
+    ///     - offersBrowserAlternative: whether the failure is one the browser flow could plausibly solve.
+    ///     - siteURL: The site URL of the login failure.
+    ///     - viewController: the view controller containing the site credential input.
+    ///
+    func presentSiteCredentialLoginFailure(error: Error,
+                                           offersBrowserAlternative: Bool,
+                                           for siteURL: String,
+                                           in viewController: UIViewController)
+
     /// Signals to the Host App to handle an error for site credential login.
     ///
     /// - Parameters:
@@ -203,6 +275,38 @@ public extension WordPressAuthenticatorDelegate {
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error, Bool) -> Void) {
         // No-op
+    }
+
+    /// Bridges the endpoint-aware contract onto Host Apps that only adopt the legacy one, so they keep
+    /// their existing behaviour and never see an endpoint recovery request.
+    ///
+    func authenticateSiteCredentials(credentials: WordPressOrgCredentials,
+                                     loginURL: String?,
+                                     adminURL: String?,
+                                     endpointUnderVerification: SiteCredentialRecoveryEndpoint?,
+                                     onLoading: @escaping (Bool) -> Void,
+                                     onSuccess: @escaping (WordPressOrgCredentials) -> Void,
+                                     onRecovery: @escaping (SiteCredentialRecovery) -> Void,
+                                     onFailure: @escaping (Error, Bool, String?) -> Void) {
+        handleSiteCredentialLogin(
+            credentials: credentials,
+            onLoading: onLoading,
+            onSuccess: { onSuccess(credentials) },
+            onFailure: { error, incorrectCredentials in
+                onFailure(error, incorrectCredentials, nil)
+            }
+        )
+    }
+
+    func presentSiteCredentialBrowserAlternative(for siteURL: String, in viewController: UIViewController) {
+        // No-op
+    }
+
+    func presentSiteCredentialLoginFailure(error: Error,
+                                           offersBrowserAlternative: Bool,
+                                           for siteURL: String,
+                                           in viewController: UIViewController) {
+        handleSiteCredentialLoginFailure(error: error, for: siteURL, in: viewController)
     }
 
     func handleSiteCredentialLoginFailure(error: Error,

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
@@ -14,12 +14,12 @@ public final class TextLabelTableViewCell: UITableViewCell {
 
     public func configureLabel(text: String?, style: TextLabelStyle = .body) {
         label.text = text
+        label.accessibilityTraits.remove(.header)
 
         switch style {
         case .body:
             label.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
             label.font = UIFont.preferredFont(forTextStyle: .body)
-            label.accessibilityTraits.remove(.header)
         case .headline:
             label.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
             label.font = UIFont.preferredFont(forTextStyle: .headline)
@@ -27,7 +27,6 @@ public final class TextLabelTableViewCell: UITableViewCell {
         case .error:
             label.textColor = WordPressAuthenticator.shared.unifiedStyle?.errorColor ?? UIColor.red
             label.font = UIFont.preferredFont(forTextStyle: .body)
-            label.accessibilityTraits.remove(.header)
         }
     }
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
@@ -19,9 +19,15 @@ public final class TextLabelTableViewCell: UITableViewCell {
         case .body:
             label.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
             label.font = UIFont.preferredFont(forTextStyle: .body)
+            label.accessibilityTraits.remove(.header)
+        case .headline:
+            label.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+            label.font = UIFont.preferredFont(forTextStyle: .headline)
+            label.accessibilityTraits.insert(.header)
         case .error:
             label.textColor = WordPressAuthenticator.shared.unifiedStyle?.errorColor ?? UIColor.red
             label.font = UIFont.preferredFont(forTextStyle: .body)
+            label.accessibilityTraits.remove(.header)
         }
     }
 
@@ -30,6 +36,7 @@ public final class TextLabelTableViewCell: UITableViewCell {
     override public func prepareForReuse() {
         super.prepareForReuse()
         label.text = nil
+        label.accessibilityTraits.remove(.header)
     }
 }
 
@@ -38,6 +45,7 @@ public extension TextLabelTableViewCell {
     ///
     enum TextLabelStyle {
         case body
+        case headline
         case error
     }
 }

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -454,7 +454,7 @@ private extension SiteCredentialsViewController {
                 return
             }
             self.recoveryDraft = textField.text ?? ""
-            self.updateRecoveryError(nil)
+            self.clearRecoveryError()
             self.configureSubmitButton(animating: self.isAuthenticatingSiteCredentials)
         }
     }
@@ -646,32 +646,15 @@ private extension SiteCredentialsViewController {
         reloadRecoveryRows(focusingError: recoveryError != nil)
     }
 
-    /// Adds, removes, or refreshes only the inline error row so editing is never interrupted.
+    /// Removes only the inline error row, so correcting the address never interrupts editing.
     ///
-    func updateRecoveryError(_ error: SiteCredentialRecoveryError?) {
-        guard recoveryError != error else {
+    func clearRecoveryError() {
+        guard recoveryError != nil, let errorIndex = rows.firstIndex(of: .recoveryError) else {
             return
         }
-        let hadError = recoveryError != nil
-        recoveryError = error
-        let errorIndexPath = IndexPath(row: 3, section: 0)
-        switch (hadError, error != nil) {
-        case (false, true):
-            rows.insert(.recoveryError, at: errorIndexPath.row)
-            tableView.insertRows(at: [errorIndexPath], with: .none)
-        case (true, false):
-            rows.remove(at: errorIndexPath.row)
-            tableView.deleteRows(at: [errorIndexPath], with: .none)
-        case (true, true):
-            tableView.reloadRows(at: [errorIndexPath], with: .none)
-        case (false, false):
-            break
-        }
-        guard error != nil else {
-            return
-        }
-        tableView.layoutIfNeeded()
-        UIAccessibility.post(notification: .layoutChanged, argument: tableView.cellForRow(at: errorIndexPath) ?? tableView)
+        recoveryError = nil
+        rows.remove(at: errorIndex)
+        tableView.deleteRows(at: [IndexPath(row: errorIndex, section: 0)], with: .none)
     }
 
     func cancelEndpointRecovery() {

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -154,13 +154,14 @@ final class SiteCredentialsViewController: LoginViewController {
     /// and chooses which element to focus on at the beginning.
     ///
     private func configureForAccessibility() {
-        view.accessibilityElements = [
-            usernameField as Any,
-            tableView as Any,
-            submitButton as Any
-        ]
-
+        updateAccessibilityElements()
         UIAccessibility.post(notification: .screenChanged, argument: usernameField)
+    }
+
+    private func updateAccessibilityElements() {
+        let visibleInputField = recoveryEndpoint == nil ? usernameField : recoveryURLField
+        let elements: [UIView?] = [visibleInputField, tableView, submitButton]
+        view.accessibilityElements = elements.compactMap { $0 }
     }
 
     /// Sets the view's state to loading or not loading.
@@ -191,6 +192,7 @@ final class SiteCredentialsViewController: LoginViewController {
             shouldChangeVoiceOverFocus = moveVoiceOverFocus
             loadRows()
             tableView.reloadData()
+            updateAccessibilityElements()
         }
     }
 
@@ -368,6 +370,7 @@ private extension SiteCredentialsViewController {
 
         // Save a reference to the textField so it can becomeFirstResponder.
         usernameField = cell.textField
+        updateAccessibilityElements()
         cell.textField.delegate = self
 
         cell.onChangeSelectionHandler = { [weak self] textfield in
@@ -446,6 +449,7 @@ private extension SiteCredentialsViewController {
         cell.onChangeSelectionHandler = nil
         cell.configure(withStyle: .url, placeholder: placeholder, text: recoveryDraft)
         recoveryURLField = cell.textField
+        updateAccessibilityElements()
         cell.textField.delegate = self
         cell.textField.isEnabled = !isAuthenticatingSiteCredentials
         cell.textField.accessibilityLabel = placeholder
@@ -676,6 +680,7 @@ private extension SiteCredentialsViewController {
         loadRows()
         tableView.reloadData()
         tableView.layoutIfNeeded()
+        updateAccessibilityElements()
         let focus: Any? = if focusingError, let errorIndex = rows.firstIndex(of: .recoveryError) {
             tableView.cellForRow(at: IndexPath(row: errorIndex, section: 0)) ?? tableView
         } else if recoveryEndpoint == nil {

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -615,11 +615,12 @@ private extension SiteCredentialsViewController {
             onRecovery: { [weak self] recovery in
                 self?.showEndpointRecovery(recovery)
             },
-            onFailure: { [weak self] error, incorrectCredentials, verifiedLoginURL in
+            onFailure: { [weak self] error, incorrectCredentials, verifiedLoginURL, offersBrowserAlternative in
                 self?.handleStructuredLoginFailure(
                     error: error,
                     incorrectCredentials: incorrectCredentials,
-                    verifiedLoginURL: verifiedLoginURL
+                    verifiedLoginURL: verifiedLoginURL,
+                    offersBrowserAlternative: offersBrowserAlternative
                 )
             }
         )
@@ -707,10 +708,13 @@ private extension SiteCredentialsViewController {
     ///
     /// A verified login entry is promoted back onto the credential form so the merchant is never asked for it again.
     ///
-    func handleStructuredLoginFailure(error: Error, incorrectCredentials: Bool, verifiedLoginURL: String?) {
+    func handleStructuredLoginFailure(error: Error,
+                                      incorrectCredentials: Bool,
+                                      verifiedLoginURL: String?,
+                                      offersBrowserAlternative: Bool) {
         configureViewLoading(false)
         if let verifiedLoginURL,
-           recoveryEndpoint == .login || (incorrectCredentials && recoveryEndpoint != nil) {
+           recoveryEndpoint == .login || (offersBrowserAlternative && recoveryEndpoint != nil) {
             recoveredLoginURL = verifiedLoginURL
             recoveredAdminURL = nil
             recoveryEndpoint = nil
@@ -724,7 +728,7 @@ private extension SiteCredentialsViewController {
         }
         WordPressAuthenticator.shared.delegate?.presentSiteCredentialLoginFailure(
             error: error,
-            offersBrowserAlternative: recoveryEndpoint == nil && recoveredLoginURL == nil && verifiedLoginURL == nil,
+            offersBrowserAlternative: recoveryEndpoint == nil && offersBrowserAlternative,
             for: loginFields.siteAddress,
             in: self
         )

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -12,26 +12,44 @@ final class SiteCredentialsViewController: LoginViewController {
 
     private weak var usernameField: UITextField?
     private weak var passwordField: UITextField?
+    private weak var recoveryURLField: UITextField?
+    private weak var browserAlternativeCell: TextLinkButtonTableViewCell?
+    private weak var cancelRecoveryCell: TextLinkButtonTableViewCell?
     private var rows = [Row]()
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
 
+    /// Endpoint currently being asked for, or `nil` when the credential form is shown.
+    private var recoveryEndpoint: SiteCredentialRecoveryEndpoint?
+    private var recoveryDraft = ""
+    private var recoveryError: SiteCredentialRecoveryError?
+
+    /// Endpoints confirmed by the merchant so far. They survive later attempts so the merchant is never asked twice.
+    private var recoveredLoginURL: String?
+    private var recoveredAdminURL: String?
+    private var isAuthenticatingSiteCredentials = false
+
     private let isDismissible: Bool
     private let completionHandler: ((WordPressOrgCredentials) -> Void)?
-    private let configuration = WordPressAuthenticator.shared.configuration
+    private let configuration: WordPressAuthenticatorConfiguration
 
     private var isWPCom: Bool {
         return loginFields.siteAddress == "https://wordpress.com"
     }
 
-    init?(coder: NSCoder, isDismissible: Bool, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
+    init?(coder: NSCoder,
+          isDismissible: Bool,
+          configuration: WordPressAuthenticatorConfiguration = WordPressAuthenticator.shared.configuration,
+          onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
         self.isDismissible = isDismissible
+        self.configuration = configuration
         self.completionHandler = onCompletion
         super.init(coder: coder)
     }
 
     required init?(coder: NSCoder) {
         self.isDismissible = false
+        self.configuration = WordPressAuthenticator.shared.configuration
         self.completionHandler = nil
         super.init(coder: coder)
     }
@@ -125,11 +143,11 @@ final class SiteCredentialsViewController: LoginViewController {
     override func configureSubmitButton(animating: Bool) {
         submitButton?.showActivityIndicator(animating)
 
-        submitButton?.isEnabled = (
-            !animating &&
-                !loginFields.username.isEmpty &&
-                !loginFields.password.isEmpty
-        )
+        if recoveryEndpoint != nil {
+            submitButton?.isEnabled = !animating && recoveryDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        } else {
+            submitButton?.isEnabled = !animating && !loginFields.username.isEmpty && !loginFields.password.isEmpty
+        }
     }
 
     /// Sets up accessibility elements in the order which they should be read aloud
@@ -150,8 +168,12 @@ final class SiteCredentialsViewController: LoginViewController {
     /// - Parameter loading: True if the form should be configured to a "loading" state.
     ///
     override func configureViewLoading(_ loading: Bool) {
+        isAuthenticatingSiteCredentials = loading
         usernameField?.isEnabled = !loading
         passwordField?.isEnabled = !loading
+        recoveryURLField?.isEnabled = !loading
+        browserAlternativeCell?.enableButton(!loading)
+        cancelRecoveryCell?.enableButton(!loading)
 
         configureSubmitButton(animating: loading)
         navigationItem.hidesBackButton = loading
@@ -200,14 +222,19 @@ extension SiteCredentialsViewController: UITableViewDelegate {
     /// After a textfield cell is done displaying, remove the textfield reference.
     ///
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        guard let row = rows[safe: indexPath.row] else {
-            return
+        if let textFieldCell = cell as? TextFieldTableViewCell {
+            if usernameField === textFieldCell.textField {
+                usernameField = nil
+            } else if passwordField === textFieldCell.textField {
+                passwordField = nil
+            } else if recoveryURLField === textFieldCell.textField {
+                recoveryURLField = nil
+            }
         }
-
-        if row == .username {
-            usernameField = nil
-        } else if row == .password {
-            passwordField = nil
+        if browserAlternativeCell === cell {
+            browserAlternativeCell = nil
+        } else if cancelRecoveryCell === cell {
+            cancelRecoveryCell = nil
         }
     }
 }
@@ -234,7 +261,7 @@ extension SiteCredentialsViewController: UITextFieldDelegate {
                 passwordField?.placeholder = nil
             }
             passwordField?.becomeFirstResponder()
-        } else if textField == passwordField {
+        } else if textField == passwordField || textField == recoveryURLField {
             validateForm()
         }
         return true
@@ -264,6 +291,15 @@ private extension SiteCredentialsViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
+        guard recoveryEndpoint == nil else {
+            rows = [.recoveryTitle, .recoveryDescription, .recoveryURL]
+            if recoveryError != nil {
+                rows.append(.recoveryError)
+            }
+            rows.append(contentsOf: [.browserAlternative, .cancelRecovery])
+            return
+        }
+
         rows = [.instructions, .username, .password]
 
         if let errorText = errorMessage, !errorText.isEmpty {
@@ -285,10 +321,22 @@ private extension SiteCredentialsViewController {
             configureUsernameTextField(cell)
         case let cell as TextFieldTableViewCell where row == .password:
             configurePasswordTextField(cell)
-        case let cell as TextLinkButtonTableViewCell:
+        case let cell as TextLinkButtonTableViewCell where row == .forgotPassword:
             configureForgotPassword(cell)
         case let cell as TextLabelTableViewCell where row == .errorMessage:
             configureErrorLabel(cell)
+        case let cell as TextLabelTableViewCell where row == .recoveryTitle:
+            configureRecoveryTitle(cell)
+        case let cell as TextLabelTableViewCell where row == .recoveryDescription:
+            configureRecoveryDescription(cell)
+        case let cell as TextFieldTableViewCell where row == .recoveryURL:
+            configureRecoveryURLField(cell)
+        case let cell as TextLabelTableViewCell where row == .recoveryError:
+            configureRecoveryError(cell)
+        case let cell as TextLinkButtonTableViewCell where row == .browserAlternative:
+            configureBrowserAlternative(cell)
+        case let cell as TextLinkButtonTableViewCell where row == .cancelRecovery:
+            configureCancelRecovery(cell)
         default:
             WPAuthenticatorLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -382,6 +430,70 @@ private extension SiteCredentialsViewController {
         }
     }
 
+    func configureRecoveryTitle(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: recoveryEndpoint == .login ? Localization.loginRecoveryTitle : Localization.adminRecoveryTitle,
+                            style: .headline)
+    }
+
+    func configureRecoveryDescription(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: recoveryEndpoint == .login ? Localization.loginRecoveryDescription : Localization.adminRecoveryDescription,
+                            style: .body)
+    }
+
+    func configureRecoveryURLField(_ cell: TextFieldTableViewCell) {
+        let placeholder = recoveryEndpoint == .login ? Localization.loginURLPlaceholder : Localization.adminURLPlaceholder
+        // `.url` styling reports the current text back, so silence the handler until the draft is in place.
+        cell.onChangeSelectionHandler = nil
+        cell.configure(withStyle: .url, placeholder: placeholder, text: recoveryDraft)
+        recoveryURLField = cell.textField
+        cell.textField.delegate = self
+        cell.textField.isEnabled = !isAuthenticatingSiteCredentials
+        cell.textField.accessibilityLabel = placeholder
+        cell.onChangeSelectionHandler = { [weak self] textField in
+            guard let self else {
+                return
+            }
+            self.recoveryDraft = textField.text ?? ""
+            self.updateRecoveryError(nil)
+            self.configureSubmitButton(animating: self.isAuthenticatingSiteCredentials)
+        }
+    }
+
+    func configureRecoveryError(_ cell: TextLabelTableViewCell) {
+        let text = switch recoveryError {
+        case .invalidURL: Localization.invalidURL
+        case .differentSite: Localization.differentSite
+        case .notFound where recoveryEndpoint == .login: Localization.loginURLNotFound
+        case .notFound: Localization.adminURLNotFound
+        case nil: ""
+        }
+        cell.configureLabel(text: text, style: .error)
+    }
+
+    func configureBrowserAlternative(_ cell: TextLinkButtonTableViewCell) {
+        browserAlternativeCell = cell
+        cell.configureButton(text: Localization.browserAlternative, accessibilityTrait: .link)
+        cell.enableButton(!isAuthenticatingSiteCredentials)
+        cell.actionHandler = { [weak self] in
+            guard let self, !self.isAuthenticatingSiteCredentials else {
+                return
+            }
+            WordPressAuthenticator.shared.delegate?.presentSiteCredentialBrowserAlternative(
+                for: self.loginFields.siteAddress,
+                in: self
+            )
+        }
+    }
+
+    func configureCancelRecovery(_ cell: TextLinkButtonTableViewCell) {
+        cancelRecoveryCell = cell
+        cell.configureButton(text: Localization.cancelRecovery, accessibilityTrait: .link)
+        cell.enableButton(!isAuthenticatingSiteCredentials)
+        cell.actionHandler = { [weak self] in
+            self?.cancelEndpointRecovery()
+        }
+    }
+
     /// Configure the view for an editing state.
     ///
     func configureViewForEditingIfNeeded() {
@@ -455,27 +567,167 @@ private extension SiteCredentialsViewController {
             return
         }
 
-        configureViewLoading(true)
+        authenticateSiteCredentials(verifying: nil)
+    }
 
+    /// Submits the address the merchant entered for the endpoint currently being recovered.
+    ///
+    func validateRecoveryURL() {
+        guard let recoveryEndpoint else {
+            return
+        }
+        let candidate = recoveryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard candidate.isEmpty == false else {
+            return
+        }
+        if recoveryEndpoint == .login {
+            recoveredLoginURL = candidate
+        } else {
+            recoveredAdminURL = candidate
+        }
+        authenticateSiteCredentials(verifying: recoveryEndpoint)
+    }
+
+    func authenticateSiteCredentials(verifying endpoint: SiteCredentialRecoveryEndpoint?) {
         guard let delegate = WordPressAuthenticator.shared.delegate else {
+            // The authenticator cannot present this screen without a delegate, so the flow is already unusable here.
             fatalError("Error: Where did the delegate go?")
         }
         // manually construct the XMLRPC since this is needed to get the site address later
-        let xmlrpc = loginFields.siteAddress + "/xmlrpc.php"
-        let wporg = WordPressOrgCredentials(username: loginFields.username,
-                                            password: loginFields.password,
-                                            xmlrpc: xmlrpc,
-                                            options: [:])
-        delegate.handleSiteCredentialLogin(credentials: wporg, onLoading: { [weak self] shouldShowLoading in
-            self?.configureViewLoading(shouldShowLoading)
-        }, onSuccess: { [weak self] in
-            self?.finishedLogin(withUsername: wporg.username,
-                                password: wporg.password,
-                                xmlrpc: wporg.xmlrpc,
-                                options: wporg.options)
-        }, onFailure: { [weak self] error, incorrectCredentials in
-            self?.handleLoginFailure(error: error, incorrectCredentials: incorrectCredentials)
-        })
+        let credentials = WordPressOrgCredentials(
+            username: loginFields.username,
+            password: loginFields.password,
+            xmlrpc: loginFields.siteAddress + "/xmlrpc.php",
+            options: [:]
+        )
+        delegate.authenticateSiteCredentials(
+            credentials: credentials,
+            loginURL: recoveredLoginURL,
+            adminURL: recoveredAdminURL,
+            endpointUnderVerification: endpoint,
+            onLoading: { [weak self] in self?.configureViewLoading($0) },
+            onSuccess: { [weak self] credentials in
+                self?.finishedLogin(withUsername: credentials.username,
+                                    password: credentials.password,
+                                    xmlrpc: credentials.xmlrpc,
+                                    options: credentials.options)
+            },
+            onRecovery: { [weak self] recovery in
+                self?.showEndpointRecovery(recovery)
+            },
+            onFailure: { [weak self] error, incorrectCredentials, verifiedLoginURL in
+                self?.handleStructuredLoginFailure(
+                    error: error,
+                    incorrectCredentials: incorrectCredentials,
+                    verifiedLoginURL: verifiedLoginURL
+                )
+            }
+        )
+    }
+
+    /// Swaps the credential form for the inline prompt asking where the given endpoint lives.
+    ///
+    func showEndpointRecovery(_ recovery: SiteCredentialRecovery) {
+        switch recovery {
+        case .login(let draftURL, let error):
+            recoveryEndpoint = .login
+            recoveryError = error
+            recoveredLoginURL = error == .invalidURL || error == .differentSite ? nil : draftURL
+            recoveredAdminURL = nil
+            recoveryDraft = draftURL
+        case .admin(let verifiedLoginURL, let draftURL, let error):
+            recoveryEndpoint = .admin
+            recoveryError = error
+            recoveredLoginURL = verifiedLoginURL
+            recoveredAdminURL = error == .invalidURL || error == .differentSite ? nil : draftURL
+            recoveryDraft = draftURL
+        }
+        reloadRecoveryRows(focusingError: recoveryError != nil)
+    }
+
+    /// Adds, removes, or refreshes only the inline error row so editing is never interrupted.
+    ///
+    func updateRecoveryError(_ error: SiteCredentialRecoveryError?) {
+        guard recoveryError != error else {
+            return
+        }
+        let hadError = recoveryError != nil
+        recoveryError = error
+        let errorIndexPath = IndexPath(row: 3, section: 0)
+        switch (hadError, error != nil) {
+        case (false, true):
+            rows.insert(.recoveryError, at: errorIndexPath.row)
+            tableView.insertRows(at: [errorIndexPath], with: .none)
+        case (true, false):
+            rows.remove(at: errorIndexPath.row)
+            tableView.deleteRows(at: [errorIndexPath], with: .none)
+        case (true, true):
+            tableView.reloadRows(at: [errorIndexPath], with: .none)
+        case (false, false):
+            break
+        }
+        guard error != nil else {
+            return
+        }
+        tableView.layoutIfNeeded()
+        UIAccessibility.post(notification: .layoutChanged, argument: tableView.cellForRow(at: errorIndexPath) ?? tableView)
+    }
+
+    func cancelEndpointRecovery() {
+        guard !isAuthenticatingSiteCredentials else {
+            return
+        }
+        let cancelledEndpoint = recoveryEndpoint
+        recoveryEndpoint = nil
+        recoveryDraft = ""
+        recoveryError = nil
+        if cancelledEndpoint == .login {
+            recoveredLoginURL = nil
+        }
+        recoveredAdminURL = nil
+        reloadRecoveryRows(focusingError: false)
+    }
+
+    func reloadRecoveryRows(focusingError: Bool) {
+        loadRows()
+        tableView.reloadData()
+        tableView.layoutIfNeeded()
+        let focus: Any? = if focusingError, let errorIndex = rows.firstIndex(of: .recoveryError) {
+            tableView.cellForRow(at: IndexPath(row: errorIndex, section: 0)) ?? tableView
+        } else if recoveryEndpoint == nil {
+            usernameField ?? tableView
+        } else {
+            recoveryURLField ?? tableView
+        }
+        UIAccessibility.post(notification: focusingError ? .layoutChanged : .screenChanged, argument: focus)
+        configureSubmitButton(animating: isAuthenticatingSiteCredentials)
+    }
+
+    /// Handles a failure that is not an endpoint recovery request.
+    ///
+    /// A verified login entry is promoted back onto the credential form so the merchant is never asked for it again.
+    ///
+    func handleStructuredLoginFailure(error: Error, incorrectCredentials: Bool, verifiedLoginURL: String?) {
+        configureViewLoading(false)
+        if let verifiedLoginURL,
+           recoveryEndpoint == .login || (incorrectCredentials && recoveryEndpoint != nil) {
+            recoveredLoginURL = verifiedLoginURL
+            recoveredAdminURL = nil
+            recoveryEndpoint = nil
+            recoveryDraft = ""
+            recoveryError = nil
+            reloadRecoveryRows(focusingError: false)
+        }
+        guard configuration.enableManualErrorHandlingForSiteCredentialLogin else {
+            handleLoginFailure(error: error, incorrectCredentials: incorrectCredentials)
+            return
+        }
+        WordPressAuthenticator.shared.delegate?.presentSiteCredentialLoginFailure(
+            error: error,
+            offersBrowserAlternative: recoveryEndpoint == nil && recoveredLoginURL == nil && verifiedLoginURL == nil,
+            for: loginFields.siteAddress,
+            in: self
+        )
     }
 
     func handleLoginFailure(error: Error, incorrectCredentials: Bool) {
@@ -534,21 +786,69 @@ private extension SiteCredentialsViewController {
         case password
         case forgotPassword
         case errorMessage
+        case recoveryTitle
+        case recoveryDescription
+        case recoveryURL
+        case recoveryError
+        case browserAlternative
+        case cancelRecovery
 
         var reuseIdentifier: String {
             switch self {
-            case .instructions:
+            case .instructions, .recoveryTitle, .recoveryDescription, .recoveryError:
                 return TextLabelTableViewCell.reuseIdentifier
-            case .username:
+            case .username, .password, .recoveryURL:
                 return TextFieldTableViewCell.reuseIdentifier
-            case .password:
-                return TextFieldTableViewCell.reuseIdentifier
-            case .forgotPassword:
+            case .forgotPassword, .browserAlternative, .cancelRecovery:
                 return TextLinkButtonTableViewCell.reuseIdentifier
             case .errorMessage:
                 return TextLabelTableViewCell.reuseIdentifier
             }
         }
+    }
+
+    enum Localization {
+        static let loginRecoveryTitle = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.login.title", value: "Where do you sign in to your store?",
+            comment: "Title shown when asking for a custom WordPress sign-in address.")
+        static let loginRecoveryDescription = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.login.description",
+            value: "A security plugin may use a custom WordPress sign-in address. Enter the address you use to sign in.",
+            comment: "Description shown when asking for a custom WordPress sign-in address.")
+        static let loginURLPlaceholder = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.login.placeholder", value: "WordPress sign-in address",
+            comment: "Placeholder for a custom WordPress sign-in address.")
+        static let adminRecoveryTitle = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.admin.title", value: "Where is your store’s dashboard?",
+            comment: "Title shown when asking for a custom WordPress dashboard address.")
+        static let adminRecoveryDescription = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.admin.description",
+            value: "A security plugin may move the WordPress dashboard. Enter the address you use to open it.",
+            comment: "Description shown when asking for a custom WordPress dashboard address.")
+        static let adminURLPlaceholder = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.admin.placeholder", value: "WordPress dashboard address",
+            comment: "Placeholder for a custom WordPress dashboard address.")
+        static let invalidURL = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.error.invalidURL", value: "Enter a full web address, including http:// or https://.",
+            comment: "Error shown when a custom WordPress address is not a full web address.")
+        static let differentSite = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.error.differentSite",
+            value: "Enter an address on the same site without changing its secure connection or port.",
+            comment: "Error shown when a custom WordPress address does not belong to the current site.")
+        static let loginURLNotFound = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.error.loginNotFound",
+            value: "We couldn’t find a WordPress sign-in page at that address. Check it and try again.",
+            comment: "Error shown when no WordPress sign-in page exists at the custom address.")
+        static let adminURLNotFound = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.error.adminNotFound",
+            value: "We couldn’t reach the WordPress dashboard at that address. Check it and try again.",
+            comment: "Error shown when no WordPress dashboard exists at the custom address.")
+        static let browserAlternative = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.browserAlternative", value: "Try signing in with your browser instead",
+            comment: "Browser authentication button shown during custom address recovery.")
+        static let cancelRecovery = NSLocalizedString(
+            "com.woocommerce.siteCredentials.recovery.cancel", value: "Cancel",
+            comment: "Button returning to the username and password form.")
     }
 }
 
@@ -573,7 +873,11 @@ extension SiteCredentialsViewController {
         if configuration.enableManualSiteCredentialLogin,
            !isWPCom {
             // asks the delegate to handle the login
-            validateFormAndTriggerDelegate()
+            if recoveryEndpoint == nil {
+                validateFormAndTriggerDelegate()
+            } else {
+                validateRecoveryURL()
+            }
         } else {
             validateFormAndLogin()
         }

--- a/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -142,7 +142,7 @@ class WordPressAuthenticatorTests: XCTestCase {
             onLoading: { _ in },
             onSuccess: { receivedCredentials.append($0) },
             onRecovery: { _ in XCTFail("Expected legacy success") },
-            onFailure: { _, _, _ in XCTFail("Expected legacy success") }
+            onFailure: { _, _, _, _ in XCTFail("Expected legacy success") }
         )
 
         // Then
@@ -167,6 +167,7 @@ class WordPressAuthenticatorTests: XCTestCase {
         var receivedError: NSError?
         var incorrectCredentials: Bool?
         var verifiedLoginURL: String?
+        var offersBrowserAlternative: Bool?
 
         // When
         delegate.authenticateSiteCredentials(
@@ -181,6 +182,7 @@ class WordPressAuthenticatorTests: XCTestCase {
                 receivedError = $0 as NSError
                 incorrectCredentials = $1
                 verifiedLoginURL = $2
+                offersBrowserAlternative = $3
             }
         )
 
@@ -190,6 +192,7 @@ class WordPressAuthenticatorTests: XCTestCase {
         XCTAssertEqual(receivedError?.code, expectedError.code)
         XCTAssertEqual(incorrectCredentials, true)
         XCTAssertNil(verifiedLoginURL)
+        XCTAssertEqual(offersBrowserAlternative, false)
     }
 }
 

--- a/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -120,4 +120,133 @@ class WordPressAuthenticatorTests: XCTestCase {
 
         XCTAssertTrue(authenticator.handleWordPressAuthUrl(url!, rootViewController: UIViewController(), restoresSiteAddress: false, automatedTesting: true))
     }
+
+    func test_authenticate_site_credentials_when_delegate_only_implements_legacy_api_then_bridges_once() throws {
+        // Given
+        let adopter = LegacyOnlyWordPressAuthenticatorDelegate()
+        let delegate: WordPressAuthenticatorDelegate = adopter
+        let credentials = WordPressOrgCredentials(
+            username: "merchant",
+            password: "secret",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            options: ["unrelated": "preserved"]
+        )
+        var receivedCredentials = [WordPressOrgCredentials]()
+
+        // When
+        delegate.authenticateSiteCredentials(
+            credentials: credentials,
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { receivedCredentials.append($0) },
+            onRecovery: { _ in XCTFail("Expected legacy success") },
+            onFailure: { _, _, _ in XCTFail("Expected legacy success") }
+        )
+
+        // Then
+        XCTAssertEqual(adopter.legacySuccessCallCount, 1)
+        XCTAssertEqual(receivedCredentials.count, 1)
+        XCTAssertEqual(try XCTUnwrap(receivedCredentials.first).options["unrelated"] as? String, "preserved")
+    }
+
+    func test_authenticate_site_credentials_when_legacy_only_delegate_fails_then_bridges_failure_once() {
+        // Given
+        let expectedError = NSError(domain: "LegacyAuthentication", code: 401)
+        let adopter = LegacyOnlyWordPressAuthenticatorDelegate()
+        adopter.errorToReturn = expectedError
+        adopter.returnsIncorrectCredentials = true
+        let delegate: WordPressAuthenticatorDelegate = adopter
+        let credentials = WordPressOrgCredentials(
+            username: "merchant",
+            password: "secret",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            options: [:]
+        )
+        var receivedError: NSError?
+        var incorrectCredentials: Bool?
+        var verifiedLoginURL: String?
+
+        // When
+        delegate.authenticateSiteCredentials(
+            credentials: credentials,
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { _ in },
+            onSuccess: { _ in XCTFail("Expected legacy failure") },
+            onRecovery: { _ in XCTFail("Expected legacy failure") },
+            onFailure: {
+                receivedError = $0 as NSError
+                incorrectCredentials = $1
+                verifiedLoginURL = $2
+            }
+        )
+
+        // Then
+        XCTAssertEqual(adopter.legacyFailureCallCount, 1)
+        XCTAssertEqual(receivedError?.domain, expectedError.domain)
+        XCTAssertEqual(receivedError?.code, expectedError.code)
+        XCTAssertEqual(incorrectCredentials, true)
+        XCTAssertNil(verifiedLoginURL)
+    }
+}
+
+/// A delegate that adopts only the legacy site credential login contract, to prove the default bridge.
+private final class LegacyOnlyWordPressAuthenticatorDelegate: WordPressAuthenticatorDelegate {
+    let dismissActionEnabled = true
+    let supportActionEnabled = true
+    let wpcomTermsOfServiceEnabled = true
+    let showSupportNotificationIndicator = true
+    let supportEnabled = true
+    let allowWPComLogin = true
+    private(set) var legacySuccessCallCount = 0
+    private(set) var legacyFailureCallCount = 0
+    var errorToReturn: Error?
+    var returnsIncorrectCredentials = false
+
+    func createdWordPressComAccount(username: String, authToken: String) {}
+    func userAuthenticatedWithAppleUserID(_ appleUserID: String) {}
+    func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {}
+    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?,
+                                                 onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {}
+    func presentLoginEpilogue(in navigationController: UINavigationController,
+                              for credentials: AuthenticatorCredentials,
+                              source: SignInSource?,
+                              onDismiss: @escaping () -> Void) {}
+    func presentSignupEpilogue(in navigationController: UINavigationController,
+                               for credentials: AuthenticatorCredentials,
+                               socialUser: SocialUser?) {}
+    func presentSupport(from sourceViewController: UIViewController,
+                        sourceTag: WordPressSupportSourceTag,
+                        lastStep: AuthenticatorAnalyticsTracker.Step,
+                        lastFlow: AuthenticatorAnalyticsTracker.Flow,
+                        siteURL: String?) {}
+    func shouldPresentLoginEpilogue(isJetpackLogin: Bool) -> Bool { true }
+    func shouldHandleError(_ error: Error) -> Bool { false }
+    func handleError(_ error: Error, onCompletion: @escaping (UIViewController) -> Void) {}
+    func shouldPresentSignupEpilogue() -> Bool { false }
+    func sync(credentials: AuthenticatorCredentials, onCompletion: @escaping () -> Void) {}
+
+    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
+                                   onLoading: @escaping (Bool) -> Void,
+                                   onSuccess: @escaping () -> Void,
+                                   onFailure: @escaping (Error, Bool) -> Void) {
+        if let errorToReturn {
+            legacyFailureCallCount += 1
+            onFailure(errorToReturn, returnsIncorrectCredentials)
+            return
+        }
+        legacySuccessCallCount += 1
+        onSuccess()
+    }
+
+    func handleSiteInfoFailure(siteURL: String, error: Error, completion: @escaping (Bool) -> Void) {
+        completion(false)
+    }
+
+    func track(event: WPAnalyticsStat) {}
+    func track(event: WPAnalyticsStat, properties: [AnyHashable: Any]) {}
+    func track(event: WPAnalyticsStat, error: Error) {}
 }

--- a/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
@@ -20,6 +20,7 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     private(set) var siteCredentialAuthenticationRequests = [SiteCredentialAuthenticationRequest]()
     private(set) var siteCredentialAuthenticationLoadingHandler: ((Bool) -> Void)?
     var siteCredentialFailure: (error: Error, incorrectCredentials: Bool, verifiedLoginURL: String?)?
+    var siteCredentialFailureOffersBrowserAlternative = false
     private(set) var presentedSiteCredentialFailureCount = 0
     private(set) var presentedSiteCredentialFailureOffersBrowserAlternative: Bool?
     private(set) var presentedSiteCredentialBrowserAlternativeCount = 0
@@ -94,7 +95,7 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
                                      onLoading: @escaping (Bool) -> Void,
                                      onSuccess: @escaping (WordPressOrgCredentials) -> Void,
                                      onRecovery: @escaping (SiteCredentialRecovery) -> Void,
-                                     onFailure: @escaping (Error, Bool, String?) -> Void) {
+                                     onFailure: @escaping (Error, Bool, String?, Bool) -> Void) {
         siteCredentialAuthenticationRequests.append(.init(
             credentials: credentials,
             loginURL: loginURL,
@@ -109,7 +110,12 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
         onLoading(false)
         if let failure = siteCredentialFailure {
             siteCredentialFailure = nil
-            onFailure(failure.error, failure.incorrectCredentials, failure.verifiedLoginURL)
+            onFailure(
+                failure.error,
+                failure.incorrectCredentials,
+                failure.verifiedLoginURL,
+                siteCredentialFailureOffersBrowserAlternative
+            )
         } else if siteCredentialRecoveries.isEmpty {
             onSuccess(siteCredentialCredentialsToReturn ?? credentials)
         } else {

--- a/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
@@ -14,6 +14,15 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     private(set) var trackedEvents: [WPAnalyticsStat] = []
     private(set) var lastTrackedProperties: [AnyHashable: Any]?
     private(set) var socialUser: SocialUser?
+    var siteCredentialCredentialsToReturn: WordPressOrgCredentials?
+    var siteCredentialRecoveries = [SiteCredentialRecovery]()
+    var defersSiteCredentialAuthentication = false
+    private(set) var siteCredentialAuthenticationRequests = [SiteCredentialAuthenticationRequest]()
+    private(set) var siteCredentialAuthenticationLoadingHandler: ((Bool) -> Void)?
+    var siteCredentialFailure: (error: Error, incorrectCredentials: Bool, verifiedLoginURL: String?)?
+    private(set) var presentedSiteCredentialFailureCount = 0
+    private(set) var presentedSiteCredentialFailureOffersBrowserAlternative: Bool?
+    private(set) var presentedSiteCredentialBrowserAlternativeCount = 0
 
     func createdWordPressComAccount(username: String, authToken: String) {
         // no-op
@@ -78,6 +87,48 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
         completion(false)
     }
 
+    func authenticateSiteCredentials(credentials: WordPressOrgCredentials,
+                                     loginURL: String?,
+                                     adminURL: String?,
+                                     endpointUnderVerification: SiteCredentialRecoveryEndpoint?,
+                                     onLoading: @escaping (Bool) -> Void,
+                                     onSuccess: @escaping (WordPressOrgCredentials) -> Void,
+                                     onRecovery: @escaping (SiteCredentialRecovery) -> Void,
+                                     onFailure: @escaping (Error, Bool, String?) -> Void) {
+        siteCredentialAuthenticationRequests.append(.init(
+            credentials: credentials,
+            loginURL: loginURL,
+            adminURL: adminURL,
+            endpointUnderVerification: endpointUnderVerification
+        ))
+        siteCredentialAuthenticationLoadingHandler = onLoading
+        onLoading(true)
+        guard defersSiteCredentialAuthentication == false else {
+            return
+        }
+        onLoading(false)
+        if let failure = siteCredentialFailure {
+            siteCredentialFailure = nil
+            onFailure(failure.error, failure.incorrectCredentials, failure.verifiedLoginURL)
+        } else if siteCredentialRecoveries.isEmpty {
+            onSuccess(siteCredentialCredentialsToReturn ?? credentials)
+        } else {
+            onRecovery(siteCredentialRecoveries.removeFirst())
+        }
+    }
+
+    func presentSiteCredentialLoginFailure(error: Error,
+                                           offersBrowserAlternative: Bool,
+                                           for siteURL: String,
+                                           in viewController: UIViewController) {
+        presentedSiteCredentialFailureCount += 1
+        presentedSiteCredentialFailureOffersBrowserAlternative = offersBrowserAlternative
+    }
+
+    func presentSiteCredentialBrowserAlternative(for siteURL: String, in viewController: UIViewController) {
+        presentedSiteCredentialBrowserAlternativeCount += 1
+    }
+
     func track(event: WPAnalyticsStat) {
         trackedEvents.append(event)
     }
@@ -90,4 +141,11 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     func track(event: WPAnalyticsStat, error: Error) {
         trackedEvents.append(event)
     }
+}
+
+struct SiteCredentialAuthenticationRequest {
+    let credentials: WordPressOrgCredentials
+    let loginURL: String?
+    let adminURL: String?
+    let endpointUnderVerification: SiteCredentialRecoveryEndpoint?
 }

--- a/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -158,6 +158,37 @@ class LoginViewControllerTests: XCTestCase {
         )
     }
 
+    func test_site_credentials_controller_when_recovery_is_toggled_then_accessibility_elements_follow_visible_field() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [.login(draftURL: "https://example.com/wp-login.php", error: nil)]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        let credentialCells = try renderedCells(in: controller)
+        let originalUsernameField = try XCTUnwrap((credentialCells[1] as? TextFieldTableViewCell)?.textField)
+        var accessibilityElements = try XCTUnwrap(controller.view.accessibilityElements as? [UIView])
+        XCTAssertTrue(accessibilityElements.first === originalUsernameField)
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        let recoveryCells = try renderedCells(in: controller)
+        let recoveryURLField = try XCTUnwrap((recoveryCells[2] as? TextFieldTableViewCell)?.textField)
+        accessibilityElements = try XCTUnwrap(controller.view.accessibilityElements as? [UIView])
+        XCTAssertTrue(accessibilityElements.first === recoveryURLField)
+        XCTAssertFalse(accessibilityElements.contains { $0 === originalUsernameField })
+
+        // When
+        try XCTUnwrap((recoveryCells[4] as? TextLinkButtonTableViewCell)?.actionHandler)()
+
+        // Then
+        let restoredCredentialCells = try renderedCells(in: controller)
+        let restoredUsernameField = try XCTUnwrap((restoredCredentialCells[1] as? TextFieldTableViewCell)?.textField)
+        accessibilityElements = try XCTUnwrap(controller.view.accessibilityElements as? [UIView])
+        XCTAssertTrue(accessibilityElements.first === restoredUsernameField)
+        XCTAssertEqual(accessibilityElements.count, 3)
+    }
+
     func test_site_credentials_controller_when_recovery_has_generic_failure_then_keeps_explicit_browser_action_only() throws {
         // Given
         let delegate = WordPressAuthenticatorDelegateSpy()

--- a/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -5,6 +5,11 @@ import XCTest
 class LoginViewControllerTests: XCTestCase {
     private var retainedWindows = [UIWindow]()
 
+    override func tearDown() {
+        retainedWindows.removeAll()
+        super.tearDown()
+    }
+
     // showSignupEpilogue with loginFields.meta.appleUser set will pass SocialService.apple to
     // the delegate
     func testShowingSignupEpilogueWithGoogleUser() throws {
@@ -33,7 +38,25 @@ class LoginViewControllerTests: XCTestCase {
         }
     }
 
-    func test_site_credentials_controller_when_login_moves_to_admin_recovery_then_uses_normalized_login_and_cancel_preserves_credentials() throws {
+    func test_site_credentials_controller_when_login_recovery_is_shown_then_prefills_attempted_url_as_a_headed_section() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [.login(draftURL: "https://example.com/wp-login.php", error: nil)]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        let cells = try renderedCells(in: controller)
+        XCTAssertEqual(cells.count, 5)
+        XCTAssertEqual(labelText(in: cells[0]), "Where do you sign in to your store?")
+        XCTAssertTrue(try XCTUnwrap(label(in: cells[0])).accessibilityTraits.contains(.header))
+        XCTAssertFalse(try XCTUnwrap(label(in: cells[1])).accessibilityTraits.contains(.header))
+        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "https://example.com/wp-login.php")
+    }
+
+    func test_site_credentials_controller_when_custom_login_is_submitted_then_verifies_it_and_asks_for_the_dashboard() throws {
         // Given
         let delegate = WordPressAuthenticatorDelegateSpy()
         delegate.siteCredentialRecoveries = [
@@ -45,40 +68,45 @@ class LoginViewControllerTests: XCTestCase {
             )
         ]
         let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        let loginCells = try renderedCells(in: controller)
+        edit(try XCTUnwrap(loginCells[2] as? TextFieldTableViewCell), text: "https://example.com/custom-login")
 
         // When
         try tapContinue(in: controller)
 
         // Then
-        var cells = try renderedCells(in: controller)
-        XCTAssertEqual(cells.count, 5)
-        XCTAssertEqual(labelText(in: cells[0]), "Where do you sign in to your store?")
-        XCTAssertTrue(try XCTUnwrap(label(in: cells[0])).accessibilityTraits.contains(.header))
-        XCTAssertFalse(try XCTUnwrap(label(in: cells[1])).accessibilityTraits.contains(.header))
-        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "https://example.com/wp-login.php")
-        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 0)
-
-        // When
-        try XCTUnwrap((cells[3] as? TextLinkButtonTableViewCell)?.actionHandler)()
-        edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "https://example.com/custom-login")
-        try tapContinue(in: controller)
-
-        // Then
-        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 1)
         let loginRequest = try XCTUnwrap(delegate.siteCredentialAuthenticationRequests.last)
         XCTAssertEqual(loginRequest.loginURL, "https://example.com/custom-login")
         XCTAssertEqual(loginRequest.endpointUnderVerification, .login)
-        cells = try renderedCells(in: controller)
-        XCTAssertEqual(labelText(in: cells[0]), "Where is your store’s dashboard?")
-        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "https://example.com/private-admin/")
+        let adminCells = try renderedCells(in: controller)
+        XCTAssertEqual(labelText(in: adminCells[0]), "Where is your store’s dashboard?")
+        XCTAssertEqual((adminCells[2] as? TextFieldTableViewCell)?.textField.text, "https://example.com/private-admin/")
+    }
+
+    func test_site_credentials_controller_when_custom_admin_is_submitted_then_sends_verified_login_and_admin_urls() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [
+            .login(draftURL: "https://example.com/wp-login.php", error: nil),
+            .admin(
+                verifiedLoginURL: "https://example.com/normalized-login",
+                draftURL: "https://example.com/private-admin/",
+                error: nil
+            ),
+            .admin(
+                verifiedLoginURL: "https://example.com/normalized-login",
+                draftURL: "https://example.com/custom-admin/",
+                error: .notFound
+            )
+        ]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        try tapContinue(in: controller)
+        let adminCells = try renderedCells(in: controller)
+        edit(try XCTUnwrap(adminCells[2] as? TextFieldTableViewCell), text: "https://example.com/custom-admin")
 
         // When
-        edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "https://example.com/custom-admin")
-        delegate.siteCredentialRecoveries.append(.admin(
-            verifiedLoginURL: "https://example.com/normalized-login",
-            draftURL: "https://example.com/custom-admin/",
-            error: .notFound
-        ))
         try tapContinue(in: controller)
 
         // Then
@@ -86,19 +114,31 @@ class LoginViewControllerTests: XCTestCase {
         XCTAssertEqual(adminRequest.loginURL, "https://example.com/normalized-login")
         XCTAssertEqual(adminRequest.adminURL, "https://example.com/custom-admin")
         XCTAssertEqual(adminRequest.endpointUnderVerification, .admin)
+    }
+
+    func test_site_credentials_controller_when_admin_recovery_is_cancelled_then_restores_credentials_and_keeps_verified_login() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [
+            .login(draftURL: "https://example.com/wp-login.php", error: nil),
+            .admin(
+                verifiedLoginURL: "https://example.com/normalized-login",
+                draftURL: "https://example.com/private-admin/",
+                error: nil
+            )
+        ]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        try tapContinue(in: controller)
+        let adminCells = try renderedCells(in: controller)
+        delegate.siteCredentialFailure = (NSError(domain: "Authentication", code: 500), false, nil)
 
         // When
-        cells = try renderedCells(in: controller)
-        try XCTUnwrap((cells[5] as? TextLinkButtonTableViewCell)?.actionHandler)()
-        delegate.siteCredentialFailure = (
-            NSError(domain: "Authentication", code: 500),
-            false,
-            nil
-        )
+        try XCTUnwrap((adminCells[4] as? TextLinkButtonTableViewCell)?.actionHandler)()
         try tapContinue(in: controller)
 
         // Then
-        cells = try renderedCells(in: controller)
+        let cells = try renderedCells(in: controller)
         XCTAssertEqual((cells[1] as? TextFieldTableViewCell)?.textField.text, "merchant")
         XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "secret")
         let credentialRequest = try XCTUnwrap(delegate.siteCredentialAuthenticationRequests.last)
@@ -106,6 +146,27 @@ class LoginViewControllerTests: XCTestCase {
         XCTAssertEqual(credentialRequest.loginURL, "https://example.com/normalized-login")
         XCTAssertNil(credentialRequest.adminURL)
         XCTAssertEqual(delegate.presentedSiteCredentialFailureOffersBrowserAlternative, false)
+    }
+
+    func test_site_credentials_controller_when_invalid_url_is_submitted_then_shows_inline_error() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [
+            .login(draftURL: "https://example.com/wp-login.php", error: nil),
+            .login(draftURL: "not-a-url", error: .invalidURL)
+        ]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        let cells = try renderedCells(in: controller)
+        edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "not-a-url")
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        let erroredCells = try renderedCells(in: controller)
+        XCTAssertEqual(erroredCells.count, 6)
+        XCTAssertEqual(labelText(in: erroredCells[3]), "Enter a full web address, including http:// or https://.")
     }
 
     func test_site_credentials_controller_when_invalid_draft_is_edited_then_clears_error_without_replacing_url_cell() throws {
@@ -117,24 +178,11 @@ class LoginViewControllerTests: XCTestCase {
         ]
         let controller = try makeSiteCredentialsController(delegate: delegate)
         try tapContinue(in: controller)
-        var cells = try renderedCells(in: controller)
+        let cells = try renderedCells(in: controller)
         edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "not-a-url")
-
-        // When
         try tapContinue(in: controller)
-
-        // Then
-        cells = try renderedCells(in: controller)
-        XCTAssertEqual(cells.count, 6)
-        XCTAssertEqual(labelText(in: cells[3]), "Enter a full web address, including http:// or https://.")
-        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 0)
-
-        // When
-        try XCTUnwrap((cells[4] as? TextLinkButtonTableViewCell)?.actionHandler)()
-
-        // Then
-        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 1)
-        let urlCell = try XCTUnwrap(cells[2] as? TextFieldTableViewCell)
+        let erroredCells = try renderedCells(in: controller)
+        let urlCell = try XCTUnwrap(erroredCells[2] as? TextFieldTableViewCell)
         XCTAssertTrue(urlCell.textField.becomeFirstResponder())
 
         // When
@@ -144,9 +192,9 @@ class LoginViewControllerTests: XCTestCase {
         urlCell.registerTextFieldAction()
 
         // Then
-        cells = try renderedCells(in: controller)
-        XCTAssertEqual(cells.count, 5)
-        XCTAssertTrue(cells[2] === urlCell)
+        let clearedCells = try renderedCells(in: controller)
+        XCTAssertEqual(clearedCells.count, 5)
+        XCTAssertTrue(clearedCells[2] === urlCell)
         XCTAssertEqual(urlCell.textField.text, "https://example.com/edited-login")
         XCTAssertTrue(urlCell.textField.isFirstResponder)
         XCTAssertEqual(

--- a/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -1,7 +1,9 @@
 @testable import WordPressAuthenticator
+import WordPressUI
 import XCTest
 
 class LoginViewControllerTests: XCTestCase {
+    private var retainedWindows = [UIWindow]()
 
     // showSignupEpilogue with loginFields.meta.appleUser set will pass SocialService.apple to
     // the delegate
@@ -29,5 +31,441 @@ class LoginViewControllerTests: XCTestCase {
         guard case .google = service else {
             return XCTFail("Expected Google social service, got \(service) instead")
         }
+    }
+
+    func test_site_credentials_controller_when_login_moves_to_admin_recovery_then_uses_normalized_login_and_cancel_preserves_credentials() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [
+            .login(draftURL: "https://example.com/wp-login.php", error: nil),
+            .admin(
+                verifiedLoginURL: "https://example.com/normalized-login",
+                draftURL: "https://example.com/private-admin/",
+                error: nil
+            )
+        ]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        var cells = try renderedCells(in: controller)
+        XCTAssertEqual(cells.count, 5)
+        XCTAssertEqual(labelText(in: cells[0]), "Where do you sign in to your store?")
+        XCTAssertTrue(try XCTUnwrap(label(in: cells[0])).accessibilityTraits.contains(.header))
+        XCTAssertFalse(try XCTUnwrap(label(in: cells[1])).accessibilityTraits.contains(.header))
+        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "https://example.com/wp-login.php")
+        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 0)
+
+        // When
+        try XCTUnwrap((cells[3] as? TextLinkButtonTableViewCell)?.actionHandler)()
+        edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "https://example.com/custom-login")
+        try tapContinue(in: controller)
+
+        // Then
+        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 1)
+        let loginRequest = try XCTUnwrap(delegate.siteCredentialAuthenticationRequests.last)
+        XCTAssertEqual(loginRequest.loginURL, "https://example.com/custom-login")
+        XCTAssertEqual(loginRequest.endpointUnderVerification, .login)
+        cells = try renderedCells(in: controller)
+        XCTAssertEqual(labelText(in: cells[0]), "Where is your store’s dashboard?")
+        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "https://example.com/private-admin/")
+
+        // When
+        edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "https://example.com/custom-admin")
+        delegate.siteCredentialRecoveries.append(.admin(
+            verifiedLoginURL: "https://example.com/normalized-login",
+            draftURL: "https://example.com/custom-admin/",
+            error: .notFound
+        ))
+        try tapContinue(in: controller)
+
+        // Then
+        let adminRequest = try XCTUnwrap(delegate.siteCredentialAuthenticationRequests.last)
+        XCTAssertEqual(adminRequest.loginURL, "https://example.com/normalized-login")
+        XCTAssertEqual(adminRequest.adminURL, "https://example.com/custom-admin")
+        XCTAssertEqual(adminRequest.endpointUnderVerification, .admin)
+
+        // When
+        cells = try renderedCells(in: controller)
+        try XCTUnwrap((cells[5] as? TextLinkButtonTableViewCell)?.actionHandler)()
+        delegate.siteCredentialFailure = (
+            NSError(domain: "Authentication", code: 500),
+            false,
+            nil
+        )
+        try tapContinue(in: controller)
+
+        // Then
+        cells = try renderedCells(in: controller)
+        XCTAssertEqual((cells[1] as? TextFieldTableViewCell)?.textField.text, "merchant")
+        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "secret")
+        let credentialRequest = try XCTUnwrap(delegate.siteCredentialAuthenticationRequests.last)
+        XCTAssertEqual(credentialRequest.credentials.password, "secret")
+        XCTAssertEqual(credentialRequest.loginURL, "https://example.com/normalized-login")
+        XCTAssertNil(credentialRequest.adminURL)
+        XCTAssertEqual(delegate.presentedSiteCredentialFailureOffersBrowserAlternative, false)
+    }
+
+    func test_site_credentials_controller_when_invalid_draft_is_edited_then_clears_error_without_replacing_url_cell() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [
+            .login(draftURL: "https://example.com/wp-login.php", error: nil),
+            .login(draftURL: "not-a-url", error: .invalidURL)
+        ]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        var cells = try renderedCells(in: controller)
+        edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "not-a-url")
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        cells = try renderedCells(in: controller)
+        XCTAssertEqual(cells.count, 6)
+        XCTAssertEqual(labelText(in: cells[3]), "Enter a full web address, including http:// or https://.")
+        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 0)
+
+        // When
+        try XCTUnwrap((cells[4] as? TextLinkButtonTableViewCell)?.actionHandler)()
+
+        // Then
+        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 1)
+        let urlCell = try XCTUnwrap(cells[2] as? TextFieldTableViewCell)
+        XCTAssertTrue(urlCell.textField.becomeFirstResponder())
+
+        // When
+        urlCell.textField.text = "https://example.com/edited-login"
+        let cursor = try XCTUnwrap(urlCell.textField.position(from: urlCell.textField.beginningOfDocument, offset: 12))
+        urlCell.textField.selectedTextRange = urlCell.textField.textRange(from: cursor, to: cursor)
+        urlCell.registerTextFieldAction()
+
+        // Then
+        cells = try renderedCells(in: controller)
+        XCTAssertEqual(cells.count, 5)
+        XCTAssertTrue(cells[2] === urlCell)
+        XCTAssertEqual(urlCell.textField.text, "https://example.com/edited-login")
+        XCTAssertTrue(urlCell.textField.isFirstResponder)
+        XCTAssertEqual(
+            urlCell.textField.offset(
+                from: urlCell.textField.beginningOfDocument,
+                to: try XCTUnwrap(urlCell.textField.selectedTextRange?.start)
+            ),
+            12
+        )
+    }
+
+    func test_site_credentials_controller_when_recovery_has_generic_failure_then_keeps_explicit_browser_action_only() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [.login(draftURL: "https://example.com/wp-login.php", error: nil)]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        delegate.siteCredentialFailure = (
+            NSError(domain: "Authentication", code: 500),
+            false,
+            nil
+        )
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        let cells = try renderedCells(in: controller)
+        XCTAssertEqual(cells.count, 5)
+        XCTAssertEqual(delegate.presentedSiteCredentialFailureCount, 1)
+        XCTAssertEqual(delegate.presentedSiteCredentialFailureOffersBrowserAlternative, false)
+        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 0)
+
+        // When
+        try XCTUnwrap((cells[3] as? TextLinkButtonTableViewCell)?.actionHandler)()
+
+        // Then
+        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 1)
+    }
+
+    func test_site_credentials_controller_when_login_recovery_error_changes_then_copies_each_inline_error_independently() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [
+            .login(draftURL: "https://other.example/login", error: .differentSite),
+            .login(draftURL: "https://example.com/missing-login", error: .notFound)
+        ]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        var cells = try renderedCells(in: controller)
+        XCTAssertEqual(
+            labelText(in: cells[3]),
+            "Enter an address on the same site without changing its secure connection or port."
+        )
+
+        // When
+        edit(try XCTUnwrap(cells[2] as? TextFieldTableViewCell), text: "https://example.com/missing-login")
+        try tapContinue(in: controller)
+
+        // Then
+        cells = try renderedCells(in: controller)
+        XCTAssertEqual(
+            labelText(in: cells[3]),
+            "We couldn’t find a WordPress sign-in page at that address. Check it and try again."
+        )
+    }
+
+    func test_site_credentials_controller_when_recovery_is_loading_then_disables_all_actions_until_loading_finishes() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [.login(draftURL: "https://example.com/wp-login.php", error: nil)]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        let cells = try renderedCells(in: controller)
+        let urlField = try XCTUnwrap((cells[2] as? TextFieldTableViewCell)?.textField)
+        let browserButton = try XCTUnwrap(button(in: cells[3]))
+        let cancelButton = try XCTUnwrap(button(in: cells[4]))
+        delegate.defersSiteCredentialAuthentication = true
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        XCTAssertFalse(urlField.isEnabled)
+        XCTAssertEqual(controller.submitButton?.isEnabled, false)
+        XCTAssertFalse(browserButton.isEnabled)
+        XCTAssertFalse(cancelButton.isEnabled)
+
+        // When
+        delegate.siteCredentialAuthenticationLoadingHandler?(false)
+
+        // Then
+        XCTAssertTrue(urlField.isEnabled)
+        XCTAssertEqual(controller.submitButton?.isEnabled, true)
+        XCTAssertTrue(browserButton.isEnabled)
+        XCTAssertTrue(cancelButton.isEnabled)
+    }
+
+    func test_site_credentials_controller_when_ordinary_failure_occurs_then_preserves_manual_handling_configuration() throws {
+        // Given
+        let inlineDelegate = WordPressAuthenticatorDelegateSpy()
+        inlineDelegate.siteCredentialFailure = (
+            NSError(domain: "Authentication", code: 401),
+            true,
+            nil
+        )
+        let inlineController = try makeSiteCredentialsController(delegate: inlineDelegate, manualErrorHandling: false)
+
+        // When
+        try tapContinue(in: inlineController)
+
+        // Then
+        let inlineCells = try renderedCells(in: inlineController)
+        XCTAssertEqual(
+            labelText(in: inlineCells[3]),
+            "It looks like this username/password isn't associated with this site."
+        )
+        XCTAssertEqual(inlineDelegate.presentedSiteCredentialFailureCount, 0)
+
+        // Given
+        let manualDelegate = WordPressAuthenticatorDelegateSpy()
+        manualDelegate.siteCredentialFailure = (
+            NSError(domain: "Authentication", code: 500),
+            false,
+            nil
+        )
+        let manualController = try makeSiteCredentialsController(delegate: manualDelegate, manualErrorHandling: true)
+
+        // When
+        try tapContinue(in: manualController)
+
+        // Then
+        XCTAssertEqual(manualDelegate.presentedSiteCredentialFailureCount, 1)
+        XCTAssertEqual(manualDelegate.presentedSiteCredentialFailureOffersBrowserAlternative, true)
+        XCTAssertEqual(manualDelegate.presentedSiteCredentialBrowserAlternativeCount, 0)
+    }
+
+    func test_site_credentials_controller_when_manual_handling_is_disabled_and_general_failure_occurs_then_shows_existing_error_ui() throws {
+        // Given
+        let testBundlePath = Bundle(for: LoginViewControllerTests.self).bundlePath
+        setenv("PACKAGE_RESOURCE_BUNDLE_PATH", testBundlePath, 1)
+        addTeardownBlock { unsetenv("PACKAGE_RESOURCE_BUNDLE_PATH") }
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialFailure = (
+            NSError(
+                domain: "Authentication",
+                code: 500,
+                userInfo: [NSLocalizedDescriptionKey: "Server failure"]
+            ),
+            false,
+            nil
+        )
+        let controller = try makeSiteCredentialsController(delegate: delegate, manualErrorHandling: false)
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        XCTAssertTrue(controller.navigationController?.presentedViewController is FancyAlertViewController)
+        XCTAssertEqual(delegate.presentedSiteCredentialFailureCount, 0)
+    }
+
+    func test_site_credentials_controller_when_admin_recovery_has_invalid_credentials_then_returns_to_visible_credentials_error() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [
+            .admin(
+                verifiedLoginURL: "https://example.com/normalized-login",
+                draftURL: "https://example.com/unverified-admin/",
+                error: nil
+            )
+        ]
+        let controller = try makeSiteCredentialsController(delegate: delegate, manualErrorHandling: false)
+        try tapContinue(in: controller)
+        delegate.siteCredentialFailure = (
+            NSError(domain: "Authentication", code: 401),
+            true,
+            "https://example.com/normalized-login"
+        )
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        var cells = try renderedCells(in: controller)
+        XCTAssertEqual(cells.count, 5)
+        XCTAssertEqual((cells[1] as? TextFieldTableViewCell)?.textField.text, "merchant")
+        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "secret")
+        XCTAssertEqual(
+            labelText(in: cells[3]),
+            "It looks like this username/password isn't associated with this site."
+        )
+
+        // When
+        delegate.defersSiteCredentialAuthentication = true
+        try tapContinue(in: controller)
+
+        // Then
+        cells = try renderedCells(in: controller)
+        XCTAssertEqual(cells.count, 4)
+        let retry = try XCTUnwrap(delegate.siteCredentialAuthenticationRequests.last)
+        XCTAssertEqual(retry.loginURL, "https://example.com/normalized-login")
+        XCTAssertNil(retry.adminURL)
+        XCTAssertNil(retry.endpointUnderVerification)
+    }
+
+    func test_site_credentials_controller_when_authentication_succeeds_then_completion_receives_normalized_endpoint_options() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialCredentialsToReturn = WordPressOrgCredentials(
+            username: "merchant",
+            password: "secret",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            options: [
+                "login_url": ["value": "https://example.com/normalized-login"],
+                "admin_url": ["value": "https://example.com/normalized-admin/"]
+            ]
+        )
+        var completedCredentials: WordPressOrgCredentials?
+        let controller = try makeSiteCredentialsController(delegate: delegate) {
+            completedCredentials = $0
+        }
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        let options = try XCTUnwrap(completedCredentials?.options)
+        XCTAssertEqual(
+            (options["login_url"] as? [String: String])?["value"],
+            "https://example.com/normalized-login"
+        )
+        XCTAssertEqual(
+            (options["admin_url"] as? [String: String])?["value"],
+            "https://example.com/normalized-admin/"
+        )
+    }
+}
+
+private extension LoginViewControllerTests {
+    func makeSiteCredentialsController(delegate: WordPressAuthenticatorDelegateSpy,
+                                       manualErrorHandling: Bool = true,
+                                       onCompletion: @escaping (WordPressOrgCredentials) -> Void = { _ in }) throws -> SiteCredentialsViewController {
+        WordPressAuthenticator.initializeForTesting()
+        WordPressAuthenticator.shared.delegate = delegate
+        addTeardownBlock { WordPressAuthenticator.shared.delegate = nil }
+        let configuration = WordPressAuthenticatorConfiguration(
+            wpcomClientId: "a",
+            wpcomSecret: "b",
+            wpcomScheme: "c",
+            wpcomTermsOfServiceURL: try XCTUnwrap(URL(string: "https://w.org")),
+            googleLoginClientId: "e",
+            googleLoginServerClientId: "f",
+            googleLoginScheme: "g",
+            userAgent: "h",
+            enableManualSiteCredentialLogin: true,
+            enableManualErrorHandlingForSiteCredentialLogin: manualErrorHandling
+        )
+        let controller = try XCTUnwrap(SiteCredentialsViewController.instantiate(from: .siteAddress) { coder in
+            SiteCredentialsViewController(
+                coder: coder,
+                isDismissible: true,
+                configuration: configuration,
+                onCompletion: onCompletion
+            )
+        })
+        controller.loadViewIfNeeded()
+        controller.loginFields.siteAddress = "https://example.com"
+        controller.loginFields.username = "merchant"
+        controller.loginFields.password = "secret"
+        controller.configureSubmitButton(animating: false)
+        let navigationController = UINavigationController(rootViewController: controller)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = navigationController
+        window.isHidden = false
+        retainedWindows.append(window)
+        navigationController.view.layoutIfNeeded()
+        return controller
+    }
+
+    func renderedCells(in controller: SiteCredentialsViewController) throws -> [UITableViewCell] {
+        let tableView: UITableView = try XCTUnwrap(firstSubview(in: controller.view))
+        tableView.layoutIfNeeded()
+        return (0..<controller.tableView(tableView, numberOfRowsInSection: 0)).map {
+            let indexPath = IndexPath(row: $0, section: 0)
+            return tableView.cellForRow(at: indexPath) ?? controller.tableView(tableView, cellForRowAt: indexPath)
+        }
+    }
+
+    func firstSubview<View: UIView>(in view: UIView) -> View? {
+        if let view = view as? View { return view }
+        for subview in view.subviews {
+            if let match: View = firstSubview(in: subview) { return match }
+        }
+        return nil
+    }
+
+    func label(in cell: UITableViewCell) -> UILabel? {
+        firstSubview(in: cell.contentView)
+    }
+
+    func labelText(in cell: UITableViewCell) -> String? {
+        label(in: cell)?.text
+    }
+
+    func button(in cell: UITableViewCell) -> UIButton? {
+        firstSubview(in: cell.contentView)
+    }
+
+    func edit(_ cell: TextFieldTableViewCell, text: String) {
+        cell.textField.text = text
+        cell.registerTextFieldAction()
+    }
+
+    func tapContinue(in controller: SiteCredentialsViewController) throws {
+        controller.handleContinueButtonTapped(try XCTUnwrap(controller.submitButton))
     }
 }

--- a/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -187,6 +187,38 @@ class LoginViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 1)
     }
 
+    func test_site_credentials_controller_when_verified_credential_response_fails_then_retains_login_and_offers_browser() throws {
+        // Given
+        let delegate = WordPressAuthenticatorDelegateSpy()
+        delegate.siteCredentialRecoveries = [.login(draftURL: "https://example.com/wp-login.php", error: nil)]
+        let controller = try makeSiteCredentialsController(delegate: delegate)
+        try tapContinue(in: controller)
+        let recoveryCells = try renderedCells(in: controller)
+        edit(try XCTUnwrap(recoveryCells[2] as? TextFieldTableViewCell), text: "https://example.com/custom-login")
+        delegate.siteCredentialFailure = (
+            NSError(domain: "Authentication", code: -1),
+            false,
+            "https://example.com/custom-login"
+        )
+        delegate.siteCredentialFailureOffersBrowserAlternative = true
+
+        // When
+        try tapContinue(in: controller)
+
+        // Then
+        let cells = try renderedCells(in: controller)
+        XCTAssertEqual((cells[1] as? TextFieldTableViewCell)?.textField.text, "merchant")
+        XCTAssertEqual((cells[2] as? TextFieldTableViewCell)?.textField.text, "secret")
+        XCTAssertEqual(delegate.presentedSiteCredentialFailureOffersBrowserAlternative, true)
+        XCTAssertEqual(delegate.presentedSiteCredentialBrowserAlternativeCount, 0)
+
+        delegate.defersSiteCredentialAuthentication = true
+        try tapContinue(in: controller)
+        let retry = try XCTUnwrap(delegate.siteCredentialAuthenticationRequests.last)
+        XCTAssertEqual(retry.loginURL, "https://example.com/custom-login")
+        XCTAssertNil(retry.endpointUnderVerification)
+    }
+
     func test_site_credentials_controller_when_login_recovery_error_changes_then_copies_each_inline_error_independently() throws {
         // Given
         let delegate = WordPressAuthenticatorDelegateSpy()
@@ -284,7 +316,7 @@ class LoginViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(manualDelegate.presentedSiteCredentialFailureCount, 1)
-        XCTAssertEqual(manualDelegate.presentedSiteCredentialFailureOffersBrowserAlternative, true)
+        XCTAssertEqual(manualDelegate.presentedSiteCredentialFailureOffersBrowserAlternative, false)
         XCTAssertEqual(manualDelegate.presentedSiteCredentialBrowserAlternativeCount, 0)
     }
 
@@ -330,6 +362,7 @@ class LoginViewControllerTests: XCTestCase {
             true,
             "https://example.com/normalized-login"
         )
+        delegate.siteCredentialFailureOffersBrowserAlternative = true
 
         // When
         try tapContinue(in: controller)


### PR DESCRIPTION
Part of: WOOMOB-3800

## Description

> [!NOTE]
> **About 61% of the raw diff is tests and test support:** 1,207 lines (`+1,194/-13`), covering the recovery contract, adapters, delegate compatibility, and UIKit state transitions.
>
> Production is 759 raw lines (`+698/-61`), or 639 lines under Danger's test/comment/blank exclusions (`+579/-60`)—above the 300-line guideline. Keeping the recovery contract, host-app mapping, delegate bridge, and independently usable inline UI together avoids an incomplete cross-layer recovery flow.

### Why

PRs #17718–#17721 establish the endpoint trust boundary, adopt it in both authentication transports, and persist verified custom endpoints. The app still has no merchant-facing way to provide a relocated WordPress login or dashboard address, so stores using security plugins that hide `wp-login.php` or `wp-admin` remain unable to complete native sign-in.

Recovery must preserve the canonical store identity and credentials while treating entered endpoints as transaction-local until authentication verifies them. It must also retain the existing failure experience: wrong credentials and browser-only challenges remain actionable, while network, server, nonce, Basic Auth, and endpoint failures keep their specific handling.

### Why separate PR

This PR contains the complete merchant-facing recovery transaction—from the login use-case result through `AuthenticationManager` and the `WordPressAuthenticator` delegate to the inline UIKit states. It is independently releasable without the later `Site`/WebView consumers: standard endpoint behavior remains unchanged, and verified endpoint results already flow into the persistence layer from PR #17721.

### How

- Adds a transaction-local recovery contract for missing login and dashboard endpoints and maps it through `AuthenticationManager` and the `WordPressAuthenticator` delegate without breaking the legacy delegate path.
- Shows **Where do you sign in to your store?** with the attempted standard login URL prefilled, while preserving canonical site identity and credentials. A standard login URL that returns HTTP 200 without an eligible WordPress login form is treated as an unverified endpoint and enters the same recovery flow; an explicitly retried address shows an inline not-found error.
- Retains a verified login entry across wrong-password and credential-response failures, closes recovery, and presents the existing centered error dialog with an explicit **Try again with WP-Admin page** action.
- Keeps the browser/Application Password action on failure dialogs limited to credential-stage challenges. Recovery forms independently provide the same flow as an explicit merchant-invoked escape hatch. Neither path launches the browser automatically; network, server, nonce, Basic Auth, and endpoint failures remain specific.
- Shows **Where is your store's dashboard?** separately, retains the verified login entry, and composes the edited admin URL through the normalized endpoint contract.
- Preserves loading, cancellation, back navigation, first-responder and cursor stability, inline error clearing, accessibility headings and focus announcements, localized copy branches, and analytics.
- Returns normalized verified endpoints without persisting transaction-local form actions.

Deliberately excluded: `Site` endpoint projection, authenticated WebView consumption, QR or WordPress.com changes, and recovery from an advertised Application Password authorization URL that itself returns 404. Those WebView concerns remain in focused follow-up work.

### Stack context

1. #17718 — endpoint trust boundary and shared rules
2. #17719 — interactive authentication
3. #17720 — runtime authentication
4. #17721 — endpoint persistence and lifecycle
5. This PR — recovery contract and inline UI
6. `Site` and authenticated WebView consumers

Automated verification before the final cleanup: 140 focused tests passed across `SiteCredentialLoginUseCase`, the neutral cookie-nonce contract, `AuthenticationManager`, `WordPressAuthenticator`, and `LoginViewController`. WooCommerce, WordPressAuthenticator, and Networking compile boundaries passed on an iPhone 17 Pro simulator. After the behavior-preserving simplification, all 11 `LoginViewControllerTests` passed on an iPhone 17 simulator; changed-file SwiftLint, Swift parsing, `git diff --check`, and the changed-Swift 163-character scan also passed. After the Copilot follow-up and test-value audit, all 46 `AuthenticationManagerTests` passed on the running iPhone 17 Pro simulator.

Manual custom-login and CAPTCHA verification confirmed that the verified login URL and credentials are retained, the browser alternative remains an explicit tap, no browser is auto-launched, and the existing centered error dialog is preserved.

## Test Steps

Use direct store credentials; QR login and WordPress.com login are out of scope.

### Default WordPress endpoints

1. Sign in to a self-hosted store using the standard `wp-login.php` and `wp-admin` paths. Confirm the store opens normally and no recovery form appears.
2. Sign out and repeat with an incorrect password. Confirm the existing centered error dialog appears, no browser opens automatically, and the store does not open.

### WP Ghost — custom sign-in and dashboard URLs

3. With Docker Desktop running, this PR build installed, and an iOS Simulator booted, open `3c497-pb` and save the standalone script as `woomob-3800-wp-ghost-ios.sh`.
4. Prepare and start the fixture:

   ```bash
   chmod +x woomob-3800-wp-ghost-ios.sh
   ./woomob-3800-wp-ghost-ios.sh up
   ```

   Keep the terminal open. The script prints the disposable store address, credentials, sign-in address, and dashboard address. If its default loopback port is unavailable, it selects another automatically; `--port PORT` can also select one explicitly.
5. Open **Log In**, enter the printed store address, and choose **Sign in with store credentials**. Enter the printed username with an incorrect password.
6. Confirm **Where do you sign in to your store?** appears with the standard login URL prefilled. Verify that a malformed or off-site URL is rejected, then enter the printed sign-in address.
7. Confirm the invalid-credentials dialog appears with **Try again with WP-Admin page**, but no browser opens automatically. Dismiss the dialog, correct only the password, and continue without entering the sign-in address again.
8. Confirm **Where is your store's dashboard?** appears after the verified sign-in address succeeds. Verify that an off-site URL is rejected, then enter the printed dashboard address.
9. Confirm the store opens natively with no automatically launched browser or repeated login loop. Return to the credentials screen if needed and verify cancel/back, editing after an inline error, and recovery focus remain stable.
10. Tear down the fixture:

    ```bash
    ./woomob-3800-wp-ghost-ios.sh down
    ```

## Screenshots
| Login | Admin |
| --- | --- |
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/bcd03c52-7e40-4a14-bdc6-3a97b9bbbfaf" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/d5c8bc6e-aea2-4398-ae57-1750a34eef6e" /> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added it to `RELEASE-NOTES.txt`.

