### PR TITLE
Fix infinite spinner on site credential login when cookie-nonce auth fails unexpectedly

### DIFF
--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -86,9 +86,6 @@ private extension CookieNonceAuthenticator {
                 invalidateLoginSequence(error: error)
             } catch {
                 DDLogError("⛔️ Cookie nonce authenticator failed with uncaught error: \(error)")
-
-                // Invalidating (rather than only completing the pending requests) resets the
-                // authenticating state so subsequent requests cannot hang forever (WOOMOB-3866).
                 invalidateLoginSequence(error: .unknown(error))
             }
         }
@@ -134,12 +131,8 @@ private extension CookieNonceAuthenticator {
         let allowRetry: Bool
         switch error {
         case .postLoginFailed, .unknown:
-            // The sequence ended without a verdict on the credentials (transport failure,
-            // unexpected response, ...) — a later attempt may succeed, so keep retrying allowed.
             allowRetry = true
         case .invalidNewPostURL, .missingNonce:
-            // Definitive outcomes for this configuration — retrying with the same
-            // credentials cannot succeed.
             allowRetry = false
         }
         state.invalidate(allowRetry: allowRetry)

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -71,7 +71,14 @@ private extension CookieNonceAuthenticator {
         }
         Task(priority: .medium) {
             do {
-                try await handleSiteCredentialLogin(session: session)
+                do {
+                    try await handleSiteCredentialLogin(session: session)
+                } catch {
+                    // Wrap raw transport/validation errors (e.g. a host whose wp-login.php responds
+                    // with HTTP 401 instead of the standard 200 + login form) so they go through
+                    // the handled invalidation path below.
+                    throw CookieNonceAuthenticator.Error.postLoginFailed(error)
+                }
                 let page = try await handleNonceRetrieval(request: nonceRequest, session: session)
                 guard let nonce = readNonceFromAjaxAction(html: page) else {
                     throw CookieNonceAuthenticator.Error.missingNonce
@@ -83,9 +90,11 @@ private extension CookieNonceAuthenticator {
             } catch {
                 DDLogError("⛔️ Cookie nonce authenticator failed with uncaught error: \(error)")
 
-                //  Complete the pending requests without retrying. This informs the clients waiting for response about the failure.
-                //
-                completeRequests(false)
+                // Invalidate the login sequence so the authenticator state is reset and the pending
+                // requests are completed. Calling only `completeRequests(false)` here would leave
+                // `isAuthenticating` set forever, making every subsequent 401 on this session enqueue
+                // a retry completion that nothing drains — an infinite hang (WOOMOB-3866).
+                invalidateLoginSequence(error: .unknown(error))
             }
         }
     }
@@ -129,7 +138,9 @@ private extension CookieNonceAuthenticator {
     func invalidateLoginSequence(error: Error) {
         var allowRetry = false
         if case .postLoginFailed(let originalError) = error {
-            let nsError = originalError as NSError
+            // The login request fails with an `AFError` wrapping the transport error,
+            // so unwrap it before checking for the connectivity failure.
+            let nsError = (originalError.asAFError?.underlyingError ?? originalError) as NSError
             if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorNotConnectedToInternet {
                 allowRetry = true
             }

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -74,9 +74,6 @@ private extension CookieNonceAuthenticator {
                 do {
                     try await handleSiteCredentialLogin(session: session)
                 } catch {
-                    // Wrap raw transport/validation errors (e.g. a host whose wp-login.php responds
-                    // with HTTP 401 instead of the standard 200 + login form) so they go through
-                    // the handled invalidation path below.
                     throw CookieNonceAuthenticator.Error.postLoginFailed(error)
                 }
                 let page = try await handleNonceRetrieval(request: nonceRequest, session: session)
@@ -90,10 +87,8 @@ private extension CookieNonceAuthenticator {
             } catch {
                 DDLogError("⛔️ Cookie nonce authenticator failed with uncaught error: \(error)")
 
-                // Invalidate the login sequence so the authenticator state is reset and the pending
-                // requests are completed. Calling only `completeRequests(false)` here would leave
-                // `isAuthenticating` set forever, making every subsequent 401 on this session enqueue
-                // a retry completion that nothing drains — an infinite hang (WOOMOB-3866).
+                // Invalidating (rather than only completing the pending requests) resets the
+                // authenticating state so subsequent requests cannot hang forever (WOOMOB-3866).
                 invalidateLoginSequence(error: .unknown(error))
             }
         }
@@ -138,8 +133,6 @@ private extension CookieNonceAuthenticator {
     func invalidateLoginSequence(error: Error) {
         var allowRetry = false
         if case .postLoginFailed(let originalError) = error {
-            // The login request fails with an `AFError` wrapping the transport error,
-            // so unwrap it before checking for the connectivity failure.
             let nsError = (originalError.asAFError?.underlyingError ?? originalError) as NSError
             if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorNotConnectedToInternet {
                 allowRetry = true

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -124,12 +124,11 @@ private extension CookieNonceAuthenticator {
     }
 
     func invalidateLoginSequence(error: Error) {
-        let allowRetry: Bool
-        switch error {
+        let allowRetry = switch error {
         case .postLoginFailed, .unknown:
-            allowRetry = true
+            true
         case .invalidNewPostURL, .missingNonce:
-            allowRetry = false
+            false
         }
         state.invalidate(allowRetry: allowRetry)
         DDLogInfo("Aborting Cookie+Nonce login sequence for \(loginURL)")

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -131,12 +131,16 @@ private extension CookieNonceAuthenticator {
     }
 
     func invalidateLoginSequence(error: Error) {
-        var allowRetry = false
-        if case .postLoginFailed(let originalError) = error {
-            let nsError = (originalError.asAFError?.underlyingError ?? originalError) as NSError
-            if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorNotConnectedToInternet {
-                allowRetry = true
-            }
+        let allowRetry: Bool
+        switch error {
+        case .postLoginFailed, .unknown:
+            // The sequence ended without a verdict on the credentials (transport failure,
+            // unexpected response, ...) — a later attempt may succeed, so keep retrying allowed.
+            allowRetry = true
+        case .invalidNewPostURL, .missingNonce:
+            // Definitive outcomes for this configuration — retrying with the same
+            // credentials cannot succeed.
+            allowRetry = false
         }
         state.invalidate(allowRetry: allowRetry)
         DDLogInfo("Aborting Cookie+Nonce login sequence for \(loginURL)")

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -71,11 +71,7 @@ private extension CookieNonceAuthenticator {
         }
         Task(priority: .medium) {
             do {
-                do {
-                    try await handleSiteCredentialLogin(session: session)
-                } catch {
-                    throw CookieNonceAuthenticator.Error.postLoginFailed(error)
-                }
+                try await handleSiteCredentialLogin(session: session)
                 let page = try await handleNonceRetrieval(request: nonceRequest, session: session)
                 guard let nonce = readNonceFromAjaxAction(html: page) else {
                     throw CookieNonceAuthenticator.Error.missingNonce
@@ -98,7 +94,7 @@ private extension CookieNonceAuthenticator {
                 .validate()
                 .response { response in
                     if let error = response.error {
-                        continuation.resume(throwing: error)
+                        continuation.resume(throwing: CookieNonceAuthenticator.Error.postLoginFailed(error))
                     } else {
                         continuation.resume(returning: ())
                     }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -1,3 +1,5 @@
+import Alamofire
+import TestKit
 import XCTest
 @testable import Networking
 @testable import NetworkingCore
@@ -38,5 +40,79 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
 
             XCTAssertEqual(value, expectedParameters[key])
         }
+    }
+
+    // MARK: - Login sequence failure handling (WOOMOB-3866)
+
+    func test_request_when_login_POST_fails_with_401_then_request_completes_with_original_error() throws {
+        // Given
+        // A host that responds with HTTP 401 to the wp-login.php POST
+        // (instead of the standard WordPress 200 + re-rendered login form).
+        let session = makeSessionWithMockURLProtocol(interceptor: makeAuthenticator())
+        MockURLProtocol.Mocks.mockResponse(["error": "unauthorized"], statusCode: 401, for: apiRequest)
+        MockURLProtocol.Mocks.mockResponse(["error": "captcha_required"], statusCode: 401, for: URLRequest(url: loginURL))
+
+        // When
+        let error: Error? = waitFor { promise in
+            session.request(self.apiRequest)
+                .validate()
+                .response { response in
+                    promise(response.error)
+                }
+        }
+
+        // Then
+        let afError = try XCTUnwrap(error as? AFError)
+        guard case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = afError else {
+            return XCTFail("Expected a 401 validation error, got \(afError)")
+        }
+    }
+
+    func test_request_when_login_sequence_previously_failed_with_unexpected_error_then_subsequent_request_completes() throws {
+        // Given
+        // A first request has already gone through a login sequence whose wp-login.php POST
+        // failed with an unexpected 401. Before the fix, this left the authenticator stuck in
+        // the authenticating state, so any subsequent 401 request would hang forever.
+        let session = makeSessionWithMockURLProtocol(interceptor: makeAuthenticator())
+        MockURLProtocol.Mocks.mockResponse(["error": "unauthorized"], statusCode: 401, for: apiRequest)
+        MockURLProtocol.Mocks.mockResponse(["error": "captcha_required"], statusCode: 401, for: URLRequest(url: loginURL))
+        _ = waitFor { promise in
+            session.request(self.apiRequest)
+                .validate()
+                .response { response in
+                    promise(response.error)
+                }
+        }
+
+        // When
+        let error: Error? = waitFor { promise in
+            session.request(self.apiRequest)
+                .validate()
+                .response { response in
+                    promise(response.error)
+                }
+        }
+
+        // Then
+        let afError = try XCTUnwrap(error as? AFError)
+        guard case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = afError else {
+            return XCTFail("Expected a 401 validation error, got \(afError)")
+        }
+    }
+}
+
+private extension CookieNonceAuthenticatorTests {
+    func makeAuthenticator() -> CookieNonceAuthenticator {
+        let config = CookieNonceAuthenticatorConfiguration(username: sampleUser,
+                                                           password: samplePassword,
+                                                           loginURL: loginURL,
+                                                           adminURL: adminURL)
+        return CookieNonceAuthenticator(configuration: config)
+    }
+
+    func makeSessionWithMockURLProtocol(interceptor: RequestInterceptor) -> Session {
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return Session(configuration: configuration, interceptor: interceptor)
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.6
 -----
+- [*] Fixed an infinite spinner on site credential login when the site rejects the wp-login.php request (e.g. hosts with captcha/security plugins). An error alert is now shown instead. [https://github.com/woocommerce/woocommerce-ios/pull/17752]
 
 
 25.5


### PR DESCRIPTION
## Description

Fixes WOOMOB-3866.

**What was broken:** When connecting a store via wp-admin site credentials (Jetpack setup → site credential login screen), some hosts reject the login request itself — e.g. a LiteSpeed host with a captcha/security plugin returns HTTP 401 from `wp-login.php` instead of the standard WordPress behavior. When that happened, the user got no feedback at all: no error alert, and the login button's spinner kept spinning forever. Retrying didn't help — the only way out was dismissing the screen. This came from a support case.

**What happens now:** The login attempt fails visibly — the "It looks like this username/password isn't associated with this site." alert is shown and the spinner stops. The user can retry, and every attempt gives feedback instead of hanging.

**Root cause, briefly:** an unexpected error from the `wp-login.php` POST left `CookieNonceAuthenticator` permanently stuck in its "authenticating" state, so requests waiting on the retry queue were never completed. The fix routes those errors through the normal invalidation path. One deliberate semantic choice on top: inconclusive failures (transport errors, unexpected responses) keep the authenticator retryable, so a later attempt performs a real login sequence; only definitive outcomes (credentials rejected, invalid admin URL) fail fast, since re-attempting with the same credentials can't succeed and repeated `wp-login.php` POSTs risk brute-force lockouts. Regression tests cover the previously-hanging scenario (the key test times out on `trunk` and passes here).

## Test Steps

The bug needs a host that returns 401 from `wp-login.php`, which is hard to find on demand. To simulate it, apply this patch (fault injection at the exact point the field failure occurs — everything else stays real):

```patch
diff --git a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
index bf2e9051fc..b9a65d3ac8 100644
--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -100,6 +100,14 @@ private extension CookieNonceAuthenticator {
     }
 
     func handleSiteCredentialLogin(session: Session) async throws {
+        // TEMPORARY — WOOMOB-3866 simulation. DO NOT COMMIT.
+        // Simulates a host (e.g. LiteSpeed + captcha plugin) whose wp-login.php POST
+        // fails with HTTP 401 instead of the standard 200-with-login-form behavior.
+        let simulateWpLogin401 = true
+        if simulateWpLogin401 {
+            throw AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401))
+        }
+
         let request = authenticatedRequest()
         return try await withCheckedThrowingContinuation { continuation in
             session.request(request)
```

Save the block above as `repro.patch` and run `git apply repro.patch`.

1. To see the bug: check out `trunk`, apply the patch, and run the app. Log in with WPCom → site picker → **Connect existing store** → enter any real WordPress site address → proceed to the site credential screen → enter any credentials → tap the login button. The spinner never stops and no error is shown (`⛔️ Cookie nonce authenticator failed with uncaught error: …401…` appears in the console).
2. To verify the fix: check out this branch, apply the same patch, repeat the flow. The "It looks like this username/password isn't associated with this site." alert appears and the spinner stops. Repeated attempts keep showing the alert instead of hanging.
3. Revert the patch (`git apply -R repro.patch`) and sanity-check a regular site credential login against a normal WordPress site still works (wrong password → alert; correct password → proceeds).

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
