### PR TITLE
DRY secrets install into a dedicated CI script

### DIFF
--- a/.buildkite/commands/install-secrets.sh
+++ b/.buildkite/commands/install-secrets.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -6,8 +6,7 @@ fi
 
 "$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh"
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
+"$(dirname "${BASH_SOURCE[0]}")/install-secrets.sh"
 
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_prototype_build

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -6,8 +6,7 @@ brew install ghostscript
 
 "$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh"
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
+"$(dirname "${BASH_SOURCE[0]}")/install-secrets.sh"
 
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_to_app_store_connect \

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -19,9 +19,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :snowflake: Complete Code Freeze'
       bundle exec fastlane complete_code_freeze skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/create-release-notes-pr.yml
+++ b/.buildkite/release-pipelines/create-release-notes-pr.yml
@@ -17,9 +17,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :memo: Create Release Notes PR'
       bundle exec fastlane create_release_notes_pr \
         version:"${RELEASE_VERSION}" \

--- a/.buildkite/release-pipelines/download-release-translations.yml
+++ b/.buildkite/release-pipelines/download-release-translations.yml
@@ -19,9 +19,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :globe_with_meridians: Download Release Translations'
       bundle exec fastlane download_release_translations skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -19,9 +19,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :fire: Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -19,9 +19,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :shipit: Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -19,9 +19,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :shipit: New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -17,9 +17,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :fire: Start New Hotfix Release'
       bundle exec fastlane new_hotfix_release version:${VERSION} skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -19,9 +19,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :package: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -17,9 +17,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :snowflake: Start Code Freeze'
       bundle exec fastlane start_code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     retry:

--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -19,9 +19,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :closed_lock_with_key: Access Secrets'
-      bundle exec fastlane run configure_apply
-
       echo '--- :shipit: Update Release Notes and Other App Store Metadata'
       bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true with_screenshots:"${WITH_SCREENSHOTS:-false}"
     retry:


### PR DESCRIPTION
Part of AINFRA-2955

## Description
Collapse the remaining `configure_apply` call sites onto one CI script so swapping to a8c-secrets is a one-file change.

Prototype and Release still decrypt. The ten release-management pipelines never compile the app, so they no longer do.

Not wired through `shared-set-up.sh` — that script also runs on the shared Build job, which must keep using dummy credentials.

## Test Steps
On this PR's Buildkite run: Prototype Build still has the Installing Secrets step; Build and Unit Tests do not. [The comment below](https://github.com/woocommerce/woocommerce-ios/pull/17760#issuecomment-5406477739) with the Prototype Build QR code shows the abstraction step did not break the build.

Release pipelines are on-demand — the YAML deletion is the review.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.