### PR TITLE
[WOOMOB-3800] Use authentication endpoints for sites and WebViews

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -340,10 +340,12 @@ private extension AuthenticatedWebViewController {
         }
     }
 
-    func finishSiteCredentialAuthentication() {
+    func finishSiteCredentialAuthentication(preservingExpectedCancellation: Bool = false) {
         siteCredentialNavigationGate = nil
         siteCredentialNavigation = nil
-        siteCredentialNavigationExpectedToCancel = nil
+        if preservingExpectedCancellation == false {
+            siteCredentialNavigationExpectedToCancel = nil
+        }
         siteCredentialReplacementLoadID = nil
     }
 
@@ -351,7 +353,8 @@ private extension AuthenticatedWebViewController {
         guard siteCredentialNavigationGate != nil else {
             return
         }
-        cancelSiteCredentialAuthentication()
+        finishSiteCredentialAuthentication()
+        webView.stopLoading()
         if let initialURL = viewModel.initialURL {
             loadContent(url: initialURL)
         }
@@ -361,7 +364,8 @@ private extension AuthenticatedWebViewController {
         guard siteCredentialNavigationGate != nil else {
             return
         }
-        finishSiteCredentialAuthentication()
+        siteCredentialNavigationExpectedToCancel = siteCredentialNavigation
+        finishSiteCredentialAuthentication(preservingExpectedCancellation: true)
         webView.stopLoading()
     }
 }
@@ -387,7 +391,7 @@ extension AuthenticatedWebViewController {
             scheduleSiteCredentialReplacementLoad(destinationURL)
             return .cancel
         case .cancelAndFinish:
-            failSiteCredentialAuthenticationAndLoadInitialURL()
+            scheduleSiteCredentialFallbackLoad()
             return .cancel
         }
     }
@@ -408,33 +412,50 @@ extension AuthenticatedWebViewController {
         case .allowContinuation:
             return .allow
         case .allowAndFinish(let destinationURL):
-            finishSiteCredentialAuthentication()
             if viewModel.initialURL == destinationURL {
+                finishSiteCredentialAuthentication()
                 return .allow
             }
-            webView.stopLoading()
-            if let initialURL = viewModel.initialURL {
-                loadContent(url: initialURL)
-            }
+            scheduleSiteCredentialFallbackLoad()
             return .cancel
         case .cancelAndFinish:
-            failSiteCredentialAuthenticationAndLoadInitialURL()
+            scheduleSiteCredentialFallbackLoad()
             return .cancel
         }
     }
 
-    private func scheduleSiteCredentialReplacementLoad(_ destinationURL: URL) {
+    private func scheduleSiteCredentialFallbackLoad() {
+        guard let initialURL = viewModel.initialURL else {
+            siteCredentialNavigationExpectedToCancel = siteCredentialNavigation
+            finishSiteCredentialAuthentication(preservingExpectedCancellation: true)
+            return
+        }
+        scheduleSiteCredentialReplacementLoad(initialURL, purpose: .finishAuthentication)
+    }
+
+    private func scheduleSiteCredentialReplacementLoad(
+        _ destinationURL: URL,
+        purpose: SiteCredentialReplacementPurpose = .continueAuthentication
+    ) {
         siteCredentialNavigationExpectedToCancel = siteCredentialNavigation
         let loadID = UUID()
         siteCredentialReplacementLoadID = loadID
         siteCredentialReplacementScheduler { [weak self] in
             guard let self,
-                  self.siteCredentialNavigationGate != nil,
                   self.siteCredentialReplacementLoadID == loadID else {
                 return
             }
-            self.siteCredentialReplacementLoadID = nil
-            self.siteCredentialNavigation = self.webView.load(URLRequest(url: destinationURL))
+            switch purpose {
+            case .continueAuthentication:
+                guard self.siteCredentialNavigationGate != nil else {
+                    return
+                }
+                self.siteCredentialReplacementLoadID = nil
+                self.siteCredentialNavigation = self.webView.load(URLRequest(url: destinationURL))
+            case .finishAuthentication:
+                self.finishSiteCredentialAuthentication(preservingExpectedCancellation: true)
+                self.loadContent(url: destinationURL)
+            }
         }
     }
 
@@ -548,6 +569,11 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
 private enum WebKitError {
     /// WebKit's internal policy-change interruption is not exposed through `WKError.Code`.
     static let frameLoadInterruptedByPolicyChange = 102
+}
+
+private enum SiteCredentialReplacementPurpose {
+    case continueAuthentication
+    case finishAuthentication
 }
 
 extension AuthenticatedWebViewController: WKUIDelegate {

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -120,8 +120,7 @@ final class AuthenticatedWebViewController: UIViewController {
         if let initialURL = viewModel.initialURL,
            var viewModel = viewModel as? WebviewReloadable {
             viewModel.reloadWebview = { [weak self] in
-                self?.finishSiteCredentialAuthentication()
-                self?.webView.stopLoading()
+                self?.cancelSiteCredentialAuthentication()
                 self?.webView.load(.init(url: initialURL))
             }
         }
@@ -144,8 +143,7 @@ final class AuthenticatedWebViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if isBeingDismissedInAnyWay {
-            finishSiteCredentialAuthentication()
-            webView.stopLoading()
+            cancelSiteCredentialAuthentication()
             viewModel.handleDismissal()
         }
     }
@@ -353,11 +351,18 @@ private extension AuthenticatedWebViewController {
         guard siteCredentialNavigationGate != nil else {
             return
         }
-        finishSiteCredentialAuthentication()
-        webView.stopLoading()
+        cancelSiteCredentialAuthentication()
         if let initialURL = viewModel.initialURL {
             loadContent(url: initialURL)
         }
+    }
+
+    private func cancelSiteCredentialAuthentication() {
+        guard siteCredentialNavigationGate != nil else {
+            return
+        }
+        finishSiteCredentialAuthentication()
+        webView.stopLoading()
     }
 }
 
@@ -367,15 +372,14 @@ extension AuthenticatedWebViewController {
         isMainFrame: Bool,
         shouldPerformDownload: Bool
     ) -> WKNavigationActionPolicy? {
-        guard var gate = siteCredentialNavigationGate else {
-            return nil
-        }
-        let decision = gate.decision(
+        // Optional chaining mutates the stored gate in place, so its phase always advances with the decision.
+        guard let decision = siteCredentialNavigationGate?.decision(
             for: request,
             isMainFrame: isMainFrame,
             shouldPerformDownload: shouldPerformDownload
-        )
-        siteCredentialNavigationGate = gate
+        ) else {
+            return nil
+        }
         switch decision {
         case .allowCredentialPost, .allowDestination:
             return .allow
@@ -393,15 +397,13 @@ extension AuthenticatedWebViewController {
         isMainFrame: Bool,
         canShowMIMEType: Bool
     ) -> WKNavigationResponsePolicy? {
-        guard var gate = siteCredentialNavigationGate else {
-            return nil
-        }
-        let decision = gate.decision(
+        guard let decision = siteCredentialNavigationGate?.decision(
             for: response,
             isMainFrame: isMainFrame,
             canShowMIMEType: canShowMIMEType
-        )
-        siteCredentialNavigationGate = gate
+        ) else {
+            return nil
+        }
         switch decision {
         case .allowContinuation:
             return .allow
@@ -438,9 +440,11 @@ extension AuthenticatedWebViewController {
 
     private func shouldSuppressSiteCredentialCancellation(for navigation: WKNavigation?, error: Error) -> Bool {
         let error = error as NSError
+        let isExpectedCancellation = error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled
+        let isWebKitPolicyInterruption = error.domain == WKError.errorDomain &&
+            error.code == WebKitError.frameLoadInterruptedByPolicyChange
         guard let expectedNavigation = siteCredentialNavigationExpectedToCancel,
-              error.domain == NSURLErrorDomain,
-              error.code == NSURLErrorCancelled,
+              isExpectedCancellation || isWebKitPolicyInterruption,
               navigation === expectedNavigation else {
             return false
         }
@@ -463,8 +467,7 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
             return .allow
         }
 
-        let policy = await viewModel.decidePolicy(for: navigationURL)
-        return policy
+        return await viewModel.decidePolicy(for: navigationURL)
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
@@ -485,21 +488,10 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
                                              authenticationFlow: authenticationFlow,
                                              isFirstNavigation: isFirstNavigation) {
             /// When automatic authentication fails, cancel the navigation and redirect to the original URL instead.
-            if siteCredentialNavigationGate != nil {
-                failSiteCredentialAuthenticationAndLoadInitialURL()
-            } else {
-                loadContent(url: initialURL)
-            }
+            loadContent(url: initialURL)
             return .cancel
         }
-        let policy = await viewModel.decidePolicy(for: response)
-        switch policy {
-        case .allow:
-            break
-        default:
-            finishSiteCredentialAuthentication()
-        }
-        return policy
+        return await viewModel.decidePolicy(for: response)
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
@@ -540,14 +532,22 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
         guard shouldSuppressSiteCredentialCancellation(for: navigation, error: error) == false else {
             return
         }
+        let wasAuthenticatingWithSiteCredentials = siteCredentialNavigationGate != nil
         failSiteCredentialAuthenticationAndLoadInitialURL()
-        viewModel.didFailProvisionalNavigation(with: error)
+        if wasAuthenticatingWithSiteCredentials == false {
+            viewModel.didFailProvisionalNavigation(with: error)
+        }
         activityIndicator.stopAnimating()
     }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         failSiteCredentialAuthenticationAndLoadInitialURL()
     }
+}
+
+private enum WebKitError {
+    /// WebKit's internal policy-change interruption is not exposed through `WKError.Code`.
+    static let frameLoadInterruptedByPolicyChange = 102
 }
 
 extension AuthenticatedWebViewController: WKUIDelegate {

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -5,6 +5,11 @@ import Yosemite
 import class Networking.UserAgent
 import struct WordPressAuthenticator.WordPressOrgCredentials
 
+struct WPOrgWebViewAuthenticationContext {
+    let credentials: WordPressOrgCredentials
+    let authenticationEndpoints: CookieNonceAuthenticationEndpoints
+}
+
 /// A web view which is authenticated for WordPress.com, when possible.
 ///
 final class AuthenticatedWebViewController: UIViewController {
@@ -34,13 +39,17 @@ final class AuthenticatedWebViewController: UIViewController {
     /// Strong reference for the subscription to update progress bar
     private var subscriptions: Set<AnyCancellable> = []
 
-    /// Optional credentials for authenticating with WP.org
-    ///
-    private let siteCredentials: WordPressOrgCredentials?
+    private let siteAuthentication: WPOrgWebViewAuthenticationContext?
 
     private let wpcomCredentials: Credentials?
 
+    private let siteCredentialReplacementScheduler: (@escaping () -> Void) -> Void
+
     private var isFirstNavigation = true
+    private var siteCredentialNavigationGate: WPOrgWebViewAuthenticationNavigationGate?
+    private var siteCredentialNavigation: WKNavigation?
+    private var siteCredentialNavigationExpectedToCancel: WKNavigation?
+    private var siteCredentialReplacementLoadID: UUID?
 
     convenience init(stores: StoresManager = ServiceLocator.stores,
                      viewModel: AuthenticatedWebViewModel,
@@ -60,28 +69,23 @@ final class AuthenticatedWebViewController: UIViewController {
                   webView: popupWebView)
     }
 
-    private init(stores: StoresManager,
-                 viewModel: AuthenticatedWebViewModel,
-                 extraCredentials: Credentials?,
-                 webView: WKWebView) {
+    init(stores: StoresManager,
+         viewModel: AuthenticatedWebViewModel,
+         extraCredentials: Credentials?,
+         webView: WKWebView,
+         siteCredentialReplacementScheduler: @escaping (@escaping () -> Void) -> Void = { work in
+             DispatchQueue.main.async(execute: work)
+         }) {
         self.viewModel = viewModel
         self.webView = webView
+        self.siteCredentialReplacementScheduler = siteCredentialReplacementScheduler
         let currentCredentials = stores.sessionManager.defaultCredentials
 
-        let siteCredentials: WordPressOrgCredentials? = {
-            if case let .wporg(username, password, siteAddress) = extraCredentials {
-                return WordPressOrgCredentials(username: username,
-                                               password: password,
-                                               xmlrpc: siteAddress + "/xmlrpc.php",
-                                               options: [:])
-            } else if case let.wporg(username, password, siteAddress) = currentCredentials {
-                return WordPressOrgCredentials(username: username,
-                                               password: password,
-                                               xmlrpc: siteAddress + "/xmlrpc.php",
-                                               options: [:])
-            }
-            return nil
-        }()
+        let siteAuthentication = Self.resolveWPOrgAuthentication(
+            extraCredentials: extraCredentials,
+            currentCredentials: currentCredentials,
+            authenticationEndpointLookup: stores.sessionManager.cookieNonceAuthenticationEndpoints(for:)
+        )
 
         let wpcomCredentials: Credentials? = {
             if case .wpcom = extraCredentials {
@@ -100,11 +104,11 @@ final class AuthenticatedWebViewController: UIViewController {
             }
             return viewModel.authenticationFlow(currentSite: currentSite,
                                                 wpcomCredentialsAvailable: wpcomCredentials != nil,
-                                                wporgCredentialsAvailable: siteCredentials != nil)
+                                                wporgCredentialsAvailable: siteAuthentication != nil)
         }()
         self.currentSite = currentSite
         self.wpcomCredentials = wpcomCredentials
-        self.siteCredentials = siteCredentials
+        self.siteAuthentication = siteAuthentication
 
         super.init(nibName: nil, bundle: nil)
 
@@ -116,6 +120,8 @@ final class AuthenticatedWebViewController: UIViewController {
         if let initialURL = viewModel.initialURL,
            var viewModel = viewModel as? WebviewReloadable {
             viewModel.reloadWebview = { [weak self] in
+                self?.finishSiteCredentialAuthentication()
+                self?.webView.stopLoading()
                 self?.webView.load(.init(url: initialURL))
             }
         }
@@ -138,6 +144,8 @@ final class AuthenticatedWebViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if isBeingDismissedInAnyWay {
+            finishSiteCredentialAuthentication()
+            webView.stopLoading()
             viewModel.handleDismissal()
         }
     }
@@ -145,6 +153,38 @@ final class AuthenticatedWebViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         viewModel.handleDisappear()
         super.viewDidDisappear(animated)
+    }
+}
+
+extension AuthenticatedWebViewController {
+    static func resolveWPOrgAuthentication(
+        extraCredentials: Credentials?,
+        currentCredentials: Credentials?,
+        authenticationEndpointLookup: (Credentials) -> CookieNonceAuthenticationEndpoints?
+    ) -> WPOrgWebViewAuthenticationContext? {
+        let selectedCredentials: Credentials?
+        if case .wporg = extraCredentials {
+            selectedCredentials = extraCredentials
+        } else if case .wporg = currentCredentials {
+            selectedCredentials = currentCredentials
+        } else {
+            selectedCredentials = nil
+        }
+
+        guard let selectedCredentials,
+              case let .wporg(username, password, siteAddress) = selectedCredentials else {
+            return nil
+        }
+        let credentials = WordPressOrgCredentials(
+            username: username,
+            password: password,
+            xmlrpc: siteAddress + "/xmlrpc.php",
+            options: [:]
+        )
+        guard let endpoints = authenticationEndpointLookup(selectedCredentials) ?? credentials.authenticationEndpoints else {
+            return nil
+        }
+        return WPOrgWebViewAuthenticationContext(credentials: credentials, authenticationEndpoints: endpoints)
     }
 }
 
@@ -246,10 +286,23 @@ private extension AuthenticatedWebViewController {
     }
 
     func authenticateUsingSiteCredentialsAndLoadContent(url: URL) {
-        guard let siteCredentials, let request = try? webView.authenticateForWPOrg(with: siteCredentials) else {
+        guard let siteAuthentication else {
             return loadContent(url: url)
         }
-        webView.load(request)
+        do {
+            let request = try webView.authenticateForWPOrg(
+                with: siteAuthentication.credentials,
+                authenticationEndpoints: siteAuthentication.authenticationEndpoints
+            )
+            siteCredentialNavigationGate = try WPOrgWebViewAuthenticationNavigationGate(
+                authenticationRequest: request,
+                authenticationEndpoints: siteAuthentication.authenticationEndpoints
+            )
+            siteCredentialNavigation = webView.load(request)
+        } catch {
+            finishSiteCredentialAuthentication()
+            loadContent(url: url)
+        }
     }
 
     func loadContent(url: URL) {
@@ -282,23 +335,136 @@ private extension AuthenticatedWebViewController {
             loadContent(url: loginURL)
 
         default:
-            if url.absoluteString.contains(WKWebView.wporgNoncePath) == true,
-               initialURL.absoluteString.contains(WKWebView.wporgNoncePath) != true {
-                // Site credentials login completes, now proceed to load the initial URL.
-                loadContent(url: initialURL)
-            } else {
-                viewModel.handleRedirect(for: url)
+            if siteCredentialNavigationGate != nil {
+                return
             }
+            viewModel.handleRedirect(for: url)
         }
+    }
+
+    func finishSiteCredentialAuthentication() {
+        siteCredentialNavigationGate = nil
+        siteCredentialNavigation = nil
+        siteCredentialNavigationExpectedToCancel = nil
+        siteCredentialReplacementLoadID = nil
+    }
+
+    func failSiteCredentialAuthenticationAndLoadInitialURL() {
+        guard siteCredentialNavigationGate != nil else {
+            return
+        }
+        finishSiteCredentialAuthentication()
+        webView.stopLoading()
+        if let initialURL = viewModel.initialURL {
+            loadContent(url: initialURL)
+        }
+    }
+}
+
+extension AuthenticatedWebViewController {
+    func decideSiteCredentialNavigation(
+        for request: URLRequest,
+        isMainFrame: Bool,
+        shouldPerformDownload: Bool
+    ) -> WKNavigationActionPolicy? {
+        guard var gate = siteCredentialNavigationGate else {
+            return nil
+        }
+        let decision = gate.decision(
+            for: request,
+            isMainFrame: isMainFrame,
+            shouldPerformDownload: shouldPerformDownload
+        )
+        siteCredentialNavigationGate = gate
+        switch decision {
+        case .allowCredentialPost, .allowDestination:
+            return .allow
+        case .cancelAndLoadDestination(let destinationURL):
+            scheduleSiteCredentialReplacementLoad(destinationURL)
+            return .cancel
+        case .cancelAndFinish:
+            failSiteCredentialAuthenticationAndLoadInitialURL()
+            return .cancel
+        }
+    }
+
+    func decideSiteCredentialNavigation(
+        for response: URLResponse,
+        isMainFrame: Bool,
+        canShowMIMEType: Bool
+    ) -> WKNavigationResponsePolicy? {
+        guard var gate = siteCredentialNavigationGate else {
+            return nil
+        }
+        let decision = gate.decision(
+            for: response,
+            isMainFrame: isMainFrame,
+            canShowMIMEType: canShowMIMEType
+        )
+        siteCredentialNavigationGate = gate
+        switch decision {
+        case .allowContinuation:
+            return .allow
+        case .allowAndFinish(let destinationURL):
+            finishSiteCredentialAuthentication()
+            if viewModel.initialURL == destinationURL {
+                return .allow
+            }
+            webView.stopLoading()
+            if let initialURL = viewModel.initialURL {
+                loadContent(url: initialURL)
+            }
+            return .cancel
+        case .cancelAndFinish:
+            failSiteCredentialAuthenticationAndLoadInitialURL()
+            return .cancel
+        }
+    }
+
+    private func scheduleSiteCredentialReplacementLoad(_ destinationURL: URL) {
+        siteCredentialNavigationExpectedToCancel = siteCredentialNavigation
+        let loadID = UUID()
+        siteCredentialReplacementLoadID = loadID
+        siteCredentialReplacementScheduler { [weak self] in
+            guard let self,
+                  self.siteCredentialNavigationGate != nil,
+                  self.siteCredentialReplacementLoadID == loadID else {
+                return
+            }
+            self.siteCredentialReplacementLoadID = nil
+            self.siteCredentialNavigation = self.webView.load(URLRequest(url: destinationURL))
+        }
+    }
+
+    private func shouldSuppressSiteCredentialCancellation(for navigation: WKNavigation?, error: Error) -> Bool {
+        let error = error as NSError
+        guard let expectedNavigation = siteCredentialNavigationExpectedToCancel,
+              error.domain == NSURLErrorDomain,
+              error.code == NSURLErrorCancelled,
+              navigation === expectedNavigation else {
+            return false
+        }
+        siteCredentialNavigationExpectedToCancel = nil
+        return true
     }
 }
 
 extension AuthenticatedWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
+        if let policy = decideSiteCredentialNavigation(
+            for: navigationAction.request,
+            isMainFrame: navigationAction.targetFrame?.isMainFrame == true,
+            shouldPerformDownload: navigationAction.shouldPerformDownload
+        ) {
+            return policy
+        }
+
         guard let navigationURL = navigationAction.request.url else {
             return .allow
         }
-        return await viewModel.decidePolicy(for: navigationURL)
+
+        let policy = await viewModel.decidePolicy(for: navigationURL)
+        return policy
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
@@ -306,19 +472,41 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
             isFirstNavigation = false
         }
         let response = navigationResponse.response
+        if let policy = decideSiteCredentialNavigation(
+            for: response,
+            isMainFrame: navigationResponse.isForMainFrame,
+            canShowMIMEType: navigationResponse.canShowMIMEType
+        ) {
+            return policy
+        }
         if let initialURL = viewModel.initialURL,
            viewModel.isAuthenticationFailure(response: response,
                                              currentSite: currentSite,
                                              authenticationFlow: authenticationFlow,
                                              isFirstNavigation: isFirstNavigation) {
             /// When automatic authentication fails, cancel the navigation and redirect to the original URL instead.
-            loadContent(url: initialURL)
+            if siteCredentialNavigationGate != nil {
+                failSiteCredentialAuthenticationAndLoadInitialURL()
+            } else {
+                loadContent(url: initialURL)
+            }
             return .cancel
         }
-        return await viewModel.decidePolicy(for: response)
+        let policy = await viewModel.decidePolicy(for: response)
+        switch policy {
+        case .allow:
+            break
+        default:
+            finishSiteCredentialAuthentication()
+        }
+        return policy
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        if siteCredentialNavigationGate != nil,
+           navigation !== siteCredentialNavigationExpectedToCancel {
+            siteCredentialNavigation = navigation
+        }
         progressBar.setProgress(0, animated: false)
         activityIndicator.startAnimating()
     }
@@ -330,18 +518,35 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         activityIndicator.stopAnimating()
         guard let url = webView.url else {
+            failSiteCredentialAuthenticationAndLoadInitialURL()
+            return
+        }
+        if siteCredentialNavigationGate != nil {
+            failSiteCredentialAuthenticationAndLoadInitialURL()
             return
         }
         viewModel.didFinishNavigation(for: url)
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
+        guard shouldSuppressSiteCredentialCancellation(for: navigation, error: error) == false else {
+            return
+        }
+        failSiteCredentialAuthenticationAndLoadInitialURL()
         activityIndicator.stopAnimating()
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        guard shouldSuppressSiteCredentialCancellation(for: navigation, error: error) == false else {
+            return
+        }
+        failSiteCredentialAuthenticationAndLoadInitialURL()
         viewModel.didFailProvisionalNavigation(with: error)
         activityIndicator.stopAnimating()
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        failSiteCredentialAuthenticationAndLoadInitialURL()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -462,7 +462,8 @@ extension AuthenticatedWebViewController {
     private func shouldSuppressSiteCredentialCancellation(for navigation: WKNavigation?, error: Error) -> Bool {
         let error = error as NSError
         let isExpectedCancellation = error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled
-        let isWebKitPolicyInterruption = error.domain == WKError.errorDomain &&
+        // Policy cancellations use WebKit's legacy domain, not WKError.errorDomain.
+        let isWebKitPolicyInterruption = error.domain == "WebKitErrorDomain" &&
             error.code == WebKitError.frameLoadInterruptedByPolicyChange
         guard let expectedNavigation = siteCredentialNavigationExpectedToCancel,
               isExpectedCancellation || isWebKitPolicyInterruption,

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -2,22 +2,39 @@ import Alamofire
 import Foundation
 import WebKit
 import struct WordPressAuthenticator.WordPressOrgCredentials
+import struct Yosemite.CookieNonceAuthenticationEndpoints
 import enum Yosemite.Credentials
 import class Networking.UserAgent
 
 /// An extension to authenticate WPCom automatically
 ///
 extension WKWebView {
-    static let wporgNoncePath = "/admin-ajax.php?action=rest-nonce"
-
     /// Cookie authentication following WordPressKit implementation:
     /// https://github.com/wordpress-mobile/WordPressKit-iOS/blob/trunk/WordPressKit/Authenticator.swift
     ///
     func authenticateForWPOrg(with credentials: WordPressOrgCredentials) throws -> URLRequest {
-        var request = try URLRequest(url: credentials.loginURL.asURL(), method: .post)
+        guard let endpoints = credentials.authenticationEndpoints else {
+            throw AFError.invalidURL(url: credentials.siteURL)
+        }
+        return try authenticateForWPOrg(with: credentials, authenticationEndpoints: endpoints)
+    }
+
+    func authenticateForWPOrg(with credentials: WordPressOrgCredentials,
+                              authenticationEndpoints: CookieNonceAuthenticationEndpoints) throws -> URLRequest {
+        // WebKit intentionally posts directly to the persisted login entry. Unlike the URLSession login flow, it does not preflight
+        // login HTML or discover a transaction-local form action; the navigation gate below constrains every follow-up request instead.
+        guard let siteURL = URL(string: credentials.siteURL) else {
+            throw AFError.invalidURL(url: credentials.siteURL)
+        }
+        let credentialIdentity = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+        guard credentialIdentity.siteURL == authenticationEndpoints.siteURL else {
+            throw AFError.invalidURL(url: credentials.siteURL)
+        }
+
+        var request = try URLRequest(url: authenticationEndpoints.loginEntryURL, method: .post)
         request.httpShouldHandleCookies = true
 
-        let redirectLink = (credentials.adminURL + Self.wporgNoncePath)
+        let redirectLink = try authenticationEndpoints.nonceURL().absoluteString
             .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
 
         let parameters = ["log": credentials.username,
@@ -46,5 +63,142 @@ extension WKWebView {
                           "authorization": "Bearer " + token]
 
         return try URLEncoding.default.encode(request, with: parameters)
+    }
+}
+
+/// Restricts WebKit navigation while a WordPress.org credential POST is in flight.
+struct WPOrgWebViewAuthenticationNavigationGate {
+    enum Decision: Equatable {
+        case allowCredentialPost
+        case allowDestination
+        case cancelAndLoadDestination(URL)
+        case cancelAndFinish
+    }
+
+    enum ResponseDecision: Equatable {
+        case allowContinuation
+        case allowAndFinish(URL)
+        case cancelAndFinish
+    }
+
+    private enum Phase {
+        case credentialPost
+        case destinationAction
+        case destinationResponse(URL)
+    }
+
+    private let credentialPostURL: URL
+    private let expectedNonceURL: URL
+    private let expectedAdminBaseURL: URL
+    private let authenticationEndpoints: CookieNonceAuthenticationEndpoints
+    private var phase = Phase.credentialPost
+    private var hasReplacedUnsafeDestinationRequest = false
+    private var pendingReplacementURL: URL?
+    private var redirectCount = 0
+    private var lastApprovedURL: URL?
+
+    init(authenticationRequest: URLRequest,
+         authenticationEndpoints: CookieNonceAuthenticationEndpoints) throws {
+        guard authenticationRequest.httpMethod?.uppercased() == HTTPMethod.post.rawValue.uppercased(),
+              authenticationRequest.url == authenticationEndpoints.loginEntryURL else {
+            throw AFError.invalidURL(url: authenticationRequest.url?.absoluteString ?? "")
+        }
+        credentialPostURL = authenticationEndpoints.loginEntryURL
+        expectedNonceURL = try authenticationEndpoints.nonceURL()
+        expectedAdminBaseURL = try authenticationEndpoints.derivedAdminBaseURL()
+        self.authenticationEndpoints = authenticationEndpoints
+    }
+
+    mutating func decision(for request: URLRequest, isMainFrame: Bool, shouldPerformDownload: Bool) -> Decision {
+        guard isMainFrame, shouldPerformDownload == false, let url = request.url else {
+            return .cancelAndFinish
+        }
+
+        switch phase {
+        case .credentialPost:
+            if request.httpMethod?.uppercased() == HTTPMethod.post.rawValue.uppercased(),
+               url == credentialPostURL {
+                phase = .destinationAction
+                return .allowCredentialPost
+            }
+        case .destinationAction, .destinationResponse:
+            let previousURL = lastApprovedURL ?? credentialPostURL
+            guard let resolvedURL = try? authenticationEndpoints.resolveRedirect(
+                location: url.absoluteString,
+                from: previousURL
+            ),
+                  resolvedURL == url,
+                  isExpectedDestination(url) else {
+                return .cancelAndFinish
+            }
+            let hasBody = request.httpBody != nil || request.httpBodyStream != nil
+            let isCleanGet = request.httpMethod?.uppercased() == HTTPMethod.get.rawValue.uppercased() && hasBody == false
+            if let pendingReplacementURL {
+                guard url == pendingReplacementURL, isCleanGet else {
+                    return .cancelAndFinish
+                }
+                self.pendingReplacementURL = nil
+                phase = .destinationResponse(url)
+                lastApprovedURL = url
+                return .allowDestination
+            }
+            guard redirectCount < CookieNonceAuthenticationEndpoints.maximumRedirectCount else {
+                return .cancelAndFinish
+            }
+            redirectCount += 1
+            if isCleanGet {
+                phase = .destinationResponse(url)
+                lastApprovedURL = url
+                return .allowDestination
+            }
+            if hasReplacedUnsafeDestinationRequest == false,
+               request.httpMethod?.uppercased() == HTTPMethod.post.rawValue.uppercased() || hasBody {
+                hasReplacedUnsafeDestinationRequest = true
+                pendingReplacementURL = url
+                return .cancelAndLoadDestination(url)
+            }
+        }
+        return .cancelAndFinish
+    }
+
+    mutating func decision(
+        for response: URLResponse,
+        isMainFrame: Bool,
+        canShowMIMEType: Bool
+    ) -> ResponseDecision {
+        guard isMainFrame,
+              let response = response as? HTTPURLResponse,
+              let responseURL = response.url else {
+            return .cancelAndFinish
+        }
+
+        switch phase {
+        case .credentialPost:
+            return .cancelAndFinish
+        case .destinationAction:
+            guard responseURL == credentialPostURL,
+                  300..<400 ~= response.statusCode else {
+                return .cancelAndFinish
+            }
+            return .allowContinuation
+        case .destinationResponse(let expectedURL):
+            if responseURL == expectedURL,
+               200..<300 ~= response.statusCode,
+               canShowMIMEType {
+                return .allowAndFinish(expectedURL)
+            }
+            guard responseURL == expectedURL,
+                  300..<400 ~= response.statusCode else {
+                return .cancelAndFinish
+            }
+            return .allowContinuation
+        }
+    }
+
+    func isExpectedDestination(_ url: URL) -> Bool {
+        url == expectedNonceURL ||
+            url == expectedAdminBaseURL ||
+            authenticationEndpoints.isExpectedNonceURL(url, afterLoginAt: url) ||
+            authenticationEndpoints.isExpectedAdminBaseURL(url, afterLoginAt: url)
     }
 }

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -99,7 +99,7 @@ struct WPOrgWebViewAuthenticationNavigationGate {
 
     init(authenticationRequest: URLRequest,
          authenticationEndpoints: CookieNonceAuthenticationEndpoints) throws {
-        guard authenticationRequest.httpMethod?.uppercased() == HTTPMethod.post.rawValue.uppercased(),
+        guard authenticationRequest.hasMethod(.post),
               authenticationRequest.url == authenticationEndpoints.loginEntryURL else {
             throw AFError.invalidURL(url: authenticationRequest.url?.absoluteString ?? "")
         }
@@ -116,7 +116,7 @@ struct WPOrgWebViewAuthenticationNavigationGate {
 
         switch phase {
         case .credentialPost:
-            if request.httpMethod?.uppercased() == HTTPMethod.post.rawValue.uppercased(),
+            if request.hasMethod(.post),
                url == credentialPostURL {
                 phase = .destinationAction
                 return .allowCredentialPost
@@ -132,7 +132,7 @@ struct WPOrgWebViewAuthenticationNavigationGate {
                 return .cancelAndFinish
             }
             let hasBody = request.httpBody != nil || request.httpBodyStream != nil
-            let isCleanGet = request.httpMethod?.uppercased() == HTTPMethod.get.rawValue.uppercased() && hasBody == false
+            let isCleanGet = request.hasMethod(.get) && hasBody == false
             if let pendingReplacementURL {
                 guard url == pendingReplacementURL, isCleanGet else {
                     return .cancelAndFinish
@@ -152,7 +152,7 @@ struct WPOrgWebViewAuthenticationNavigationGate {
                 return .allowDestination
             }
             if hasReplacedUnsafeDestinationRequest == false,
-               request.httpMethod?.uppercased() == HTTPMethod.post.rawValue.uppercased() || hasBody {
+               request.hasMethod(.post) || hasBody {
                 hasReplacedUnsafeDestinationRequest = true
                 pendingReplacementURL = url
                 return .cancelAndLoadDestination(url)
@@ -195,10 +195,22 @@ struct WPOrgWebViewAuthenticationNavigationGate {
         }
     }
 
+    /// The two destinations the credential POST may reach: the derived nonce endpoint and the admin base.
+    ///
+    /// The `afterLoginAt: url` checks are deliberately self-referential: they re-derive the endpoints as if the login
+    /// transaction ended at `url`, which admits the default-port HTTP-to-HTTPS promoted variants on an `http` site.
+    /// Same host and scheme upgrades only — a downgrade is already rejected by `resolveRedirect` before this runs.
     func isExpectedDestination(_ url: URL) -> Bool {
         url == expectedNonceURL ||
             url == expectedAdminBaseURL ||
             authenticationEndpoints.isExpectedNonceURL(url, afterLoginAt: url) ||
             authenticationEndpoints.isExpectedAdminBaseURL(url, afterLoginAt: url)
+    }
+}
+
+private extension URLRequest {
+    /// Case-insensitive HTTP method comparison, since WebKit may surface a differently cased method than it was given.
+    func hasMethod(_ method: HTTPMethod) -> Bool {
+        httpMethod?.uppercased() == method.rawValue.uppercased()
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -527,7 +527,7 @@ class DefaultStoresManager: StoresManager {
     /// Overlays verified direct-site endpoints while preserving the fetched site's identity and metadata.
     /// Returns the original site whenever the credential, endpoint, and fetched-site identities do not all match.
     func siteByApplyingCookieNonceAuthenticationEndpoints(to site: Site) -> Site {
-        guard site.siteID == WooConstants.placeholderStoreID,
+        guard site.isNonJetpackSite,
               let credentials = sessionManager.defaultCredentials,
               case let .wporg(_, _, siteAddress) = credentials,
               let credentialURL = URL(string: siteAddress),

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -539,8 +539,10 @@ class DefaultStoresManager: StoresManager {
         do {
             let credentialIdentity = try CookieNonceAuthenticationEndpoints(siteURL: credentialURL)
             let siteIdentity = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+            let siteIdentityMatchesEndpoints = siteIdentity.siteURL == endpoints.siteURL ||
+                isDefaultPortHTTPSPromotion(from: endpoints.siteURL, to: siteIdentity.siteURL)
             guard credentialIdentity.siteURL == endpoints.siteURL,
-                  siteIdentity.siteURL == endpoints.siteURL else {
+                  siteIdentityMatchesEndpoints else {
                 return site
             }
             return site.copy(
@@ -550,6 +552,19 @@ class DefaultStoresManager: StoresManager {
         } catch {
             return site
         }
+    }
+
+    /// WordPress may report an HTTPS canonical URL after credentials and endpoints were verified against HTTP.
+    /// This mirrors the endpoint policy's only supported cross-scheme identity change: default-port HTTP to HTTPS.
+    private func isDefaultPortHTTPSPromotion(from source: URL, to destination: URL) -> Bool {
+        guard source.scheme == "http",
+              destination.scheme == "https",
+              var promotedSource = URLComponents(url: source, resolvingAgainstBaseURL: false),
+              promotedSource.port == nil else {
+            return false
+        }
+        promotedSource.scheme = "https"
+        return promotedSource.url == destination
     }
 }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -495,7 +495,7 @@ class DefaultStoresManager: StoresManager {
             return
         }
 
-        sessionManager.defaultSite = site
+        sessionManager.defaultSite = siteByApplyingCookieNonceAuthenticationEndpoints(to: site)
 
         /// Triggers root endpoint to check if application password is available
         dispatch(SettingAction.retrieveSiteAPI(siteID: site.siteID) { [weak self] result in
@@ -503,7 +503,7 @@ class DefaultStoresManager: StoresManager {
             switch result {
             case .success(let siteAPI):
                 let updatedSite = site.copy(applicationPasswordAvailable: siteAPI.applicationPasswordAvailable)
-                sessionManager.defaultSite = updatedSite
+                sessionManager.defaultSite = siteByApplyingCookieNonceAuthenticationEndpoints(to: updatedSite)
             case .failure:
                 break // ignores failure
             }
@@ -522,6 +522,34 @@ class DefaultStoresManager: StoresManager {
             return false
         }
         return true
+    }
+
+    /// Overlays verified direct-site endpoints while preserving the fetched site's identity and metadata.
+    /// Returns the original site whenever the credential, endpoint, and fetched-site identities do not all match.
+    func siteByApplyingCookieNonceAuthenticationEndpoints(to site: Site) -> Site {
+        guard site.siteID == WooConstants.placeholderStoreID,
+              let credentials = sessionManager.defaultCredentials,
+              case let .wporg(_, _, siteAddress) = credentials,
+              let credentialURL = URL(string: siteAddress),
+              let siteURL = URL(string: site.url),
+              let endpoints = sessionManager.cookieNonceAuthenticationEndpoints(for: credentials) else {
+            return site
+        }
+
+        do {
+            let credentialIdentity = try CookieNonceAuthenticationEndpoints(siteURL: credentialURL)
+            let siteIdentity = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+            guard credentialIdentity.siteURL == endpoints.siteURL,
+                  siteIdentity.siteURL == endpoints.siteURL else {
+                return site
+            }
+            return site.copy(
+                adminURL: endpoints.adminBaseURL.absoluteString,
+                loginURL: endpoints.loginEntryURL.absoluteString
+            )
+        } catch {
+            return site
+        }
     }
 }
 
@@ -918,7 +946,7 @@ private extension DefaultStoresManager {
             guard let self else { return }
             switch result {
             case .success(let site):
-                self.sessionManager.defaultSite = site
+                self.sessionManager.defaultSite = self.siteByApplyingCookieNonceAuthenticationEndpoints(to: site)
                 self.updateAndReloadWidgetInformation(with: site.siteID)
                 /// Trigger the `v1.1/connect/site-info` API to get information about
                 /// the site's Jetpack status and whether it's a WPCom site.
@@ -929,7 +957,7 @@ private extension DefaultStoresManager {
                         let updatedSite = site.copy(isJetpackThePluginInstalled: info.hasJetpack,
                                                     isJetpackConnected: info.isJetpackConnected,
                                                     isWordPressComStore: info.isWPCom)
-                        self.sessionManager.defaultSite = updatedSite
+                        self.sessionManager.defaultSite = self.siteByApplyingCookieNonceAuthenticationEndpoints(to: updatedSite)
                         trackSiteConnectionType()
                         self.updateAndReloadWidgetInformation(with: site.siteID)
                     case .failure(let error):

--- a/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 import WebKit
 import WordPressAuthenticator
+import Fakes
+import Yosemite
 @testable import WooCommerce
 
 @MainActor
@@ -115,4 +117,481 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         // Then
         XCTAssertNil(credentials.authenticationEndpoints)
     }
+
+    func test_web_view_authentication_with_custom_endpoints_posts_to_configured_entry_and_redirects_to_policy_nonce() throws {
+        // Given
+        let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: [:])
+        let endpoints = try makeEndpoints()
+
+        // When
+        let request = try WKWebView().authenticateForWPOrg(with: credentials, authenticationEndpoints: endpoints)
+
+        // Then
+        XCTAssertEqual(request.url, endpoints.loginEntryURL)
+        XCTAssertEqual(request.url?.absoluteString, "https://test.com/custom-login?entry=1")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(try formValue(named: "log", in: request), username)
+        XCTAssertEqual(try formValue(named: "pwd", in: request), password)
+        XCTAssertEqual(try formValue(named: "redirect_to", in: request), try endpoints.nonceURL().absoluteString)
+    }
+
+    func test_web_view_authentication_with_endpoints_for_different_site_throws() throws {
+        // Given
+        let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: [:])
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: XCTUnwrap(URL(string: "https://other.example")))
+
+        // Then
+        XCTAssertThrowsError(try WKWebView().authenticateForWPOrg(with: credentials, authenticationEndpoints: endpoints))
+    }
+
+    func test_resolve_wporg_authentication_prefers_extra_credentials_and_looks_up_their_exact_endpoints() throws {
+        // Given
+        let extra: Yosemite.Credentials = .wporg(username: "extra", password: "extra-pass", siteAddress: "https://test.com")
+        let current: Yosemite.Credentials = .wporg(username: "current", password: "current-pass", siteAddress: "https://current.example")
+        let endpoints = try makeEndpoints()
+        var lookedUpCredentials: Yosemite.Credentials?
+
+        // When
+        let context = AuthenticatedWebViewController.resolveWPOrgAuthentication(
+            extraCredentials: extra,
+            currentCredentials: current,
+            authenticationEndpointLookup: { credentials in
+                lookedUpCredentials = credentials
+                return endpoints
+            }
+        )
+
+        // Then
+        XCTAssertEqual(lookedUpCredentials, extra)
+        XCTAssertEqual(context?.credentials.username, "extra")
+        XCTAssertEqual(context?.credentials.password, "extra-pass")
+        XCTAssertEqual(context?.authenticationEndpoints, endpoints)
+    }
+
+    func test_resolve_wporg_authentication_without_persisted_endpoints_uses_selected_credentials_defaults() throws {
+        // Given
+        let current: Yosemite.Credentials = .wporg(username: username, password: password, siteAddress: "https://test.com")
+
+        // When
+        let context = AuthenticatedWebViewController.resolveWPOrgAuthentication(
+            extraCredentials: .wpcom(username: "wpcom", authToken: "token", siteAddress: "https://wordpress.com"),
+            currentCredentials: current,
+            authenticationEndpointLookup: { _ in nil }
+        )
+
+        // Then
+        XCTAssertEqual(context?.credentials.username, username)
+        XCTAssertEqual(context?.authenticationEndpoints.loginEntryURL.absoluteString, "https://test.com/wp-login.php")
+        XCTAssertEqual(context?.authenticationEndpoints.adminBaseURL.absoluteString, "https://test.com/wp-admin/")
+    }
+
+    func test_navigation_gate_allows_initial_main_frame_post_only_once() throws {
+        // Given
+        let (request, endpoints) = try makeAuthenticationRequestAndEndpoints()
+        var gate = try WPOrgWebViewAuthenticationNavigationGate(
+            authenticationRequest: request,
+            authenticationEndpoints: endpoints
+        )
+
+        // When
+        let firstDecision = gate.decision(for: request, isMainFrame: true, shouldPerformDownload: false)
+        let repeatedDecision = gate.decision(for: request, isMainFrame: true, shouldPerformDownload: false)
+
+        // Then
+        XCTAssertEqual(firstDecision, .allowCredentialPost)
+        XCTAssertEqual(repeatedDecision, .cancelAndFinish)
+    }
+
+    func test_navigation_gate_rejects_subframe_and_download_credential_posts() throws {
+        // Given
+        let (request, endpoints) = try makeAuthenticationRequestAndEndpoints()
+        var subframeGate = try WPOrgWebViewAuthenticationNavigationGate(
+            authenticationRequest: request,
+            authenticationEndpoints: endpoints
+        )
+        var downloadGate = subframeGate
+
+        // Then
+        XCTAssertEqual(
+            subframeGate.decision(for: request, isMainFrame: false, shouldPerformDownload: false),
+            .cancelAndFinish
+        )
+        XCTAssertEqual(
+            downloadGate.decision(for: request, isMainFrame: true, shouldPerformDownload: true),
+            .cancelAndFinish
+        )
+    }
+
+    func test_navigation_gate_rewrites_preserved_destination_post_once_then_accepts_clean_get_and_exact_2xx_response() throws {
+        // Given
+        let (request, endpoints) = try makeAuthenticationRequestAndEndpoints()
+        let nonceURL = try endpoints.nonceURL()
+        var gate = try WPOrgWebViewAuthenticationNavigationGate(
+            authenticationRequest: request,
+            authenticationEndpoints: endpoints
+        )
+        XCTAssertEqual(gate.decision(for: request, isMainFrame: true, shouldPerformDownload: false), .allowCredentialPost)
+        var preservedPost = URLRequest(url: nonceURL)
+        preservedPost.httpMethod = "POST"
+        preservedPost.httpBody = Data("credentials".utf8)
+
+        // When
+        let preservedPostDecision = gate.decision(for: preservedPost, isMainFrame: true, shouldPerformDownload: false)
+        let cleanGet = URLRequest(url: nonceURL)
+        let cleanGetDecision = gate.decision(for: cleanGet, isMainFrame: true, shouldPerformDownload: false)
+        let response = try XCTUnwrap(HTTPURLResponse(url: nonceURL, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let responseDecision = gate.decision(for: response, isMainFrame: true, canShowMIMEType: true)
+
+        // Then
+        XCTAssertEqual(preservedPostDecision, .cancelAndLoadDestination(nonceURL))
+        XCTAssertEqual(cleanGetDecision, .allowDestination)
+        XCTAssertEqual(responseDecision, .allowAndFinish(nonceURL))
+    }
+
+    func test_navigation_gate_rejects_arbitrary_same_site_and_cross_site_destinations() throws {
+        // Given
+        let disallowedURLs = [
+            try XCTUnwrap(URL(string: "https://test.com/wp-admin/admin-ajax.php?action=other")),
+            try XCTUnwrap(URL(string: "https://test.com/another-admin/admin-ajax.php?action=rest-nonce")),
+            try XCTUnwrap(URL(string: "https://attacker.example/wp-admin/admin-ajax.php?action=rest-nonce"))
+        ]
+
+        // When
+        let decisions = try disallowedURLs.map { url -> WPOrgWebViewAuthenticationNavigationGate.Decision in
+            let (request, endpoints) = try makeAuthenticationRequestAndEndpoints()
+            var gate = try WPOrgWebViewAuthenticationNavigationGate(
+                authenticationRequest: request,
+                authenticationEndpoints: endpoints
+            )
+            _ = gate.decision(for: request, isMainFrame: true, shouldPerformDownload: false)
+            return gate.decision(for: URLRequest(url: url), isMainFrame: true, shouldPerformDownload: false)
+        }
+
+        // Then
+        XCTAssertEqual(decisions, Array(repeating: .cancelAndFinish, count: disallowedURLs.count))
+    }
+
+    func test_navigation_gate_accepts_controlled_default_port_https_promotion_but_rejects_downgrade_afterwards() throws {
+        // Given
+        let siteURL = try XCTUnwrap(URL(string: "http://test.com:80"))
+        let endpoints = try CookieNonceAuthenticationEndpoints(siteURL: siteURL)
+        let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: "http://test.com/xmlrpc.php", options: [:])
+        let request = try WKWebView().authenticateForWPOrg(with: credentials, authenticationEndpoints: endpoints)
+        var gate = try WPOrgWebViewAuthenticationNavigationGate(
+            authenticationRequest: request,
+            authenticationEndpoints: endpoints
+        )
+        _ = gate.decision(for: request, isMainFrame: true, shouldPerformDownload: false)
+        let insecureAdminURL = try endpoints.derivedAdminBaseURL()
+        let secureNonceURL = try XCTUnwrap(URL(string: "https://test.com/wp-admin/admin-ajax.php?action=rest-nonce"))
+
+        // When
+        let adminDecision = gate.decision(for: URLRequest(url: insecureAdminURL), isMainFrame: true, shouldPerformDownload: false)
+        let promotedDecision = gate.decision(for: URLRequest(url: secureNonceURL), isMainFrame: true, shouldPerformDownload: false)
+        let insecureNonceURL = try endpoints.nonceURL()
+        let downgradeDecision = gate.decision(for: URLRequest(url: insecureNonceURL), isMainFrame: true, shouldPerformDownload: false)
+
+        // Then
+        XCTAssertEqual(adminDecision, .allowDestination)
+        XCTAssertEqual(promotedDecision, .allowDestination)
+        XCTAssertEqual(downgradeDecision, .cancelAndFinish)
+    }
+
+    func test_navigation_gate_bounds_redirect_action_chain_without_double_counting_redirect_responses() throws {
+        // Given
+        let (request, endpoints) = try makeAuthenticationRequestAndEndpoints()
+        var gate = try WPOrgWebViewAuthenticationNavigationGate(
+            authenticationRequest: request,
+            authenticationEndpoints: endpoints
+        )
+        XCTAssertEqual(gate.decision(for: request, isMainFrame: true, shouldPerformDownload: false), .allowCredentialPost)
+        let loginURL = try XCTUnwrap(request.url)
+        let loginResponse = try XCTUnwrap(HTTPURLResponse(url: loginURL, statusCode: 302, httpVersion: nil, headerFields: nil))
+        XCTAssertEqual(gate.decision(for: loginResponse, isMainFrame: true, canShowMIMEType: false), .allowContinuation)
+        let adminURL = endpoints.adminBaseURL
+        let nonceURL = try endpoints.nonceURL()
+        let allowedURLs = [adminURL, nonceURL, adminURL]
+
+        // When
+        let allowedDecisions = try allowedURLs.map { url -> WPOrgWebViewAuthenticationNavigationGate.Decision in
+            let decision = gate.decision(for: URLRequest(url: url), isMainFrame: true, shouldPerformDownload: false)
+            let response = try XCTUnwrap(HTTPURLResponse(url: url, statusCode: 302, httpVersion: nil, headerFields: nil))
+            XCTAssertEqual(gate.decision(for: response, isMainFrame: true, canShowMIMEType: false), .allowContinuation)
+            return decision
+        }
+        let overLimitDecision = gate.decision(for: URLRequest(url: nonceURL), isMainFrame: true, shouldPerformDownload: false)
+
+        // Then
+        XCTAssertEqual(allowedDecisions, Array(repeating: .allowDestination, count: allowedURLs.count))
+        XCTAssertEqual(overLimitDecision, .cancelAndFinish)
+    }
+
+    func test_navigation_gate_allows_exact_configured_admin_base_get() throws {
+        // Given
+        let (request, endpoints) = try makeAuthenticationRequestAndEndpoints()
+        var gate = try WPOrgWebViewAuthenticationNavigationGate(
+            authenticationRequest: request,
+            authenticationEndpoints: endpoints
+        )
+        _ = gate.decision(for: request, isMainFrame: true, shouldPerformDownload: false)
+
+        // When
+        let decision = gate.decision(
+            for: URLRequest(url: endpoints.adminBaseURL),
+            isMainFrame: true,
+            shouldPerformDownload: false
+        )
+
+        // Then
+        XCTAssertEqual(decision, .allowDestination)
+    }
+
+    func test_controller_boundary_rewrites_preserved_post_and_finishes_only_after_exact_2xx_response() throws {
+        // Given
+        let harness = try makeAuthenticatedControllerHarness()
+        defer { harness.cleanup() }
+        let (sut, webView, endpoints, initialURL) = (harness.controller, harness.webView, harness.endpoints, harness.initialURL)
+        sut.loadViewIfNeeded()
+        let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        XCTAssertEqual(
+            sut.decideSiteCredentialNavigation(for: credentialRequest, isMainFrame: true, shouldPerformDownload: false),
+            .allow
+        )
+        let nonceURL = try endpoints.nonceURL()
+        var preservedPost = URLRequest(url: nonceURL)
+        preservedPost.httpMethod = "POST"
+        preservedPost.httpBody = Data("credentials".utf8)
+
+        // When
+        let preservedPolicy = sut.decideSiteCredentialNavigation(
+            for: preservedPost,
+            isMainFrame: true,
+            shouldPerformDownload: false
+        )
+        let cleanGet = try XCTUnwrap(webView.loadedRequests.last)
+        let cleanGetPolicy = sut.decideSiteCredentialNavigation(for: cleanGet, isMainFrame: true, shouldPerformDownload: false)
+        let response = try XCTUnwrap(HTTPURLResponse(url: nonceURL, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let responsePolicy = sut.decideSiteCredentialNavigation(
+            for: response,
+            isMainFrame: true,
+            canShowMIMEType: true
+        )
+
+        // Then
+        XCTAssertEqual(preservedPolicy, .cancel)
+        XCTAssertEqual(cleanGet.url, nonceURL)
+        XCTAssertEqual(cleanGet.httpMethod, "GET")
+        XCTAssertNil(cleanGet.httpBody)
+        XCTAssertEqual(cleanGetPolicy, .allow)
+        XCTAssertEqual(responsePolicy, .cancel)
+        XCTAssertEqual(webView.loadedRequests.last?.url, initialURL)
+        XCTAssertNil(
+            sut.decideSiteCredentialNavigation(for: URLRequest(url: initialURL), isMainFrame: true, shouldPerformDownload: false)
+        )
+    }
+
+    func test_policy_cancellation_does_not_supersede_scheduled_clean_get_but_clean_get_failure_falls_back_once() throws {
+        // Given
+        let harness = try makeAuthenticatedControllerHarness()
+        defer { harness.cleanup() }
+        let (sut, webView, endpoints, initialURL) = (harness.controller, harness.webView, harness.endpoints, harness.initialURL)
+        sut.loadViewIfNeeded()
+        let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        let credentialNavigation = try XCTUnwrap(webView.loadedNavigations.first)
+        XCTAssertEqual(
+            sut.decideSiteCredentialNavigation(for: credentialRequest, isMainFrame: true, shouldPerformDownload: false),
+            .allow
+        )
+        let nonceURL = try endpoints.nonceURL()
+        var preservedPost = URLRequest(url: nonceURL)
+        preservedPost.httpMethod = "POST"
+        preservedPost.httpBody = Data("credentials".utf8)
+
+        // When
+        let preservedPolicy = sut.decideSiteCredentialNavigation(
+            for: preservedPost,
+            isMainFrame: true,
+            shouldPerformDownload: false
+        )
+        sut.webView(
+            webView,
+            didFailProvisionalNavigation: credentialNavigation,
+            withError: URLError(.cancelled)
+        )
+        let cleanNavigation = try XCTUnwrap(webView.loadedNavigations.last)
+        sut.webView(webView, didFailProvisionalNavigation: cleanNavigation, withError: URLError(.cannotConnectToHost))
+        sut.webView(webView, didFailProvisionalNavigation: cleanNavigation, withError: URLError(.cannotConnectToHost))
+
+        // Then
+        XCTAssertEqual(preservedPolicy, .cancel)
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url, nonceURL, initialURL])
+        XCTAssertEqual(webView.loadedRequests[1].httpMethod, "GET")
+        XCTAssertNil(webView.loadedRequests[1].httpBody)
+    }
+
+    func test_controller_with_mismatched_persisted_endpoint_identity_falls_back_to_unauthenticated_initial_url() throws {
+        // Given
+        let credentials: Yosemite.Credentials = .wporg(username: username, password: password, siteAddress: "https://test.com")
+        let sessionManager = MockSessionManager()
+        sessionManager.defaultCredentials = credentials
+        sessionManager.defaultSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: "https://test.com")
+        sessionManager.cookieNonceAuthenticationEndpointsToReturn = try CookieNonceAuthenticationEndpoints(
+            siteURL: XCTUnwrap(URL(string: "https://other.example"))
+        )
+        let initialURL = try XCTUnwrap(URL(string: "https://test.com/products/13"))
+        let webView = RecordingWKWebView()
+        let sut = AuthenticatedWebViewController(
+            stores: DefaultStoresManager(sessionManager: sessionManager),
+            viewModel: StubAuthenticatedWebViewModel(initialURL: initialURL),
+            extraCredentials: nil,
+            webView: webView
+        )
+
+        // When
+        sut.loadViewIfNeeded()
+
+        // Then
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [initialURL])
+    }
+
+    func test_controller_rewrites_preserved_post_and_never_loads_attacker_request() throws {
+        // Given
+        let harness = try makeAuthenticatedControllerHarness()
+        defer { harness.cleanup() }
+        let (sut, webView, endpoints) = (harness.controller, harness.webView, harness.endpoints)
+        sut.loadViewIfNeeded()
+        let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        let credentialPolicy = sut.decideSiteCredentialNavigation(
+            for: credentialRequest,
+            isMainFrame: true,
+            shouldPerformDownload: false
+        )
+        XCTAssertEqual(credentialPolicy, .allow)
+        let nonceURL = try endpoints.nonceURL()
+        var preservedPost = URLRequest(url: nonceURL)
+        preservedPost.httpMethod = "POST"
+        preservedPost.httpBody = Data("credentials".utf8)
+
+        // When
+        let preservedPolicy = sut.decideSiteCredentialNavigation(
+            for: preservedPost,
+            isMainFrame: true,
+            shouldPerformDownload: false
+        )
+        let attackerURL = try XCTUnwrap(URL(string: "https://attacker.example/collect"))
+        let attackerPolicy = sut.decideSiteCredentialNavigation(
+            for: URLRequest(url: attackerURL),
+            isMainFrame: true,
+            shouldPerformDownload: false
+        )
+
+        // Then
+        XCTAssertEqual(preservedPolicy, .cancel)
+        XCTAssertTrue(webView.loadedRequests.contains { $0.url == nonceURL && $0.httpMethod == "GET" })
+        XCTAssertEqual(attackerPolicy, .cancel)
+        XCTAssertFalse(webView.loadedRequests.contains { $0.url == attackerURL })
+    }
+
+    func test_process_termination_during_authentication_loads_one_fresh_initial_get_and_clears_gate() throws {
+        // Given
+        let harness = try makeAuthenticatedControllerHarness()
+        defer { harness.cleanup() }
+        let (sut, webView, initialURL) = (harness.controller, harness.webView, harness.initialURL)
+        sut.loadViewIfNeeded()
+        let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        XCTAssertEqual(
+            sut.decideSiteCredentialNavigation(for: credentialRequest, isMainFrame: true, shouldPerformDownload: false),
+            .allow
+        )
+
+        // When
+        sut.webViewWebContentProcessDidTerminate(webView)
+        sut.webViewWebContentProcessDidTerminate(webView)
+
+        // Then
+        XCTAssertEqual(webView.loadedRequests.count, 2)
+        XCTAssertEqual(webView.loadedRequests.last?.url, initialURL)
+        XCTAssertEqual(webView.loadedRequests.last?.httpMethod, "GET")
+        XCTAssertNil(webView.loadedRequests.last?.httpBody)
+        XCTAssertNil(
+            sut.decideSiteCredentialNavigation(for: URLRequest(url: initialURL), isMainFrame: true, shouldPerformDownload: false)
+        )
+    }
+
+    private func makeEndpoints() throws -> CookieNonceAuthenticationEndpoints {
+        try CookieNonceAuthenticationEndpoints(
+            siteURL: XCTUnwrap(URL(string: "https://test.com")),
+            loginEntryURL: XCTUnwrap(URL(string: "https://test.com/custom-login?entry=1")),
+            adminBaseURL: XCTUnwrap(URL(string: "https://test.com/private-admin/"))
+        )
+    }
+
+    private func makeAuthenticationRequestAndEndpoints() throws -> (URLRequest, CookieNonceAuthenticationEndpoints) {
+        let credentials = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: [:])
+        let endpoints = try makeEndpoints()
+        return (try WKWebView().authenticateForWPOrg(with: credentials, authenticationEndpoints: endpoints), endpoints)
+    }
+
+    private func makeAuthenticatedControllerHarness() throws -> (
+        controller: AuthenticatedWebViewController,
+        webView: RecordingWKWebView,
+        endpoints: CookieNonceAuthenticationEndpoints,
+        initialURL: URL,
+        cleanup: () -> Void
+    ) {
+        let suiteName = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let sessionManager = SessionManager(defaults: defaults, keychainServiceName: UUID().uuidString)
+        let credentials: Yosemite.Credentials = .wporg(username: username, password: password, siteAddress: "https://test.com")
+        let endpoints = try makeEndpoints()
+        let initialURL = try XCTUnwrap(URL(string: "https://test.com/products/13"))
+        sessionManager.defaultCredentials = credentials
+        sessionManager.defaultSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: "https://test.com")
+        sessionManager.saveCookieNonceAuthenticationEndpoints(endpoints, for: credentials)
+        let webView = RecordingWKWebView()
+        let controller = AuthenticatedWebViewController(
+            stores: MockStoresManager(sessionManager: sessionManager),
+            viewModel: StubAuthenticatedWebViewModel(initialURL: initialURL),
+            extraCredentials: nil,
+            webView: webView,
+            siteCredentialReplacementScheduler: { $0() }
+        )
+        return (controller, webView, endpoints, initialURL, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    private func formValue(named name: String, in request: URLRequest) throws -> String? {
+        let body = try XCTUnwrap(request.httpBody)
+        let encodedParameters = try XCTUnwrap(String(data: body, encoding: .utf8))
+        var components = URLComponents()
+        components.percentEncodedQuery = encodedParameters
+        return components.queryItems?.first(where: { $0.name == name })?.value
+    }
+}
+
+@MainActor
+private final class RecordingWKWebView: WKWebView {
+    private(set) var loadedRequests: [URLRequest] = []
+    private(set) var loadedNavigations: [WKNavigation] = []
+
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        loadedRequests.append(request)
+        let navigation = StubNavigation()
+        loadedNavigations.append(navigation)
+        return navigation
+    }
+}
+
+private final class StubNavigation: WKNavigation { }
+
+private final class StubAuthenticatedWebViewModel: AuthenticatedWebViewModel {
+    let title = ""
+    let initialURL: URL?
+
+    init(initialURL: URL) {
+        self.initialURL = initialURL
+    }
+
+    func handleDismissal() { }
+    func handleRedirect(for url: URL?) { }
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy { .allow }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
@@ -348,11 +348,21 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
 
     func test_controller_boundary_rewrites_preserved_post_and_finishes_only_after_exact_2xx_response() throws {
         // Given
-        let harness = try makeAuthenticatedControllerHarness()
+        var scheduledWork: [() -> Void] = []
+        let harness = try makeAuthenticatedControllerHarness { work in
+            scheduledWork.append(work)
+        }
         defer { harness.cleanup() }
-        let (sut, webView, endpoints, initialURL) = (harness.controller, harness.webView, harness.endpoints, harness.initialURL)
+        let (sut, webView, endpoints, initialURL, viewModel) = (
+            harness.controller,
+            harness.webView,
+            harness.endpoints,
+            harness.initialURL,
+            harness.viewModel
+        )
         sut.loadViewIfNeeded()
         let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        let credentialNavigation = try XCTUnwrap(webView.loadedNavigations.first)
         XCTAssertEqual(
             sut.decideSiteCredentialNavigation(for: credentialRequest, isMainFrame: true, shouldPerformDownload: false),
             .allow
@@ -368,7 +378,12 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
             isMainFrame: true,
             shouldPerformDownload: false
         )
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url])
+        XCTAssertEqual(scheduledWork.count, 1)
+        scheduledWork.removeFirst()()
+        sut.webView(webView, didFailProvisionalNavigation: credentialNavigation, withError: URLError(.cancelled))
         let cleanGet = try XCTUnwrap(webView.loadedRequests.last)
+        let cleanGetNavigation = try XCTUnwrap(webView.loadedNavigations.last)
         let cleanGetPolicy = sut.decideSiteCredentialNavigation(for: cleanGet, isMainFrame: true, shouldPerformDownload: false)
         let response = try XCTUnwrap(HTTPURLResponse(url: nonceURL, statusCode: 200, httpVersion: nil, headerFields: nil))
         let responsePolicy = sut.decideSiteCredentialNavigation(
@@ -376,6 +391,10 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
             isMainFrame: true,
             canShowMIMEType: true
         )
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url, nonceURL])
+        XCTAssertEqual(scheduledWork.count, 1)
+        scheduledWork.removeFirst()()
+        sut.webView(webView, didFailProvisionalNavigation: cleanGetNavigation, withError: URLError(.cancelled))
 
         // Then
         XCTAssertEqual(preservedPolicy, .cancel)
@@ -385,9 +404,90 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         XCTAssertEqual(cleanGetPolicy, .allow)
         XCTAssertEqual(responsePolicy, .cancel)
         XCTAssertEqual(webView.loadedRequests.last?.url, initialURL)
+        XCTAssertTrue(viewModel.provisionalNavigationErrors.isEmpty)
         XCTAssertNil(
             sut.decideSiteCredentialNavigation(for: URLRequest(url: initialURL), isMainFrame: true, shouldPerformDownload: false)
         )
+    }
+
+    func test_rejected_navigation_action_defers_fallback_and_suppresses_policy_cancellation() throws {
+        // Given
+        var scheduledWork: [() -> Void] = []
+        let harness = try makeAuthenticatedControllerHarness { work in
+            scheduledWork.append(work)
+        }
+        defer { harness.cleanup() }
+        let (sut, webView, initialURL, viewModel) = (
+            harness.controller,
+            harness.webView,
+            harness.initialURL,
+            harness.viewModel
+        )
+        sut.loadViewIfNeeded()
+        let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        let credentialNavigation = try XCTUnwrap(webView.loadedNavigations.first)
+        XCTAssertEqual(
+            sut.decideSiteCredentialNavigation(for: credentialRequest, isMainFrame: true, shouldPerformDownload: false),
+            .allow
+        )
+        let attackerURL = try XCTUnwrap(URL(string: "https://attacker.example/collect"))
+
+        // When
+        let policy = sut.decideSiteCredentialNavigation(
+            for: URLRequest(url: attackerURL),
+            isMainFrame: true,
+            shouldPerformDownload: false
+        )
+
+        // Then
+        XCTAssertEqual(policy, .cancel)
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url])
+        XCTAssertEqual(scheduledWork.count, 1)
+        scheduledWork.removeFirst()()
+        sut.webView(webView, didFailProvisionalNavigation: credentialNavigation, withError: URLError(.cancelled))
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url, initialURL])
+        XCTAssertTrue(viewModel.provisionalNavigationErrors.isEmpty)
+    }
+
+    func test_rejected_navigation_response_defers_fallback_and_suppresses_policy_cancellation() throws {
+        // Given
+        var scheduledWork: [() -> Void] = []
+        let harness = try makeAuthenticatedControllerHarness { work in
+            scheduledWork.append(work)
+        }
+        defer { harness.cleanup() }
+        let (sut, webView, initialURL, viewModel) = (
+            harness.controller,
+            harness.webView,
+            harness.initialURL,
+            harness.viewModel
+        )
+        sut.loadViewIfNeeded()
+        let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        let credentialNavigation = try XCTUnwrap(webView.loadedNavigations.first)
+        XCTAssertEqual(
+            sut.decideSiteCredentialNavigation(for: credentialRequest, isMainFrame: true, shouldPerformDownload: false),
+            .allow
+        )
+        let rejectedResponse = try XCTUnwrap(
+            HTTPURLResponse(url: try XCTUnwrap(credentialRequest.url), statusCode: 200, httpVersion: nil, headerFields: nil)
+        )
+
+        // When
+        let policy = sut.decideSiteCredentialNavigation(
+            for: rejectedResponse,
+            isMainFrame: true,
+            canShowMIMEType: true
+        )
+
+        // Then
+        XCTAssertEqual(policy, .cancel)
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url])
+        XCTAssertEqual(scheduledWork.count, 1)
+        scheduledWork.removeFirst()()
+        sut.webView(webView, didFailProvisionalNavigation: credentialNavigation, withError: URLError(.cancelled))
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url, initialURL])
+        XCTAssertTrue(viewModel.provisionalNavigationErrors.isEmpty)
     }
 
     func test_policy_cancellation_does_not_supersede_scheduled_clean_get_but_clean_get_failure_falls_back_once() throws {
@@ -511,13 +611,16 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
             harness.initialURL
         )
         sut.loadViewIfNeeded()
+        let credentialNavigation = try XCTUnwrap(webView.loadedNavigations.first)
 
         // When
         viewModel.reloadWebview()
+        sut.webView(webView, didFailProvisionalNavigation: credentialNavigation, withError: URLError(.cancelled))
 
         // Then
         XCTAssertEqual(webView.stopLoadingCallCount, 1)
         XCTAssertEqual(webView.loadedRequests.last?.url, initialURL)
+        XCTAssertTrue(viewModel.provisionalNavigationErrors.isEmpty)
         XCTAssertNil(
             sut.decideSiteCredentialNavigation(for: URLRequest(url: initialURL), isMainFrame: true, shouldPerformDownload: false)
         )
@@ -626,7 +729,9 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         return (try WKWebView().authenticateForWPOrg(with: credentials, authenticationEndpoints: endpoints), endpoints)
     }
 
-    private func makeAuthenticatedControllerHarness() throws -> (
+    private func makeAuthenticatedControllerHarness(
+        siteCredentialReplacementScheduler: @escaping (@escaping () -> Void) -> Void = { $0() }
+    ) throws -> (
         controller: AuthenticatedWebViewController,
         webView: RecordingWKWebView,
         endpoints: CookieNonceAuthenticationEndpoints,
@@ -650,7 +755,7 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
             viewModel: viewModel,
             extraCredentials: nil,
             webView: webView,
-            siteCredentialReplacementScheduler: { $0() }
+            siteCredentialReplacementScheduler: siteCredentialReplacementScheduler
         )
         return (controller, webView, endpoints, initialURL, viewModel, { defaults.removePersistentDomain(forName: suiteName) })
     }

--- a/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
@@ -394,7 +394,13 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         // Given
         let harness = try makeAuthenticatedControllerHarness()
         defer { harness.cleanup() }
-        let (sut, webView, endpoints, initialURL) = (harness.controller, harness.webView, harness.endpoints, harness.initialURL)
+        let (sut, webView, endpoints, initialURL, viewModel) = (
+            harness.controller,
+            harness.webView,
+            harness.endpoints,
+            harness.initialURL,
+            harness.viewModel
+        )
         sut.loadViewIfNeeded()
         let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
         let credentialNavigation = try XCTUnwrap(webView.loadedNavigations.first)
@@ -420,13 +426,101 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         )
         let cleanNavigation = try XCTUnwrap(webView.loadedNavigations.last)
         sut.webView(webView, didFailProvisionalNavigation: cleanNavigation, withError: URLError(.cannotConnectToHost))
-        sut.webView(webView, didFailProvisionalNavigation: cleanNavigation, withError: URLError(.cannotConnectToHost))
+        XCTAssertTrue(viewModel.provisionalNavigationErrors.isEmpty)
+        let fallbackNavigation = try XCTUnwrap(webView.loadedNavigations.last)
+        sut.webView(webView, didFailProvisionalNavigation: fallbackNavigation, withError: URLError(.cannotConnectToHost))
 
         // Then
         XCTAssertEqual(preservedPolicy, .cancel)
         XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url, nonceURL, initialURL])
         XCTAssertEqual(webView.loadedRequests[1].httpMethod, "GET")
         XCTAssertNil(webView.loadedRequests[1].httpBody)
+        XCTAssertEqual(viewModel.provisionalNavigationErrors.count, 1)
+    }
+
+    func test_WebKit_policy_interruption_does_not_cancel_scheduled_clean_get() throws {
+        // Given
+        let harness = try makeAuthenticatedControllerHarness()
+        defer { harness.cleanup() }
+        let (sut, webView, endpoints) = (harness.controller, harness.webView, harness.endpoints)
+        sut.loadViewIfNeeded()
+        let credentialRequest = try XCTUnwrap(webView.loadedRequests.first)
+        let credentialNavigation = try XCTUnwrap(webView.loadedNavigations.first)
+        XCTAssertEqual(
+            sut.decideSiteCredentialNavigation(for: credentialRequest, isMainFrame: true, shouldPerformDownload: false),
+            .allow
+        )
+        let nonceURL = try endpoints.nonceURL()
+        var preservedPost = URLRequest(url: nonceURL)
+        preservedPost.httpMethod = "POST"
+        preservedPost.httpBody = Data("credentials".utf8)
+        XCTAssertEqual(
+            sut.decideSiteCredentialNavigation(for: preservedPost, isMainFrame: true, shouldPerformDownload: false),
+            .cancel
+        )
+        let cleanGet = try XCTUnwrap(webView.loadedRequests.last)
+
+        // When
+        sut.webView(
+            webView,
+            didFailProvisionalNavigation: credentialNavigation,
+            withError: NSError(domain: WKError.errorDomain, code: 102)
+        )
+        let cleanGetPolicy = sut.decideSiteCredentialNavigation(for: cleanGet, isMainFrame: true, shouldPerformDownload: false)
+
+        // Then
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url, nonceURL])
+        XCTAssertEqual(cleanGet.httpMethod, "GET")
+        XCTAssertNil(cleanGet.httpBody)
+        XCTAssertEqual(cleanGetPolicy, .allow)
+    }
+
+    func test_reload_without_site_credential_authentication_does_not_stop_unrelated_navigation() throws {
+        // Given
+        let suiteName = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let sessionManager = SessionManager(defaults: defaults, keychainServiceName: UUID().uuidString)
+        let initialURL = try XCTUnwrap(URL(string: "https://test.com/products/13"))
+        let webView = RecordingWKWebView()
+        let viewModel = StubAuthenticatedWebViewModel(initialURL: initialURL)
+        let sut = AuthenticatedWebViewController(
+            stores: MockStoresManager(sessionManager: sessionManager),
+            viewModel: viewModel,
+            extraCredentials: nil,
+            webView: webView
+        )
+        sut.loadViewIfNeeded()
+
+        // When
+        viewModel.reloadWebview()
+
+        // Then
+        XCTAssertEqual(webView.stopLoadingCallCount, 0)
+        XCTAssertEqual(webView.loadedRequests.map(\.url), [initialURL, initialURL])
+    }
+
+    func test_reload_during_site_credential_authentication_stops_navigation_and_clears_gate() throws {
+        // Given
+        let harness = try makeAuthenticatedControllerHarness()
+        defer { harness.cleanup() }
+        let (sut, webView, viewModel, initialURL) = (
+            harness.controller,
+            harness.webView,
+            harness.viewModel,
+            harness.initialURL
+        )
+        sut.loadViewIfNeeded()
+
+        // When
+        viewModel.reloadWebview()
+
+        // Then
+        XCTAssertEqual(webView.stopLoadingCallCount, 1)
+        XCTAssertEqual(webView.loadedRequests.last?.url, initialURL)
+        XCTAssertNil(
+            sut.decideSiteCredentialNavigation(for: URLRequest(url: initialURL), isMainFrame: true, shouldPerformDownload: false)
+        )
     }
 
     func test_controller_with_mismatched_persisted_endpoint_identity_falls_back_to_unauthenticated_initial_url() throws {
@@ -537,6 +631,7 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         webView: RecordingWKWebView,
         endpoints: CookieNonceAuthenticationEndpoints,
         initialURL: URL,
+        viewModel: StubAuthenticatedWebViewModel,
         cleanup: () -> Void
     ) {
         let suiteName = UUID().uuidString
@@ -549,14 +644,15 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         sessionManager.defaultSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: "https://test.com")
         sessionManager.saveCookieNonceAuthenticationEndpoints(endpoints, for: credentials)
         let webView = RecordingWKWebView()
+        let viewModel = StubAuthenticatedWebViewModel(initialURL: initialURL)
         let controller = AuthenticatedWebViewController(
             stores: MockStoresManager(sessionManager: sessionManager),
-            viewModel: StubAuthenticatedWebViewModel(initialURL: initialURL),
+            viewModel: viewModel,
             extraCredentials: nil,
             webView: webView,
             siteCredentialReplacementScheduler: { $0() }
         )
-        return (controller, webView, endpoints, initialURL, { defaults.removePersistentDomain(forName: suiteName) })
+        return (controller, webView, endpoints, initialURL, viewModel, { defaults.removePersistentDomain(forName: suiteName) })
     }
 
     private func formValue(named name: String, in request: URLRequest) throws -> String? {
@@ -572,6 +668,7 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
 private final class RecordingWKWebView: WKWebView {
     private(set) var loadedRequests: [URLRequest] = []
     private(set) var loadedNavigations: [WKNavigation] = []
+    private(set) var stopLoadingCallCount = 0
 
     override func load(_ request: URLRequest) -> WKNavigation? {
         loadedRequests.append(request)
@@ -579,13 +676,19 @@ private final class RecordingWKWebView: WKWebView {
         loadedNavigations.append(navigation)
         return navigation
     }
+
+    override func stopLoading() {
+        stopLoadingCallCount += 1
+    }
 }
 
 private final class StubNavigation: WKNavigation { }
 
-private final class StubAuthenticatedWebViewModel: AuthenticatedWebViewModel {
+private final class StubAuthenticatedWebViewModel: AuthenticatedWebViewModel, WebviewReloadable {
     let title = ""
     let initialURL: URL?
+    var reloadWebview: () -> Void = { }
+    private(set) var provisionalNavigationErrors: [Error] = []
 
     init(initialURL: URL) {
         self.initialURL = initialURL
@@ -594,4 +697,7 @@ private final class StubAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     func handleDismissal() { }
     func handleRedirect(for url: URL?) { }
     func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy { .allow }
+    func didFailProvisionalNavigation(with error: Error) {
+        provisionalNavigationErrors.append(error)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/WordPressOrgCredentialsAuthenticatorTests.swift
@@ -394,7 +394,7 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         XCTAssertEqual(webView.loadedRequests.map(\.url), [credentialRequest.url, nonceURL])
         XCTAssertEqual(scheduledWork.count, 1)
         scheduledWork.removeFirst()()
-        sut.webView(webView, didFailProvisionalNavigation: cleanGetNavigation, withError: URLError(.cancelled))
+        sut.webView(webView, didFailProvisionalNavigation: cleanGetNavigation, withError: NSError(domain: "WebKitErrorDomain", code: 102))
 
         // Then
         XCTAssertEqual(preservedPolicy, .cancel)
@@ -539,8 +539,19 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
     }
 
     func test_WebKit_policy_interruption_does_not_cancel_scheduled_clean_get() throws {
+        try assertWebKitPolicyInterruption(replacementRunsFirst: false)
+    }
+
+    func test_WebKit_policy_interruption_after_clean_get_does_not_report_failure() throws {
+        try assertWebKitPolicyInterruption(replacementRunsFirst: true)
+    }
+
+    private func assertWebKitPolicyInterruption(replacementRunsFirst: Bool) throws {
         // Given
-        let harness = try makeAuthenticatedControllerHarness()
+        var scheduledWork: [() -> Void] = []
+        let harness = try makeAuthenticatedControllerHarness { work in
+            scheduledWork.append(work)
+        }
         defer { harness.cleanup() }
         let (sut, webView, endpoints) = (harness.controller, harness.webView, harness.endpoints)
         sut.loadViewIfNeeded()
@@ -558,14 +569,20 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
             sut.decideSiteCredentialNavigation(for: preservedPost, isMainFrame: true, shouldPerformDownload: false),
             .cancel
         )
-        let cleanGet = try XCTUnwrap(webView.loadedRequests.last)
-
         // When
+        XCTAssertEqual(scheduledWork.count, 1)
+        if replacementRunsFirst {
+            scheduledWork.removeFirst()()
+        }
         sut.webView(
             webView,
             didFailProvisionalNavigation: credentialNavigation,
-            withError: NSError(domain: WKError.errorDomain, code: 102)
+            withError: NSError(domain: "WebKitErrorDomain", code: 102)
         )
+        if !replacementRunsFirst {
+            scheduledWork.removeFirst()()
+        }
+        let cleanGet = try XCTUnwrap(webView.loadedRequests.last)
         let cleanGetPolicy = sut.decideSiteCredentialNavigation(for: cleanGet, isMainFrame: true, shouldPerformDownload: false)
 
         // Then
@@ -573,6 +590,7 @@ final class WordPressOrgCredentialsAuthenticatorTests: XCTestCase {
         XCTAssertEqual(cleanGet.httpMethod, "GET")
         XCTAssertNil(cleanGet.httpBody)
         XCTAssertEqual(cleanGetPolicy, .allow)
+        XCTAssertTrue(harness.viewModel.provisionalNavigationErrors.isEmpty)
     }
 
     func test_reload_without_site_credential_authentication_does_not_stop_unrelated_navigation() throws {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -507,6 +507,49 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertEqual(sessionManager.cookieNonceAuthenticationEndpointCredentials, sessionManager.defaultCredentials)
     }
 
+    func test_site_endpoint_overlay_when_site_is_default_port_HTTPS_promotion_then_replaces_login_and_admin_urls() throws {
+        // Given
+        let credentialSiteAddress = "http://example.com:80/store/"
+        let site = Site.fake().copy(
+            siteID: WooConstants.placeholderStoreID,
+            url: "https://example.com/store",
+            adminURL: "https://example.com/store/wp-admin/",
+            loginURL: "https://example.com/store/wp-login.php"
+        )
+        let endpoints = try CookieNonceAuthenticationEndpoints(
+            siteURL: XCTUnwrap(URL(string: credentialSiteAddress)),
+            loginEntryURL: XCTUnwrap(URL(string: "https://example.com/store/hidden-login")),
+            adminBaseURL: XCTUnwrap(URL(string: "https://example.com/store/hidden-admin/"))
+        )
+        let (sut, _) = makeStoresManager(
+            credentials: .wporg(username: "merchant", password: "secret", siteAddress: credentialSiteAddress),
+            endpoints: endpoints
+        )
+
+        // When
+        let result = sut.siteByApplyingCookieNonceAuthenticationEndpoints(to: site)
+
+        // Then
+        XCTAssertEqual(result, site.copy(adminURL: endpoints.adminBaseURL.absoluteString, loginURL: endpoints.loginEntryURL.absoluteString))
+    }
+
+    func test_site_endpoint_overlay_when_non_default_port_changes_scheme_then_leaves_site_unchanged() throws {
+        // Given
+        let credentialSiteAddress = "http://example.com:8080/store"
+        let site = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: "https://example.com:8080/store")
+        let endpoints = try makeCookieNonceAuthenticationEndpoints(siteAddress: credentialSiteAddress)
+        let (sut, _) = makeStoresManager(
+            credentials: .wporg(username: "merchant", password: "secret", siteAddress: credentialSiteAddress),
+            endpoints: endpoints
+        )
+
+        // When
+        let result = sut.siteByApplyingCookieNonceAuthenticationEndpoints(to: site)
+
+        // Then
+        XCTAssertEqual(result, site)
+    }
+
     func test_site_endpoint_overlay_when_site_has_positive_id_then_leaves_site_unchanged() throws {
         // Given
         let site = Site.fake().copy(siteID: 42, url: "https://example.com")

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -485,6 +485,103 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertNil(manager.sessionManager.defaultSite)
     }
 
+    func test_site_endpoint_overlay_when_direct_site_identities_match_then_replaces_only_login_and_admin_urls() throws {
+        // Given
+        let site = Site.fake().copy(
+            siteID: WooConstants.placeholderStoreID,
+            url: "https://example.com/store",
+            adminURL: "https://example.com/store/wp-admin/",
+            loginURL: "https://example.com/store/wp-login.php"
+        )
+        let endpoints = try makeCookieNonceAuthenticationEndpoints(siteAddress: "https://example.com/store/")
+        let (sut, sessionManager) = makeStoresManager(
+            credentials: .wporg(username: "merchant", password: "secret", siteAddress: "https://example.com/store/"),
+            endpoints: endpoints
+        )
+
+        // When
+        let result = sut.siteByApplyingCookieNonceAuthenticationEndpoints(to: site)
+
+        // Then
+        XCTAssertEqual(result, site.copy(adminURL: endpoints.adminBaseURL.absoluteString, loginURL: endpoints.loginEntryURL.absoluteString))
+        XCTAssertEqual(sessionManager.cookieNonceAuthenticationEndpointCredentials, sessionManager.defaultCredentials)
+    }
+
+    func test_site_endpoint_overlay_when_site_has_positive_id_then_leaves_site_unchanged() throws {
+        // Given
+        let site = Site.fake().copy(siteID: 42, url: "https://example.com")
+        let endpoints = try makeCookieNonceAuthenticationEndpoints(siteAddress: site.url)
+        let (sut, sessionManager) = makeStoresManager(
+            credentials: .wporg(username: "merchant", password: "secret", siteAddress: site.url),
+            endpoints: endpoints
+        )
+        sessionManager.resetCookieNonceAuthenticationEndpointCredentials()
+
+        // When
+        let result = sut.siteByApplyingCookieNonceAuthenticationEndpoints(to: site)
+
+        // Then
+        XCTAssertEqual(result, site)
+        XCTAssertNil(sessionManager.cookieNonceAuthenticationEndpointCredentials)
+    }
+
+    func test_site_endpoint_overlay_when_any_identity_differs_then_leaves_site_unchanged() throws {
+        // Given
+        let site = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: "https://site.example")
+        let siteEndpoints = try makeCookieNonceAuthenticationEndpoints(siteAddress: site.url)
+        let otherEndpoints = try makeCookieNonceAuthenticationEndpoints(siteAddress: "https://other.example")
+        let cases: [(Credentials, CookieNonceAuthenticationEndpoints?)] = [
+            (.wporg(username: "merchant", password: "secret", siteAddress: "https://credentials.example"), siteEndpoints),
+            (.wporg(username: "merchant", password: "secret", siteAddress: site.url), otherEndpoints),
+            (.wpcom(username: "merchant", authToken: "token", siteAddress: site.url), siteEndpoints),
+            (.wporg(username: "merchant", password: "secret", siteAddress: site.url), nil)
+        ]
+
+        // When
+        let results = cases.map { credentials, endpoints in
+            makeStoresManager(credentials: credentials, endpoints: endpoints).0
+                .siteByApplyingCookieNonceAuthenticationEndpoints(to: site)
+        }
+
+        // Then
+        XCTAssertEqual(results, Array(repeating: site, count: cases.count))
+    }
+
+    func test_update_default_store_when_direct_site_api_copy_completes_then_reapplies_latest_endpoints() throws {
+        // Given
+        let site = Site.fake().copy(
+            siteID: WooConstants.placeholderStoreID,
+            url: "https://example.com",
+            applicationPasswordAvailable: false
+        )
+        let initialEndpoints = try makeCookieNonceAuthenticationEndpoints(siteAddress: site.url, pathPrefix: "initial")
+        let latestEndpoints = try makeCookieNonceAuthenticationEndpoints(siteAddress: site.url, pathPrefix: "latest")
+        let sessionManager = MockSessionManager()
+        let sut = DeferredSiteAPIStoresManager(sessionManager: sessionManager)
+        sessionManager.defaultCredentials = .wporg(username: "merchant", password: "secret", siteAddress: site.url)
+        sessionManager.cookieNonceAuthenticationEndpointsToReturn = initialEndpoints
+        sessionManager.defaultStoreID = site.siteID
+        sut.updateDefaultStore(site)
+        XCTAssertEqual(
+            sessionManager.defaultSite,
+            site.copy(adminURL: initialEndpoints.adminBaseURL.absoluteString, loginURL: initialEndpoints.loginEntryURL.absoluteString)
+        )
+        sessionManager.cookieNonceAuthenticationEndpointsToReturn = latestEndpoints
+
+        // When
+        sut.completeSiteAPI(with: .success(SiteAPI(siteID: site.siteID, namespaces: [], applicationPasswordAvailable: true)))
+
+        // Then
+        XCTAssertEqual(
+            sessionManager.defaultSite,
+            site.copy(
+                adminURL: latestEndpoints.adminBaseURL.absoluteString,
+                loginURL: latestEndpoints.loginEntryURL.absoluteString,
+                applicationPasswordAvailable: true
+            )
+        )
+    }
+
     func test_deauthenticating_invokes_ProductImageUploader_reset() {
         // Given
         let mockProductImageUploader = MockProductImageUploader()
@@ -715,6 +812,28 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertFalse(manager.isAuthenticated)
         XCTAssertTrue(manager.needsDefaultStore)
     }
+
+    private func makeCookieNonceAuthenticationEndpoints(
+        siteAddress: String,
+        pathPrefix: String = "hidden"
+    ) throws -> CookieNonceAuthenticationEndpoints {
+        let siteURL = try XCTUnwrap(URL(string: siteAddress))
+        return try CookieNonceAuthenticationEndpoints(
+            siteURL: siteURL,
+            loginEntryURL: siteURL.appendingPathComponent("\(pathPrefix)-login"),
+            adminBaseURL: siteURL.appendingPathComponent("\(pathPrefix)-admin", isDirectory: true)
+        )
+    }
+
+    private func makeStoresManager(
+        credentials: Credentials,
+        endpoints: CookieNonceAuthenticationEndpoints?
+    ) -> (DefaultStoresManager, MockSessionManager) {
+        let sessionManager = MockSessionManager()
+        sessionManager.defaultCredentials = credentials
+        sessionManager.cookieNonceAuthenticationEndpointsToReturn = endpoints
+        return (DefaultStoresManager(sessionManager: sessionManager), sessionManager)
+    }
 }
 
 
@@ -769,6 +888,22 @@ private final class MockGRDBManager: GRDBManagerProtocol {
     }
 }
 
+private final class DeferredSiteAPIStoresManager: DefaultStoresManager {
+    private var siteAPICompletion: ((Result<SiteAPI, Error>) -> Void)?
+
+    override func dispatch(_ action: Action) {
+        guard let action = action as? SettingAction,
+              case let .retrieveSiteAPI(_, completion) = action else {
+            return
+        }
+        siteAPICompletion = completion
+    }
+
+    func completeSiteAPI(with result: Result<SiteAPI, Error>) {
+        siteAPICompletion?(result)
+    }
+}
+
 final class MockSessionManager: SessionManagerProtocol {
 
     private(set) var deleteApplicationPasswordInvoked: Bool = false
@@ -806,8 +941,16 @@ final class MockSessionManager: SessionManagerProtocol {
 
     var defaultCredentials: Yosemite.Credentials? = nil
 
+    var cookieNonceAuthenticationEndpointsToReturn: Yosemite.CookieNonceAuthenticationEndpoints?
+    private(set) var cookieNonceAuthenticationEndpointCredentials: Yosemite.Credentials?
+
     func cookieNonceAuthenticationEndpoints(for credentials: Credentials) -> CookieNonceAuthenticationEndpoints? {
-        nil
+        cookieNonceAuthenticationEndpointCredentials = credentials
+        return cookieNonceAuthenticationEndpointsToReturn
+    }
+
+    func resetCookieNonceAuthenticationEndpointCredentials() {
+        cookieNonceAuthenticationEndpointCredentials = nil
     }
 
     func saveCookieNonceAuthenticationEndpoints(_ endpoints: CookieNonceAuthenticationEndpoints,


### PR DESCRIPTION
Part of: WOOMOB-3800

## Description

> [!NOTE]
> **About 63% of the raw diff is tests and test support:** 878 lines (`+877/-1`), covering direct `Site` projection, endpoint identity mismatch and corruption, authenticated WebView URL selection, and the in-flight credential navigation boundary.
>
> Production is 520 raw lines (`+480/-40`), or 468 lines under Danger's test/comment/blank exclusions (`+432/-36`)—above the 300-line guideline. Keeping direct-site projection, credential-context selection, and the WebKit navigation gate together avoids an incomplete consumer path that could either forget verified endpoints or post credentials outside the validated transaction.

### Why

PRs #17718–#17724 establish the endpoint trust boundary, use it in both native authentication transports, persist verified custom endpoints, and let merchants recover relocated sign-in and dashboard addresses. The remaining direct `Site` and authenticated WebView consumers still need to use those identity-bound values.

Without this layer, a transient direct `Site` can regain standard `wp-login.php`/`wp-admin` values after fetch or restoration, and authenticated WebViews can start from the wrong login entry. WebKit credential submission also needs its own navigation boundary because browser redirects can preserve a credential POST body.

### Why separate PR

This PR contains the complete consumer layer for verified endpoint metadata while leaving the recovery contract and UI unchanged. It is independently releasable on top of #17724: standard endpoints retain their existing behavior, unusable metadata remains inert, and canonical `Site.url` identity is never rewritten.

### How

- Overlays verified login and admin endpoints on the placeholder direct `Site` at both fetch/refresh and restoration seams, including the later metadata copies, while preserving canonical `Site.url`.
- Requires the credential identity, fetched-site identity, and persisted endpoint identity to match before projecting values, with only the endpoint policy's default-port HTTP-to-HTTPS promotion allowed. Corrupt, unsafe, or mismatched metadata falls back without mutating credentials or deleting secrets.
- Resolves authenticated WebView endpoint context for the exact selected WP.org credentials, preferring explicitly supplied credentials when present and preserving standard endpoint behavior otherwise.
- Posts directly to the persisted configured login entry and uses the validated nonce destination as `redirect_to`.
- Gates the in-flight credential navigation to the initial main-frame POST and policy-approved bodyless destinations. Cross-site, downgraded, subframe, download, repeated, or excessive redirects fail closed.
- Replaces one policy-approved body-preserving destination request with a fresh bodyless GET after the WebKit policy callback returns, suppresses only its expected WebKit cancellation, and clears authentication state on completion, failure, dismissal, reload, or Web Content process termination.
- Never opens an external browser automatically when authenticated WebView credential submission fails.

WebKit deliberately does not perform the URLSession login flow's HTML preflight or transaction-local form-action discovery. It uses the persisted configured login entry and constrains every follow-up request with the navigation gate.

Deliberately excluded: recovery contract/UI changes, new endpoint persistence, authentication transport rewrites, QR or WordPress.com changes, strings, analytics, and release notes.

### Stack context

1. #17718 — endpoint trust boundary and shared rules
2. #17719 — interactive authentication
3. #17720 — runtime authentication
4. #17721 — endpoint persistence and lifecycle
5. #17724 — recovery contract and inline UI
6. This PR — direct `Site` and authenticated WebView consumers

Automated verification: all 68 focused `StoresManagerTests` and `WordPressOrgCredentialsAuthenticatorTests` passed. The WooCommerce app built successfully for an iPhone 17 Pro simulator. Changed-file SwiftLint, Swift parsing, `git diff --check`, and the changed-Swift 163-character scan also passed. The built app launched to the expected login prologue without crashing.

Latest review fix (`fab24ca86a`): matches WebKit's legacy `WebKitErrorDomain` for policy cancellation code 102. Regression tests cover cancellation before and after the replacement GET and after the successful nonce response. Changed-file SwiftLint, Swift parsing, line-length and diff checks pass. The focused test rerun is blocked before execution by existing compilation errors in `HardwareTests/CardReaderEventStripeTests.swift` (`String.multipleContactlessCardsDetected` and `String.generic`); the 68-test result above predates this fix.

## Test Steps

Use a real, publicly reachable WordPress/WooCommerce test store served over HTTPS. Sign in with the store's WordPress username and password.

### 1. Custom-endpoint WebView authentication

1. On the test store, use WP Ghost to configure a custom login address and dashboard address. Keep an existing WP Admin session open so you can restore the settings.
2. In the app, sign in using the canonical store address, complete the custom-address recovery flow, and confirm the native dashboard opens.
3. Open Menu → WooCommerce Admin.
4. Confirm the store's admin loads as the authenticated merchant without another login prompt, an automatic browser launch, or a fallback to the standard WordPress login path.
5. Force-quit and restart the app, then open Menu → WooCommerce Admin again. Confirm the same authenticated destination loads.

### 2. Standard-endpoint regression

1. Use a real HTTPS test store with the standard WordPress login and admin addresses.
2. Sign in with WordPress credentials and open Menu → WooCommerce Admin.
3. Confirm the authenticated admin loads without another login prompt or an automatic browser launch.

Application-password revocation is excluded from these acceptance steps: it exposes a pre-existing trunk issue where a failed launch-time site-info fetch is not retried after password regeneration.

## Screenshots

N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

No release-note entry is included because the user-facing custom-endpoint recovery behavior is already covered by #17724; this PR completes its internal consumers without adding UI or copy.
