### PR TITLE
Normalise HTTP site URLs to HTTPS

### DIFF
--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -691,7 +691,8 @@ extension NetworkingCore.Site {
             isAdmin: .fake(),
             wasEcommerceTrial: .fake(),
             hasSSOEnabled: .fake(),
-            applicationPasswordAvailable: .fake()
+            applicationPasswordAvailable: .fake(),
+            wasURLNormalizedToHTTPS: .fake()
         )
     }
 }

--- a/Modules/Sources/Networking/Model/WordPressSite.swift
+++ b/Modules/Sources/Networking/Model/WordPressSite.swift
@@ -88,12 +88,13 @@ public extension WordPressSite {
     /// Converts to `Site` with placeholder values for unknown fields.
     ///
     var asSite: Site {
-        .init(siteID: WooConstants.placeholderSiteID, // Placeholder site ID
+        let normalizedURL = url.normalizedToHTTPS()
+        return .init(siteID: WooConstants.placeholderSiteID, // Placeholder site ID
               name: name,
               description: description,
-              url: url,
-              adminURL: url + Constants.adminPath, // this would not work for sites with custom URLs
-              loginURL: url + Constants.loginPath, // this would not work for sites with custom URLs
+              url: normalizedURL,
+              adminURL: normalizedURL + Constants.adminPath, // this would not work for sites with custom URLs
+              loginURL: normalizedURL + Constants.loginPath, // this would not work for sites with custom URLs
               isSiteOwner: false,
               frameNonce: "",
               plan: "",
@@ -110,7 +111,8 @@ public extension WordPressSite {
               isAdmin: false,
               wasEcommerceTrial: false,
               hasSSOEnabled: false,
-              applicationPasswordAvailable: false)
+              applicationPasswordAvailable: false,
+              wasURLNormalizedToHTTPS: url.requiresHTTPSNormalization)
     }
 
     struct Authentication: Decodable {

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -234,7 +234,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
                                 downloadURL: String,
                                 allowCellular: Bool,
                                 snapshotDate: Date) async throws -> POSCatalogResponse {
-        guard let url = URL(string: downloadURL) else {
+        guard let url = URL(string: downloadURL.normalizedToHTTPS()) else {
             throw NetworkError.invalidURL
         }
 

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
@@ -36,7 +36,7 @@ public final class OneTimeApplicationPasswordUseCase: ApplicationPasswordUseCase
             storage.saveApplicationPassword(applicationPassword)
         }
         self.applicationPassword = storage.applicationPassword
-        self.siteAddress = siteAddress
+        self.siteAddress = siteAddress.normalizedToHTTPS()
         self.session = session
         if let discovery {
             self.discovery = discovery
@@ -123,7 +123,7 @@ private extension OneTimeApplicationPasswordUseCase {
     }
 
     func restAPIURL(for path: String, discoveredRoot: String?) -> URL? {
-        let root = discoveredRoot ?? WordPressAPIDiscovery.defaultRESTAPIRootURL(for: siteAddress)
+        let root = (discoveredRoot ?? WordPressAPIDiscovery.defaultRESTAPIRootURL(for: siteAddress)).normalizedToHTTPS()
         return URL(string: root + path)
     }
 

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestAuthenticator.swift
@@ -175,8 +175,9 @@ private extension DefaultRequestAuthenticator {
         let siteBase = siteAddress.trimSlashes()
 
         // Use cached REST API root if available, otherwise fall back to default
-        let restRoot = WordPressRESTAPIRootCache.shared.root(for: siteAddress)
+        let restRoot = (WordPressRESTAPIRootCache.shared.root(for: siteAddress)
             ?? WordPressAPIDiscovery.defaultRESTAPIRootURL(for: siteBase)
+        ).normalizedToHTTPS()
         return absoluteString.hasPrefix(restRoot.trimSlashes())
     }
 

--- a/Modules/Sources/NetworkingCore/Extensions/String+URL.swift
+++ b/Modules/Sources/NetworkingCore/Extensions/String+URL.swift
@@ -8,4 +8,24 @@ public extension String {
     func trimSlashes() -> String {
         removingPrefix("/").removingSuffix("/")
     }
+
+    /// Replaces an HTTP scheme with HTTPS while preserving all other URL components.
+    ///
+    /// This does not validate that the destination supports TLS. It only normalizes the
+    /// scheme so callers do not attempt an insecure connection that iOS will reject.
+    func normalizedToHTTPS() -> String {
+        guard let originalURL = URL(string: self),
+              originalURL.scheme?.lowercased() == "http" else {
+            return self
+        }
+
+        var components = URLComponents(url: originalURL, resolvingAgainstBaseURL: false)
+        components?.scheme = "https"
+        return components?.string ?? self
+    }
+
+    /// Whether normalizing this value to HTTPS changes it.
+    var requiresHTTPSNormalization: Bool {
+        normalizedToHTTPS() != self
+    }
 }

--- a/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
@@ -1010,7 +1010,8 @@ extension NetworkingCore.Site {
         isAdmin: CopiableProp<Bool> = .copy,
         wasEcommerceTrial: CopiableProp<Bool> = .copy,
         hasSSOEnabled: CopiableProp<Bool> = .copy,
-        applicationPasswordAvailable: CopiableProp<Bool> = .copy
+        applicationPasswordAvailable: CopiableProp<Bool> = .copy,
+        wasURLNormalizedToHTTPS: NullableCopiableProp<Bool> = .copy
     ) -> NetworkingCore.Site {
         let siteID = siteID ?? self.siteID
         let name = name ?? self.name
@@ -1035,6 +1036,7 @@ extension NetworkingCore.Site {
         let wasEcommerceTrial = wasEcommerceTrial ?? self.wasEcommerceTrial
         let hasSSOEnabled = hasSSOEnabled ?? self.hasSSOEnabled
         let applicationPasswordAvailable = applicationPasswordAvailable ?? self.applicationPasswordAvailable
+        let wasURLNormalizedToHTTPS = wasURLNormalizedToHTTPS ?? self.wasURLNormalizedToHTTPS
 
         return NetworkingCore.Site(
             siteID: siteID,
@@ -1059,7 +1061,8 @@ extension NetworkingCore.Site {
             isAdmin: isAdmin,
             wasEcommerceTrial: wasEcommerceTrial,
             hasSSOEnabled: hasSSOEnabled,
-            applicationPasswordAvailable: applicationPasswordAvailable
+            applicationPasswordAvailable: applicationPasswordAvailable,
+            wasURLNormalizedToHTTPS: wasURLNormalizedToHTTPS
         )
     }
 }

--- a/Modules/Sources/NetworkingCore/Model/Site.swift
+++ b/Modules/Sources/NetworkingCore/Model/Site.swift
@@ -96,6 +96,12 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
     ///
     public let applicationPasswordAvailable: Bool
 
+    /// Whether the site URL supplied by the server used HTTP and was normalized to HTTPS.
+    ///
+    /// `nil` means this information was unavailable, for example when restoring a site
+    /// from local storage created before this property existed.
+    public let wasURLNormalizedToHTTPS: Bool?
+
     /// Decodable Conformance.
     ///
     public init(from decoder: Decoder) throws {
@@ -104,7 +110,8 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
         let siteID = try siteContainer.decode(Int64.self, forKey: .siteID)
         let name = try siteContainer.decode(String.self, forKey: .name)
         let description = try siteContainer.decode(String.self, forKey: .description)
-        let url = Self.safeURL(try siteContainer.decode(String.self, forKey: .url))
+        let originalURL = try siteContainer.decode(String.self, forKey: .url)
+        let url = originalURL.normalizedToHTTPS()
         let capabilitiesContainer = try siteContainer.nestedContainer(keyedBy: CapabilitiesKeys.self, forKey: .capabilities)
         let isSiteOwner = try capabilitiesContainer.decode(Bool.self, forKey: .isSiteOwner)
         let isAdmin = try capabilitiesContainer.decode(Bool.self, forKey: .isAdmin)
@@ -117,8 +124,8 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
         let jetpackConnectionActivePlugins = try optionsContainer.decodeIfPresent([String].self, forKey: .jetpackConnectionActivePlugins) ?? []
         let timezone = try optionsContainer.decode(String.self, forKey: .timezone)
         let gmtOffset = try optionsContainer.decode(Double.self, forKey: .gmtOffset)
-        let adminURL = Self.safeURL(try optionsContainer.decode(String.self, forKey: .adminURL))
-        let loginURL = Self.safeURL(try optionsContainer.decode(String.self, forKey: .loginURL))
+        let adminURL = try optionsContainer.decode(String.self, forKey: .adminURL).normalizedToHTTPS()
+        let loginURL = try optionsContainer.decode(String.self, forKey: .loginURL).normalizedToHTTPS()
         let frameNonce = try optionsContainer.decode(String.self, forKey: .frameNonce)
         let canBlaze = optionsContainer.failsafeDecodeIfPresent(booleanForKey: .canBlaze) ?? false
         let visibility = optionsContainer.failsafeDecodeIfPresent(SiteVisibility.self, forKey: .visibility) ?? .privateSite
@@ -161,7 +168,8 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
                   isAdmin: isAdmin,
                   wasEcommerceTrial: wasEcommerceTrial,
                   hasSSOEnabled: hasSSOEnabled,
-                  applicationPasswordAvailable: false) // to be updated by fetching SiteAPI
+                  applicationPasswordAvailable: false, // to be updated by fetching SiteAPI
+                  wasURLNormalizedToHTTPS: originalURL.requiresHTTPSNormalization)
     }
 
     /// Designated Initializer.
@@ -188,7 +196,8 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
                 isAdmin: Bool,
                 wasEcommerceTrial: Bool,
                 hasSSOEnabled: Bool,
-                applicationPasswordAvailable: Bool) {
+                applicationPasswordAvailable: Bool,
+                wasURLNormalizedToHTTPS: Bool? = nil) {
         self.siteID = siteID
         self.name = name
         self.description = description
@@ -212,6 +221,7 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
         self.wasEcommerceTrial = wasEcommerceTrial
         self.hasSSOEnabled = hasSSOEnabled
         self.applicationPasswordAvailable = applicationPasswordAvailable
+        self.wasURLNormalizedToHTTPS = wasURLNormalizedToHTTPS
     }
 }
 
@@ -303,21 +313,6 @@ public enum SiteVisibility: Int, Codable, GeneratedFakeable {
 /// Computed properties
 ///
 public extension Site {
-
-    /// Force URL to use HTTPS if possible to avoid App Transport Security errors
-    private static func safeURL(_ url: String) -> String {
-        guard let originalURL = URL(string: url),
-              originalURL.scheme?.lowercased() == "http"
-        else {
-            return url
-        }
-
-        var components = URLComponents(url: originalURL, resolvingAgainstBaseURL: false)
-        components?.scheme = "https"
-
-        return components?.string ?? url
-    }
-
     /// Returns the TimeZone using the gmtOffset
     ///
     var siteTimezone: TimeZone {

--- a/Modules/Sources/NetworkingCore/Requests/RESTRequest.swift
+++ b/Modules/Sources/NetworkingCore/Requests/RESTRequest.swift
@@ -220,6 +220,7 @@ public struct RESTRequest: Request {
         }
         let components = rootComponents
             .compactMap { $0 }
+            .map { $0.normalizedToHTTPS() }
             .map { $0.trimSlashes() }
             .filter { $0.isEmpty == false }
         let url = try components.joined(separator: "/").asURL()

--- a/Modules/Sources/Yosemite/Stores/AccountStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AccountStore.swift
@@ -169,7 +169,10 @@ private extension AccountStore {
                                               return site
                                           }
                                     site = site.copy(isWooCommerceActive: isWooCommerceActive)
-                                    site = site.copy(name: wpSiteSettings.name, description: wpSiteSettings.description, url: wpSiteSettings.url)
+                                    site = site.copy(name: wpSiteSettings.name,
+                                                     description: wpSiteSettings.description,
+                                                     url: wpSiteSettings.url.normalizedToHTTPS(),
+                                                     wasURLNormalizedToHTTPS: .some(wpSiteSettings.url.requiresHTTPSNormalization))
                                     return site
                                 }.eraseToAnyPublisher()
                         } else {

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/OneTimeApplicationPasswordUseCaseTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/OneTimeApplicationPasswordUseCaseTests.swift
@@ -81,6 +81,18 @@ final class OneTimeApplicationPasswordUseCaseTests: XCTestCase {
         XCTAssertEqual(mockSession.lastRequest?.value(forHTTPHeaderField: "Authorization"), "Basic dGVzdHVzZXI6c2VjcmV0")
     }
 
+    func test_validateApplicationPassword_normalizes_HTTP_site_address_to_HTTPS() async throws {
+        // Given
+        simulateIntrospectResponse(uuid: "test-uuid")
+        let sut = createSUT(password: createTestPassword(), siteAddress: "http://test.com")
+
+        // When
+        _ = try await sut.validateApplicationPassword()
+
+        // Then
+        XCTAssertEqual(mockSession.lastRequest?.url?.absoluteString, introspectURL())
+    }
+
     func test_validateApplicationPassword_throws_notSupported_when_password_is_missing() async {
         // Given
         let sut = createSUT()
@@ -220,6 +232,26 @@ final class OneTimeApplicationPasswordUseCaseTests: XCTestCase {
         // Then
         XCTAssertNil(storage.applicationPassword)
         XCTAssertEqual(mockSession.lastRequest?.url?.absoluteString, deleteURL)
+    }
+
+    func test_deletePassword_when_discovery_returns_HTTP_root_then_uses_HTTPS_url() async throws {
+        // Given
+        let deleteUUID = "fetched-uuid-456"
+        simulateIntrospectResponse(uuid: deleteUUID)
+        simulateDeleteResponse(for: deleteUUID)
+        let sut = OneTimeApplicationPasswordUseCase(
+            applicationPassword: createTestPassword(),
+            siteAddress: siteAddress,
+            injectedStorage: storage,
+            session: mockSession,
+            discovery: { _ in "http://test.com/wp-json/" }
+        )
+
+        // When
+        try await sut.deletePassword(locally: true)
+
+        // Then
+        XCTAssertEqual(mockSession.lastRequest?.url?.absoluteString, deleteURL(for: deleteUUID))
     }
 
     func test_deletePassword_when_discovery_returns_rest_route_root_then_uses_rest_route_url() async throws {

--- a/Modules/Tests/NetworkingTests/Extensions/StringURLTests.swift
+++ b/Modules/Tests/NetworkingTests/Extensions/StringURLTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import NetworkingCore
+
+struct StringURLTests {
+    @Test func normalizedToHTTPS_when_scheme_is_http_replaces_only_the_scheme() {
+        // Given
+        let input = "http://example.com:8080/path?token=abc#fragment"
+
+        // When
+        let result = input.normalizedToHTTPS()
+
+        // Then
+        #expect(result == "https://example.com:8080/path?token=abc#fragment")
+        #expect(input.requiresHTTPSNormalization)
+    }
+
+    @Test func normalizedToHTTPS_when_scheme_uses_mixed_case_normalizes_to_https() {
+        // Given
+        let input = "HtTp://example.com"
+
+        // When
+        let result = input.normalizedToHTTPS()
+
+        // Then
+        #expect(result == "https://example.com")
+    }
+
+    @Test func normalizedToHTTPS_when_scheme_is_already_https_leaves_url_unchanged() {
+        // Given
+        let input = "https://example.com/path"
+
+        // When
+        let result = input.normalizedToHTTPS()
+
+        // Then
+        #expect(result == input)
+        #expect(!input.requiresHTTPSNormalization)
+    }
+
+    @Test func normalizedToHTTPS_when_value_is_not_an_http_url_leaves_value_unchanged() {
+        // Given
+        let input = "example.com/path"
+
+        // When
+        let result = input.normalizedToHTTPS()
+
+        // Then
+        #expect(result == input)
+        #expect(!input.requiresHTTPSNormalization)
+    }
+}

--- a/Modules/Tests/NetworkingTests/Mapper/SiteListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/SiteListMapperTests.swift
@@ -51,6 +51,7 @@ final class SiteListMapperTests: XCTestCase {
         XCTAssertEqual(site.url, "https://insecure-site.testing.blog")
         XCTAssertEqual(site.adminURL, "https://insecure-site.testing.blog/wp-admin/")
         XCTAssertEqual(site.loginURL, "https://insecure-site.testing.blog/wp-login.php")
+        XCTAssertEqual(site.wasURLNormalizedToHTTPS, true)
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Mapper/WordPressSiteMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/WordPressSiteMapperTests.swift
@@ -17,6 +17,26 @@ final class WordPressSiteMapperTests: XCTestCase {
         XCTAssertFalse(site.namespaces.isEmpty)
         XCTAssertFalse(site.isWooCommerceActive)
     }
+
+    func test_asSite_normalizes_http_url_and_records_that_normalization_was_required() {
+        // Given
+        let originalURL = "http://example.com"
+
+        // When
+        let site = WordPressSite(name: "Store",
+                                 description: "Description",
+                                 url: originalURL,
+                                 timezone: "UTC",
+                                 gmtOffset: "0",
+                                 namespaces: [],
+                                 applicationPasswordAuthorizationURL: nil).asSite
+
+        // Then
+        XCTAssertEqual(site.url, "https://example.com")
+        XCTAssertEqual(site.adminURL, "https://example.com/wp-admin/")
+        XCTAssertEqual(site.loginURL, "https://example.com/wp-login.php")
+        XCTAssertEqual(site.wasURLNormalizedToHTTPS, true)
+    }
 }
 
 // MARK: - Private Methods.

--- a/Modules/Tests/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
@@ -57,6 +57,23 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
         XCTAssertTrue(authorizationValue.hasPrefix("Basic"))
     }
 
+    func test_authenticatedRequest_attaches_application_password_when_http_site_url_is_normalized_to_https() throws {
+        // Given
+        let siteURL = "http://test.com/"
+        let credentials: Credentials = .applicationPassword(username: "admin", password: "supersecret", siteAddress: siteURL)
+        let useCase = MockApplicationPasswordUseCase(mockApplicationPassword: applicationPassword)
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
+        let restRequest = RESTRequest(siteURL: siteURL, wooApiVersion: .mark1, method: .get, path: "test")
+
+        // When
+        let request = try restRequest.asURLRequest()
+        let updatedRequest = try authenticator.authenticate(request)
+
+        // Then
+        XCTAssertEqual(updatedRequest.url?.scheme, "https")
+        XCTAssertTrue(try XCTUnwrap(updatedRequest.value(forHTTPHeaderField: "Authorization")).hasPrefix("Basic"))
+    }
+
     func test_authenticatedRequest_returns_REST_request_with_authorization_header_if_authenticated_with_application_password() throws {
         // Given
         let siteURL = "https://test.com/"

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -1038,6 +1038,22 @@ struct POSCatalogSyncRemoteTests {
         #expect(mockBackgroundDownloader.lastSessionIdentifier?.contains("com.woocommerce.pos.catalog.download.\(sampleSiteID)") == true)
     }
 
+    @Test func downloadCatalog_normalizes_http_download_url_to_https() async throws {
+        // Given
+        let remote = createRemote()
+        let mockFileURL = mockBackgroundDownloader.createMockDownloadFile(withContent: "[]")
+        mockBackgroundDownloader.mockSuccessfulDownload(fileURL: mockFileURL)
+
+        // When
+        _ = try await remote.downloadCatalog(for: sampleSiteID,
+                                             downloadURL: "http://example.com/catalog.json?token=abc",
+                                             allowCellular: true,
+                                             snapshotDate: sampleSnapshotDate)
+
+        // Then
+        #expect(mockBackgroundDownloader.lastDownloadURL?.absoluteString == "https://example.com/catalog.json?token=abc")
+    }
+
     @Test func downloadCatalog_generates_unique_session_identifiers() async throws {
         // Given
         let remote = createRemote()

--- a/Modules/Tests/NetworkingTests/Requests/RESTRequestTests.swift
+++ b/Modules/Tests/NetworkingTests/Requests/RESTRequestTests.swift
@@ -268,6 +268,30 @@ final class RESTRequestTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, "https://wordpress.com/wp-json/sample")
     }
 
+    func test_request_url_normalizes_http_site_url_to_https() throws {
+        // Given
+        let request = RESTRequest(siteURL: "http://example.com", method: .get, path: sampleRPC)
+
+        // When
+        let url = try XCTUnwrap(request.asURLRequest().url)
+
+        // Then
+        XCTAssertEqual(url.absoluteString, "https://example.com/wp-json/sample")
+    }
+
+    func test_request_url_normalizes_cached_http_rest_route_root_to_https() throws {
+        // Given
+        let siteURL = "http://example.com"
+        WordPressRESTAPIRootCache.shared.setRoot("http://example.com/?rest_route=/", for: siteURL)
+        let request = RESTRequest(siteURL: siteURL, method: .get, path: sampleRPC)
+
+        // When
+        let url = try XCTUnwrap(request.asURLRequest().url)
+
+        // Then
+        XCTAssertEqual(url.absoluteString, "https://example.com/?rest_route=/sample")
+    }
+
     func test_request_url_with_cached_wp_json_root_and_api_version() throws {
         // Given
         WordPressRESTAPIRootCache.shared.setRoot("https://wordpress.com/wp-json/", for: sampleSiteAddress)

--- a/Modules/Tests/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AccountStoreTests.swift
@@ -322,7 +322,7 @@ final class AccountStoreTests: XCTestCase {
         ])
         remote.whenFetchingWordPressSiteSettings(siteID: siteIDOfJCPSite, thenReturn: .success(.init(name: "new name",
                                                                                                      description: "new description",
-                                                                                                     url: "newurl")))
+                                                                                                     url: "http://example.com")))
         remote.whenCheckingIfWooCommerceIsActive(siteID: siteIDOfJCPSite, thenReturn: .success(true))
 
         let store = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
@@ -348,7 +348,7 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(jcpSite.siteID, siteIDOfJCPSite)
         XCTAssertEqual(jcpSite.name, "new name")
         XCTAssertEqual(jcpSite.tagline, "new description")
-        XCTAssertEqual(jcpSite.url, "newurl")
+        XCTAssertEqual(jcpSite.url, "https://example.com")
         XCTAssertTrue(jcpSite.isWooCommerceActive?.boolValue == true)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Site.self, matching: jetpackSitePredicate), 1)


### PR DESCRIPTION
Closes: WOOMOB-3746
Closes: WOOMOB-3864

## Description
Most URLs are already normalised from `http` to `https` before the app uses them — with App Transport Security, HTTP requests are blocked before reaching the app, so the app would not work for stores with their url setting using HTTP.

A few (RESTRequest, POS catalog downloads) did not undergo this normalisation. This PR updates them so they do.

Application-password REST requests no longer miss stored credentials when the request URL scheme differs. It also normalizes WordPress site conversion and POS catalog file download URLs while recording when a site URL required normalization for follow-up UI.

## Test Steps
1. Configure a test site to report its URL with an `http` scheme.
2. Log in using an application password and confirm REST requests are sent to the equivalent `https` URL with authentication attached.
3. Trigger a POS catalog sync and confirm an HTTP catalog file URL is downloaded over HTTPS.
4. Confirm an existing HTTPS site continues to work without URL changes.

You can use the following snippet to get a site to report `http` for its site URL and POS catalog downloads:

```
add_filter(
    'rest_index',
    static function ( $response ) {
        $data = $response->get_data();
        $data['url'] = preg_replace('#^https://#i', 'http://', $data['url']);
        $response->set_data($data);
        return $response;
    },
    PHP_INT_MAX
);

add_filter(
	'upload_dir',
	static function ( array $uploads ): array {
		$uploads['baseurl'] = set_url_scheme( $uploads['baseurl'], 'http' );
		$uploads['url']     = set_url_scheme( $uploads['url'], 'http' );

		return $uploads;
	},
	PHP_INT_MAX
);
```

Note that you'll need to force a regeneration of the POS catalog for the `http` url to be returned there.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.