### PR TITLE
Fix product list UI test assertion on the cell detail label

### DIFF
--- a/Modules/Sources/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -55,8 +55,8 @@ public final class SingleOrderScreen: ScreenObject {
         XCTAssertTrue(app.otherElements.containing(orderTotalPredicate).element.exists)
 
         // Check name on order summary
-        orderDetailTableView.assertElement(matching: "summary-table-view-cell",
-                                           existsOnCellWithIdentifier: "\(order.billing.first_name) \(order.billing.last_name)")
+        orderDetailTableView.assertStaticText(withLabel: "\(order.billing.first_name) \(order.billing.last_name)",
+                                              existsOnCellWithIdentifier: "summary-table-view-cell")
 
         // Check product(s) on order
         for product in order.line_items {

--- a/Modules/Sources/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -108,7 +108,9 @@ public final class ProductsScreen: ScreenObject {
     @discardableResult
     public func verifyProductList(products: [ProductData]) throws -> Self {
         app.assertTextVisibilityCount(textToFind: products[0].name, expectedCount: 1)
-        app.assertElement(matching: products[0].name, existsOnCellWithIdentifier: products[0].stock_status)
+        // The cell's detail line is a single label composing stock status, price and SKU (e.g. "On back order • $150.00"),
+        // so only the stock status part is matched here.
+        app.assertStaticText(containing: products[0].stock_status, existsOnCellWithIdentifier: products[0].name)
         let productListTable = app.tables["products-table-view"]
         XCTAssertEqual(products.count, productListTable.cells.count, "Expected '\(products.count)' products but found '\(productListTable.cells.count)' instead!")
 

--- a/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
+++ b/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
@@ -132,29 +132,33 @@ extension XCUIElement {
         XCTAssertEqual(try! getStaticTextVisibilityCount(textToFind: textToFind), expectedCount)
     }
 
-    // Parent element is accessibilityIdentifier, child element is staticText
-    func verifyElementOnCell(parent: String, child: String) throws -> Bool {
-        let parentPredicate = NSPredicate(format: "identifier == %@", parent)
-        let childPredicate = NSPredicate(format: "label ==[c] %@", child)
+    /// Looks for a `staticText` child of the cell with the given accessibility identifier, whose label satisfies `labelPredicate`.
+    /// Note: the lookup always starts from the application, not from the receiver.
+    func verifyStaticTextOnCell(cellIdentifier: String, labelPredicate: NSPredicate) -> Bool {
+        let cellPredicate = NSPredicate(format: "identifier == %@", cellIdentifier)
 
-        return XCUIApplication().tables.cells.matching(parentPredicate).children(matching: .staticText).element(matching: childPredicate).firstMatch.exists
+        return XCUIApplication().tables.cells.matching(cellPredicate)
+            .children(matching: .staticText)
+            .element(matching: labelPredicate)
+            .firstMatch
+            .exists
     }
 
-    public func assertElement(matching: String, existsOnCellWithIdentifier cellIdentifier: String) {
-        XCTAssertTrue(try verifyElementOnCell(parent: matching, child: cellIdentifier), "Element does not exist on cell!")
+    /// Asserts that a cell identified by `cellIdentifier` has a `staticText` child whose label is exactly `label`.
+    public func assertStaticText(withLabel label: String, existsOnCellWithIdentifier cellIdentifier: String) {
+        let labelPredicate = NSPredicate(format: "label ==[c] %@", label)
+
+        XCTAssertTrue(verifyStaticTextOnCell(cellIdentifier: cellIdentifier, labelPredicate: labelPredicate),
+                      "No static text labeled '\(label)' found on cell '\(cellIdentifier)'!")
     }
 
     /// Asserts that a cell identified by `cellIdentifier` has a `staticText` child whose label contains `substring`.
     /// Use this when the label is a composed detail line (e.g. "On back order • $150.00") and only one part of it is under test.
     public func assertStaticText(containing substring: String, existsOnCellWithIdentifier cellIdentifier: String) {
-        let cellPredicate = NSPredicate(format: "identifier == %@", cellIdentifier)
         let labelPredicate = NSPredicate(format: "label CONTAINS[c] %@", substring)
-        let staticText = XCUIApplication().tables.cells.matching(cellPredicate)
-            .children(matching: .staticText)
-            .element(matching: labelPredicate)
-            .firstMatch
 
-        XCTAssertTrue(staticText.exists, "No static text containing '\(substring)' found on cell '\(cellIdentifier)'!")
+        XCTAssertTrue(verifyStaticTextOnCell(cellIdentifier: cellIdentifier, labelPredicate: labelPredicate),
+                      "No static text containing '\(substring)' found on cell '\(cellIdentifier)'!")
     }
 
     func verifyLabelContains(substring firstSubstring: String, and secondSubstring: String) throws -> Bool {

--- a/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
+++ b/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
@@ -144,6 +144,19 @@ extension XCUIElement {
         XCTAssertTrue(try verifyElementOnCell(parent: matching, child: cellIdentifier), "Element does not exist on cell!")
     }
 
+    /// Asserts that a cell identified by `cellIdentifier` has a `staticText` child whose label contains `substring`.
+    /// Use this when the label is a composed detail line (e.g. "On back order • $150.00") and only one part of it is under test.
+    public func assertStaticText(containing substring: String, existsOnCellWithIdentifier cellIdentifier: String) {
+        let cellPredicate = NSPredicate(format: "identifier == %@", cellIdentifier)
+        let labelPredicate = NSPredicate(format: "label CONTAINS[c] %@", substring)
+        let staticText = XCUIApplication().tables.cells.matching(cellPredicate)
+            .children(matching: .staticText)
+            .element(matching: labelPredicate)
+            .firstMatch
+
+        XCTAssertTrue(staticText.exists, "No static text containing '\(substring)' found on cell '\(cellIdentifier)'!")
+    }
+
     func verifyLabelContains(substring firstSubstring: String, and secondSubstring: String) throws -> Bool {
         let firstPredicate = NSPredicate(format: "label CONTAINS[c] %@", firstSubstring)
         let secondPredicate = NSPredicate(format: "label CONTAINS[c] %@", secondSubstring)


### PR DESCRIPTION
WOOMOB-3904

## Description

`ProductsTests.test_load_products_screen` fails on `trunk` with `XCTAssertTrue failed - Element does not exist on cell!`. The assertion in `ProductsScreen.verifyProductList` requires the product cell to have a `staticText` child whose label is **exactly** the product's stock status, but #17700 (Display product prices and SKUs in product list) turned on `isSKUShown`/`isPriceShown` for the list, and the cell's detail line is a single label joining status, stock, price and variations with ` • `. For the first mocked product it now reads `On back order • $150.00` instead of `On back order`, so the exact-match predicate finds nothing. Nothing is broken in the app itself — this is a test-only breakage.

- Match the stock status as a substring of the cell's detail label instead of requiring equality, so the test no longer breaks when other information is added to that line.
- Add `assertStaticText(containing:existsOnCellWithIdentifier:)` to `XCTest+Extensions` for that substring assertion.
- Rename `assertElement(matching:existsOnCellWithIdentifier:)` to `assertStaticText(withLabel:existsOnCellWithIdentifier:)`, with the arguments in their true roles — it took the cell identifier as `matching:` and the static text label as `existsOnCellWithIdentifier:`. Exact-match semantics are unchanged.
- Update the renamed helper's other call site in `SingleOrderScreen`.

## Test Steps

1. Start the mock server: `rake mocks`
2. Run the previously failing test:
   ```
   xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerceUITests \
     -destination 'platform=iOS Simulator,name=iPhone 17' \
     test -only-testing:"WooCommerceUITests/ProductsTests/test_load_products_screen"
   ```
   It should pass. On `trunk` it fails at `XCTest+Extensions.swift` with `Element does not exist on cell!`.
3. Check the renamed helper's other call site still passes:
   ```
   xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerceUITests \
     -destination 'platform=iOS Simulator,name=iPhone 17' \
     test -only-testing:"WooCommerceUITests/OrdersTests/test_load_order_list"
   ```

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
