### PR TITLE
Fix POS Tracks instrumentation defects: epoch leak in waiting_time, missing site properties, search_method discriminator

### DIFF
--- a/Modules/Sources/PointOfSale/Analytics/POSItemFetchAnalytics.swift
+++ b/Modules/Sources/PointOfSale/Analytics/POSItemFetchAnalytics.swift
@@ -32,7 +32,7 @@ struct POSItemFetchAnalytics: POSItemFetchAnalyticsTracking {
         )
     }
 
-    /// Tracks when a remote search results fetch completes
+    /// Tracks when a remote search results fetch completes. Always reports `POSSearchMethod.remote`.
     /// - Parameters:
     ///   - milliseconds: The time taken to fetch results in milliseconds
     ///   - totalItems: The total number of items found in the search
@@ -50,7 +50,7 @@ struct POSItemFetchAnalytics: POSItemFetchAnalyticsTracking {
     /// - Parameters:
     ///   - millisecondsSinceRequestSent: The time taken to fetch results in milliseconds
     ///   - totalItems: The total number of items found in the search
-    ///   - searchMethod: The search method used (FTS or LIKE)
+    ///   - searchMethod: How the local catalog produced the results
     ///   - source: The source of the results
     func trackSearchLocalResultsFetchComplete(millisecondsSinceRequestSent: Int,
                                               totalItems: Int,

--- a/Modules/Sources/PointOfSale/Analytics/POSItemFetchAnalytics.swift
+++ b/Modules/Sources/PointOfSale/Analytics/POSItemFetchAnalytics.swift
@@ -34,7 +34,7 @@ struct POSItemFetchAnalytics: POSItemFetchAnalyticsTracking {
 
     /// Tracks when a remote search results fetch completes. Always reports `POSSearchMethod.remote`.
     /// - Parameters:
-    ///   - milliseconds: The time taken to fetch results in milliseconds
+    ///   - millisecondsSinceRequestSent: The time taken to fetch results in milliseconds
     ///   - totalItems: The total number of items found in the search
     func trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
         analytics.track(

--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -2,6 +2,7 @@ import Foundation
 import enum Yosemite.CardPresentPaymentOnboardingState
 import enum Yosemite.POSItemType
 import enum Yosemite.POSItem
+import enum Yosemite.POSSearchMethod
 import struct Yosemite.POSSimpleProduct
 import struct Yosemite.POSVariation
 import enum WooFoundation.CountryCode
@@ -408,7 +409,8 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Key.sourceView: SourceView(itemType: itemType).rawValue,
                                 Key.resultsCount: "\(resultsCount)",
-                                Key.millisecondsSinceRequestSent: "\(millisecondsSinceRequestSent)"
+                                Key.millisecondsSinceRequestSent: "\(millisecondsSinceRequestSent)",
+                                Key.searchMethod: POSSearchMethod.remote.rawValue
                               ])
         }
 

--- a/Modules/Sources/Yosemite/PointOfSale/POSItemFetchAnalyticsTracking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/POSItemFetchAnalyticsTracking.swift
@@ -4,7 +4,7 @@ import Foundation
 /// events so a single query can span the local catalog rollout without a fabricated step change.
 ///
 /// `remote` declines as stores adopt the local catalog, but never reaches zero: coupon search has no
-/// local catalogue at all (`PointOfSaleCouponFetchStrategy`), so every coupon search reports `remote`.
+/// local catalog at all (`PointOfSaleCouponFetchStrategy`), so every coupon search reports `remote`.
 public enum POSSearchMethod: String {
     case fts
     case like

--- a/Modules/Sources/Yosemite/PointOfSale/POSItemFetchAnalyticsTracking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/POSItemFetchAnalyticsTracking.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// The search method that produced the results. Present on both the local and the remote search
 /// events so a single query can span the local catalog rollout without a fabricated step change.
+///
+/// `remote` declines as stores adopt the local catalog, but never reaches zero: coupon search has no
+/// local catalogue at all (`PointOfSaleCouponFetchStrategy`), so every coupon search reports `remote`.
 public enum POSSearchMethod: String {
     case fts
     case like
@@ -21,7 +24,7 @@ public protocol POSItemFetchAnalyticsTracking {
     ///   - totalItems: The total number of items in the store
     func trackItemsFetchComplete(totalItems: Int)
 
-    /// Tracks when a remote search results fetch completes
+    /// Tracks when a remote search results fetch completes. Always reports `POSSearchMethod.remote`.
     /// - Parameters:
     ///   - millisecondsSinceRequestSent: The time taken to fetch results in milliseconds
     ///   - totalItems: The total number of items found in the search
@@ -31,7 +34,7 @@ public protocol POSItemFetchAnalyticsTracking {
     /// - Parameters:
     ///   - millisecondsSinceRequestSent: The time taken to fetch results in milliseconds
     ///   - totalItems: The total number of items found in the search
-    ///   - searchMethod: The search method used (FTS or LIKE)
+    ///   - searchMethod: How the local catalog produced the results
     ///   - source: The source of the results
     func trackSearchLocalResultsFetchComplete(millisecondsSinceRequestSent: Int,
                                               totalItems: Int,

--- a/Modules/Sources/Yosemite/PointOfSale/POSItemFetchAnalyticsTracking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/POSItemFetchAnalyticsTracking.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-/// The search method used for local search
+/// The search method that produced the results. Present on both the local and the remote search
+/// events so a single query can span the local catalog rollout without a fabricated step change.
 public enum POSSearchMethod: String {
     case fts
     case like
+    case remote
 }
 
 /// The source of search results

--- a/Modules/Tests/PointOfSaleTests/Analytics/POSItemFetchAnalyticsTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Analytics/POSItemFetchAnalyticsTests.swift
@@ -1,0 +1,48 @@
+import Testing
+import Foundation
+import enum WooFoundationCore.WooAnalyticsStat
+import enum Yosemite.POSItemType
+import enum Yosemite.POSSearchMethod
+import enum Yosemite.POSSearchSource
+@testable import PointOfSale
+
+private enum AnalyticsKeys {
+    static let searchMethod = "search_method"
+    static let resultsCount = "results_count"
+    static let millisecondsSinceRequestSent = "milliseconds_since_request_sent"
+}
+
+struct POSItemFetchAnalyticsTests {
+    @Test func trackSearchRemoteResultsFetchComplete_tracks_remote_search_method() throws {
+        // Given
+        let mockAnalytics = MockPOSAnalytics()
+        let sut = POSItemFetchAnalytics(itemType: .product, analytics: mockAnalytics)
+
+        // When
+        sut.trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: 250, totalItems: 7)
+
+        // Then
+        let event = try #require(mockAnalytics.events.first)
+        #expect(event.eventName == WooAnalyticsStat.pointOfSaleSearchRemoteResultsFetched.rawValue)
+        #expect(event.properties[AnalyticsKeys.searchMethod] as? String == POSSearchMethod.remote.rawValue)
+        #expect(event.properties[AnalyticsKeys.resultsCount] as? String == "7")
+        #expect(event.properties[AnalyticsKeys.millisecondsSinceRequestSent] as? String == "250")
+    }
+
+    @Test func trackSearchLocalResultsFetchComplete_keeps_the_local_search_method() throws {
+        // Given
+        let mockAnalytics = MockPOSAnalytics()
+        let sut = POSItemFetchAnalytics(itemType: .product, analytics: mockAnalytics)
+
+        // When
+        sut.trackSearchLocalResultsFetchComplete(millisecondsSinceRequestSent: 12,
+                                                 totalItems: 3,
+                                                 searchMethod: .fts,
+                                                 source: .purchasableItems)
+
+        // Then
+        let event = try #require(mockAnalytics.events.first)
+        #expect(event.eventName == WooAnalyticsStat.pointOfSaleSearchResultsFetched.rawValue)
+        #expect(event.properties[AnalyticsKeys.searchMethod] as? String == POSSearchMethod.fts.rawValue)
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.5
 -----
+- [Internal] POS: Fixed `waiting_time` reporting a Unix timestamp instead of an elapsed duration, restored site properties (`store_id`, `blog_id`, `site_url`) on events tracked by raw name, and added a `search_method` discriminator to the remote search event. [https://github.com/woocommerce/woocommerce-ios/pull/17731]
 - [*] Products: Product prices and SKUs are now visible from the product list. [https://github.com/woocommerce/woocommerce-ios/pull/17700]
 - [*] In-Person Payments: Fixed card payment options being unavailable when trying a Tap to Pay payment on multi-currency stores. [https://github.com/woocommerce/woocommerce-ios/pull/17704]
 - [*] Analytics Hub: Fixed quarter date ranges displaying incorrect dates for some store timezones. [https://github.com/woocommerce/woocommerce-ios/pull/17713]

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -112,7 +112,8 @@ extension WooAnalytics {
         guard userHasOptedIn == true else {
             return
         }
-        let properties = combinedProperties(from: error, with: passedProperties)
+        let siteEnrichedProperties = siteEnrichedPropertiesIfNeeded(for: eventName, properties: passedProperties)
+        let properties = combinedProperties(from: error, with: siteEnrichedProperties)
         if let properties {
             analyticsProvider.track(eventName, withProperties: properties)
         } else {
@@ -235,6 +236,16 @@ fileprivate extension Analytics {
         updatedProperties[PropertyKeys.storeID] = ServiceLocator.stores.sessionManager.defaultStoreUUID
         updatedProperties[PropertyKeys.cachedWooCommerceVersionKey] = ServiceLocator.stores.sessionManager.cachedWooCommerceVersion
         return updatedProperties
+    }
+
+    /// Callers outside the app target (the Yosemite data layer) can only reach the `String`-named `track`,
+    /// which used to skip enrichment and drop `store_id` from those events. Enrichment is idempotent, so
+    /// re-running it for callers that already enriched is harmless.
+    func siteEnrichedPropertiesIfNeeded(for eventName: String, properties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
+        guard let stat = WooAnalyticsStat(rawValue: eventName), stat.shouldSendSiteProperties else {
+            return properties
+        }
+        return appendSiteProperties(to: properties)
     }
 }
 

--- a/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSCollectOrderPaymentAnalyticsAdaptor.swift
@@ -184,7 +184,7 @@ final class POSCollectOrderPaymentAnalyticsAdaptor: POSCollectOrderPaymentAnalyt
     }
 
     private func trackElapsedTimeFromOrderSyncToCardReady() {
-        let elapsedTime = cardReaderReady - orderSync
+        let elapsedTime = calculateElapsedTimeInSeconds(from: orderSync, to: cardReaderReady)
         analytics.track(event: .PointOfSale.cardReaderReadyForCardPayment(waitingTime: elapsedTime))
     }
 }
@@ -202,6 +202,15 @@ private extension POSCollectOrderPaymentAnalyticsAdaptor {
 
         let end = currentTimestamp()
         return floor((end - start) * 1000)
+    }
+
+    /// Both markers are Unix timestamps: subtracting an unset one reports the wall clock as if it were a duration.
+    func calculateElapsedTimeInSeconds(from start: Double, to end: Double) -> Double {
+        guard start > 0, end > 0 else {
+            return 0
+        }
+
+        return end - start
     }
 
     private func resetProcessingPaymentTracking() {

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -209,6 +209,23 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(property("waiting_time", in: "reader_ready_for_card_payment") == "3.0")
     }
 
+    @Test func test_track_card_reader_ready_when_order_sync_never_succeeded_then_reports_zero_waiting_time() {
+        // Given
+        let clock = TestClock()
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US),
+                                                         currentTimestamp: { clock.now })
+
+        // When
+        clock.now = 1_786_307_015 // customer interaction started (resets the order sync marker)
+        sut.trackCustomerInteractionStarted()
+        clock.now = 1_786_307_018 // reader ready before any order sync
+        sut.trackCardReaderReady()
+
+        // Then
+        #expect(property("waiting_time", in: "reader_ready_for_card_payment") == "0.0")
+    }
+
     @Test func test_track_successful_cash_payment_when_customer_interaction_started_then_reports_correct_elapsed_milliseconds() {
         // Given
         let clock = TestClock()

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -352,6 +352,82 @@ class WooAnalyticsTests: XCTestCase {
         XCTAssertEqual(receivedProperties["booking_status"] as? String, "attended")
         XCTAssertNil(receivedProperties["blog_id"])
     }
+
+    // MARK: - Data-layer tracking by raw event name
+
+    func test_track_by_raw_stat_name_when_authenticated_then_includes_site_properties() {
+        // Given
+        guard let testingProvider else {
+            return XCTFail("Testing provider not available")
+        }
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                   defaultSite: Site.fake().copy(
+                                                                    siteID: sampleSiteID,
+                                                                    url: sampleSiteURL),
+                                                                   defaultStoreUUID: "sample_store_uuid",
+                                                                   cachedWooCommerceVersion: "10.0"))
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+
+        // When
+        analytics.track(WooAnalyticsStat.cardReaderLocationSuccess.rawValue, properties: Constants.testProperty1, error: nil)
+
+        // Then
+        XCTAssertEqual(testingProvider.receivedEvents.first, WooAnalyticsStat.cardReaderLocationSuccess.rawValue)
+        guard let receivedProperties = testingProvider.receivedProperties.first else {
+            return XCTFail("No properties found")
+        }
+        XCTAssertEqual(receivedProperties["store_id"] as? String, "sample_store_uuid")
+        XCTAssertEqual(receivedProperties["blog_id"] as? Int64, sampleSiteID)
+        XCTAssertEqual(receivedProperties["prop-key1"] as? String, "prop-value1")
+    }
+
+    func test_track_by_raw_stat_name_when_stat_opts_out_of_site_properties_then_skips_them() {
+        // Given
+        guard let testingProvider else {
+            return XCTFail("Testing provider not available")
+        }
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                   defaultSite: Site.fake().copy(
+                                                                    siteID: sampleSiteID,
+                                                                    url: sampleSiteURL),
+                                                                   defaultStoreUUID: "sample_store_uuid"))
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+
+        // When
+        analytics.track(WooAnalyticsStat.wooPushTokenRegisterSuccess.rawValue, properties: Constants.testProperty1, error: nil)
+
+        // Then
+        guard let receivedProperties = testingProvider.receivedProperties.first else {
+            return XCTFail("No properties found")
+        }
+        XCTAssertNil(receivedProperties["store_id"])
+        XCTAssertNil(receivedProperties["blog_id"])
+    }
+
+    func test_track_by_unknown_event_name_then_skips_site_properties() {
+        // Given
+        guard let testingProvider else {
+            return XCTFail("Testing provider not available")
+        }
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                   defaultSite: Site.fake().copy(
+                                                                    siteID: sampleSiteID,
+                                                                    url: sampleSiteURL),
+                                                                   defaultStoreUUID: "sample_store_uuid"))
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+
+        // When
+        analytics.track("an_event_name_that_is_not_a_stat", properties: Constants.testProperty1, error: nil)
+
+        // Then
+        guard let receivedProperties = testingProvider.receivedProperties.first else {
+            return XCTFail("No properties found")
+        }
+        XCTAssertNil(receivedProperties["store_id"])
+    }
 }
 
 


### PR DESCRIPTION
WOOMOB-3873

## Description

Three POS Tracks defects, all analytics-only — no user-facing behaviour change.

**1. `waiting_time` leaked a Unix epoch.** `POSCollectOrderPaymentAnalyticsAdaptor.trackElapsedTimeFromOrderSyncToCardReady()` computed `cardReaderReady - orderSync` with no guard, and `orderSync` is zeroed at the start of every customer interaction. When the reader became ready before the order synced, the raw timestamp shipped as an elapsed duration — production max 1,786,307,015. Now guarded by `calculateElapsedTimeInSeconds(from:to:)`. The `milliseconds_since_*` half was fixed on trunk in `c06e2e68da`; this is the seconds path that fix missed.

**2. Site properties restored on the raw-name track path.** `WooAnalytics` has two `track` entry points and only the `WooAnalyticsStat` one appended site properties, which the Yosemite data layer cannot reach. That cost `card_reader_location_success`/`_failure` and every `pos_local_catalog_*` event their site enrichment. The raw-name path now resolves the name back to a `WooAnalyticsStat` before enriching. Enrichment is idempotent, the `wooPushToken*` opt-outs stay opted out, and non-`WooAnalyticsStat` names (EventHorizon) are untouched.

**3. `search_method` on the remote search event.** `search_remote_results_fetched` and `search_results_fetched` are not a rename pair, so a query spanning both showed a fabricated step change at the local catalog rollout. The local event already carried `search_method`; the remote one now does too, via a new `remote` case on `POSSearchMethod`. Purely additive.

## Test Steps

End-to-end on an iPad simulator against WireMock

- **(1)** `pos_reader_ready_for_card_payment` reported `waiting_time: 8.86` and `0.23` across two card payments — plausible durations, not an epoch.
- **(2)** `pos_local_catalog_sync_skipped`, tracked by raw name from Yosemite, carried `blog_id`, `site_url`, `is_wpcom_store` and the Jetpack properties.
- **(3)** `pos_search_remote_results_fetched` carried `search_method: remote` on every emission.

## Screenshots

N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
