### PR TITLE
Update card reader's `StatementDescriptor` validation rules

### DIFF
--- a/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
+++ b/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
@@ -1,13 +1,9 @@
 import Foundation
 
-/// A property wrapper to return a string where:
-/// - The characters <>"' are replaced.
-/// - The maximum length of the string is 22 characters
-/// We do this to add an extra layer of validation to the values that we
-/// pass to the Stripe Terminal SDK when creating a payment intent:
-/// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)statementDescriptor
-/// If we pass strings longer than 22 characters or that contain any of the
-/// characters that are not allowed, the Stripe Terminal SDK will crash.
+/// A property wrapper that sanitizes statement descriptors before passing them to Stripe Terminal.
+/// Valid descriptors contain 5 to 22 ASCII characters, at least one letter, and none of Stripe's
+/// forbidden characters. Invalid descriptors are returned as `nil` so Stripe can use the account default.
+/// https://docs.stripe.com/get-started/account/statement-descriptors#requirements
 @propertyWrapper
 public struct StatementDescriptor {
 
@@ -23,9 +19,7 @@ public struct StatementDescriptor {
                 return nil
             }
 
-            return String(value.components(separatedBy: Constants.charactersToReplace)
-                .joined(separator: Constants.replacement)
-                            .prefix(Constants.maxLength))
+            return Self.sanitize(value)
         }
         set {
             value = newValue
@@ -34,9 +28,48 @@ public struct StatementDescriptor {
 }
 
 private extension StatementDescriptor {
+    static func sanitize(_ value: String) -> String? {
+        let normalizedValue = value.applyingTransform(Constants.latinToASCII, reverse: false) ?? value
+        let sanitizedValue = normalizedValue.map { character in
+            guard character.isPrintableASCII,
+                  !Constants.forbiddenCharacters.contains(character) else {
+                return Constants.replacement
+            }
+            return character
+        }
+        let truncatedValue = String(sanitizedValue.prefix(Constants.maxLength))
+
+        guard truncatedValue.count >= Constants.minLength,
+              truncatedValue.contains(where: \.isASCIILetter) else {
+            return nil
+        }
+
+        return truncatedValue
+    }
+
     enum Constants {
-        static let charactersToReplace = CharacterSet(["<", ">", "'", "\""])
-        static let replacement = "-"
+        static let forbiddenCharacters: Set<Character> = ["<", ">", "\\", "'", "\"", "*"]
+        static let replacement: Character = "-"
+        static let latinToASCII = StringTransform("Latin-ASCII")
+        static let minLength = 5
         static let maxLength = 22
+    }
+}
+
+private extension Character {
+    var isPrintableASCII: Bool {
+        guard unicodeScalars.count == 1,
+              let scalar = unicodeScalars.first else {
+            return false
+        }
+        return (32...126).contains(scalar.value)
+    }
+
+    var isASCIILetter: Bool {
+        guard unicodeScalars.count == 1,
+              let value = unicodeScalars.first?.value else {
+            return false
+        }
+        return (65...90).contains(value) || (97...122).contains(value)
     }
 }

--- a/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
+++ b/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
@@ -33,8 +33,7 @@ private extension StatementDescriptor {
             .joined(separator: Constants.replacement)
             .prefix(Constants.maxLength))
 
-        guard truncatedValue.count >= Constants.minLength,
-              truncatedValue.contains(where: \.isASCIILetter) else {
+        guard truncatedValue.count >= Constants.minLength else {
             return nil
         }
 
@@ -46,15 +45,5 @@ private extension StatementDescriptor {
         static let replacement = "-"
         static let minLength = 5
         static let maxLength = 22
-    }
-}
-
-private extension Character {
-    var isASCIILetter: Bool {
-        guard unicodeScalars.count == 1,
-              let value = unicodeScalars.first?.value else {
-            return false
-        }
-        return (65...90).contains(value) || (97...122).contains(value)
     }
 }

--- a/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
+++ b/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
@@ -29,15 +29,9 @@ public struct StatementDescriptor {
 
 private extension StatementDescriptor {
     static func sanitize(_ value: String) -> String? {
-        let normalizedValue = value.applyingTransform(Constants.latinToASCII, reverse: false) ?? value
-        let sanitizedValue = normalizedValue.map { character in
-            guard character.isPrintableASCII,
-                  !Constants.forbiddenCharacters.contains(character) else {
-                return Constants.replacement
-            }
-            return character
-        }
-        let truncatedValue = String(sanitizedValue.prefix(Constants.maxLength))
+        let truncatedValue = String(value.components(separatedBy: Constants.charactersToReplace)
+            .joined(separator: Constants.replacement)
+            .prefix(Constants.maxLength))
 
         guard truncatedValue.count >= Constants.minLength,
               truncatedValue.contains(where: \.isASCIILetter) else {
@@ -48,23 +42,14 @@ private extension StatementDescriptor {
     }
 
     enum Constants {
-        static let forbiddenCharacters: Set<Character> = ["<", ">", "\\", "'", "\"", "*"]
-        static let replacement: Character = "-"
-        static let latinToASCII = StringTransform("Latin-ASCII")
+        static let charactersToReplace = CharacterSet(["<", ">", "'", "\"", "*"])
+        static let replacement = "-"
         static let minLength = 5
         static let maxLength = 22
     }
 }
 
 private extension Character {
-    var isPrintableASCII: Bool {
-        guard unicodeScalars.count == 1,
-              let scalar = unicodeScalars.first else {
-            return false
-        }
-        return (32...126).contains(scalar.value)
-    }
-
     var isASCIILetter: Bool {
         guard unicodeScalars.count == 1,
               let value = unicodeScalars.first?.value else {

--- a/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
@@ -76,47 +76,6 @@ final class PaymentIntentParametersTests: XCTestCase {
         XCTAssertEqual(expectation, stripeParams.amount)
     }
 
-    func test_statementDescription_replaces_expected_characters() throws {
-        let params = PaymentIntentParameters(
-            amount: 100,
-            currency: "usd",
-            stripeSmallestCurrencyUnitMultiplier: 100,
-            statementDescription: "A < DESCRIPTION' longer THAN 22 Characters",
-            paymentMethodTypes: [.cardPresent]
-        )
-
-        let statementDescription = try XCTUnwrap(params.statementDescription)
-
-        XCTAssertTrue(statementDescription.count <= 22)
-        XCTAssertEqual(params.statementDescription, "A - DESCRIPTION- longe")
-    }
-
-    func test_statementDescription_leaves_strings_untouched_when_no_replacement_is_necessary() throws {
-        let params = PaymentIntentParameters(amount: 100,
-                                             currency: "usd",
-                                             stripeSmallestCurrencyUnitMultiplier: 100,
-                                             statementDescription: "A DESCRIPTION",
-                                             paymentMethodTypes: [.cardPresent])
-
-        let statementDescription = try XCTUnwrap(params.statementDescription)
-
-        XCTAssertEqual(statementDescription, "A DESCRIPTION")
-    }
-
-    func test_statementDescription_trims_strings_to_22_characters() throws {
-        let params = PaymentIntentParameters(
-            amount: 100,
-            currency: "usd",
-            stripeSmallestCurrencyUnitMultiplier: 100,
-            statementDescription: "A DESCRIPTION LONGER THAN 22 CHARACTERS",
-            paymentMethodTypes: [.cardPresent]
-        )
-
-        let statementDescription = try XCTUnwrap(params.statementDescription)
-
-        XCTAssertEqual(statementDescription, "A DESCRIPTION LONGER T")
-    }
-
     func test_statementDescription_is_passed_as_nil_when_empty() throws {
         let params = PaymentIntentParameters(amount: 100,
                                              currency: "usd",

--- a/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
@@ -76,6 +76,47 @@ final class PaymentIntentParametersTests: XCTestCase {
         XCTAssertEqual(expectation, stripeParams.amount)
     }
 
+    func test_statementDescription_replaces_expected_characters() throws {
+        let params = PaymentIntentParameters(
+            amount: 100,
+            currency: "usd",
+            stripeSmallestCurrencyUnitMultiplier: 100,
+            statementDescription: "A < DESCRIPTION' longer THAN 22 Characters",
+            paymentMethodTypes: [.cardPresent]
+        )
+
+        let statementDescription = try XCTUnwrap(params.statementDescription)
+
+        XCTAssertTrue(statementDescription.count <= 22)
+        XCTAssertEqual(params.statementDescription, "A - DESCRIPTION- longe")
+    }
+
+    func test_statementDescription_leaves_strings_untouched_when_no_replacement_is_necessary() throws {
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "usd",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             statementDescription: "A DESCRIPTION",
+                                             paymentMethodTypes: [.cardPresent])
+
+        let statementDescription = try XCTUnwrap(params.statementDescription)
+
+        XCTAssertEqual(statementDescription, "A DESCRIPTION")
+    }
+
+    func test_statementDescription_trims_strings_to_22_characters() throws {
+        let params = PaymentIntentParameters(
+            amount: 100,
+            currency: "usd",
+            stripeSmallestCurrencyUnitMultiplier: 100,
+            statementDescription: "A DESCRIPTION LONGER THAN 22 CHARACTERS",
+            paymentMethodTypes: [.cardPresent]
+        )
+
+        let statementDescription = try XCTUnwrap(params.statementDescription)
+
+        XCTAssertEqual(statementDescription, "A DESCRIPTION LONGER T")
+    }
+
     func test_statementDescription_is_passed_as_nil_when_empty() throws {
         let params = PaymentIntentParameters(amount: 100,
                                              currency: "usd",

--- a/Modules/Tests/HardwareTests/StatementDescriptorTests.swift
+++ b/Modules/Tests/HardwareTests/StatementDescriptorTests.swift
@@ -103,28 +103,6 @@ struct StatementDescriptorTests {
         // Then
         #expect(result == nil)
     }
-
-    @Test func test_wrappedValue_when_value_does_not_contain_a_letter_then_returns_nil() {
-        // Given
-        let value = "12345"
-
-        // When
-        let result = sanitizedDescriptor(value)
-
-        // Then
-        #expect(result == nil)
-    }
-
-    @Test func test_wrappedValue_when_value_contains_only_non_ASCII_letters_then_returns_nil() {
-        // Given
-        let value = "中国商店中国"
-
-        // When
-        let result = sanitizedDescriptor(value)
-
-        // Then
-        #expect(result == nil)
-    }
 }
 
 private extension StatementDescriptorTests {

--- a/Modules/Tests/HardwareTests/StatementDescriptorTests.swift
+++ b/Modules/Tests/HardwareTests/StatementDescriptorTests.swift
@@ -1,0 +1,145 @@
+import Testing
+@testable import Hardware
+
+struct StatementDescriptorTests {
+    @Test func test_wrappedValue_when_value_is_nil_then_returns_nil() {
+        // Given
+        let value: String? = nil
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func test_wrappedValue_when_value_is_empty_then_returns_nil() {
+        // Given
+        let value = ""
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func test_wrappedValue_when_value_is_valid_then_returns_value_unchanged() {
+        // Given
+        let value = "MY.FANCY.STORE"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == value)
+    }
+
+    @Test func test_wrappedValue_when_value_is_at_length_boundaries_then_returns_value() {
+        // Given
+        let minimumLengthValue = "Store"
+        let maximumLengthValue = "A DESCRIPTION LONGER T"
+
+        // When
+        let minimumLengthResult = sanitizedDescriptor(minimumLengthValue)
+        let maximumLengthResult = sanitizedDescriptor(maximumLengthValue)
+
+        // Then
+        #expect(minimumLengthResult == minimumLengthValue)
+        #expect(maximumLengthResult == maximumLengthValue)
+    }
+
+    @Test func test_wrappedValue_when_value_exceeds_maximum_length_then_truncates_value() {
+        // Given
+        let value = "A DESCRIPTION LONGER THAN 22 CHARACTERS"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == "A DESCRIPTION LONGER T")
+    }
+
+    @Test func test_wrappedValue_when_value_contains_forbidden_characters_then_replaces_them() {
+        // Given
+        let value = "A<B>C\\D'E\"F*G"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == "A-B-C-D-E-F-G")
+    }
+
+    @Test func test_wrappedValue_when_value_contains_latin_diacritics_then_folds_them_to_ASCII() {
+        // Given
+        let value = "Café Øresund Łódź"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == "Cafe Oresund Lodz")
+    }
+
+    @Test func test_wrappedValue_when_value_contains_non_ASCII_characters_then_replaces_them() {
+        // Given
+        let value = "Store 店 😀"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == "Store - -")
+    }
+
+    @Test func test_wrappedValue_when_value_contains_control_characters_then_replaces_them() {
+        // Given
+        let value = "Store\nName\t"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == "Store-Name-")
+    }
+
+    @Test func test_wrappedValue_when_sanitized_value_is_too_short_then_returns_nil() {
+        // Given
+        let value = "Shop"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func test_wrappedValue_when_value_does_not_contain_a_letter_then_returns_nil() {
+        // Given
+        let value = "12345"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func test_wrappedValue_when_sanitization_produces_an_invalid_value_then_returns_nil() {
+        // Given
+        let value = "店名"
+
+        // When
+        let result = sanitizedDescriptor(value)
+
+        // Then
+        #expect(result == nil)
+    }
+}
+
+private extension StatementDescriptorTests {
+    func sanitizedDescriptor(_ value: String?) -> String? {
+        StatementDescriptor(wrappedValue: value).wrappedValue
+    }
+}

--- a/Modules/Tests/HardwareTests/StatementDescriptorTests.swift
+++ b/Modules/Tests/HardwareTests/StatementDescriptorTests.swift
@@ -62,16 +62,16 @@ struct StatementDescriptorTests {
 
     @Test func test_wrappedValue_when_value_contains_forbidden_characters_then_replaces_them() {
         // Given
-        let value = "A<B>C\\D'E\"F*G"
+        let value = "A<B>C'D\"E*F"
 
         // When
         let result = sanitizedDescriptor(value)
 
         // Then
-        #expect(result == "A-B-C-D-E-F-G")
+        #expect(result == "A-B-C-D-E-F")
     }
 
-    @Test func test_wrappedValue_when_value_contains_latin_diacritics_then_folds_them_to_ASCII() {
+    @Test func test_wrappedValue_when_value_contains_latin_diacritics_then_returns_value_unchanged() {
         // Given
         let value = "Café Øresund Łódź"
 
@@ -79,29 +79,18 @@ struct StatementDescriptorTests {
         let result = sanitizedDescriptor(value)
 
         // Then
-        #expect(result == "Cafe Oresund Lodz")
+        #expect(result == value)
     }
 
-    @Test func test_wrappedValue_when_value_contains_non_ASCII_characters_then_replaces_them() {
+    @Test func test_wrappedValue_when_value_contains_mixed_unicode_then_returns_value_unchanged() {
         // Given
-        let value = "Store 店 😀"
+        let value = "CAFÉ 商店 🛒 - INDIMELO"
 
         // When
         let result = sanitizedDescriptor(value)
 
         // Then
-        #expect(result == "Store - -")
-    }
-
-    @Test func test_wrappedValue_when_value_contains_control_characters_then_replaces_them() {
-        // Given
-        let value = "Store\nName\t"
-
-        // When
-        let result = sanitizedDescriptor(value)
-
-        // Then
-        #expect(result == "Store-Name-")
+        #expect(result == value)
     }
 
     @Test func test_wrappedValue_when_sanitized_value_is_too_short_then_returns_nil() {
@@ -126,9 +115,9 @@ struct StatementDescriptorTests {
         #expect(result == nil)
     }
 
-    @Test func test_wrappedValue_when_sanitization_produces_an_invalid_value_then_returns_nil() {
+    @Test func test_wrappedValue_when_value_contains_only_non_ASCII_letters_then_returns_nil() {
         // Given
-        let value = "店名"
+        let value = "中国商店中国"
 
         // When
         let result = sanitizedDescriptor(value)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 25.6
 -----
-
+- [*] Payments: Update card reader's statement descriptor validation rules [https://github.com/woocommerce/woocommerce-ios/pull/17751]
 
 25.5
 -----


### PR DESCRIPTION
Closes WOOMOB-3517

## Description
Updates the card reader statement descriptor sanitizer to match Stripe’s/WooPayment validation requirements. 

The existing property already did some defensive sanitization before passing WooPayments’ statement descriptor to Stripe Terminal. It previously replaced <, >, ', and " and truncated values to 22 characters. This PR fills the remaining gaps with WooPayments’ validation:

- Adds * to the replaced characters.
- Enforces the minimum length of 5 characters.
- Returns nil when the sanitized descriptor is invalid, allowing Stripe to use the account default.

## Test Steps
- Validation already happens in the web, so we just assure that works as before. Under WP Admin > Payments > Settings, update your statement as you see fit:

<img width="464" height="140" alt="Screenshot 2026-08-25 at 16 15 55" src="https://github.com/user-attachments/assets/a2e3ae59-120d-4df6-a185-84d42b682ffa" />

- Add breakpoint to `PaymentIntentParameters+Stripe` line 45:
```swift
if !descriptor.isEmpty {
```
- Launch the app and collect payment. Confirm:
  - The descriptors match the web
```
(lldb) po descriptor
CAFÉ - INDIMELO
(lldb) po statementDescription
▿ CAFÉ - INDIMELO
  - some : "CAFÉ - INDIMELO"
```
  - Payment preparation proceeds without a crash or descriptor error.
  - The payment completes successfully.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
