### PR TITLE
[WOOMOB-3809] Show HTTPS warning across store tabs

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -14,6 +14,8 @@ struct ItemListView: View {
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
+    @State private var showsHTTPSConfigurationNotice: Bool
+    private let httpsConfigurationNotice: POSHTTPSConfigurationNotice?
     /// Optional builder rendered in the trailing slot of the items list header when not searching.
     /// The dashboard uses this to fold the "create coupon" entry into its overflow menu when the
     /// merchant is on the Coupons tab, without leaking ItemListView's internal state.
@@ -21,9 +23,12 @@ struct ItemListView: View {
 
     init(selectedItemListType: Binding<ItemListType>,
          searchTerm: Binding<String>,
+         httpsConfigurationNotice: POSHTTPSConfigurationNotice? = nil,
          phoneHeaderAccessoryBuilder: ((PhoneHeaderAccessoryContext) -> AnyView)? = nil) {
         self._selectedItemListType = selectedItemListType
         self._searchTerm = searchTerm
+        self.httpsConfigurationNotice = httpsConfigurationNotice
+        self._showsHTTPSConfigurationNotice = State(initialValue: httpsConfigurationNotice != nil)
         self.phoneHeaderAccessoryBuilder = phoneHeaderAccessoryBuilder
     }
 
@@ -238,6 +243,15 @@ struct ItemListView: View {
     @ViewBuilder
     private func listView(itemListType: ItemListType) -> some View {
         VStack(spacing: 0) {
+            if itemListType.itemType == .product,
+               let httpsConfigurationNotice,
+               showsHTTPSConfigurationNotice {
+                httpsConfigurationWarningBanner(httpsConfigurationNotice)
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.vertical, POSPadding.medium)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             if posModel.showSunsetWarning {
                 sunsetWarningBanner
                     .padding(.horizontal, POSPadding.medium)
@@ -290,6 +304,30 @@ struct ItemListView: View {
         .task {
             await posModel.checkStaleSyncStatus()
             await posModel.checkSunsetWarningStatus()
+        }
+    }
+
+    @ViewBuilder
+    private func httpsConfigurationWarningBanner(_ notice: POSHTTPSConfigurationNotice) -> some View {
+        POSNoticeView(
+            title: notice.title,
+            icon: Image(systemName: "info.circle"),
+            style: .alertLowest,
+            onDismiss: {
+                notice.onDismiss()
+                withAnimation {
+                    showsHTTPSConfigurationNotice = false
+                }
+            },
+            onTap: notice.onAction
+        ) {
+            VStack(alignment: .leading, spacing: POSSpacing.small) {
+                Text(notice.message)
+                    .font(.posBodyMediumRegular())
+                Text(notice.actionTitle)
+                    .font(.posBodySmallBold())
+                    .foregroundColor(Color.posOnAlertLowest)
+            }
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSHTTPSConfigurationNotice.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSHTTPSConfigurationNotice.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Content and actions for the HTTPS configuration warning supplied by the host app.
+public struct POSHTTPSConfigurationNotice {
+    let title: String
+    let message: String
+    let actionTitle: String
+    let onAction: () -> Void
+    let onDismiss: () -> Void
+
+    public init(title: String,
+                message: String,
+                actionTitle: String,
+                onAction: @escaping () -> Void,
+                onDismiss: @escaping () -> Void) {
+        self.title = title
+        self.message = message
+        self.actionTitle = actionTitle
+        self.onAction = onAction
+        self.onDismiss = onDismiss
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -75,67 +75,64 @@ struct PointOfSaleDashboardView: View {
 
     var body: some View {
         @Bindable var posModel = posModel
-        ZStack {
-            Group {
-                switch viewState {
-                case .loading(let catalogSyncState):
-                    PointOfSaleLoadingView(
-                        catalogSyncState: catalogSyncState,
-                        onExit: { dismiss() }
-                    )
-                        .transition(.opacity)
-                        .ignoresSafeArea()
-                case .ineligible(let reason):
-                    POSIneligibleView(reason: reason, onRefresh: {
-                        try await posModel.entryPointController.refreshEligibility(reason: reason)
-                    })
-                    .frame(maxWidth: .infinity)
-                case .error(let error):
-                    PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
-                        if error.errorType == .initialCatalogSyncError {
-                            analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
-                        }
+        Group {
+            switch viewState {
+            case .loading(let catalogSyncState):
+                PointOfSaleLoadingView(
+                    catalogSyncState: catalogSyncState,
+                    onExit: { dismiss() }
+                )
+                    .transition(.opacity)
+                    .ignoresSafeArea()
+            case .ineligible(let reason):
+                POSIneligibleView(reason: reason, onRefresh: {
+                    try await posModel.entryPointController.refreshEligibility(reason: reason)
+                })
+                .frame(maxWidth: .infinity)
+            case .error(let error):
+                PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
+                    if error.errorType == .initialCatalogSyncError {
+                        analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
+                    }
 
-                        Task {
-                            switch viewStateCoordinator.selectedItemListType {
-                            case .products(search: false):
-                                await posModel.purchasableItemsController.loadItems(base: .root)
-                            case .products(search: true):
-                                await posModel.purchasableItemsSearchController.loadItems(base: .root)
-                            case .coupons(search: false):
-                                await posModel.couponsSearchController.loadItems(base: .root)
-                            case .coupons(search: true):
-                                await posModel.couponsSearchController.loadItems(base: .root)
-                            }
+                    Task {
+                        switch viewStateCoordinator.selectedItemListType {
+                        case .products(search: false):
+                            await posModel.purchasableItemsController.loadItems(base: .root)
+                        case .products(search: true):
+                            await posModel.purchasableItemsSearchController.loadItems(base: .root)
+                        case .coupons(search: false):
+                            await posModel.couponsSearchController.loadItems(base: .root)
+                        case .coupons(search: true):
+                            await posModel.couponsSearchController.loadItems(base: .root)
                         }
-                    }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
-                        dismiss()
-                    } : nil)
-                case .content:
-                    contentView
-                        .accessibilitySortPriority(2)
-                }
+                    }
+                }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
+                    dismiss()
+                } : nil)
+            case .content:
+                contentView
+                    .accessibilitySortPriority(2)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            // Anchor the controls to stable dashboard bounds. The product-list banner can briefly
-            // report its own ideal height while POS is being presented, which must not drive this position.
-            .overlay(alignment: .bottomLeading) {
-                POSFloatingControlView(onExitSelected: requestExitPermission,
-                                       showSupport: $showSupport,
-                                       showDocumentation: $showDocumentation,
-                                       onSettingsSelected: requestSettingsPermission,
-                                       onOrdersSelected: presentOrders)
-                .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
-                .padding(.bottom, Constants.floatingControlBottomPadding)
-                .trackSize(size: $floatingSize)
-                .accessibilitySortPriority(1)
-                .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
-            }
-
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Anchor the controls to stable dashboard bounds. The product-list banner can briefly
+        // report its own ideal height while POS is being presented, which must not drive this position.
+        .overlay(alignment: .bottomLeading) {
+            POSFloatingControlView(onExitSelected: requestExitPermission,
+                                   showSupport: $showSupport,
+                                   showDocumentation: $showDocumentation,
+                                   onSettingsSelected: requestSettingsPermission,
+                                   onOrdersSelected: presentOrders)
+            .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
+            .padding(.bottom, Constants.floatingControlBottomPadding)
+            .trackSize(size: $floatingSize)
+            .accessibilitySortPriority(1)
+            .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
+        }
+        .overlay {
             POSConnectivityView()
         }
-        // Dashboard-owned modals also need the complete presentation bounds for centring.
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .environment(\.floatingControlAreaSize,
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -25,6 +25,11 @@ struct PointOfSaleDashboardView: View {
     @State private var floatingControlSuppressed: Bool = false
     @State private var phoneShowingCart: Bool = false
     @State private var phoneCartPresentationDetent: PresentationDetent = .medium
+    private let httpsConfigurationNotice: POSHTTPSConfigurationNotice?
+
+    init(httpsConfigurationNotice: POSHTTPSConfigurationNotice? = nil) {
+        self.httpsConfigurationNotice = httpsConfigurationNotice
+    }
 
     /// Tracks Dynamic Type scaling for the phone overflow menu chip so it grows in sync with
     /// the adjacent `POSPageHeaderActionButton` (search) at large content sizes. Same 1.0…1.2x
@@ -70,59 +75,67 @@ struct PointOfSaleDashboardView: View {
 
     var body: some View {
         @Bindable var posModel = posModel
-        ZStack(alignment: .bottomLeading) {
-            switch viewState {
-            case .loading(let catalogSyncState):
-                PointOfSaleLoadingView(
-                    catalogSyncState: catalogSyncState,
-                    onExit: { dismiss() }
-                )
-                    .transition(.opacity)
-                    .ignoresSafeArea()
-            case .ineligible(let reason):
-                POSIneligibleView(reason: reason, onRefresh: {
-                    try await posModel.entryPointController.refreshEligibility(reason: reason)
-                })
-                .frame(maxWidth: .infinity)
-            case .error(let error):
-                PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
-                    if error.errorType == .initialCatalogSyncError {
-                        analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
-                    }
-
-                    Task {
-                        switch viewStateCoordinator.selectedItemListType {
-                        case .products(search: false):
-                            await posModel.purchasableItemsController.loadItems(base: .root)
-                        case .products(search: true):
-                            await posModel.purchasableItemsSearchController.loadItems(base: .root)
-                        case .coupons(search: false):
-                            await posModel.couponsSearchController.loadItems(base: .root)
-                        case .coupons(search: true):
-                            await posModel.couponsSearchController.loadItems(base: .root)
+        ZStack {
+            Group {
+                switch viewState {
+                case .loading(let catalogSyncState):
+                    PointOfSaleLoadingView(
+                        catalogSyncState: catalogSyncState,
+                        onExit: { dismiss() }
+                    )
+                        .transition(.opacity)
+                        .ignoresSafeArea()
+                case .ineligible(let reason):
+                    POSIneligibleView(reason: reason, onRefresh: {
+                        try await posModel.entryPointController.refreshEligibility(reason: reason)
+                    })
+                    .frame(maxWidth: .infinity)
+                case .error(let error):
+                    PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
+                        if error.errorType == .initialCatalogSyncError {
+                            analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
                         }
-                    }
-                }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
-                    dismiss()
-                } : nil)
-            case .content:
-                contentView
-                    .accessibilitySortPriority(2)
-            }
 
-            POSFloatingControlView(onExitSelected: requestExitPermission,
-                                   showSupport: $showSupport,
-                                   showDocumentation: $showDocumentation,
-                                   onSettingsSelected: requestSettingsPermission,
-                                   onOrdersSelected: presentOrders)
-            .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
-            .padding(.bottom, Constants.floatingControlBottomPadding)
-            .trackSize(size: $floatingSize)
-            .accessibilitySortPriority(1)
-            .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
+                        Task {
+                            switch viewStateCoordinator.selectedItemListType {
+                            case .products(search: false):
+                                await posModel.purchasableItemsController.loadItems(base: .root)
+                            case .products(search: true):
+                                await posModel.purchasableItemsSearchController.loadItems(base: .root)
+                            case .coupons(search: false):
+                                await posModel.couponsSearchController.loadItems(base: .root)
+                            case .coupons(search: true):
+                                await posModel.couponsSearchController.loadItems(base: .root)
+                            }
+                        }
+                    }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
+                        dismiss()
+                    } : nil)
+                case .content:
+                    contentView
+                        .accessibilitySortPriority(2)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Anchor the controls to stable dashboard bounds. The product-list banner can briefly
+            // report its own ideal height while POS is being presented, which must not drive this position.
+            .overlay(alignment: .bottomLeading) {
+                POSFloatingControlView(onExitSelected: requestExitPermission,
+                                       showSupport: $showSupport,
+                                       showDocumentation: $showDocumentation,
+                                       onSettingsSelected: requestSettingsPermission,
+                                       onOrdersSelected: presentOrders)
+                .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
+                .padding(.bottom, Constants.floatingControlBottomPadding)
+                .trackSize(size: $floatingSize)
+                .accessibilitySortPriority(1)
+                .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
+            }
 
             POSConnectivityView()
         }
+        // Dashboard-owned modals also need the complete presentation bounds for centring.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .environment(\.floatingControlAreaSize,
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))
@@ -232,6 +245,7 @@ struct PointOfSaleDashboardView: View {
                     ItemListView(
                         selectedItemListType: $viewStateCoordinator.selectedItemListType,
                         searchTerm: $viewStateCoordinator.searchTerm,
+                        httpsConfigurationNotice: httpsConfigurationNotice,
                         phoneHeaderAccessoryBuilder: { context in
                             AnyView(phoneOverflowMenu(
                                 canCreateCoupon: context.canCreateCoupon,
@@ -491,7 +505,8 @@ struct PointOfSaleDashboardView: View {
 
             HStack(spacing: POSSpacing.none) {
                 ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
-                             searchTerm: $viewStateCoordinator.searchTerm)
+                             searchTerm: $viewStateCoordinator.searchTerm,
+                             httpsConfigurationNotice: httpsConfigurationNotice)
                     .frame(width: productsWidth)
                     .accessibilitySortPriority(posModel.orderStage == .building ? 2 : 0)
                     .allowsHitTesting(posModel.orderStage == .building)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -57,6 +57,7 @@ public struct PointOfSaleEntryPointView: View {
     private let tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking?
     private let preferredConnectionMethod: CardReaderConnectionMethod
     private let receiptPrinter: ReceiptPrinterServiceProtocol?
+    private let httpsConfigurationNotice: POSHTTPSConfigurationNotice?
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -91,6 +92,7 @@ public struct PointOfSaleEntryPointView: View {
          receiptPrinter: ReceiptPrinterServiceProtocol? = nil,
          staffSettingsService: POSStaffSettingsService? = nil,
          services: POSDependencyProviding,
+         httpsConfigurationNotice: POSHTTPSConfigurationNotice? = nil,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
         self._accessSession = State(initialValue: POSAccessSessionFactory.make(
@@ -187,12 +189,13 @@ public struct PointOfSaleEntryPointView: View {
         self.tapToPayAvailabilityChecker = tapToPayAvailabilityChecker
         self.preferredConnectionMethod = preferredConnectionMethod
         self.receiptPrinter = receiptPrinter
+        self.httpsConfigurationNotice = httpsConfigurationNotice
     }
 
     public var body: some View {
         Group {
             if let posModel {
-                PointOfSaleDashboardView()
+                PointOfSaleDashboardView(httpsConfigurationNotice: httpsConfigurationNotice)
                     .environment(posModel)
                     .environment(posModel.paymentModel)
                     .posAutoLockActivityTracking(

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSConnectivityView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSConnectivityView.swift
@@ -11,6 +11,7 @@ struct POSConnectivityView: View {
         ZStack(alignment: .top) {
             if isVisible {
                 noConnectionBanner
+                    .padding(.top, POSPadding.small)
                     .transition(.asymmetric(insertion: .push(from: .top), removal: .move(edge: .top)))
             }
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] POS: When the store rejects a refund because the order changed, for example another register refunded part of it, the refund screen now offers to reload the remaining items instead of a retry that cannot succeed. [https://github.com/woocommerce/woocommerce-ios/pull/17732]
 - [Internal] POS: every POS analytics event now carries device_type (phone/tablet) and entry_point (pos_tab or auto_reopen), so POS usage can be split by form factor and merchant-opened sessions separated from POS-lock cold-launch restores. [https://github.com/woocommerce/woocommerce-ios/pull/17705]
 - [*] Settings: All retained application logs can now be shared together as a ZIP file. [https://github.com/woocommerce/woocommerce-ios/pull/17714]
+- [*] Added a warning when a store is configured with an HTTP URL, with guidance for setting it up to use HTTPS. [https://github.com/woocommerce/woocommerce-ios/pull/17735]
 - [*] Fixed a crash that could occur while checking iOS age-range compliance. [https://github.com/woocommerce/woocommerce-ios/pull/17661]
 - [*] Dashboard: Performance stats now remain visible when the selected dates have no revenue. [https://github.com/woocommerce/woocommerce-ios/pull/17717]
 - [*] Google Ads: Fixed the dashboard campaign card failing to show existing campaign performance data. [https://github.com/woocommerce/woocommerce-ios/pull/17706]

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -42,6 +42,7 @@ final class POSTabCoordinator {
     private let currencySettings: CurrencySettings
     private let pushNotesManager: PushNotesManager
     private let eligibilityChecker: POSEntryPointEligibilityCheckerProtocol
+    private let httpsConfigurationNoticeProvider: () -> POSHTTPSConfigurationNotice?
 
     private lazy var posSyncDispatcher = ForegroundPOSCatalogSyncDispatcher()
 
@@ -119,7 +120,8 @@ final class POSTabCoordinator {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          eligibilityChecker: POSEntryPointEligibilityCheckerProtocol,
-         localCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol?) {
+         localCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol?,
+         httpsConfigurationNoticeProvider: @escaping () -> POSHTTPSConfigurationNotice? = { nil }) {
         self.siteID = siteID
         self.storesManager = storesManager
         self.defaultSitePublisher = storesManager.sessionManager.defaultSitePublisher
@@ -137,6 +139,7 @@ final class POSTabCoordinator {
         self.pushNotesManager = pushNotesManager
         self.eligibilityChecker = eligibilityChecker
         self.localCatalogEligibilityService = localCatalogEligibilityService
+        self.httpsConfigurationNoticeProvider = httpsConfigurationNoticeProvider
 
         tabContainerController.wrappedController = POSTabViewController()
     }
@@ -191,6 +194,7 @@ private extension POSTabCoordinator {
     }
 
     func presentPOSView(siteID: Int64) {
+        let httpsConfigurationNotice = httpsConfigurationNoticeProvider()
         let hostingController = UIHostingController(
             rootView: POSPresentationRootView(posView: nil)
         )
@@ -402,6 +406,7 @@ private extension POSTabCoordinator {
                     receiptPrinter: receiptPrinter,
                     staffSettingsService: staffSettingsService,
                     services: serviceAdaptor,
+                    httpsConfigurationNotice: httpsConfigurationNotice,
                     itemProvider: itemProvider
                 )
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -13,12 +13,18 @@ struct HubMenu: View {
     /// Set from the hosting controller to open Google Ads campaigns.
     var googleAdsCampaignHandler: () -> Void = {}
 
+    var httpsConfigurationHelpHandler: () -> Void = {}
+
     @ObservedObject private var iO = Inject.observer
 
     @ObservedObject private var viewModel: HubMenuViewModel
 
-    init(viewModel: HubMenuViewModel) {
+    @ObservedObject private var httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel
+
+    init(viewModel: HubMenuViewModel,
+         httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel) {
         self.viewModel = viewModel
+        self.httpsConfigurationWarningViewModel = httpsConfigurationWarningViewModel
     }
 
     var body: some View {
@@ -26,6 +32,14 @@ struct HubMenu: View {
             /// TODO: switch to `navigationDestination(item:destination)`
             /// when we drop support for iOS 16.
             menuList
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    if httpsConfigurationWarningViewModel.isVisible {
+                        HTTPSConfigurationWarningBanner(
+                            onAction: httpsConfigurationHelpHandler,
+                            onDismiss: httpsConfigurationWarningViewModel.dismiss
+                        )
+                    }
+                }
                 .navigationDestination(for: HubMenuNavigationDestination.self) { destination in
                     detailView(destination: destination)
                 }
@@ -383,17 +397,21 @@ private extension HubMenu {
 
 struct HubMenu_Previews: PreviewProvider {
     static var previews: some View {
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()),
+                httpsConfigurationWarningViewModel: .init())
             .environment(\.colorScheme, .light)
 
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()),
+                httpsConfigurationWarningViewModel: .init())
             .environment(\.colorScheme, .dark)
 
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()),
+                httpsConfigurationWarningViewModel: .init())
             .previewLayout(.fixed(width: 312, height: 528))
             .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
 
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()),
+                httpsConfigurationWarningViewModel: .init())
             .previewLayout(.fixed(width: 1024, height: 768))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -17,6 +17,7 @@ final class HubMenuCoordinator {
     private let storesManager: StoresManager
     private let noticePresenter: NoticePresenter
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
+    private let httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel
 
     private var notificationsSubscription: AnyCancellable?
 
@@ -29,6 +30,7 @@ final class HubMenuCoordinator {
          storesManager: StoresManager = ServiceLocator.stores,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          switchStoreUseCase: SwitchStoreUseCaseProtocol,
+         httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel,
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker,
          willPresentReviewDetailsFromPushNotification: @escaping () async -> Void) {
 
@@ -36,6 +38,7 @@ final class HubMenuCoordinator {
         self.storesManager = storesManager
         self.noticePresenter = noticePresenter
         self.switchStoreUseCase = switchStoreUseCase
+        self.httpsConfigurationWarningViewModel = httpsConfigurationWarningViewModel
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
         self.willPresentReviewDetailsFromPushNotification = willPresentReviewDetailsFromPushNotification
         self.tabContainerController = tabContainerController
@@ -43,11 +46,13 @@ final class HubMenuCoordinator {
 
     convenience init(tabContainerController: TabContainerController,
                      storesManager: StoresManager = ServiceLocator.stores,
+                     httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel,
                      tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker,
                      willPresentReviewDetailsFromPushNotification: @escaping () async -> Void) {
         self.init(tabContainerController: tabContainerController,
                   storesManager: storesManager,
                   switchStoreUseCase: SwitchStoreUseCase(stores: storesManager),
+                  httpsConfigurationWarningViewModel: httpsConfigurationWarningViewModel,
                   tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker,
                   willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
     }
@@ -61,6 +66,7 @@ final class HubMenuCoordinator {
     func activate(siteID: Int64) {
         hubMenuController = HubMenuViewController(siteID: siteID,
                                                   stores: storesManager,
+                                                  httpsConfigurationWarningViewModel: httpsConfigurationWarningViewModel,
                                                   tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker)
         if let hubMenuController {
             let navigationController = UINavigationController(rootViewController: hubMenuController)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -14,13 +14,15 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
+         httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel,
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker) {
         self.viewModel = HubMenuViewModel(siteID: siteID,
                                           tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker,
                                           stores: stores)
 
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
-        super.init(rootView: HubMenu(viewModel: viewModel))
+        super.init(rootView: HubMenu(viewModel: viewModel,
+                                    httpsConfigurationWarningViewModel: httpsConfigurationWarningViewModel))
         configureTabBarItem()
 
         rootView.switchStoreHandler = { [weak self] in
@@ -29,6 +31,11 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
 
         rootView.googleAdsCampaignHandler = { [weak self] in
             self?.presentGoogleAds()
+        }
+
+        rootView.httpsConfigurationHelpHandler = { [weak self] in
+            guard let self else { return }
+            WebviewHelper.launch(HTTPSConfigurationWarningContent.helpURL, with: self)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -87,7 +87,6 @@ extension WooTab {
     }
 }
 
-
 // MARK: - MainTabBarController
 
 /// A view controller that shows the tabs Store, Orders, Products, and Reviews.
@@ -112,6 +111,28 @@ final class MainTabBarController: UITabBarController {
     /// ViewModel
     ///
     private let viewModel = MainTabViewModel()
+    private let httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel
+    private lazy var httpsConfigurationWarningPresenter = HTTPSConfigurationWarningPresenter(
+        viewModel: httpsConfigurationWarningViewModel,
+        presentingViewController: self,
+        tabViewController: { [weak self] tab in
+            self?.rootTabViewController(tab: tab)
+        },
+        visibleTabs: { [weak self] in
+            guard let self else { return [] }
+            return WooTab.visibleTabs(isPOSTabVisible: isPOSTabVisible, isBookingsTabVisible: isBookingsTabVisible)
+        },
+        selectedTab: { [weak self] in
+            guard let self else { return nil }
+            return WooTab(visibleIndex: selectedIndex,
+                          isPOSTabVisible: isPOSTabVisible,
+                          isBookingsTabVisible: isBookingsTabVisible)
+        },
+        onAction: { [weak self] in
+            guard let self else { return }
+            WebviewHelper.launch(HTTPSConfigurationWarningContent.helpURL, with: self)
+        }
+    )
 
     /// Tab view controllers
     ///
@@ -190,6 +211,7 @@ final class MainTabBarController: UITabBarController {
         self.productImageUploader = productImageUploader
         self.analytics = analytics
         self.stores = stores
+        self.httpsConfigurationWarningViewModel = HTTPSConfigurationWarningViewModel(stores: stores)
         self.posTabVisibilityCheckerFactory = posTabVisibilityCheckerFactory ?? { site in
             POSTabVisibilityChecker(site: site)
         }
@@ -209,6 +231,7 @@ final class MainTabBarController: UITabBarController {
         self.productImageUploader = ServiceLocator.productImageUploader
         self.analytics = ServiceLocator.analytics
         self.stores = ServiceLocator.stores
+        self.httpsConfigurationWarningViewModel = HTTPSConfigurationWarningViewModel(stores: ServiceLocator.stores)
         self.posTabVisibilityCheckerFactory = { site in
             POSTabVisibilityChecker(site: site)
         }
@@ -240,6 +263,7 @@ final class MainTabBarController: UITabBarController {
 
         observeSiteIDForViewControllers()
         observeSiteForConditionalTabs()
+        httpsConfigurationWarningPresenter.start()
         observeProductImageUploadStatusUpdates()
 
         startListeningToHubMenuTabBadgeUpdates()
@@ -273,6 +297,7 @@ final class MainTabBarController: UITabBarController {
         super.viewDidAppear(animated)
 
         viewModel.onViewDidAppear()
+        httpsConfigurationWarningPresenter.update()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -282,6 +307,7 @@ final class MainTabBarController: UITabBarController {
             self?.configureTabBarLayoutOnIpad()
         } completion: { [weak self] _ in
             self?.configureTabBarLayoutOnIpad()
+            self?.httpsConfigurationWarningPresenter.update()
         }
     }
 
@@ -289,6 +315,7 @@ final class MainTabBarController: UITabBarController {
         super.viewDidLayoutSubviews()
 
         configureLiquidGlassTabBarLayoutOnIpad()
+        httpsConfigurationWarningPresenter.update()
     }
 
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
@@ -305,6 +332,7 @@ final class MainTabBarController: UITabBarController {
         } else {
             trackTabSelected(newTab: userSelectedTab)
         }
+        httpsConfigurationWarningPresenter.selectedTabDidChange(to: userSelectedTab)
     }
 
     // MARK: - Public Methods
@@ -326,6 +354,7 @@ final class MainTabBarController: UITabBarController {
     func navigateToTabWithViewController(_ tab: WooTab, animated: Bool = false, completion: ((UIViewController) -> Void)? = nil) {
         dismiss(animated: animated) { [weak self] in
             guard let self else { return }
+            httpsConfigurationWarningPresenter.update(for: tab)
             selectedIndex = tab.visibleIndex(isPOSTabVisible: isPOSTabVisible, isBookingsTabVisible: isBookingsTabVisible)
             guard let selectedViewController else {
                 return
@@ -911,6 +940,7 @@ private extension MainTabBarController {
         viewControllers = controllers
         self.isPOSTabVisible = isPOSTabVisible
         self.isBookingsTabVisible = isBookingsTabVisible
+        httpsConfigurationWarningPresenter.updateAll()
     }
 
     func rootTabViewController(tab: WooTab) -> UIViewController {
@@ -939,6 +969,8 @@ private extension MainTabBarController {
                 }
 
                 conditionalTabsSite = site
+                httpsConfigurationWarningViewModel.update(site: site,
+                                                          fallbackSiteAddress: stores.sessionManager.defaultCredentials?.siteAddress)
                 observePOSEligibilityForPOSTabVisibility(site: site)
                 observeBookingsEligibilityForBookingsTabVisibility(site: site)
             }
@@ -952,6 +984,8 @@ private extension MainTabBarController {
                 guard let self, let site = conditionalTabsSite else {
                     return
                 }
+                httpsConfigurationWarningViewModel.update(site: site,
+                                                          fallbackSiteAddress: stores.sessionManager.defaultCredentials?.siteAddress)
                 observePOSEligibilityForPOSTabVisibility(site: site)
             }
     }
@@ -1019,6 +1053,8 @@ private extension MainTabBarController {
 
         // Updates site ID for the bookings tab to display correct bookings
         (bookingsContainerController.wrappedController as? BookingsTabViewHostingController)?.didSwitchStore(id: siteID)
+
+        httpsConfigurationWarningPresenter.updateAll()
     }
 
     func createDashboardViewController(siteID: Int64) -> UIViewController {
@@ -1036,6 +1072,7 @@ private extension MainTabBarController {
     func createHubMenuTabCoordinator() -> HubMenuCoordinator {
         HubMenuCoordinator(tabContainerController: hubMenuContainerController,
                            storesManager: stores,
+                           httpsConfigurationWarningViewModel: httpsConfigurationWarningViewModel,
                            tapToPayBadgePromotionChecker: viewModel.tapToPayBadgePromotionChecker,
                            willPresentReviewDetailsFromPushNotification: { [weak self] in
             await withCheckedContinuation { [weak self] continuation in

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -9,6 +9,7 @@ import enum WooFoundationCore.BuildConfiguration
 import protocol WooFoundation.Analytics
 import protocol PointOfSale.POSEntryPointEligibilityCheckerProtocol
 import enum PointOfSale.POSLockStateKey
+import struct PointOfSale.POSHTTPSConfigurationNotice
 
 
 /// Enum representing the individual tabs
@@ -1042,7 +1043,25 @@ private extension MainTabBarController {
             viewControllerToPresent: self,
             storesManager: stores,
             eligibilityChecker: POSTabEligibilityChecker(siteID: siteID),
-            localCatalogEligibilityService: stores.posCatalogEligibilityChecker
+            localCatalogEligibilityService: stores.posCatalogEligibilityChecker,
+            httpsConfigurationNoticeProvider: { [weak self] in
+                guard let self, httpsConfigurationWarningViewModel.isVisible else {
+                    return nil
+                }
+                return POSHTTPSConfigurationNotice(
+                    title: HTTPSConfigurationWarningContent.title,
+                    message: HTTPSConfigurationWarningContent.message,
+                    actionTitle: HTTPSConfigurationWarningContent.actionTitle,
+                    onAction: { [weak self] in
+                        guard let self,
+                              let presenter = presentedViewController else { return }
+                        WebviewHelper.launch(HTTPSConfigurationWarningContent.helpURL, with: presenter)
+                    },
+                    onDismiss: { [weak self] in
+                        self?.httpsConfigurationWarningViewModel.dismiss()
+                    }
+                )
+            }
         )
         posTabCoordinator = coordinator
         autoReopenPOSIfNeeded(siteID: siteID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuCoordinatorTests.swift
@@ -7,6 +7,7 @@ import Yosemite
 
 /// Test cases for `HubMenuCoordinator`.
 ///
+@MainActor
 final class HubMenuCoordinatorTests: XCTestCase {
     private var pushNotificationsManager: MockPushNotificationsManager!
     private var storesManager: MockStoresManager!
@@ -128,12 +129,14 @@ final class HubMenuCoordinatorTests: XCTestCase {
 
 // MARK: - Utils
 private extension HubMenuCoordinatorTests {
+    @MainActor
     func makeHubMenuCoordinator(willPresentReviewDetailsFromPushNotification: (@escaping () -> Void) = { }) -> HubMenuCoordinator {
         HubMenuCoordinator(tabContainerController: TabContainerController(),
                            pushNotificationsManager: pushNotificationsManager,
                            storesManager: storesManager,
                            noticePresenter: noticePresenter,
                            switchStoreUseCase: switchStoreUseCase,
+                           httpsConfigurationWarningViewModel: HTTPSConfigurationWarningViewModel(stores: storesManager),
                            tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                            willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
     }


### PR DESCRIPTION
WOOMOB-3809
Closes: WOOMOB-3864
Stacked on #17733.

## Description

Some stores are served over both HTTP and HTTPS, but have their store URL set to HTTP. We normalise this to HTTP for the app's purposes, but it's much better for them to update the setting so their customers are not exposed to HTTP versions of the site. The app will not allow login for sites which are HTTP-only, due to our App Transport Security settings.

This PR shows the warning banner in the main app (not POS).

The warning:
- Appears on Dashboard, Orders, Products, and Menu.
- Pins beneath the navigation bar.
- Uses the detail column for expanded Orders and Products split views.
- Moves with pushed and popped detail controllers on compact layouts.
- Links directly to the “For new websites/stores” HTTPS configuration guidance.
- Can be dismissed per store for one day.

## Test Steps
1. Use a store that reports an `http` site URL while remaining reachable over HTTPS. See the setup steps on #17728.
2. Confirm the warning appears on Dashboard, Orders, Products, and Menu.
3. On iPhone, open and close order and product details and confirm the banner does not obscure their content.
4. On iPad, confirm Orders and Products place the banner in the detail column.
5. Switch tabs, rotate the device, and collapse large navigation titles; confirm content remains correctly inset.
6. Open the information link and confirm it targets the “For new websites/stores” documentation section.
7. Dismiss the warning and confirm it remains hidden for one day.

## Screenshots

https://github.com/user-attachments/assets/4674bda2-a5a3-455f-8281-f9b0e7536db5

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.