### PR TITLE
[WOOMOB-3809] Show HTTPS warning in POS

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -14,6 +14,8 @@ struct ItemListView: View {
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
+    @State private var showsHTTPSConfigurationNotice: Bool
+    private let httpsConfigurationNotice: POSHTTPSConfigurationNotice?
     /// Optional builder rendered in the trailing slot of the items list header when not searching.
     /// The dashboard uses this to fold the "create coupon" entry into its overflow menu when the
     /// merchant is on the Coupons tab, without leaking ItemListView's internal state.
@@ -21,9 +23,12 @@ struct ItemListView: View {
 
     init(selectedItemListType: Binding<ItemListType>,
          searchTerm: Binding<String>,
+         httpsConfigurationNotice: POSHTTPSConfigurationNotice? = nil,
          phoneHeaderAccessoryBuilder: ((PhoneHeaderAccessoryContext) -> AnyView)? = nil) {
         self._selectedItemListType = selectedItemListType
         self._searchTerm = searchTerm
+        self.httpsConfigurationNotice = httpsConfigurationNotice
+        self._showsHTTPSConfigurationNotice = State(initialValue: httpsConfigurationNotice != nil)
         self.phoneHeaderAccessoryBuilder = phoneHeaderAccessoryBuilder
     }
 
@@ -238,6 +243,15 @@ struct ItemListView: View {
     @ViewBuilder
     private func listView(itemListType: ItemListType) -> some View {
         VStack(spacing: 0) {
+            if itemListType.itemType == .product,
+               let httpsConfigurationNotice,
+               showsHTTPSConfigurationNotice {
+                httpsConfigurationWarningBanner(httpsConfigurationNotice)
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.vertical, POSPadding.medium)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             if posModel.showSunsetWarning {
                 sunsetWarningBanner
                     .padding(.horizontal, POSPadding.medium)
@@ -290,6 +304,30 @@ struct ItemListView: View {
         .task {
             await posModel.checkStaleSyncStatus()
             await posModel.checkSunsetWarningStatus()
+        }
+    }
+
+    @ViewBuilder
+    private func httpsConfigurationWarningBanner(_ notice: POSHTTPSConfigurationNotice) -> some View {
+        POSNoticeView(
+            title: notice.title,
+            icon: Image(systemName: "info.circle"),
+            style: .alertLowest,
+            onDismiss: {
+                notice.onDismiss()
+                withAnimation {
+                    showsHTTPSConfigurationNotice = false
+                }
+            },
+            onTap: notice.onAction
+        ) {
+            VStack(alignment: .leading, spacing: POSSpacing.small) {
+                Text(notice.message)
+                    .font(.posBodyMediumRegular())
+                Text(notice.actionTitle)
+                    .font(.posBodySmallBold())
+                    .foregroundColor(Color.posOnAlertLowest)
+            }
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSHTTPSConfigurationNotice.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSHTTPSConfigurationNotice.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Content and actions for the HTTPS configuration warning supplied by the host app.
+public struct POSHTTPSConfigurationNotice {
+    let title: String
+    let message: String
+    let actionTitle: String
+    let onAction: () -> Void
+    let onDismiss: () -> Void
+
+    public init(title: String,
+                message: String,
+                actionTitle: String,
+                onAction: @escaping () -> Void,
+                onDismiss: @escaping () -> Void) {
+        self.title = title
+        self.message = message
+        self.actionTitle = actionTitle
+        self.onAction = onAction
+        self.onDismiss = onDismiss
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -75,67 +75,64 @@ struct PointOfSaleDashboardView: View {
 
     var body: some View {
         @Bindable var posModel = posModel
-        ZStack {
-            Group {
-                switch viewState {
-                case .loading(let catalogSyncState):
-                    PointOfSaleLoadingView(
-                        catalogSyncState: catalogSyncState,
-                        onExit: { dismiss() }
-                    )
-                        .transition(.opacity)
-                        .ignoresSafeArea()
-                case .ineligible(let reason):
-                    POSIneligibleView(reason: reason, onRefresh: {
-                        try await posModel.entryPointController.refreshEligibility(reason: reason)
-                    })
-                    .frame(maxWidth: .infinity)
-                case .error(let error):
-                    PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
-                        if error.errorType == .initialCatalogSyncError {
-                            analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
-                        }
+        Group {
+            switch viewState {
+            case .loading(let catalogSyncState):
+                PointOfSaleLoadingView(
+                    catalogSyncState: catalogSyncState,
+                    onExit: { dismiss() }
+                )
+                    .transition(.opacity)
+                    .ignoresSafeArea()
+            case .ineligible(let reason):
+                POSIneligibleView(reason: reason, onRefresh: {
+                    try await posModel.entryPointController.refreshEligibility(reason: reason)
+                })
+                .frame(maxWidth: .infinity)
+            case .error(let error):
+                PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
+                    if error.errorType == .initialCatalogSyncError {
+                        analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
+                    }
 
-                        Task {
-                            switch viewStateCoordinator.selectedItemListType {
-                            case .products(search: false):
-                                await posModel.purchasableItemsController.loadItems(base: .root)
-                            case .products(search: true):
-                                await posModel.purchasableItemsSearchController.loadItems(base: .root)
-                            case .coupons(search: false):
-                                await posModel.couponsSearchController.loadItems(base: .root)
-                            case .coupons(search: true):
-                                await posModel.couponsSearchController.loadItems(base: .root)
-                            }
+                    Task {
+                        switch viewStateCoordinator.selectedItemListType {
+                        case .products(search: false):
+                            await posModel.purchasableItemsController.loadItems(base: .root)
+                        case .products(search: true):
+                            await posModel.purchasableItemsSearchController.loadItems(base: .root)
+                        case .coupons(search: false):
+                            await posModel.couponsSearchController.loadItems(base: .root)
+                        case .coupons(search: true):
+                            await posModel.couponsSearchController.loadItems(base: .root)
                         }
-                    }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
-                        dismiss()
-                    } : nil)
-                case .content:
-                    contentView
-                        .accessibilitySortPriority(2)
-                }
+                    }
+                }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
+                    dismiss()
+                } : nil)
+            case .content:
+                contentView
+                    .accessibilitySortPriority(2)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            // Anchor the controls to stable dashboard bounds. The product-list banner can briefly
-            // report its own ideal height while POS is being presented, which must not drive this position.
-            .overlay(alignment: .bottomLeading) {
-                POSFloatingControlView(onExitSelected: requestExitPermission,
-                                       showSupport: $showSupport,
-                                       showDocumentation: $showDocumentation,
-                                       onSettingsSelected: requestSettingsPermission,
-                                       onOrdersSelected: presentOrders)
-                .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
-                .padding(.bottom, Constants.floatingControlBottomPadding)
-                .trackSize(size: $floatingSize)
-                .accessibilitySortPriority(1)
-                .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
-            }
-
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Anchor the controls to stable dashboard bounds. The product-list banner can briefly
+        // report its own ideal height while POS is being presented, which must not drive this position.
+        .overlay(alignment: .bottomLeading) {
+            POSFloatingControlView(onExitSelected: requestExitPermission,
+                                   showSupport: $showSupport,
+                                   showDocumentation: $showDocumentation,
+                                   onSettingsSelected: requestSettingsPermission,
+                                   onOrdersSelected: presentOrders)
+            .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
+            .padding(.bottom, Constants.floatingControlBottomPadding)
+            .trackSize(size: $floatingSize)
+            .accessibilitySortPriority(1)
+            .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
+        }
+        .overlay {
             POSConnectivityView()
         }
-        // Dashboard-owned modals also need the complete presentation bounds for centring.
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .environment(\.floatingControlAreaSize,
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -25,6 +25,11 @@ struct PointOfSaleDashboardView: View {
     @State private var floatingControlSuppressed: Bool = false
     @State private var phoneShowingCart: Bool = false
     @State private var phoneCartPresentationDetent: PresentationDetent = .medium
+    private let httpsConfigurationNotice: POSHTTPSConfigurationNotice?
+
+    init(httpsConfigurationNotice: POSHTTPSConfigurationNotice? = nil) {
+        self.httpsConfigurationNotice = httpsConfigurationNotice
+    }
 
     /// Tracks Dynamic Type scaling for the phone overflow menu chip so it grows in sync with
     /// the adjacent `POSPageHeaderActionButton` (search) at large content sizes. Same 1.0…1.2x
@@ -70,59 +75,67 @@ struct PointOfSaleDashboardView: View {
 
     var body: some View {
         @Bindable var posModel = posModel
-        ZStack(alignment: .bottomLeading) {
-            switch viewState {
-            case .loading(let catalogSyncState):
-                PointOfSaleLoadingView(
-                    catalogSyncState: catalogSyncState,
-                    onExit: { dismiss() }
-                )
-                    .transition(.opacity)
-                    .ignoresSafeArea()
-            case .ineligible(let reason):
-                POSIneligibleView(reason: reason, onRefresh: {
-                    try await posModel.entryPointController.refreshEligibility(reason: reason)
-                })
-                .frame(maxWidth: .infinity)
-            case .error(let error):
-                PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
-                    if error.errorType == .initialCatalogSyncError {
-                        analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
-                    }
-
-                    Task {
-                        switch viewStateCoordinator.selectedItemListType {
-                        case .products(search: false):
-                            await posModel.purchasableItemsController.loadItems(base: .root)
-                        case .products(search: true):
-                            await posModel.purchasableItemsSearchController.loadItems(base: .root)
-                        case .coupons(search: false):
-                            await posModel.couponsSearchController.loadItems(base: .root)
-                        case .coupons(search: true):
-                            await posModel.couponsSearchController.loadItems(base: .root)
+        ZStack {
+            Group {
+                switch viewState {
+                case .loading(let catalogSyncState):
+                    PointOfSaleLoadingView(
+                        catalogSyncState: catalogSyncState,
+                        onExit: { dismiss() }
+                    )
+                        .transition(.opacity)
+                        .ignoresSafeArea()
+                case .ineligible(let reason):
+                    POSIneligibleView(reason: reason, onRefresh: {
+                        try await posModel.entryPointController.refreshEligibility(reason: reason)
+                    })
+                    .frame(maxWidth: .infinity)
+                case .error(let error):
+                    PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
+                        if error.errorType == .initialCatalogSyncError {
+                            analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
                         }
-                    }
-                }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
-                    dismiss()
-                } : nil)
-            case .content:
-                contentView
-                    .accessibilitySortPriority(2)
-            }
 
-            POSFloatingControlView(onExitSelected: requestExitPermission,
-                                   showSupport: $showSupport,
-                                   showDocumentation: $showDocumentation,
-                                   onSettingsSelected: requestSettingsPermission,
-                                   onOrdersSelected: presentOrders)
-            .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
-            .padding(.bottom, Constants.floatingControlBottomPadding)
-            .trackSize(size: $floatingSize)
-            .accessibilitySortPriority(1)
-            .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
+                        Task {
+                            switch viewStateCoordinator.selectedItemListType {
+                            case .products(search: false):
+                                await posModel.purchasableItemsController.loadItems(base: .root)
+                            case .products(search: true):
+                                await posModel.purchasableItemsSearchController.loadItems(base: .root)
+                            case .coupons(search: false):
+                                await posModel.couponsSearchController.loadItems(base: .root)
+                            case .coupons(search: true):
+                                await posModel.couponsSearchController.loadItems(base: .root)
+                            }
+                        }
+                    }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
+                        dismiss()
+                    } : nil)
+                case .content:
+                    contentView
+                        .accessibilitySortPriority(2)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Anchor the controls to stable dashboard bounds. The product-list banner can briefly
+            // report its own ideal height while POS is being presented, which must not drive this position.
+            .overlay(alignment: .bottomLeading) {
+                POSFloatingControlView(onExitSelected: requestExitPermission,
+                                       showSupport: $showSupport,
+                                       showDocumentation: $showDocumentation,
+                                       onSettingsSelected: requestSettingsPermission,
+                                       onOrdersSelected: presentOrders)
+                .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
+                .padding(.bottom, Constants.floatingControlBottomPadding)
+                .trackSize(size: $floatingSize)
+                .accessibilitySortPriority(1)
+                .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
+            }
 
             POSConnectivityView()
         }
+        // Dashboard-owned modals also need the complete presentation bounds for centring.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .environment(\.floatingControlAreaSize,
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))
@@ -232,6 +245,7 @@ struct PointOfSaleDashboardView: View {
                     ItemListView(
                         selectedItemListType: $viewStateCoordinator.selectedItemListType,
                         searchTerm: $viewStateCoordinator.searchTerm,
+                        httpsConfigurationNotice: httpsConfigurationNotice,
                         phoneHeaderAccessoryBuilder: { context in
                             AnyView(phoneOverflowMenu(
                                 canCreateCoupon: context.canCreateCoupon,
@@ -491,7 +505,8 @@ struct PointOfSaleDashboardView: View {
 
             HStack(spacing: POSSpacing.none) {
                 ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
-                             searchTerm: $viewStateCoordinator.searchTerm)
+                             searchTerm: $viewStateCoordinator.searchTerm,
+                             httpsConfigurationNotice: httpsConfigurationNotice)
                     .frame(width: productsWidth)
                     .accessibilitySortPriority(posModel.orderStage == .building ? 2 : 0)
                     .allowsHitTesting(posModel.orderStage == .building)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -57,6 +57,7 @@ public struct PointOfSaleEntryPointView: View {
     private let tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking?
     private let preferredConnectionMethod: CardReaderConnectionMethod
     private let receiptPrinter: ReceiptPrinterServiceProtocol?
+    private let httpsConfigurationNotice: POSHTTPSConfigurationNotice?
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -91,6 +92,7 @@ public struct PointOfSaleEntryPointView: View {
          receiptPrinter: ReceiptPrinterServiceProtocol? = nil,
          staffSettingsService: POSStaffSettingsService? = nil,
          services: POSDependencyProviding,
+         httpsConfigurationNotice: POSHTTPSConfigurationNotice? = nil,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
         self._accessSession = State(initialValue: POSAccessSessionFactory.make(
@@ -187,12 +189,13 @@ public struct PointOfSaleEntryPointView: View {
         self.tapToPayAvailabilityChecker = tapToPayAvailabilityChecker
         self.preferredConnectionMethod = preferredConnectionMethod
         self.receiptPrinter = receiptPrinter
+        self.httpsConfigurationNotice = httpsConfigurationNotice
     }
 
     public var body: some View {
         Group {
             if let posModel {
-                PointOfSaleDashboardView()
+                PointOfSaleDashboardView(httpsConfigurationNotice: httpsConfigurationNotice)
                     .environment(posModel)
                     .environment(posModel.paymentModel)
                     .posAutoLockActivityTracking(

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSConnectivityView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSConnectivityView.swift
@@ -11,6 +11,7 @@ struct POSConnectivityView: View {
         ZStack(alignment: .top) {
             if isVisible {
                 noConnectionBanner
+                    .padding(.top, POSPadding.small)
                     .transition(.asymmetric(insertion: .push(from: .top), removal: .move(edge: .top)))
             }
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] POS: When the store rejects a refund because the order changed, for example another register refunded part of it, the refund screen now offers to reload the remaining items instead of a retry that cannot succeed. [https://github.com/woocommerce/woocommerce-ios/pull/17732]
 - [Internal] POS: every POS analytics event now carries device_type (phone/tablet) and entry_point (pos_tab or auto_reopen), so POS usage can be split by form factor and merchant-opened sessions separated from POS-lock cold-launch restores. [https://github.com/woocommerce/woocommerce-ios/pull/17705]
 - [*] Settings: All retained application logs can now be shared together as a ZIP file. [https://github.com/woocommerce/woocommerce-ios/pull/17714]
+- [*] Added a warning when a store is configured with an HTTP URL, with guidance for setting it up to use HTTPS. [https://github.com/woocommerce/woocommerce-ios/pull/17735]
 - [*] Fixed a crash that could occur while checking iOS age-range compliance. [https://github.com/woocommerce/woocommerce-ios/pull/17661]
 - [*] Dashboard: Performance stats now remain visible when the selected dates have no revenue. [https://github.com/woocommerce/woocommerce-ios/pull/17717]
 - [*] Google Ads: Fixed the dashboard campaign card failing to show existing campaign performance data. [https://github.com/woocommerce/woocommerce-ios/pull/17706]

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -42,6 +42,7 @@ final class POSTabCoordinator {
     private let currencySettings: CurrencySettings
     private let pushNotesManager: PushNotesManager
     private let eligibilityChecker: POSEntryPointEligibilityCheckerProtocol
+    private let httpsConfigurationNoticeProvider: () -> POSHTTPSConfigurationNotice?
 
     private lazy var posSyncDispatcher = ForegroundPOSCatalogSyncDispatcher()
 
@@ -119,7 +120,8 @@ final class POSTabCoordinator {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          eligibilityChecker: POSEntryPointEligibilityCheckerProtocol,
-         localCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol?) {
+         localCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol?,
+         httpsConfigurationNoticeProvider: @escaping () -> POSHTTPSConfigurationNotice? = { nil }) {
         self.siteID = siteID
         self.storesManager = storesManager
         self.defaultSitePublisher = storesManager.sessionManager.defaultSitePublisher
@@ -137,6 +139,7 @@ final class POSTabCoordinator {
         self.pushNotesManager = pushNotesManager
         self.eligibilityChecker = eligibilityChecker
         self.localCatalogEligibilityService = localCatalogEligibilityService
+        self.httpsConfigurationNoticeProvider = httpsConfigurationNoticeProvider
 
         tabContainerController.wrappedController = POSTabViewController()
     }
@@ -191,6 +194,7 @@ private extension POSTabCoordinator {
     }
 
     func presentPOSView(siteID: Int64) {
+        let httpsConfigurationNotice = httpsConfigurationNoticeProvider()
         let hostingController = UIHostingController(
             rootView: POSPresentationRootView(posView: nil)
         )
@@ -402,6 +406,7 @@ private extension POSTabCoordinator {
                     receiptPrinter: receiptPrinter,
                     staffSettingsService: staffSettingsService,
                     services: serviceAdaptor,
+                    httpsConfigurationNotice: httpsConfigurationNotice,
                     itemProvider: itemProvider
                 )
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -9,6 +9,7 @@ import enum WooFoundationCore.BuildConfiguration
 import protocol WooFoundation.Analytics
 import protocol PointOfSale.POSEntryPointEligibilityCheckerProtocol
 import enum PointOfSale.POSLockStateKey
+import struct PointOfSale.POSHTTPSConfigurationNotice
 
 
 /// Enum representing the individual tabs
@@ -1042,7 +1043,25 @@ private extension MainTabBarController {
             viewControllerToPresent: self,
             storesManager: stores,
             eligibilityChecker: POSTabEligibilityChecker(siteID: siteID),
-            localCatalogEligibilityService: stores.posCatalogEligibilityChecker
+            localCatalogEligibilityService: stores.posCatalogEligibilityChecker,
+            httpsConfigurationNoticeProvider: { [weak self] in
+                guard let self, httpsConfigurationWarningViewModel.isVisible else {
+                    return nil
+                }
+                return POSHTTPSConfigurationNotice(
+                    title: HTTPSConfigurationWarningContent.title,
+                    message: HTTPSConfigurationWarningContent.message,
+                    actionTitle: HTTPSConfigurationWarningContent.actionTitle,
+                    onAction: { [weak self] in
+                        guard let self,
+                              let presenter = presentedViewController else { return }
+                        WebviewHelper.launch(HTTPSConfigurationWarningContent.helpURL, with: presenter)
+                    },
+                    onDismiss: { [weak self] in
+                        self?.httpsConfigurationWarningViewModel.dismiss()
+                    }
+                )
+            }
         )
         posTabCoordinator = coordinator
         autoReopenPOSIfNeeded(siteID: siteID)


### PR DESCRIPTION
WOOMOB-3809

Stacked on #17734.

## Description
Some stores are served over both HTTP and HTTPS, but have their store URL set to HTTP. We normalise this to HTTP for the app's purposes, but it's much better for them to update the setting so their customers are not exposed to HTTP versions of the site. The app will not allow login for sites which are HTTP-only, due to our App Transport Security settings.

This PR shows the warning in the POS product list using the POS alert notice treatment introduced in #17729.

The notice is limited to the product-list surface so it does not constrain checkout or payment screens. This PR also anchors the POS floating controls and dashboard-owned modals to stable dashboard bounds, preventing banner layout changes from moving those controls or modal presentations.

## Test Steps
1. Use a store that reports an `http` site URL while remaining reachable over HTTPS. See setup steps on #17728 
2. Open POS and confirm the warning appears above the product list.
3. Confirm the warning does not appear in the checkout or payment flow.
4. Confirm “Learn more” opens the HTTPS configuration guidance.
5. Dismiss the warning and confirm it remains hidden after reopening POS, and on the rest of the app.
6. On iPad, confirm the floating controls remain at the bottom-left and the Exit POS modal remains centered.
7. Test light and dark mode and confirm the alert colors remain legible.

## Screenshots

https://github.com/user-attachments/assets/4674bda2-a5a3-455f-8281-f9b0e7536db5

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.