### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
     - name: "Check out Project"
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: "Set up Ruby"
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
       with:
         bundler-cache: true
 
@@ -32,7 +32,7 @@ jobs:
     - name: Archive Build Products
       run: tar -cf build-products.tar -C DerivedData/Build/Products Debug-iphonesimulator
     - name: Upload Build Products
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: screenshot-build-products
         path: build-products.tar
@@ -51,14 +51,14 @@ jobs:
         language: [ar-SA, de-DE, en-US, es-ES, fr-FR, he, id, it, ja, ko, nl-NL, pt-BR, ru, sv, tr, zh-Hans, zh-Hant]
         mode: [dark, light]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: "Set up Ruby"
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
       with:
         bundler-cache: true
 
     - name: Download Build Products
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: screenshot-build-products
     - name: Extract Build Products
@@ -72,7 +72,7 @@ jobs:
 
     - name: Store Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: "screenshot-log-${{ matrix.language }}-${{ matrix.mode }}"
         path: |
@@ -80,7 +80,7 @@ jobs:
           fastlane/screenshots/test_output
 
     - name: Archive Generated Screenshots
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: "screenshots-${{ matrix.language }}-${{ matrix.mode }}"
         path: fastlane/screenshots/
@@ -99,7 +99,7 @@ jobs:
       BUNDLE_WITH: screenshots
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Checkout the PR branch directly (not the merge commit) so we can push back to it
           ref: ${{ github.head_ref }}
@@ -120,12 +120,12 @@ jobs:
           brew install automattic/build-tools/drawText
 
       - name: "Set up Ruby"
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           bundler-cache: true
 
       - name: Download Generated Screenshots
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: "screenshots-*"
           path: fastlane/screenshots/
@@ -136,13 +136,13 @@ jobs:
           bundle exec fastlane create_screenshot_summary
 
       - name: Upload Screenshot Summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: screenshot-summary
           path: fastlane/screenshots/screenshots.html
 
       - name: Archive Raw Screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: raw-screenshots
           path: fastlane/screenshots
@@ -157,7 +157,7 @@ jobs:
           bundle exec fastlane create_promo_screenshots force:true commit:true
 
       - name: Archive Promo Screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: promo-screenshots
           path: fastlane/promo_screenshots


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

WooCommerce intends to enforce full-length commit SHA pinning for GitHub Actions across the organization. This pins every remote action reference in the screenshot workflow to the commit currently identified by its existing tag, retaining that tag in a comment. Immutable references reduce the risk that a moved or compromised upstream ref can silently change CI code and narrow the supply-chain compromise surface.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Re-run the action reference scanner in check mode and confirm zero unpinned remote action references remain.
2. Run `git diff --check`.
3. Parse the changed workflow file as YAML.

All three checks pass on this branch. No changelog is needed because this changes workflow configuration only and is not shipped to users.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Not applicable.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release notes are needed for workflow-only configuration.
