### PR TITLE
Stabilize Orders refresh controls during navigation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -34,6 +34,8 @@ final class OrderDetailsViewController: UIViewController {
     ///
     private lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
+        refreshControl.isEnabled = false
+        refreshControl.isHidden = true
         refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
         return refreshControl
     }()
@@ -104,10 +106,8 @@ final class OrderDetailsViewController: UIViewController {
                 self?.topLoaderView.isHidden = true
             }
 
-            /// We add the refresh control to the tableview just after the `topLoaderView` disappear for the first time.
-            if self?.tableView.refreshControl == nil {
-                self?.tableView.refreshControl = self?.refreshControl
-            }
+            self?.refreshControl.isHidden = false
+            self?.refreshControl.isEnabled = true
         }
     }
 
@@ -141,6 +141,7 @@ private extension OrderDetailsViewController {
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.refreshControl = refreshControl
 
         tableView.dataSource = viewModel.dataSource
         tableView.accessibilityIdentifier = "order-details-table-view"
@@ -343,7 +344,6 @@ private extension OrderDetailsViewController {
 
     @objc func pullToRefresh() {
         ServiceLocator.analytics.track(.orderDetailPulledToRefresh)
-        refreshControl.beginRefreshing()
         syncEverything { [weak self] in
             NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
             self?.refreshControl.endRefreshing()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -204,15 +204,19 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
         syncingCoordinator.resynchronize(reason: SyncReason.viewWillAppear.rawValue)
 
-        // Fix any incomplete animation of the refresh control
-        // when switching tabs mid-animation
-        refreshControl.resetAnimation(in: tableView)
-
         // Fix any _incomplete_ animation if the orders were deleted and refetched from
         // a different location (or Orders tab).
         //
         // We can remove this once we've replaced XLPagerTabStrip.
         tableView.reloadData()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        // Do not carry an active refresh animation across tab or navigation transitions.
+        // The underlying synchronization continues and updates the list when it completes.
+        refreshControl.endRefreshing()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -371,7 +375,6 @@ private extension OrderListViewController {
             return
         }
 
-        setContentScrollView(tableView, for: .bottom)
         view.pinSubviewBottomToBottomAnchorReplacingSafeArea(tableView)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -444,7 +444,7 @@ private extension OrdersRootViewController {
 
         // The list table lives in a child controller, so register it from the root
         // controller that owns the navigation item for native large title tracking.
-        setContentScrollView(ordersViewController.tableView, for: .top)
+        setContentScrollView(ordersViewController.tableView, for: [.top, .bottom])
         view.pinSubviewBottomToBottomAnchorReplacingSafeArea(stackView)
     }
 


### PR DESCRIPTION
Part of: WOOMOB-3694

## Description

All the recent instances of [Sentry issue 7612187120](https://a8c.sentry.io/issues/7612187120/) include refresh control in the stack trace. We had some special handling of it to avoid seeing a stale non-animating copy when switching tabs, in `UIRefreshControl.resetAnimation(in:completion:)`, which also changed the content offset.

The stacks pointed to refresh-control ownership, content-offset, navigation-bar, and safe-area updates recursively triggering one another.

As a speculative fix, I've replaced calls to `resetAnimation` to the built in `endRefreshing`. This will simply hide the refresh control, not try to reinstate it when coming back to the tab, which didn't work anyway. This PR reduces the state changes we're doing, without visual changes.

Additionally, the content scroll registration was split across the root controller and the detail, which didn't make sense. Now, the Orders root controller becomes the sole owner of the list table's iOS 26 content-scroll registration, covering both the top navigation bar and bottom tab bar.

The redundant `beginRefreshing()` call in the Order Details pull handler is removed because UIKit has already begun refreshing before sending `.valueChanged`.

This follows the same general effort to avoid refresh-control and navigation ownership changes during iOS 26 transitions as #17671, while keeping both Orders controls permanently attached because both the list and Details support pull to refresh. #17740 addresses a related class of iOS 26 navigation ownership recursion in Product Search.

## Test Steps

On an iOS 26 device or simulator:

1. Open Orders, pull to refresh, switch to another tab before it completes, then return. Confirm there is no stopped spinner or extra space above the first order.
2. Pull to refresh Orders and immediately open an order. Confirm Order Details has a working pull-to-refresh control.
3. Pull to refresh Order Details, then navigate back and forward between the list and Details repeatedly.
4. While either screen is refreshing, change between compact and regular width where possible. Confirm pull to refresh remains available on both screens.
5. Confirm the selected order is highlighted promptly after returning to the list.

Note that in these artificially fast steps, I sometimes see a stopped spinner in the order details screen. It resolves itself quickly, and I think this is a better trade off if it reduces the crash rate. There's an existing issue where order details sometimes doesn't have a pull to refresh control – you can fix this by going back out and in to another order, then the original order again. I don't want to try and change this at the same time as the crash fix, as the fix didn't fall out of these changes, but it's present on trunk.

On iOS 18, confirm the Orders spinner retains its existing placement below the filter bar and both list and Details pull to refresh still work.

## Screenshots

https://github.com/user-attachments/assets/04bdbede-e83f-471a-84db-5f87d53a0a45



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release note is needed for this internal crash fix.
