### PR TITLE
Refunds: Remove redundant refund retrieval call after creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -458,8 +458,7 @@ private extension RefundSubmissionUseCase {
                 return onCompletion(.failure(RefundSubmissionUseCaseSubmissionError.missingCreatedRefund))
             }
 
-            // Workaround for https://github.com/woocommerce/woocommerce/issues/33389. This can be removed when the related API issue is fixed
-            self.retrieveUpdatedRefundData(refund: refundData)
+            self.retrieveUpdatedRefundDataIfNeeded(refund: refundData)
             onCompletion(.success(()))
             self.trackCreateRefundRequestSuccess()
         }
@@ -481,7 +480,7 @@ private extension RefundSubmissionUseCase {
                                                                      restockItems: true,
                                                                      amountOverride: nil,
                                                                      lineItems: lineItems)
-            retrieveUpdatedRefundData(refund: createdRefund)
+            retrieveUpdatedRefundDataIfNeeded(refund: createdRefund)
             onCompletion(.success(()))
             trackCreateRefundRequestSuccess()
         } catch {
@@ -496,10 +495,16 @@ private extension RefundSubmissionUseCase {
         }
     }
 
-    /// Retrieves the up-to-date refund data
+    /// Retrieves the up-to-date refund data when the create response does not include whether the
+    /// payment was refunded automatically. WooCommerce 7.8 added `refunded_payment` to create
+    /// responses, but the fallback remains necessary for older stores.
     /// - Parameters:
     ///   - refund: the refund to retrieve details from.
-    private func retrieveUpdatedRefundData(refund: Refund) {
+    private func retrieveUpdatedRefundDataIfNeeded(refund: Refund) {
+        guard refund.isAutomated == nil else {
+            return
+        }
+
         let action = RefundAction.retrieveRefund(siteID: details.order.siteID, orderID: details.order.orderID, refundID: refund.refundID) { _, error in
                 if let error {
                     DDLogError("Error retrieving refund: \(String(describing: refund))\nWith Error: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -452,13 +452,12 @@ private extension RefundSubmissionUseCase {
                 return onCompletion(.failure(error))
             }
 
-            guard let refundData else {
+            guard refundData != nil else {
                 DDLogError("Error creating refund: \(refund)\nWith Error: missing created refund response")
                 self.trackCreateRefundRequestFailed(error: RefundSubmissionUseCaseSubmissionError.missingCreatedRefund)
                 return onCompletion(.failure(RefundSubmissionUseCaseSubmissionError.missingCreatedRefund))
             }
 
-            self.retrieveUpdatedRefundDataIfNeeded(refund: refundData)
             onCompletion(.success(()))
             self.trackCreateRefundRequestSuccess()
         }
@@ -473,14 +472,13 @@ private extension RefundSubmissionUseCase {
                                             onCompletion: @escaping (Result<Void, Error>) -> Void) async {
         trackCreateRefundRequest()
         do {
-            let createdRefund = try await refundService.createRefund(siteID: details.order.siteID,
-                                                                     orderID: details.order.orderID,
-                                                                     reason: refund.reason,
-                                                                     automaticRefund: refund.createAutomated ?? false,
-                                                                     restockItems: true,
-                                                                     amountOverride: nil,
-                                                                     lineItems: lineItems)
-            retrieveUpdatedRefundDataIfNeeded(refund: createdRefund)
+            _ = try await refundService.createRefund(siteID: details.order.siteID,
+                                                     orderID: details.order.orderID,
+                                                     reason: refund.reason,
+                                                     automaticRefund: refund.createAutomated ?? false,
+                                                     restockItems: true,
+                                                     amountOverride: nil,
+                                                     lineItems: lineItems)
             onCompletion(.success(()))
             trackCreateRefundRequestSuccess()
         } catch {
@@ -493,24 +491,6 @@ private extension RefundSubmissionUseCase {
             }
             onCompletion(.failure(error))
         }
-    }
-
-    /// Retrieves the up-to-date refund data when the create response does not include whether the
-    /// payment was refunded automatically. WooCommerce 7.8 added `refunded_payment` to create
-    /// responses, but the fallback remains necessary for older stores.
-    /// - Parameters:
-    ///   - refund: the refund to retrieve details from.
-    private func retrieveUpdatedRefundDataIfNeeded(refund: Refund) {
-        guard refund.isAutomated == nil else {
-            return
-        }
-
-        let action = RefundAction.retrieveRefund(siteID: details.order.siteID, orderID: details.order.orderID, refundID: refund.refundID) { _, error in
-                if let error {
-                    DDLogError("Error retrieving refund: \(String(describing: refund))\nWith Error: \(error)")
-                }
-            }
-            stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -106,8 +106,9 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertFalse(dispatchedV3Create)
     }
 
-    func test_submitRefund_with_server_line_items_when_create_response_includes_refunded_payment_then_does_not_retrieve_refund() {
-        for isAutomated in [true, false] {
+    func test_submitRefund_with_server_line_items_does_not_retrieve_refund_after_creation() {
+        let isAutomatedValues: [Bool?] = [true, false, nil]
+        for isAutomated in isAutomatedValues {
             // Given
             let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
                                         charge: nil,
@@ -125,29 +126,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
             }
 
             // Then
-            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(isAutomated)")
+            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(String(describing: isAutomated))")
         }
-    }
-
-    func test_submitRefund_with_server_line_items_when_create_response_omits_refunded_payment_then_retrieves_refund() {
-        // Given
-        let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
-                                    charge: nil,
-                                    amount: "2.28",
-                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID),
-                                    serverLineItems: [.quantityBased(lineItemID: 10, quantity: 2)])
-        let useCase = createUseCase(details: details)
-        refundService.createRefundResult = .success(MockRefunds.sampleRefund(isAutomated: nil))
-
-        // When
-        waitFor { promise in
-            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
-                promise(())
-            }
-        }
-
-        // Then
-        XCTAssertTrue(didDispatchRetrieveRefund)
     }
 
     func test_submitRefund_with_server_line_items_relays_create_failure() throws {
@@ -234,8 +214,9 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertEqual(result.failure as? RefundAPIError, .orderNotRefundable)
     }
 
-    func test_submitRefund_with_classic_create_when_response_includes_refunded_payment_then_does_not_retrieve_refund() {
-        for isAutomated in [true, false] {
+    func test_submitRefund_with_classic_create_does_not_retrieve_refund_after_creation() {
+        let isAutomatedValues: [Bool?] = [true, false, nil]
+        for isAutomated in isAutomatedValues {
             // Given
             let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
                                                        charge: nil,
@@ -251,27 +232,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
             }
 
             // Then
-            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(isAutomated)")
+            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(String(describing: isAutomated))")
         }
-    }
-
-    func test_submitRefund_with_classic_create_when_response_omits_refunded_payment_then_retrieves_refund() {
-        // Given
-        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
-                                                   charge: nil,
-                                                   amount: "2.28",
-                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
-        mockServerSideRefund(refund: MockRefunds.sampleRefund(isAutomated: nil), error: nil)
-
-        // When
-        waitFor { promise in
-            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
-                promise(())
-            }
-        }
-
-        // Then
-        XCTAssertTrue(didDispatchRetrieveRefund)
     }
 
     func test_submitRefund_with_interac_payment_method_dispatches_CardPresentPaymentActions() throws {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -106,28 +106,27 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertFalse(dispatchedV3Create)
     }
 
-    func test_submitRefund_with_server_line_items_does_not_retrieve_refund_after_creation() {
-        let isAutomatedValues: [Bool?] = [true, false, nil]
-        for isAutomated in isAutomatedValues {
-            // Given
-            let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
-                                        charge: nil,
-                                        amount: "2.28",
-                                        paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID),
-                                        serverLineItems: [.quantityBased(lineItemID: 10, quantity: 2)])
-            let useCase = createUseCase(details: details)
-            refundService.createRefundResult = .success(MockRefunds.sampleRefund(isAutomated: isAutomated))
+    // Regression test for WOOMOB-3522: the create response is sufficient, so submission must not
+    // dispatch an additional `retrieveRefund` action.
+    func test_submitRefund_regression_with_server_line_items_does_not_retrieve_refund_after_creation() {
+        // Given
+        let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
+                                    charge: nil,
+                                    amount: "2.28",
+                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID),
+                                    serverLineItems: [.quantityBased(lineItemID: 10, quantity: 2)])
+        let useCase = createUseCase(details: details)
+        refundService.createRefundResult = .success(MockRefunds.sampleRefund(isAutomated: true))
 
-            // When
-            waitFor { promise in
-                useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
-                    promise(())
-                }
+        // When
+        waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
+                promise(())
             }
-
-            // Then
-            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(String(describing: isAutomated))")
         }
+
+        // Then
+        XCTAssertFalse(didDispatchRetrieveRefund)
     }
 
     func test_submitRefund_with_server_line_items_relays_create_failure() throws {
@@ -214,26 +213,25 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertEqual(result.failure as? RefundAPIError, .orderNotRefundable)
     }
 
-    func test_submitRefund_with_classic_create_does_not_retrieve_refund_after_creation() {
-        let isAutomatedValues: [Bool?] = [true, false, nil]
-        for isAutomated in isAutomatedValues {
-            // Given
-            let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
-                                                       charge: nil,
-                                                       amount: "2.28",
-                                                       paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
-            mockServerSideRefund(refund: MockRefunds.sampleRefund(isAutomated: isAutomated), error: nil)
+    // Regression test for WOOMOB-3522: the create response is sufficient, so submission must not
+    // dispatch an additional `retrieveRefund` action.
+    func test_submitRefund_regression_with_classic_create_does_not_retrieve_refund_after_creation() {
+        // Given
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
+                                                   charge: nil,
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
+        mockServerSideRefund(refund: MockRefunds.sampleRefund(isAutomated: true), error: nil)
 
-            // When
-            waitFor { promise in
-                useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
-                    promise(())
-                }
+        // When
+        waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
+                promise(())
             }
-
-            // Then
-            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(String(describing: isAutomated))")
         }
+
+        // Then
+        XCTAssertFalse(didDispatchRetrieveRefund)
     }
 
     func test_submitRefund_with_interac_payment_method_dispatches_CardPresentPaymentActions() throws {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -106,6 +106,50 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertFalse(dispatchedV3Create)
     }
 
+    func test_submitRefund_with_server_line_items_when_create_response_includes_refunded_payment_then_does_not_retrieve_refund() {
+        for isAutomated in [true, false] {
+            // Given
+            let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
+                                        charge: nil,
+                                        amount: "2.28",
+                                        paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID),
+                                        serverLineItems: [.quantityBased(lineItemID: 10, quantity: 2)])
+            let useCase = createUseCase(details: details)
+            refundService.createRefundResult = .success(MockRefunds.sampleRefund(isAutomated: isAutomated))
+
+            // When
+            waitFor { promise in
+                useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
+                    promise(())
+                }
+            }
+
+            // Then
+            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(isAutomated)")
+        }
+    }
+
+    func test_submitRefund_with_server_line_items_when_create_response_omits_refunded_payment_then_retrieves_refund() {
+        // Given
+        let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
+                                    charge: nil,
+                                    amount: "2.28",
+                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID),
+                                    serverLineItems: [.quantityBased(lineItemID: 10, quantity: 2)])
+        let useCase = createUseCase(details: details)
+        refundService.createRefundResult = .success(MockRefunds.sampleRefund(isAutomated: nil))
+
+        // When
+        waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertTrue(didDispatchRetrieveRefund)
+    }
+
     func test_submitRefund_with_server_line_items_relays_create_failure() throws {
         // Given
         let details = RefundDetails(order: .fake().copy(siteID: Mocks.siteID, total: "2.28"),
@@ -188,6 +232,46 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertEqual(result.failure as? RefundAPIError, .orderNotRefundable)
+    }
+
+    func test_submitRefund_with_classic_create_when_response_includes_refunded_payment_then_does_not_retrieve_refund() {
+        for isAutomated in [true, false] {
+            // Given
+            let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
+                                                       charge: nil,
+                                                       amount: "2.28",
+                                                       paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
+            mockServerSideRefund(refund: MockRefunds.sampleRefund(isAutomated: isAutomated), error: nil)
+
+            // When
+            waitFor { promise in
+                useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
+                    promise(())
+                }
+            }
+
+            // Then
+            XCTAssertFalse(didDispatchRetrieveRefund, "Expected no retrieval when isAutomated is \(isAutomated)")
+        }
+    }
+
+    func test_submitRefund_with_classic_create_when_response_omits_refunded_payment_then_retrieves_refund() {
+        // Given
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
+                                                   charge: nil,
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
+        mockServerSideRefund(refund: MockRefunds.sampleRefund(isAutomated: nil), error: nil)
+
+        // When
+        waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertTrue(didDispatchRetrieveRefund)
     }
 
     func test_submitRefund_with_interac_payment_method_dispatches_CardPresentPaymentActions() throws {
@@ -575,6 +659,16 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 }
 
 private extension RefundSubmissionUseCaseTests {
+    var didDispatchRetrieveRefund: Bool {
+        stores.receivedActions.contains { action in
+            guard let refundAction = action as? RefundAction,
+                  case .retrieveRefund = refundAction else {
+                return false
+            }
+            return true
+        }
+    }
+
     func interacRefundDetails(siteID: Int64 = Mocks.siteID) -> RefundDetails {
         .init(order: .fake().copy(siteID: siteID, total: "2.28"),
               charge: .fake().copy(paymentMethodDetails: .interacPresent(


### PR DESCRIPTION
Closes WOOMOB-3522

## Description
WooCommerce 7.8 added a `refunded_payment` parameter to the refund creation responses, making the existing `RefundAction.retrieveRefund` workaround that performed a second fallback request unnecessary, we just never removed the code.

This PR removes that additional request from both the classic and server-computed refund creation paths. The refund returned by the POST request is already persisted by Yosemite and contains the data required to display the correct refund payment method.

My initial approach was just to skip the 2ns request when the parameter was present (bee9e367acee36318f0ac6cf5575773e3b1d61e7) but since this version of woo is more than 3 years old and we have 0 merchants using it, I'd vote to remove the fallback entirely (bee9e367acee36318f0ac6cf5575773e3b1d61e7)

## Test Steps 

1. Classic refund flow (optional)
- Open a completed order paid through a gateway that supports automatic refunds (any?).
- Issue a refund to the original payment method.
- Confirm the refund succeeds.
- Confirm the order details display the original payment method for the refund, rather than “Manual
  refund".

2.  Server-computed/POS flow ( cc @samiuelson mostly tagging you to review this PR because of the new server-computed use case 👍 )
- On a store supporting server-computed refunds, complete a POS order and issue a refund.
- Confirm the refund succeeds and the payment method is displayed correctly.
- Confirm the creation POST request is not followed by a GET request for the created refund.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
