### PR TITLE
Remove `ios_build_preflight` call

### DIFF
--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -12,5 +12,4 @@ bundle exec fastlane run configure_apply
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_to_app_store_connect \
   skip_confirm:true \
-  skip_prechecks:true \
   beta_release:${1:-true} # use first call param, default to true for safety

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -871,12 +871,10 @@ platform :ios do
   #####################################################################################
   desc 'Builds and uploads for distribution to the App Store'
   lane :build_and_upload_to_app_store_connect do |options|
-    unless options[:skip_prechecks]
-      # Verify that there's nothing in progress in the working copy
-      ensure_git_status_clean unless is_ci
-      # Ensure we're using the right version of Xcode, defined in `.xcode-version` file
-      xcversion
-    end
+    # Verify that there's nothing in progress in the working copy
+    ensure_git_status_clean unless is_ci
+    # Ensure we're using the right version of Xcode, defined in `.xcode-version` file
+    xcversion
 
     ensure_sentry_installed
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -874,9 +874,8 @@ platform :ios do
     unless options[:skip_prechecks]
       # Verify that there's nothing in progress in the working copy
       ensure_git_status_clean unless is_ci
-
-      ios_build_preflight(derived_data_path: DERIVED_DATA_DIR)
-      xcversion # Ensure we're using the right version of Xcode, defined in `.xcode-version` file
+      # Ensure we're using the right version of Xcode, defined in `.xcode-version` file
+      xcversion
     end
 
     ensure_sentry_installed


### PR DESCRIPTION
The action runs check that are mostly unnecessary:

- Decrypt secrets, which should already be decrypted
- Ensure ImageMagick and GhostScript are available, but they are not required by builds
- Check gems are up to date, unrelated to app builds

It also

- Runs CocoaPods, which we no longer use
- Deleted the DerivedData folder, but build actions have "clean" options for that

See https://github.com/wordpress-mobile/release-toolkit/blob/9322fff453fb4622d4d1add8040dc8d13cee2a1d/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb#L6-L39

Close https://linear.app/a8c/issue/AINFRA-2956