### PR TITLE
Payments: Persist multiple contactless card guidance

### DIFF
--- a/Modules/Sources/Hardware/CardReader/CardReaderEvent.swift
+++ b/Modules/Sources/Hardware/CardReader/CardReaderEvent.swift
@@ -7,7 +7,7 @@ public enum CardReaderEvent: Equatable {
     /// Request that a prompt be displayed in the app.
     /// For example, if the prompt is SwipeCard,
     /// the app should instruct the user to present the card again by swiping it.
-    case displayMessage(String)
+    case displayMessage(CardReaderDisplayMessage)
 
     /// The reader has accepted cardholder input and the card can be removed.
     case removeCardRequested(String)
@@ -32,4 +32,20 @@ public enum CardReaderEvent: Equatable {
 
     /// The card reader disconnected.
     case disconnected
+}
+
+/// A message that a connected reader requests the app to display.
+public enum CardReaderDisplayMessage: Equatable {
+    /// A reader message that does not require specialized presentation behavior.
+    case generic(String)
+
+    /// The reader detected more than one contactless card or NFC device.
+    case multipleContactlessCardsDetected(String)
+
+    public var text: String {
+        switch self {
+        case .generic(let message), .multipleContactlessCardsDetected(let message):
+            message
+        }
+    }
 }

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/CardReaderEvent+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/CardReaderEvent+Stripe.swift
@@ -15,8 +15,10 @@ extension CardReaderEvent {
         switch displayMessage {
         case .removeCard:
             return .removeCardRequested(displayMessage.localizedMessage)
+        case .multipleContactlessCardsDetected:
+            return .displayMessage(.multipleContactlessCardsDetected(displayMessage.localizedMessage))
         default:
-            return .displayMessage(displayMessage.localizedMessage)
+            return .displayMessage(.generic(displayMessage.localizedMessage))
         }
     }
 }

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/ReaderDisplayMessage+Localization.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/ReaderDisplayMessage+Localization.swift
@@ -40,9 +40,9 @@ extension ReaderDisplayMessage {
             "Insert Or Swipe Card",
             comment: "Message from the in-person payment card reader prompting user to insert or swipe their card")
         static let multipleContactlessCards = NSLocalizedString(
-            "Multiple Contactless Cards Detected",
-            comment: "Message from the in-person payment card reader when payment could not be taken because " +
-            "multiple cards were detected")
+            "cardPresentPayment.reader.multipleContactlessCardsDetected",
+            value: "Multiple cards detected. Try again with a single card.",
+            comment: "Message from the in-person payment card reader when payment could not be taken because multiple cards were detected")
         static let removeCard = NSLocalizedString(
             "Remove Card",
             comment: "Message from the in-person payment card reader prompting user to remove their card")

--- a/Modules/Tests/HardwareTests/CardReaderEventStripeTests.swift
+++ b/Modules/Tests/HardwareTests/CardReaderEventStripeTests.swift
@@ -1,0 +1,42 @@
+#if !targetEnvironment(macCatalyst)
+import StripeTerminal
+import Testing
+@testable import Hardware
+
+struct CardReaderEventStripeTests {
+    @Test func test_make_when_multiple_contactless_cards_are_detected_then_returns_typed_display_message() {
+        // Given
+        let stripeMessage = ReaderDisplayMessage.multipleContactlessCardsDetected
+
+        // When
+        let event = CardReaderEvent.make(displayMessage: stripeMessage)
+
+        // Then
+        #expect(event == .displayMessage(.multipleContactlessCardsDetected(
+            "Multiple cards detected. Try again with a single card."
+        )))
+    }
+
+    @Test func test_make_when_generic_reader_message_is_received_then_returns_generic_display_message() {
+        // Given
+        let stripeMessage = ReaderDisplayMessage.retryCard
+
+        // When
+        let event = CardReaderEvent.make(displayMessage: stripeMessage)
+
+        // Then
+        #expect(event == .displayMessage(.generic("Retry Card")))
+    }
+
+    @Test func test_make_when_remove_card_is_received_then_returns_remove_card_request() {
+        // Given
+        let stripeMessage = ReaderDisplayMessage.removeCard
+
+        // When
+        let event = CardReaderEvent.make(displayMessage: stripeMessage)
+
+        // Then
+        #expect(event == .removeCardRequested("Remove Card"))
+    }
+}
+#endif

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -39,13 +39,15 @@ final class CardPresentRefundOrchestrator {
 
         /// Refunds payment in-person with a card reader.
         let refundParameters = RefundParameters(chargeId: charge.id, amount: amount, currency: charge.currency)
+        let readerEventFilter = CardReaderEventPresentationFilter()
         let refundAction = CardPresentPaymentAction.refundPayment(parameters: refundParameters,
                                                                   onCardReaderMessage: { event in
+            guard let event = readerEventFilter.filter(event) else { return }
             switch event {
             case .waitingForInput(let inputMethods):
                 onWaitingForInput(inputMethods)
             case .displayMessage(let message):
-                onDisplayMessage(message)
+                onDisplayMessage(message.text)
             case .removeCardRequested(let message):
                 onDisplayMessage(message)
             case .cardInserted:
@@ -57,6 +59,7 @@ final class CardPresentRefundOrchestrator {
             }
         }, onCompletion: { [weak self] result in
             guard let self else { return }
+            readerEventFilter.reset()
             self.allowPassPresentation()
             onProcessingMessage()
             onCompletion(result)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardReaderEventPresentationFilter.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardReaderEventPresentationFilter.swift
@@ -1,0 +1,23 @@
+import Yosemite
+
+/// Keeps actionable reader guidance visible while the reader re-arms for another card presentation.
+final class CardReaderEventPresentationFilter {
+    private var isShowingMultipleContactlessCardsMessage = false
+
+    func filter(_ event: CardReaderEvent) -> CardReaderEvent? {
+        switch event {
+        case .displayMessage(.multipleContactlessCardsDetected):
+            isShowingMultipleContactlessCardsMessage = true
+            return event
+        case .waitingForInput where isShowingMultipleContactlessCardsMessage:
+            return nil
+        default:
+            isShowingMultipleContactlessCardsMessage = false
+            return event
+        }
+    }
+
+    func reset() {
+        isShowingMultipleContactlessCardsMessage = false
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -80,12 +80,14 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                         onDisplayMessage: @escaping (String) -> Void,
                         onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                         onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void) {
+        let readerEventFilter = CardReaderEventPresentationFilter()
         handlersForActivePayment = PaymentHandlers(onPreparingReader: onPreparingReader,
                                                    onWaitingForInput: onWaitingForInput,
                                                    onCardInserted: onCardInserted,
                                                    onProcessingMessage: onProcessingMessage,
                                                    onDisplayMessage: onDisplayMessage,
                                                    onProcessingCompletion: onProcessingCompletion,
+                                                   readerEventFilter: readerEventFilter,
                                                    countryCode: countryCode,
                                                    terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled)
         onPreparingReader()
@@ -110,11 +112,12 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
             countryCode: countryCode,
             terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
             onCardReaderMessage: { event in
+                guard let event = readerEventFilter.filter(event) else { return }
                 switch event {
                 case .waitingForInput(let inputMethods):
                     onWaitingForInput(inputMethods)
                 case .displayMessage(let message):
-                    onDisplayMessage(message)
+                    onDisplayMessage(message.text)
                 case .removeCardRequested(let message):
                     onDisplayMessage(message)
                 case .cardDetailsCollected, .cardRemovedAfterClientSidePaymentCapture:
@@ -129,6 +132,7 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                 onProcessingCompletion(intent)
             },
             onCompletion: { [weak self] result in
+                readerEventFilter.reset()
                 self?.allowPassPresentation()
                 self?.completePaymentIntentCapture(
                     order: order,
@@ -148,6 +152,7 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         }
 
         handlers.onPreparingReader()
+        handlers.readerEventFilter.reset()
 
         let retryPaymentAction = CardPresentPaymentAction.retryPayment(
             siteID: order.siteID,
@@ -155,11 +160,12 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
             countryCode: handlers.countryCode,
             terminalPaymentPreparationEnabled: handlers.terminalPaymentPreparationEnabled,
             onCardReaderMessage: { event in
+                guard let event = handlers.readerEventFilter.filter(event) else { return }
                 switch event {
                 case .waitingForInput(let inputMethods):
                     handlers.onWaitingForInput(inputMethods)
                 case .displayMessage(let message):
-                    handlers.onDisplayMessage(message)
+                    handlers.onDisplayMessage(message.text)
                 case .removeCardRequested(let message):
                     handlers.onDisplayMessage(message)
                 case .cardDetailsCollected, .cardRemovedAfterClientSidePaymentCapture:
@@ -174,6 +180,7 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                 handlers.onProcessingCompletion(intent)
             },
             onCompletion: { [weak self] result in
+                handlers.readerEventFilter.reset()
                 self?.allowPassPresentation()
                 self?.completePaymentIntentCapture(
                     order: order,
@@ -186,6 +193,7 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
     }
 
     func cancelPayment(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        handlersForActivePayment?.readerEventFilter.reset()
         let action = CardPresentPaymentAction.cancelPayment() { [weak self] result in
             self?.allowPassPresentation()
             onCompletion(result)
@@ -407,6 +415,7 @@ private extension PaymentCaptureOrchestrator {
         let onProcessingMessage: () -> Void
         let onDisplayMessage: (String) -> Void
         let onProcessingCompletion: (PaymentIntent) -> Void
+        let readerEventFilter: CardReaderEventPresentationFilter
         let countryCode: CountryCode
         let terminalPaymentPreparationEnabled: Bool
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentRefundOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentRefundOrchestratorTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Yosemite
+@testable import WooCommerce
+
+struct CardPresentRefundOrchestratorTests {
+    @Test func test_refund_when_reader_rearms_after_multiple_cards_then_keeps_message_visible_until_refund_advances() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let sut = CardPresentRefundOrchestrator(stores: stores)
+        var onCardReaderMessage: ((CardReaderEvent) -> Void)?
+        var displayedMessages: [String] = []
+        var waitingForInputCount = 0
+        var processingMessageCount = 0
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            guard case let .refundPayment(_, readerMessage, _) = action else { return }
+            onCardReaderMessage = readerMessage
+        }
+        sut.refund(
+            amount: 1,
+            charge: .fake(),
+            paymentGatewayAccount: .fake(),
+            onWaitingForInput: { _ in waitingForInputCount += 1 },
+            onCardInserted: {},
+            onProcessingMessage: { processingMessageCount += 1 },
+            onDisplayMessage: { displayedMessages.append($0) },
+            onCompletion: { _ in }
+        )
+
+        // When
+        onCardReaderMessage?(.displayMessage(.multipleContactlessCardsDetected("Try one card")))
+        onCardReaderMessage?(.waitingForInput(.tap))
+        onCardReaderMessage?(.cardDetailsCollected)
+
+        // Then
+        #expect(displayedMessages == ["Try one card"])
+        #expect(waitingForInputCount == 0)
+        #expect(processingMessageCount == 1)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentRefundOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentRefundOrchestratorTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Yosemite
 @testable import WooCommerce
 
+@MainActor
 struct CardPresentRefundOrchestratorTests {
     @Test func test_refund_when_reader_rearms_after_multiple_cards_then_keeps_message_visible_until_refund_advances() {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardReaderEventPresentationFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardReaderEventPresentationFilterTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Yosemite
+@testable import WooCommerce
+
+struct CardReaderEventPresentationFilterTests {
+    @Test func test_filter_when_reader_rearms_after_multiple_cards_then_keeps_multiple_cards_message_visible() {
+        // Given
+        let sut = CardReaderEventPresentationFilter()
+        let message = CardReaderEvent.displayMessage(.multipleContactlessCardsDetected("Multiple cards"))
+
+        // When
+        let displayedMessage = sut.filter(message)
+        let waitingForInput = sut.filter(.waitingForInput(.tap))
+
+        // Then
+        #expect(displayedMessage == message)
+        #expect(waitingForInput == nil)
+    }
+
+    @Test func test_filter_when_payment_advances_after_multiple_cards_then_forwards_new_events() {
+        // Given
+        let sut = CardReaderEventPresentationFilter()
+        _ = sut.filter(.displayMessage(.multipleContactlessCardsDetected("Multiple cards")))
+
+        // When
+        let cardDetailsCollected = sut.filter(.cardDetailsCollected)
+        let waitingForInput = sut.filter(.waitingForInput(.tap))
+
+        // Then
+        #expect(cardDetailsCollected == .cardDetailsCollected)
+        #expect(waitingForInput == .waitingForInput(.tap))
+    }
+
+    @Test func test_filter_when_generic_message_is_received_then_does_not_suppress_waiting_for_input() {
+        // Given
+        let sut = CardReaderEventPresentationFilter()
+
+        // When
+        let displayedMessage = sut.filter(.displayMessage(.generic("Retry card")))
+        let waitingForInput = sut.filter(.waitingForInput(.tap))
+
+        // Then
+        #expect(displayedMessage == .displayMessage(.generic("Retry card")))
+        #expect(waitingForInput == .waitingForInput(.tap))
+    }
+
+    @Test func test_reset_when_multiple_cards_message_is_visible_then_forwards_waiting_for_input() {
+        // Given
+        let sut = CardReaderEventPresentationFilter()
+        _ = sut.filter(.displayMessage(.multipleContactlessCardsDetected("Multiple cards")))
+
+        // When
+        sut.reset()
+        let waitingForInput = sut.filter(.waitingForInput(.tap))
+
+        // Then
+        #expect(waitingForInput == .waitingForInput(.tap))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -418,6 +418,88 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         let expectedFee = NSDecimalNumber(string: "2.65").decimalValue
         assertEqual(expectedFee, parameters.applicationFee)
     }
+
+    func test_collect_payment_when_reader_rearms_after_multiple_cards_then_keeps_message_visible_until_payment_advances() {
+        // Given
+        var onCardReaderMessage: ((CardReaderEvent) -> Void)?
+        var displayedMessages: [String] = []
+        var waitingForInputCount = 0
+        var processingMessageCount = 0
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            guard case let .collectPayment(_, _, _, _, _, readerMessage, _, _) = action else { return }
+            onCardReaderMessage = readerMessage
+        }
+        sut.collectPayment(
+            for: .fake(),
+            orderTotal: 1,
+            paymentGatewayAccount: .fake(),
+            paymentMethodTypes: [.cardPresent],
+            stripeSmallestCurrencyUnitMultiplier: 100,
+            countryCode: .US,
+            terminalPaymentPreparationEnabled: false,
+            channel: .storeManagement,
+            onPreparingReader: {},
+            onWaitingForInput: { _ in waitingForInputCount += 1 },
+            onCardInserted: {},
+            onProcessingMessage: { processingMessageCount += 1 },
+            onDisplayMessage: { displayedMessages.append($0) },
+            onProcessingCompletion: { _ in },
+            onCompletion: { _ in }
+        )
+
+        // When
+        onCardReaderMessage?(.displayMessage(.multipleContactlessCardsDetected("Try one card")))
+        onCardReaderMessage?(.waitingForInput(.tap))
+        onCardReaderMessage?(.cardDetailsCollected)
+
+        // Then
+        XCTAssertEqual(displayedMessages, ["Try one card"])
+        XCTAssertEqual(waitingForInputCount, 0)
+        XCTAssertEqual(processingMessageCount, 1)
+    }
+
+    func test_retry_payment_after_multiple_cards_then_forwards_waiting_for_input_for_new_attempt() {
+        // Given
+        var initialReaderMessage: ((CardReaderEvent) -> Void)?
+        var retryReaderMessage: ((CardReaderEvent) -> Void)?
+        var waitingForInputCount = 0
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            switch action {
+            case .collectPayment(_, _, _, _, _, let readerMessage, _, _):
+                initialReaderMessage = readerMessage
+            case .retryPayment(_, _, _, _, let readerMessage, _, _):
+                retryReaderMessage = readerMessage
+            default:
+                break
+            }
+        }
+        let order = Order.fake()
+        sut.collectPayment(
+            for: order,
+            orderTotal: 1,
+            paymentGatewayAccount: .fake(),
+            paymentMethodTypes: [.cardPresent],
+            stripeSmallestCurrencyUnitMultiplier: 100,
+            countryCode: .US,
+            terminalPaymentPreparationEnabled: false,
+            channel: .storeManagement,
+            onPreparingReader: {},
+            onWaitingForInput: { _ in waitingForInputCount += 1 },
+            onCardInserted: {},
+            onProcessingMessage: {},
+            onDisplayMessage: { _ in },
+            onProcessingCompletion: { _ in },
+            onCompletion: { _ in }
+        )
+        initialReaderMessage?(.displayMessage(.multipleContactlessCardsDetected("Try one card")))
+
+        // When
+        sut.retryPayment(for: order, onCompletion: { _ in })
+        retryReaderMessage?(.waitingForInput(.tap))
+
+        // Then
+        XCTAssertEqual(waitingForInputCount, 1)
+    }
 }
 
 struct MockReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {


### PR DESCRIPTION
Closes WOOMOB-3685

## Description
Preserves Stripe’s multiple-contactless-cards message while the reader re-arms, instead of immediately replacing it with the generic card prompt. The message now provides actionable guidance:

 > Multiple cards detected. Try again with a single card.

This follows Android implementation where Stripe’s reader message is passed as a typed state (`MULTIPLE_CONTACTLESS_CARDS_DETECTED` in this case) instead of flattening it to a string. 

This applies to all flows, so standard app-side payments, POS, and card-present refunds (Interac).

## Test Steps 
1. With `-simulate-stripe-card-reader`, in `StripeCardReaderService.swift` send the multiple contactless card detected event by adding to lines 1127 and 1221:
```diff
    public func reader(_ reader: Reader, didRequestReaderInput inputOptions: ReaderInputOptions = []) {
+        if shouldUseSimulatedCardReader { sendReaderEvent(CardReaderEvent.make(displayMessage: .multipleContactlessCardsDetected)) }
        sendReaderEvent(CardReaderEvent.make(stripeReaderInputOptions: inputOptions))
    }

    public func tapToPayReader(_ reader: Reader, didRequestReaderInput inputOptions: ReaderInputOptions = []) {
+        if shouldUseSimulatedCardReader { sendReaderEvent(CardReaderEvent.make(displayMessage: .multipleContactlessCardsDetected)) }
        sendReaderEvent(CardReaderEvent.make(stripeReaderInputOptions: inputOptions))
    }
```

Note that the simulated payment will just continue processing after presenting the message, this is expected.

2. Optional: with two physical cards together near the reader. I tried to test this one with the Stripe and the Interac card, as is the only test ones I have and _didn't work_ in the sense that only captures Stripe every try, so I could only simulate-test.
  - Start a card-present payment.
  - Present two contactless cards together near the reader.
  - Confirm “Multiple cards detected. Try again with a single card.” remains visible instead of immediately reverting to the generic card prompt.
  - Remove one card and present a single card.
  - Confirm payment proceeds normally and the multiple-card message is cleared.
  - Cancel and start another payment; confirm the normal card prompt appears.
  - Repeat in POS

## Screenshots

<img width="600"  alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-08-25 at 11 41 36" src="https://github.com/user-attachments/assets/45b096a8-f27a-40d6-8b3e-894f4fa6b7fc" />

