### PR TITLE
[WOOMOB-3751] Recover from deterministic refund rejections instead of retrying

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -41,6 +41,7 @@ protocol POSOrderListControllerProtocol {
     func updateOrder(orderID: Int64) async throws
     func preloadRefundDetails() async
     func startRefundFlow() async -> StartRefundFlowResult
+    func refreshRefundableItems() async -> StartRefundFlowResult
     func toggleRefundItemSelection(at index: Int)
     func clearRefundSelection()
     func toggleAllRefundItemsSelection()
@@ -70,8 +71,8 @@ enum POSRefundReviewPreparationState: Equatable {
     case loading
     /// `message` carries the server's rejection copy when the preview failed with an actionable
     /// code (for example the order changed since the screen was loaded); `nil` shows the generic
-    /// preview error copy.
-    case previewError(message: String? = nil)
+    /// preview error copy. `recovery` is what the cashier is offered next to it.
+    case previewError(message: String? = nil, recovery: POSRefundRecovery = .retry)
 }
 
 /// Outcome of `prepareRefundReview()`, returned directly to the caller.
@@ -79,6 +80,9 @@ enum POSRefundReviewPreparationResult: Equatable {
     case ready(POSRefundReviewData)
     case previewError
     case preparationError
+    /// The store rejected the preview because the order has nothing refundable left, so the flow
+    /// ends on the terminal screen rather than back on the selection.
+    case nothingToRefund
     /// A newer preparation or a selection change invalidated this one; callers ignore it.
     case superseded
 }
@@ -456,6 +460,25 @@ enum POSRefundProcessingError: LocalizedError, Equatable {
         return refundSelectableItems.isEmpty ? .nothingToRefund : .hasItemsToRefund
     }
 
+    /// Reloads the refundable items after the store rejected a preview or a create because the
+    /// order changed since the flow was opened, for example when another register refunded part of
+    /// it. Items the store has since refunded are gone from the reloaded list, so the previous
+    /// selection is intersected with it; when nothing is left of it the default selection applies.
+    @MainActor
+    func refreshRefundableItems() async -> StartRefundFlowResult {
+        let previousSelection = Set(refundSelectableItems.filter { $0.isSelected }.map(\.id))
+        let result = await startRefundFlow()
+
+        guard case .hasItemsToRefund = result,
+              refundSelectableItems.contains(where: { previousSelection.contains($0.id) }) else {
+            return result
+        }
+
+        for index in refundSelectableItems.indices {
+            refundSelectableItems[index].isSelected = previousSelection.contains(refundSelectableItems[index].id)
+        }
+        return result
+    }
 
     @MainActor
     func toggleRefundItemSelection(at index: Int) {
@@ -522,8 +545,11 @@ enum POSRefundProcessingError: LocalizedError, Equatable {
             } catch POSRefundSubmissionError.refundPreviewFailed {
                 state = .previewError()
                 result = .previewError
+            } catch RefundAPIError.orderNotRefundable {
+                state = .idle
+                result = .nothingToRefund
             } catch let rejection as RefundAPIError {
-                state = .previewError(message: rejection.localizedDescription)
+                state = .previewError(message: rejection.localizedDescription, recovery: rejection.recovery)
                 result = .previewError
             } catch {
                 state = .idle

--- a/Modules/Sources/PointOfSale/Models/POSRefundRecovery.swift
+++ b/Modules/Sources/PointOfSale/Models/POSRefundRecovery.swift
@@ -1,0 +1,36 @@
+import enum Yosemite.RefundAPIError
+
+/// What the cashier can do about a failed refund.
+///
+/// The refund endpoints reject with deterministic validation errors, so repeating the same request
+/// against the same order data fails identically. `refreshItems` reloads the order and its refunds
+/// so the next selection is made against the true remaining quantities, and `dismiss` leaves only
+/// the way out of the flow. `retry` is for failures that can pass on a second attempt, a network
+/// error for example.
+enum POSRefundRecovery: Equatable {
+    case retry
+    case refreshItems
+    case dismiss
+}
+
+extension RefundAPIError {
+    /// None of the mapped rejections are retryable: the store answers an identical request the
+    /// same way every time, so the way out is a fresh item list or leaving the flow.
+    var recovery: POSRefundRecovery {
+        switch self {
+        case .quantityExceedsRefundable,
+             .lineItemAlreadyRefunded,
+             .refundExceedsRemaining,
+             .refundTotalExceedsLine:
+            return .refreshItems
+        case .orderNotRefundable:
+            // Nothing on the order can be refunded any more, so there is no selection to recover
+            // to. The preview and create paths route this to the terminal screen before the
+            // recovery is read.
+            return .dismiss
+        case .invalidRefundAmount:
+            // The amount we sent is malformed rather than too large, which a fresh list won't fix.
+            return .dismiss
+        }
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -140,7 +140,8 @@ struct POSOrderDetailsView: View {
                         onRetryPreparation: {
                             self.refundSelectionState = .itemSelection
                         },
-                        onContinue: { navigateToRefundReview() }
+                        onContinue: { navigateToRefundReview() },
+                        onRefreshItems: { refreshRefundSelection() }
                     )
                 }
             }
@@ -153,6 +154,12 @@ struct POSOrderDetailsView: View {
                     order: order,
                     onDismiss: { dismissRefundFlow() },
                     onReturnToSelection: { returnToRefundSelection() },
+                    onRefreshSelection: { refreshRefundSelection() },
+                    onNothingToRefund: {
+                        refundModalState = nil
+                        refundSelectionState = .nothingToRefund
+                        presentRefundSelection()
+                    },
                     initialRefundReason: currentRefundReason,
                     onRefundReasonChanged: { currentRefundReason = $0 },
                     onRefundSuccess: onRefundSuccess,
@@ -633,6 +640,9 @@ private extension POSOrderDetailsView {
                 refundModalState = .review(reviewData)
             case .preparationError:
                 refundSelectionState = .preparationError
+            case .nothingToRefund:
+                refundModalState = nil
+                refundSelectionState = .nothingToRefund
             case .previewError, .superseded:
                 break
             }
@@ -642,6 +652,35 @@ private extension POSOrderDetailsView {
     func returnToRefundSelection() {
         refundSelectionState = .itemSelection
         refundModalState = nil
+    }
+
+    /// Reloads the refundable items after the store rejected the preview or the create because the
+    /// order changed since the flow was opened, then returns to the selection with the remaining
+    /// quantities. The flow is already running, so unlike `initiateRefundFlow()` this does not
+    /// report a refund flow start.
+    func refreshRefundSelection() {
+        let preparationID = UUID()
+        refundFlowPreparationID = preparationID
+        refundModalState = nil
+        refundSelectionState = .loading
+        presentRefundSelection()
+        Task { @MainActor in
+            let result = await orderListModel.ordersController.refreshRefundableItems()
+            guard refundFlowPreparationID == preparationID else {
+                return
+            }
+            refundFlowPreparationID = nil
+            switch result {
+            case .hasItemsToRefund:
+                refundSelectionState = .itemSelection
+            case .nothingToRefund:
+                refundSelectionState = .nothingToRefund
+            case .ineligible(let eligibilityFailure):
+                refundSelectionState = .ineligible(eligibilityFailure)
+            case .failed:
+                refundSelectionState = .loadingError
+            }
+        }
     }
 
     func dismissRefundFlow() {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -4,6 +4,9 @@ struct POSRefundErrorView: View {
     let title: String
     let subtitle: String
     let onRetry: (() -> Void)?
+    /// Label for the primary action. Defaults to "Retry"; a recovery that is not a retry, such as
+    /// reloading the refundable items, passes its own.
+    let retryButtonTitle: String?
     let cancelButtonTitle: String?
     let onCancel: () -> Void
     let onClose: () -> Void
@@ -14,12 +17,14 @@ struct POSRefundErrorView: View {
     init(title: String,
          subtitle: String,
          onRetry: (() -> Void)?,
+         retryButtonTitle: String? = nil,
          cancelButtonTitle: String? = nil,
          onCancel: @escaping () -> Void,
          onClose: @escaping () -> Void) {
         self.title = title
         self.subtitle = subtitle
         self.onRetry = onRetry
+        self.retryButtonTitle = retryButtonTitle
         self.cancelButtonTitle = cancelButtonTitle
         self.onCancel = onCancel
         self.onClose = onClose
@@ -73,7 +78,7 @@ private extension POSRefundErrorView {
     var buttonsSection: some View {
         VStack(spacing: POSSpacing.medium) {
             if let onRetry {
-                Button(Localization.retryButton, action: onRetry)
+                Button(retryButtonTitle ?? Localization.retryButton, action: onRetry)
                     .buttonStyle(POSFilledButtonStyle(size: .normal))
             }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -4,6 +4,7 @@ import struct WooFoundation.WooAnalyticsEvent
 struct POSRefundItemsSelectionView: View {
     let onClose: () -> Void
     let onContinue: () -> Void
+    let onRefreshItems: () -> Void
 
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(\.posModalParentSize) private var parentSize
@@ -21,10 +22,20 @@ struct POSRefundItemsSelectionView: View {
     /// The inline error shown above the continue button: the server's rejection copy when the
     /// preview failed with an actionable code, or the generic copy for other preview failures.
     private var previewErrorMessage: String? {
-        guard case .previewError(let message) = reviewPreparationState else {
+        guard case .previewError(let message, _) = reviewPreparationState else {
             return nil
         }
         return message ?? Localization.previewError
+    }
+
+    /// What the failed preview offers the cashier next. A recognised rejection is deterministic,
+    /// so the same request cannot succeed: the way forward is a reloaded item list, or changing
+    /// the selection. Only unrecognised failures, network errors among them, keep the retry.
+    private var previewRecovery: POSRefundRecovery? {
+        guard case .previewError(_, let recovery) = reviewPreparationState else {
+            return nil
+        }
+        return recovery
     }
 
     private var selectedItems: [POSRefundSelectableItem] {
@@ -135,7 +146,9 @@ private extension POSRefundItemsSelectionView {
                     .multilineTextAlignment(.center)
             }
 
-            Button(continueButtonTitle) {
+            recoveryButton
+
+            Button(Localization.continueButton) {
                 onContinue()
             }
             .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: reviewPreparationState == .loading))
@@ -143,18 +156,34 @@ private extension POSRefundItemsSelectionView {
         }
     }
 
-    var continueButtonTitle: String {
-        previewErrorMessage != nil ? Localization.retryButton : Localization.continueButton
+    @ViewBuilder
+    var recoveryButton: some View {
+        switch previewRecovery {
+        case .retry:
+            Button(Localization.retryButton) {
+                onContinue()
+            }
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        case .refreshItems:
+            Button(Localization.reviewRemainingItemsButton) {
+                onRefreshItems()
+            }
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        case .dismiss, nil:
+            EmptyView()
+        }
     }
 
+    /// A failed preview always disables Continue: the same selection produces the same answer, so
+    /// the cashier moves on by changing the selection or through the recovery button above it.
     var isContinueDisabled: Bool {
         guard hasSelectedItems else {
             return true
         }
         switch reviewPreparationState {
-        case .loading:
+        case .loading, .previewError:
             return true
-        case .idle, .previewError:
+        case .idle:
             return false
         }
     }
@@ -184,6 +213,11 @@ private extension POSRefundItemsSelectionView {
             "pos.refundItemsSelectionView.retryButton",
             value: "Retry",
             comment: "Button to retry fetching the server-calculated refund total on the refund item-selection step"
+        )
+        static let reviewRemainingItemsButton = NSLocalizedString(
+            "pos.refundItemsSelectionView.reviewRemainingItemsButton",
+            value: "Review remaining items",
+            comment: "Button to reload the refundable items after the store rejected the refund because the order changed"
         )
 
         static let backButtonAccessibilityLabel = NSLocalizedString(
@@ -216,7 +250,8 @@ private extension POSRefundItemsSelectionView {
 #Preview("POSRefundItemsSelectionView") {
     POSRefundItemsSelectionView(
         onClose: { },
-        onContinue: { }
+        onContinue: { },
+        onRefreshItems: { }
     )
     .environment(POSPreviewHelpers.makePreviewOrdersModel(state: POSPreviewHelpers.loadedState()))
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -85,6 +85,10 @@ struct POSRefundModalContentView: View {
     let order: POSOrder
     let onDismiss: () -> Void
     let onReturnToSelection: () -> Void
+    /// Reloads the refundable items and returns to the selection, for rejections a fresh list fixes.
+    let onRefreshSelection: () -> Void
+    /// Ends the flow on the terminal screen when the store reports the order as not refundable.
+    let onNothingToRefund: () -> Void
     let initialRefundReason: String?
     let onRefundReasonChanged: ((String?) -> Void)?
     let onRefundSuccess: (() -> Void)?
@@ -99,10 +103,10 @@ struct POSRefundModalContentView: View {
     @State private var currentRefundReason: String?
     @State private var reasonInputReviewData: POSRefundReviewData?
     @State private var isDismissingAfterAmbiguousRefund = false
-    /// The server's rejection copy when the refund create failed with an actionable code (for
-    /// example the order changed since the screen was loaded); shown instead of the generic
-    /// create-error subtitle.
-    @State private var refundRejectionMessage: String?
+    /// The store's rejection when the refund create failed with an actionable code (for example the
+    /// order changed since the screen was loaded). It carries the copy shown instead of the generic
+    /// create-error subtitle, and what the cashier is offered next.
+    @State private var refundRejection: RefundAPIError?
 
     var body: some View {
         ZStack {
@@ -234,11 +238,27 @@ struct POSRefundModalContentView: View {
                     dismissRefundFlow()
                 }
             }
+            // A recognised rejection is a deterministic validation error, so resubmitting the same
+            // request cannot succeed. Those get the item reload, or no action at all, in place of
+            // the retry; unrecognised failures keep it.
+            let recovery: POSRefundRecovery = isCardPresentRefundError ? .dismiss : (refundRejection?.recovery ?? .retry)
             POSRefundErrorView(
                 title: isCardPresentRefundError ? Localization.cardPresentCreateErrorTitle : errorStrings.createTitle,
-                subtitle: isCardPresentRefundError ? Localization.cardPresentCreateErrorSubtitle : (refundRejectionMessage ?? errorStrings.createSubtitle),
-                onRetry: isCardPresentRefundError ? nil : { modalState = .confirmation(reviewData) },
-                cancelButtonTitle: isCardPresentRefundError ? Localization.backToOrderButton : nil,
+                subtitle: isCardPresentRefundError ?
+                    Localization.cardPresentCreateErrorSubtitle :
+                    (refundRejection?.localizedDescription ?? errorStrings.createSubtitle),
+                onRetry: {
+                    switch recovery {
+                    case .retry:
+                        return { modalState = .confirmation(reviewData) }
+                    case .refreshItems:
+                        return { onRefreshSelection() }
+                    case .dismiss:
+                        return nil
+                    }
+                }(),
+                retryButtonTitle: recovery == .refreshItems ? Localization.reviewRemainingItemsButton : nil,
+                cancelButtonTitle: recovery == .retry ? nil : Localization.backToOrderButton,
                 onCancel: dismissError,
                 onClose: dismissError
             )
@@ -376,7 +396,15 @@ struct POSRefundModalContentView: View {
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingFailed(error: error))
             onRefundFailure?(error)
             refundSubmissionModel.reset()
-            refundRejectionMessage = (error as? RefundAPIError)?.localizedDescription
+            let rejection = error as? RefundAPIError
+            guard rejection != .orderNotRefundable else {
+                // Nothing on the order can be refunded any more, so there is no selection to go
+                // back to: end the flow on the terminal screen instead of an error with no way on.
+                refundRejection = nil
+                onNothingToRefund()
+                return
+            }
+            refundRejection = rejection
             modalState = .error(reviewData)
         }
     }
@@ -397,7 +425,7 @@ struct POSRefundModalContentView: View {
 
     @MainActor
     private func startProcessingRefund(reviewData: POSRefundReviewData) {
-        refundRejectionMessage = nil
+        refundRejection = nil
         modalState = .processing(reviewData)
         Task { @MainActor in
             await processRefund(reviewData: reviewData)
@@ -465,6 +493,12 @@ struct POSRefundModalContentView: View {
 
 private extension POSRefundModalContentView {
     enum Localization {
+        static let reviewRemainingItemsButton = NSLocalizedString(
+            "pos.refundModalContentView.reviewRemainingItemsButton",
+            value: "Review remaining items",
+            comment: "Button to reload the refundable items after the store rejected the refund because the order changed"
+        )
+
         static let cardPresentCreateErrorTitle = NSLocalizedString(
             "pos.refundModalContentView.cardPresentCreateError.title",
             value: "Couldn't confirm refund",

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -230,38 +230,66 @@ struct POSRefundModalContentView: View {
                 onEmailReceipt: { isShowingEmailReceiptView = true }
             )
         case .error(let reviewData):
-            let isCardPresentRefundError = orderListModel.ordersController.currentRefundRequiresCardPresentRefund
-            let dismissError = {
-                if isCardPresentRefundError {
-                    dismissRefundFlowAndRefreshOrder()
-                } else {
-                    dismissRefundFlow()
-                }
-            }
-            // A recognised rejection is a deterministic validation error, so resubmitting the same
-            // request cannot succeed. Those get the item reload, or no action at all, in place of
-            // the retry; unrecognised failures keep it.
-            let recovery: POSRefundRecovery = isCardPresentRefundError ? .dismiss : (refundRejection?.recovery ?? .retry)
-            POSRefundErrorView(
-                title: isCardPresentRefundError ? Localization.cardPresentCreateErrorTitle : errorStrings.createTitle,
-                subtitle: isCardPresentRefundError ?
-                    Localization.cardPresentCreateErrorSubtitle :
-                    (refundRejection?.localizedDescription ?? errorStrings.createSubtitle),
-                onRetry: {
-                    switch recovery {
-                    case .retry:
-                        return { modalState = .confirmation(reviewData) }
-                    case .refreshItems:
-                        return { onRefreshSelection() }
-                    case .dismiss:
-                        return nil
-                    }
-                }(),
-                retryButtonTitle: recovery == .refreshItems ? Localization.reviewRemainingItemsButton : nil,
-                cancelButtonTitle: recovery == .retry ? nil : Localization.backToOrderButton,
-                onCancel: dismissError,
-                onClose: dismissError
-            )
+            errorView(reviewData: reviewData)
+        }
+    }
+
+    // MARK: - Refund Error
+
+    private func errorView(reviewData: POSRefundReviewData) -> some View {
+        POSRefundErrorView(
+            title: errorTitle,
+            subtitle: errorSubtitle,
+            onRetry: errorRecoveryAction(reviewData: reviewData),
+            retryButtonTitle: errorRecovery == .refreshItems ? Localization.reviewRemainingItemsButton : nil,
+            cancelButtonTitle: errorRecovery == .retry ? nil : Localization.backToOrderButton,
+            onCancel: dismissAfterError,
+            onClose: dismissAfterError
+        )
+    }
+
+    /// `true` when the card-present refund itself failed, rather than the store rejecting the request.
+    private var isCardPresentRefundError: Bool {
+        orderListModel.ordersController.currentRefundRequiresCardPresentRefund
+    }
+
+    /// A recognised rejection is a deterministic validation error, so resubmitting the same request
+    /// cannot succeed. Those get the item reload, or no action at all, in place of the retry;
+    /// unrecognised failures keep it.
+    private var errorRecovery: POSRefundRecovery {
+        guard !isCardPresentRefundError else {
+            return .dismiss
+        }
+        return refundRejection?.recovery ?? .retry
+    }
+
+    private var errorTitle: String {
+        isCardPresentRefundError ? Localization.cardPresentCreateErrorTitle : errorStrings.createTitle
+    }
+
+    private var errorSubtitle: String {
+        guard !isCardPresentRefundError else {
+            return Localization.cardPresentCreateErrorSubtitle
+        }
+        return refundRejection?.localizedDescription ?? errorStrings.createSubtitle
+    }
+
+    private func errorRecoveryAction(reviewData: POSRefundReviewData) -> (() -> Void)? {
+        switch errorRecovery {
+        case .retry:
+            return { modalState = .confirmation(reviewData) }
+        case .refreshItems:
+            return onRefreshSelection
+        case .dismiss:
+            return nil
+        }
+    }
+
+    private func dismissAfterError() {
+        if isCardPresentRefundError {
+            dismissRefundFlowAndRefreshOrder()
+        } else {
+            dismissRefundFlow()
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
@@ -38,6 +38,7 @@ struct POSRefundSelectionFlowView: View {
     let onRetryLoading: () -> Void
     let onRetryPreparation: () -> Void
     let onContinue: () -> Void
+    let onRefreshItems: () -> Void
 
     var body: some View {
         content
@@ -84,7 +85,8 @@ struct POSRefundSelectionFlowView: View {
         case .itemSelection:
             POSRefundItemsSelectionView(
                 onClose: onDismiss,
-                onContinue: onContinue
+                onContinue: onContinue,
+                onRefreshItems: onRefreshItems
             )
         }
     }
@@ -98,7 +100,8 @@ struct POSRefundSelectionFlowView: View {
         onDismiss: {},
         onRetryLoading: {},
         onRetryPreparation: {},
-        onContinue: {}
+        onContinue: {},
+        onRefreshItems: {}
     )
 }
 
@@ -109,7 +112,8 @@ struct POSRefundSelectionFlowView: View {
         onDismiss: {},
         onRetryLoading: {},
         onRetryPreparation: {},
-        onContinue: {}
+        onContinue: {},
+        onRefreshItems: {}
     )
     .environment(POSPreviewHelpers.makePreviewOrdersModel(state: POSPreviewHelpers.loadedState()))
 }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -549,6 +549,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     func searchOrders(searchTerm: String) async {}
     func clearSearchOrders() {}
     func startRefundFlow() async -> StartRefundFlowResult { .hasItemsToRefund }
+    func refreshRefundableItems() async -> StartRefundFlowResult { .hasItemsToRefund }
     func toggleRefundItemSelection(at index: Int) {}
     func clearRefundSelection() {}
     func toggleAllRefundItemsSelection() {}

--- a/Modules/Sources/Yosemite/Tools/Refunds/RefundAPIError.swift
+++ b/Modules/Sources/Yosemite/Tools/Refunds/RefundAPIError.swift
@@ -87,9 +87,9 @@ extension RefundAPIError: LocalizedError {
             comment: "Error shown when a refund is rejected because the selected quantity exceeds what is still refundable for an item."
         )
         static let lineItemAlreadyRefunded = NSLocalizedString(
-            "refundAPIError.lineItemAlreadyRefunded",
+            "refundAPIError.selectedItemAlreadyRefunded",
             value: "One of the selected items has already been fully refunded.",
-            comment: "Error shown when a refund is rejected because the selected item is already fully refunded."
+            comment: "Error shown when a refund is rejected because one of the selected items is already fully refunded."
         )
         static let orderNotRefundable = NSLocalizedString(
             "refundAPIError.orderNotRefundable",

--- a/Modules/Sources/Yosemite/Tools/Refunds/RefundAPIError.swift
+++ b/Modules/Sources/Yosemite/Tools/Refunds/RefundAPIError.swift
@@ -88,7 +88,7 @@ extension RefundAPIError: LocalizedError {
         )
         static let lineItemAlreadyRefunded = NSLocalizedString(
             "refundAPIError.lineItemAlreadyRefunded",
-            value: "This item has already been fully refunded.",
+            value: "One of the selected items has already been fully refunded.",
             comment: "Error shown when a refund is rejected because the selected item is already fully refunded."
         )
         static let orderNotRefundable = NSLocalizedString(

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1168,14 +1168,68 @@ final class POSOrderListControllerTests {
         let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
         sut.selectOrder(order)
         _ = await sut.startRefundFlow()
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.quantityExceedsRefundable
+
+        // When
+        let result = await awaitReviewPreparation(sut)
+
+        // Then the inline-error state carries the rejection's cashier-facing copy, and offers the
+        // item reload rather than a retry that would be rejected the same way
+        #expect(result == .previewError)
+        #expect(sut.refundReviewPreparationState == .previewError(
+            message: RefundAPIError.quantityExceedsRefundable.localizedDescription,
+            recovery: .refreshItems
+        ))
+    }
+
+    @MainActor
+    @Test func prepareRefundReview_when_order_is_not_refundable_then_flow_ends_on_the_terminal_state() async throws {
+        // Given the store reports the order as having nothing refundable left
+        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
         refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.orderNotRefundable
 
         // When
         let result = await awaitReviewPreparation(sut)
 
-        // Then the inline-error state carries the rejection's cashier-facing copy
-        #expect(result == .previewError)
-        #expect(sut.refundReviewPreparationState == .previewError(message: RefundAPIError.orderNotRefundable.localizedDescription))
+        // Then there is no selection to recover to, so the caller is told to end the flow
+        #expect(result == .nothingToRefund)
+        #expect(sut.refundReviewPreparationState == .idle)
+    }
+
+    @MainActor
+    @Test func refreshRefundableItems_then_keeps_the_selection_that_is_still_refundable() async throws {
+        // Given two refundable units, with only the first one selected
+        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")])
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        sut.toggleRefundItemSelection(at: 1)
+        let selectedIDs = Set(sut.refundSelectableItems.filter { $0.isSelected }.map(\.id))
+
+        // When
+        let result = await sut.refreshRefundableItems()
+
+        // Then
+        #expect(result == .hasItemsToRefund)
+        #expect(Set(sut.refundSelectableItems.filter { $0.isSelected }.map(\.id)) == selectedIDs)
+    }
+
+    @MainActor
+    @Test func refreshRefundableItems_when_a_preview_error_is_shown_then_it_is_cleared() async throws {
+        // Given a rejected preview
+        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.lineItemAlreadyRefunded
+        _ = await awaitReviewPreparation(sut)
+
+        // When the cashier reloads the refundable items
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = nil
+        _ = await sut.refreshRefundableItems()
+
+        // Then the selection step is back to a clean state
+        #expect(sut.refundReviewPreparationState == .idle)
     }
 
     @MainActor

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -70,6 +70,24 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
         return stubStartRefundFlowResult
     }
 
+    private(set) var refreshRefundableItemsCallCount = 0
+    var stubRefreshedRefundSelectableItems: [POSRefundSelectableItem]?
+
+    func refreshRefundableItems() async -> StartRefundFlowResult {
+        refreshRefundableItemsCallCount += 1
+        let previousSelection = Set(refundSelectableItems.filter { $0.isSelected }.map(\.id))
+        if let stubRefreshedRefundSelectableItems {
+            refundSelectableItems = stubRefreshedRefundSelectableItems
+        }
+        if refundSelectableItems.contains(where: { previousSelection.contains($0.id) }) {
+            for index in refundSelectableItems.indices {
+                refundSelectableItems[index].isSelected = previousSelection.contains(refundSelectableItems[index].id)
+            }
+        }
+        hasModifiedRefundSelection = false
+        return stubStartRefundFlowResult
+    }
+
     func toggleRefundItemSelection(at index: Int) {
         guard refundSelectableItems.indices.contains(index) else { return }
         refundSelectableItems[index].isSelected.toggle()

--- a/Modules/Tests/PointOfSaleTests/Models/POSRefundRecoveryTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSRefundRecoveryTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import enum Yosemite.RefundAPIError
+@testable import PointOfSale
+
+struct POSRefundRecoveryTests {
+    @Test func refund_rejections_a_reload_can_fix_offer_the_item_refresh() {
+        let expected: [(RefundAPIError, POSRefundRecovery)] = [
+            (.quantityExceedsRefundable, .refreshItems),
+            (.lineItemAlreadyRefunded, .refreshItems),
+            (.refundExceedsRemaining, .refreshItems),
+            (.refundTotalExceedsLine, .refreshItems),
+            (.orderNotRefundable, .dismiss),
+            (.invalidRefundAmount, .dismiss)
+        ]
+
+        for (rejection, recovery) in expected {
+            #expect(rejection.recovery == recovery, "recovery for \(rejection)")
+        }
+    }
+
+    @Test func no_refund_rejection_offers_a_retry() {
+        // Every mapped code is a deterministic validation rejection: the same request always gets
+        // the same answer, so a retry cannot be the way out.
+        let rejections: [RefundAPIError] = [
+            .quantityExceedsRefundable,
+            .lineItemAlreadyRefunded,
+            .orderNotRefundable,
+            .refundExceedsRemaining,
+            .refundTotalExceedsLine,
+            .invalidRefundAmount
+        ]
+
+        #expect(rejections.allSatisfy { $0.recovery != .retry })
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.5
 -----
 - [*] Analytics Hub: Fixed quarter date ranges displaying incorrect dates for some store timezones. [https://github.com/woocommerce/woocommerce-ios/pull/17713]
+- [*] POS: When the store rejects a refund because the order changed, for example another register refunded part of it, the refund screen now offers to reload the remaining items instead of a retry that cannot succeed.
 - [Internal] POS: every POS analytics event now carries device_type (phone/tablet) and entry_point (pos_tab or auto_reopen), so POS usage can be split by form factor and merchant-opened sessions separated from POS-lock cold-launch restores. [https://github.com/woocommerce/woocommerce-ios/pull/17705]
 - [*] Settings: All retained application logs can now be shared together as a ZIP file. [https://github.com/woocommerce/woocommerce-ios/pull/17714]
 - [*] Fixed a crash that could occur while checking iOS age-range compliance. [https://github.com/woocommerce/woocommerce-ios/pull/17661]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 25.5
 -----
 - [*] Analytics Hub: Fixed quarter date ranges displaying incorrect dates for some store timezones. [https://github.com/woocommerce/woocommerce-ios/pull/17713]
-- [*] POS: When the store rejects a refund because the order changed, for example another register refunded part of it, the refund screen now offers to reload the remaining items instead of a retry that cannot succeed.
+- [*] POS: When the store rejects a refund because the order changed, for example another register refunded part of it, the refund screen now offers to reload the remaining items instead of a retry that cannot succeed. [https://github.com/woocommerce/woocommerce-ios/pull/17732]
 - [Internal] POS: every POS analytics event now carries device_type (phone/tablet) and entry_point (pos_tab or auto_reopen), so POS usage can be split by form factor and merchant-opened sessions separated from POS-lock cold-launch restores. [https://github.com/woocommerce/woocommerce-ios/pull/17705]
 - [*] Settings: All retained application logs can now be shared together as a ZIP file. [https://github.com/woocommerce/woocommerce-ios/pull/17714]
 - [*] Fixed a crash that could occur while checking iOS age-range compliance. [https://github.com/woocommerce/woocommerce-ios/pull/17661]


### PR DESCRIPTION
## Description

Fixes WOOMOB-3751

The mapped refund errors always fail the same way, so the Retry we show cannot work. Each error now offers what can help:

- `order_not_refundable`: the "nothing to refund" screen.
- quantity / amount / already refunded: "Review remaining items", which reloads the order and keeps the selection that is still refundable.
- `invalid_refund_amount`: no action.
- unmapped errors, network failures among them: Retry, as before.

Continue is now disabled whenever the preview failed, and the recovery sits in its own button below the error text instead of relabelling Continue. The reload does not re-report `refundFlowStarted`: it continues the flow the cashier already started.

Copy fix: the already-refunded message no longer claims to name one item. It renders once for the whole selection, so it never could.

Android: woocommerce-android#16440

## Test Steps

Needs a second client (web admin) to change the order while the flow is open.

1. Use a store that supports server-calculated refunds - this requires WooCommerce 11.1.0 or newer - e.g. you can use nightly build .zip \*
2. In POS, start a refund on a paid order with an item of quantity 2 or more.
3. In the web admin, refund one unit of that item.
4. In POS, tap Continue: the store's reason shows, Continue is disabled, "Review remaining items" appears.
5. Tap it: the list reloads with the units still refundable and keeps your selection.
6. Refund the whole order in the web admin and repeat steps 2-4: the flow ends on the "nothing to refund" screen.
7. Turn off the network mid-preview: the error is generic and still offers Retry.
8. To hit the create path instead of the preview, let the web-admin refund land after you tap Continue but before you confirm: the error screen shows the store's reason with "Review remaining items" as the primary action and "Back to order" below it.

\* You can also use the test store cool-shop.mystagingwebsite.com which contains 

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
