### PR TITLE
Let Product Search coordinator own navigation bar visibility

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -101,7 +101,6 @@ private extension ProductsSplitViewCoordinator {
                 }, onCancel: { [weak self] in
                     guard let self else { return }
                     primaryNavigationController.viewControllers = [productsViewController]
-                    primaryNavigationController.setNavigationBarHiddenIfNeeded(false, animated: false)
                 })
                 let searchViewController = SearchViewController(storeID: siteID,
                                                                 command: searchCommand,
@@ -292,10 +291,14 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
         if didNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode(navigationController, didShow: viewController, animated: animated) {
             let dismissedProduct = productShownInSecondaryContent()
             DispatchQueue.main.async { [weak self] in
-                self?.clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
+                guard let self else { return }
+                clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
+                updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
             }
             return
         }
+
+        updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
 
         // The goal here is to detect when the user pops a view controller in the secondary navigation stack like from tapping the back button,
         // so that the secondary content types state can be updated accordingly.
@@ -316,6 +319,17 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
 }
 
 private extension ProductsSplitViewCoordinator {
+    /// Updates the primary navigation bar only after its navigation controller has finished showing a view controller.
+    /// In a collapsed layout, UIKit temporarily wraps the secondary navigation stack in the primary one. Updating the bar
+    /// from the search view controller's lifecycle can force layout while navigation items are still changing owners.
+    func updatePrimaryNavigationBarVisibility(afterShowing viewController: UIViewController, in navigationController: UINavigationController) {
+        guard navigationController == primaryNavigationController else {
+            return
+        }
+        let isShowingProductSearch = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
+        primaryNavigationController.setNavigationBarHiddenIfNeeded(isShowingProductSearch, animated: false)
+    }
+
     /// In the collapsed mode, the secondary navigation controller is added to the primary navigation stack and the primary navigation stack is shown.
     /// When the user taps the back button to leave the last secondary view controller (e.g. product form), we want to reset `contentTypes`
     /// while there is no proper callback that I can find other than observing the primary navigation controller's `didShow`.

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -18,10 +18,9 @@ final class ProductSearchUICommand: SearchUICommand {
 
     let cancelButtonAccessibilityIdentifier = "product-search-screen-cancel-button"
 
-    /// Product search replaces the primary navigation stack of a split view, unlike Order search, which is presented
-    /// in its own modal navigation controller. Avoid animating the navigation bar while UIKit transfers presentation
-    /// to the secondary navigation stack in a collapsed layout.
-    let animateNavigationBarVisibilityChanges = false
+    /// The split-view coordinator owns the primary navigation bar because it knows when UIKit has finished transferring
+    /// navigation items between the primary and secondary navigation controllers in a collapsed layout.
+    let hideNavigationBar = false
 
     var reloadUIRequests: AnyPublisher<Void, Never> {
         reloadUINeeded.eraseToAnyPublisher()

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -191,7 +191,9 @@ where Cell.SearchModel == Command.CellViewModel {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        navigationController?.setNavigationBarHiddenIfNeeded(false, animated: searchUICommand.animateNavigationBarVisibilityChanges)
+        if searchUICommand.hideNavigationBar {
+            navigationController?.setNavigationBarHiddenIfNeeded(false, animated: searchUICommand.animateNavigationBarVisibilityChanges)
+        }
     }
 
     // MARK: - UITableViewDataSource Conformance

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import UIKit
+
+@testable import WooCommerce
+
+@MainActor
+struct ProductsSplitViewCoordinatorTests {
+    @Test
+    func test_navigationController_didShow_productSearch_then_hides_primary_navigation_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        let command = ProductSearchUICommand(siteID: 123,
+                                             isSearchProductsBySKUEnabled: false,
+                                             onProductSelection: { _ in },
+                                             onCancel: {})
+        let searchViewController = SearchViewController(storeID: 123,
+                                                        command: command,
+                                                        cellType: ProductsTabProductTableViewCell.self,
+                                                        cellSeparator: .none)
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+
+        // When
+        sut.navigationController(primaryNavigationController, didShow: searchViewController, animated: false)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden)
+    }
+
+    @Test
+    func test_navigationController_didShow_productList_then_shows_primary_navigation_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        let productListViewController = try #require(primaryNavigationController.topViewController)
+        primaryNavigationController.setNavigationBarHidden(true, animated: false)
+
+        // When
+        sut.navigationController(primaryNavigationController, didShow: productListViewController, animated: false)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden == false)
+    }
+
+    @Test
+    func test_navigationController_didShow_secondary_content_then_does_not_change_primary_navigation_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, secondaryNavigationController) = try makeSUT()
+        primaryNavigationController.setNavigationBarHidden(true, animated: false)
+
+        // When
+        sut.navigationController(secondaryNavigationController, didShow: UIViewController(), animated: false)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden)
+    }
+}
+
+private extension ProductsSplitViewCoordinatorTests {
+    func makeSUT() throws -> (ProductsSplitViewCoordinator, UINavigationController, UINavigationController) {
+        let splitViewController = UISplitViewController(style: .doubleColumn)
+        let sut = ProductsSplitViewCoordinator(siteID: 123, splitViewController: splitViewController)
+        sut.start()
+        let primaryNavigationController = try #require(splitViewController.viewController(for: .primary) as? UINavigationController)
+        let secondaryNavigationController = try #require(splitViewController.viewController(for: .secondary) as? UINavigationController)
+        return (sut, primaryNavigationController, secondaryNavigationController)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
@@ -182,12 +182,12 @@ final class ProductSearchUICommandTests: XCTestCase {
 
     // MARK: - Split view support
 
-    func test_animateNavigationBarVisibilityChanges_when_using_product_search_then_is_false() {
+    func test_hideNavigationBar_when_using_product_search_then_is_false() {
         // Given
         let command = ProductSearchUICommand(siteID: sampleSiteID, isSearchProductsBySKUEnabled: true)
 
         // Then
-        XCTAssertFalse(command.animateNavigationBarVisibilityChanges)
+        XCTAssertFalse(command.hideNavigationBar)
     }
 
     func test_didSelectSearchResult_ends_editing_before_invoking_onProductSelection() {


### PR DESCRIPTION
Closes: WOOMOB-3881

## Description
This follows the beta mitigation in #17737 with an ownership-based fix for the Product Search navigation bar crash tracked in https://a8c.sentry.io/issues/7669931391.

Product Search replaces the primary stack of a split view while Product Detail uses its secondary navigation controller. In collapsed layouts, UIKit temporarily wraps and transfers that secondary stack. Updating navigation bar visibility from `SearchViewController` lifecycle callbacks can therefore force layout while navigation items are changing owners.

Product Search now opts out of the generic search controller's navigation bar handling. `ProductsSplitViewCoordinator`, which owns both navigation controllers, updates the primary bar after `didShow`. When returning from the final secondary controller, it waits for the deferred secondary-stack cleanup before hiding the bar for Search. The idempotent helper from #17737 remains as a secondary guard.

Focused tests cover Product Search opting out of lifecycle ownership, the coordinator hiding and restoring the primary bar, and secondary callbacks leaving the primary bar unchanged.

## Test Steps
1. On an iPhone, open **Products** and enter Product Search. Confirm the search screen has no navigation bar.
2. Search for and select a product. Confirm Product Detail has its normal navigation bar.
3. Navigate back to Search, then repeat selecting a product and returning several times.
4. Cancel Product Search and confirm the Products navigation bar is restored.
5. Repeat with a variable product and after editing and saving a product.
6. On iPad, repeat while switching between collapsed and expanded split-view layouts.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release note is needed for this internal crash fix.
