### PR TITLE
Events: Add `payment_method_type` to POS card payment failure events when available

### DIFF
--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -6,6 +6,8 @@ import enum Yosemite.POSSearchMethod
 import struct Yosemite.POSSimpleProduct
 import struct Yosemite.POSVariation
 import enum WooFoundation.CountryCode
+import protocol WooFoundation.WooAnalyticsEventPropertyType
+import enum Yosemite.CardReaderServiceError
 import enum Yosemite.PaymentMethod
 import struct WooFoundation.WooAnalyticsEvent
 
@@ -284,16 +286,24 @@ extension WooAnalyticsEvent {
                                                            millisecondsSinceReaderReadyToCollect: Double,
                                                            millisecondsSinceCardTapped: Double,
                                                            checkoutTapCount: Int) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .collectPaymentFailed, properties: [
+            let paymentMethod: PaymentMethod? = {
+                guard case let CardReaderServiceError.paymentCaptureWithPaymentMethod(_, paymentMethod) = error else {
+                    return nil
+                }
+                return paymentMethod
+            }()
+            let properties: [String: WooAnalyticsEventPropertyType] = [
                 Key.cardReaderModel: readerModel(for: cardReaderModel),
                 Key.countryCode: countryCode.rawValue,
                 Key.gatewayID: safeGatewayID(for: forGatewayID),
+                Key.paymentMethodType: paymentMethod.map(analyticsValue(for:)),
                 Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
                 Key.millisecondsSinceOrderSyncSuccess: "\(millisecondsSinceOrderSyncSuccess)",
                 Key.millisecondsSinceReaderReadyToCollect: "\(millisecondsSinceReaderReadyToCollect)",
                 Key.millisecondsSinceCardTapped: "\(millisecondsSinceCardTapped)",
                 Key.checkoutTapCount: "\(checkoutTapCount)"
-            ], error: error)
+            ].compactMapValues { $0 }
+            return WooAnalyticsEvent(statName: .collectPaymentFailed, properties: properties, error: error)
         }
 
         /// Tracked when a card present payment is cancelled in POS.

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -1,6 +1,7 @@
 @testable import WooCommerce
 import protocol WooFoundation.Analytics
 import struct Yosemite.CardPresentPaymentsConfiguration
+import enum Yosemite.CardReaderServiceError
 import typealias Yosemite.PaymentIntent
 import enum WooFoundation.CountryCode
 import Foundation
@@ -267,6 +268,32 @@ struct POSCollectOrderPaymentAnalyticsTests {
         #expect(trackedEvent != nil)
         #expect(trackedEvent?.error is TestError)
         #expect(expectedProperties.allSatisfy { trackedEvent?.properties.keys.contains($0) == true })
+    }
+
+    @Test func test_track_payment_failure_when_error_carries_interac_payment_method_then_reports_payment_method_type() {
+        // Given
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .CA))
+        let error = CardReaderServiceError.paymentCaptureWithPaymentMethod(underlyingError: .paymentDeclinedByCardReader,
+                                                                          paymentMethod: .interacPresent(details: .fake()))
+
+        // When
+        sut.trackPaymentFailure(with: error)
+
+        // Then
+        #expect(property("payment_method_type", in: "card_present_collect_payment_failed") == "card_interac")
+    }
+
+    @Test func test_track_payment_failure_when_error_carries_no_payment_method_then_omits_payment_method_type() {
+        // Given
+        let sut = POSCollectOrderPaymentAnalyticsAdaptor(analytics: analytics,
+                                                         configuration: CardPresentPaymentsConfiguration(country: .US))
+
+        // When
+        sut.trackPaymentFailure(with: TestError())
+
+        // Then
+        #expect(property("payment_method_type", in: "card_present_collect_payment_failed") == nil)
     }
 
     @Test func test_track_payment_cancelation_then_tracks_event_with_cancellation_source() {


### PR DESCRIPTION
Closes WOOMOB-3745

## Description

This PR improves the POS card payment failure event by adding `payment_method_type` by adding the method.

We already track `paymentMethod: Hardware.PaymentMethod.XYZ` so this could be a bit redundant, however,  `Hardware.PaymentMethod` only appears inside `error_description`, which makes it harder to analyze when filtering through track events. Also is table, so does not change based on error formatting.

## Test Steps (optional)
1. In POS, force a failure when collecting payment via card, you can do so by adding the following line to  `CardPresentPaymentInvalidatablePaymentOrchestrator.swift:28`
```diff
guard invalidated == false else {
  return onCompletion(.failure(CardPresentPaymentInvalidatablePaymentOrchestratorError.paymentInvalidated))
}
+ // Force card failure
+ return onCompletion(.failure(CardReaderServiceError.paymentCaptureWithPaymentMethod(underlyingError: .paymentDeclinedByCardReader, paymentMethod: .card)))
```
2. See the failure screen

<img width="600" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-08-21 at 13 59 47" src="https://github.com/user-attachments/assets/2e8d21f7-f166-43b2-a44f-472867746b70"/>


4. See the failure event with `payment_method_type: card` property

```
🔵 Tracked pos_card_present_collect_payment_failed, properties: [error_code: 6, site_url: https://cool-shop.mystagingwebsite.com, milliseconds_since_order_sync_success: 20561.0, cached_woo_core_version: 11.1.0-dev, error_description: Hardware.CardReaderServiceError.paymentCaptureWithPaymentMethod(underlyingError: Hardware.UnderlyingError.paymentDeclinedByCardReader, paymentMethod: Hardware.PaymentMethod.card), is_wpcom_store: false, is_jetpack_connected: true, milliseconds_since_customer_interaction_started: 25200.0, is_jetpack_installed: true, milliseconds_since_reader_ready_to_collect_payment: 0.0, country: US, store_id: e9bb3936-a6d1-45e5-8a4a-694f00a1b3ab, error_domain: Hardware.CardReaderServiceError, payment_method_type: card, device_type: phone, horizontal_size_class: compact, entry_point: pos_tab, checkout_tap_count: 1, milliseconds_since_card_tapped: 0.0, card_reader_model: CHIPPER_2X, plugin_slug: woocommerce-payments, is_jetpack_cp_connected: false, blog_id: 211362451]
```
