### PR TITLE
Fix Product Search navigation bar crash

### DIFF
--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -6,6 +6,18 @@ import UIKit
 //
 extension UINavigationController {
 
+    /// Updates the navigation bar visibility only when it differs from the requested state.
+    ///
+    /// Avoiding redundant visibility updates is important when this navigation controller is wrapped by a split view.
+    /// UIKit can otherwise try to lay out the wrapper's navigation bar using an item that still belongs to this bar.
+    func setNavigationBarHiddenIfNeeded(_ hidden: Bool, animated: Bool) {
+        guard isNavigationBarHidden != hidden else {
+            return
+        }
+
+        setNavigationBarHidden(hidden, animated: animated)
+    }
+
     /// Whenever there's a single viewController onscreen, this method will set the "Top" UIScrollView's
     /// Content Offset to zero.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -101,7 +101,7 @@ private extension ProductsSplitViewCoordinator {
                 }, onCancel: { [weak self] in
                     guard let self else { return }
                     primaryNavigationController.viewControllers = [productsViewController]
-                    primaryNavigationController.setNavigationBarHidden(false, animated: false)
+                    primaryNavigationController.setNavigationBarHiddenIfNeeded(false, animated: false)
                 })
                 let searchViewController = SearchViewController(storeID: siteID,
                                                                 command: searchCommand,

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -173,7 +173,7 @@ where Cell.SearchModel == Command.CellViewModel {
         super.viewWillAppear(animated)
 
         if searchUICommand.hideNavigationBar {
-            navigationController?.setNavigationBarHidden(true, animated: searchUICommand.animateNavigationBarVisibilityChanges)
+            navigationController?.setNavigationBarHiddenIfNeeded(true, animated: searchUICommand.animateNavigationBarVisibilityChanges)
         }
 
         if searchUICommand.makeSearchBarFirstResponderOnStart {
@@ -191,7 +191,7 @@ where Cell.SearchModel == Command.CellViewModel {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        navigationController?.setNavigationBarHidden(false, animated: searchUICommand.animateNavigationBarVisibilityChanges)
+        navigationController?.setNavigationBarHiddenIfNeeded(false, animated: searchUICommand.animateNavigationBarVisibilityChanges)
     }
 
     // MARK: - UITableViewDataSource Conformance

--- a/WooCommerce/WooCommerceTests/System/WooNavigationControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooNavigationControllerTests.swift
@@ -7,6 +7,34 @@ import WooFoundation
 @Suite(.serialized)
 struct WooNavigationControllerTests {
 
+    @Test func test_setNavigationBarHiddenIfNeeded_when_navigation_bar_is_already_in_requested_state_then_does_not_update_it() {
+        // Given
+        let navigationController = NavigationBarVisibilitySpyNavigationController()
+        navigationController.setNavigationBarHidden(false, animated: false)
+        navigationController.resetVisibilityUpdates()
+
+        // When
+        navigationController.setNavigationBarHiddenIfNeeded(false, animated: true)
+
+        // Then
+        #expect(navigationController.visibilityUpdates.isEmpty)
+    }
+
+    @Test func test_setNavigationBarHiddenIfNeeded_when_navigation_bar_visibility_differs_then_updates_it() {
+        // Given
+        let navigationController = NavigationBarVisibilitySpyNavigationController()
+        navigationController.setNavigationBarHidden(false, animated: false)
+        navigationController.resetVisibilityUpdates()
+
+        // When
+        navigationController.setNavigationBarHiddenIfNeeded(true, animated: false)
+
+        // Then
+        #expect(navigationController.visibilityUpdates.count == 1)
+        #expect(navigationController.visibilityUpdates.first?.hidden == true)
+        #expect(navigationController.visibilityUpdates.first?.animated == false)
+    }
+
     @Test func test_connectivity_change_when_current_controller_is_visible_and_top_then_updates_offline_banner() {
         // Given
         let connectivityObserver = MockConnectivityObserver()
@@ -80,5 +108,18 @@ private final class OfflineBannerViewController: UIViewController {
 private final class StableNavigationController: WooNavigationController {
     override var transitionCoordinator: UIViewControllerTransitionCoordinator? {
         nil
+    }
+}
+
+private final class NavigationBarVisibilitySpyNavigationController: UINavigationController {
+    private(set) var visibilityUpdates: [(hidden: Bool, animated: Bool)] = []
+
+    override func setNavigationBarHidden(_ hidden: Bool, animated: Bool) {
+        visibilityUpdates.append((hidden, animated))
+        super.setNavigationBarHidden(hidden, animated: animated)
+    }
+
+    func resetVisibilityUpdates() {
+        visibilityUpdates = []
     }
 }


### PR DESCRIPTION
Closes: WOOMOB-3881

## Description
A further speculative fix for the Product Search navigation bar crash tracked in https://a8c.sentry.io/issues/7669931391.

To get the crash rate down, this is branched as a beta fix on 25.4.

The theory is that when Product Search reappears during a collapsed split-view transition, its inner navigation bar can already be hidden. `SearchViewController.viewWillAppear` nevertheless asks UIKit to hide it again. The redundant visibility update can make UIKit lay out a wrapper navigation bar using an item owned by the hidden inner bar, raising an `NSInternalInconsistencyException`.

This adds a guarded navigation-bar visibility helper and uses it for Search lifecycle and Product Search cancellation updates, so UIKit is only called when the requested visibility differs from the current state. Regression tests cover both the no-op and update paths.

## Test Steps
1. On an iPhone, open **Products** and enter Product Search.
2. Search for and select a product, then navigate back to the search screen. Repeat this transition several times.
3. Cancel Product Search and confirm the Products navigation bar is restored.
4. Repeat while resizing or rotating an iPad between collapsed and expanded split-view layouts.
5. Confirm there is no crash and the navigation bar remains correct throughout.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release note is needed for this internal crash fix.