### PR TITLE
POS Update `POSNotificationScheduler` to pass utms

### DIFF
--- a/WooCommerce/Classes/POS/POSNotificationScheduler.swift
+++ b/WooCommerce/Classes/POS/POSNotificationScheduler.swift
@@ -131,9 +131,21 @@ final class POSNotificationScheduler: POSNotificationScheduling {
     }
 
     private func scheduleLocalNotification(for merchantType: POSNotificationScheduler.MerchantType) async {
+        guard let surveyURL = URL(string: merchantType.surveyURL) else {
+            assertionFailure("Invalid POS survey URL: \(merchantType.surveyURL)")
+            return
+        }
+
+        let sessionManager = stores.sessionManager
+        let taggedSurveyURL = surveyURL
+            .tagPlatform("ios")
+            .tagAppVersion(Bundle.main.bundleVersion())
+            .tagSiteInfo(siteID: sessionManager.defaultSite?.siteID,
+                         storeUUID: sessionManager.defaultStoreUUID,
+                         storeURL: sessionManager.defaultSite?.url)
 
         let payload: [AnyHashable: Any] = [
-            LocalNotification.UserInfoKey.surveyURL: merchantType.surveyURL
+            LocalNotification.UserInfoKey.surveyURL: taggedSurveyURL.absoluteString
         ]
 
         let notification = LocalNotification(

--- a/WooCommerce/WooCommerceTests/POS/POSNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSNotificationSchedulerTests.swift
@@ -5,6 +5,9 @@ import UserNotifications
 
 @MainActor
 struct POSNotificationSchedulerTests {
+    private static let siteID: Int64 = 123
+    private static let storeUUID = "8363cd24-2501-463f-b21b-649315a0d507"
+    private static let storeURL = "https://example.com"
     private let mockFeatureFlagService: MockFeatureFlagService
     private let mockPushNotesManager: MockPushNotificationsManager
     private let mockStores: MockStoresManager
@@ -12,7 +15,10 @@ struct POSNotificationSchedulerTests {
     init() async throws {
         mockFeatureFlagService = MockFeatureFlagService()
         mockPushNotesManager = MockPushNotificationsManager()
-        mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let site = Site.fake().copy(siteID: Self.siteID, url: Self.storeURL)
+        mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                       defaultSite: site,
+                                                                       defaultStoreUUID: Self.storeUUID))
     }
 
     @Test func scheduleLocalNotificationIfEligible_when_country_is_US_then_notification_is_scheduled() async throws {
@@ -143,7 +149,7 @@ struct POSNotificationSchedulerTests {
 
         #expect(notification.scenario == .pointOfSalePotentialMerchant)
         #expect(notification.userInfo[LocalNotification.UserInfoKey.surveyURL] as? String ==
-                LocalNotification.SurveyURL.pointOfSalePotentialMerchant)
+                taggedSurveyURL(for: LocalNotification.SurveyURL.pointOfSalePotentialMerchant).absoluteString)
         #expect(trigger.timeInterval == 60)
         #expect(trigger.repeats == false)
     }
@@ -173,9 +179,66 @@ struct POSNotificationSchedulerTests {
 
         #expect(notification.scenario == .pointOfSaleCurrentMerchant)
         #expect(notification.userInfo[LocalNotification.UserInfoKey.surveyURL] as? String ==
-                LocalNotification.SurveyURL.pointOfSaleCurrentMerchant)
+                taggedSurveyURL(for: LocalNotification.SurveyURL.pointOfSaleCurrentMerchant).absoluteString)
         #expect(trigger.timeInterval == 300)
         #expect(trigger.repeats == false)
+    }
+
+    @Test func scheduleLocalNotificationIfEligible_when_store_metadata_is_available_then_tags_survey_URL() async throws {
+        // Given
+        let siteSettings = sampleSiteSettings(countryCode: "US")
+        setupMockStores()
+
+        let scheduler = POSNotificationScheduler(
+            stores: mockStores,
+            siteSettings: siteSettings,
+            featureFlagService: mockFeatureFlagService,
+            pushNotificationsManager: mockPushNotesManager
+        )
+
+        // When
+        await scheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+
+        // Then
+        let notification = try #require(mockPushNotesManager.requestedLocalNotifications.first)
+        let surveyURL = try #require(notification.userInfo[LocalNotification.UserInfoKey.surveyURL] as? String)
+        let components = try #require(URLComponents(string: surveyURL))
+        let queryItems = try #require(components.queryItems)
+
+        #expect(queryItems.first(where: { $0.name == "woo-mobile-platform" })?.value == "ios")
+        #expect(queryItems.first(where: { $0.name == "app-version" })?.value == Bundle.main.bundleVersion())
+        #expect(queryItems.first(where: { $0.name == "site-id" })?.value == "\(Self.siteID)")
+        #expect(queryItems.first(where: { $0.name == "store-id" })?.value == Self.storeUUID)
+        #expect(queryItems.first(where: { $0.name == "store-url" })?.value == Self.storeURL)
+    }
+
+    @Test func scheduleLocalNotificationIfEligible_when_store_metadata_is_unavailable_then_tags_platform_and_app_version() async throws {
+        // Given
+        let siteSettings = sampleSiteSettings(countryCode: "US")
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        setupMockStores(stores: stores)
+
+        let scheduler = POSNotificationScheduler(
+            stores: stores,
+            siteSettings: siteSettings,
+            featureFlagService: mockFeatureFlagService,
+            pushNotificationsManager: mockPushNotesManager
+        )
+
+        // When
+        await scheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+
+        // Then
+        let notification = try #require(mockPushNotesManager.requestedLocalNotifications.first)
+        let surveyURL = try #require(notification.userInfo[LocalNotification.UserInfoKey.surveyURL] as? String)
+        let components = try #require(URLComponents(string: surveyURL))
+        let queryItems = try #require(components.queryItems)
+
+        #expect(queryItems.first(where: { $0.name == "woo-mobile-platform" })?.value == "ios")
+        #expect(queryItems.first(where: { $0.name == "app-version" })?.value == Bundle.main.bundleVersion())
+        #expect(queryItems.contains(where: { $0.name == "site-id" }) == false)
+        #expect(queryItems.contains(where: { $0.name == "store-id" }) == false)
+        #expect(queryItems.contains(where: { $0.name == "store-url" }) == false)
     }
 
     @Test func scheduleLocalNotificationIfEligible_when_eligible_then_notification_manager_receives_correct_notification() async throws {
@@ -318,10 +381,19 @@ struct POSNotificationSchedulerTests {
         ]
     }
 
-    private func setupMockStores(isPotentialMerchantScheduled: Bool = false,
+    private func taggedSurveyURL(for surveyURL: String) -> URL {
+        URL(string: surveyURL)!
+            .tagPlatform("ios")
+            .tagAppVersion(Bundle.main.bundleVersion())
+            .tagSiteInfo(siteID: Self.siteID, storeUUID: Self.storeUUID, storeURL: Self.storeURL)
+    }
+
+    private func setupMockStores(stores: MockStoresManager? = nil,
+                                  isPotentialMerchantScheduled: Bool = false,
                                   isCurrentMerchantScheduled: Bool = false,
                                   hasPOSBeenOpened: Bool = false) {
-        mockStores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+        let stores = stores ?? mockStores
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case .getPOSSurveyPotentialMerchantNotificationScheduled(let onCompletion):
                 onCompletion(isPotentialMerchantScheduled)


### PR DESCRIPTION
Closes WOOMOB-3910

## Description
Adds `platform`, `app version`, `site ID`, `store UUID`, and `store URL` tags to POS survey URLs when scheduling local notifications. This ensures survey responses are attributed to the originating iOS store.

## Test Steps (optional)
- In `POSNotificationScheduler`: Change `timeIntervalInSeconds ` to 5 seconds or similar, and remove the check for `isNotificationAlreadyScheduled`
```diff
    func scheduleLocalNotificationIfEligible(for merchantType: POSNotificationScheduler.MerchantType) async {
        guard stores.isAuthenticated else { return }

-        let isScheduled = await isNotificationAlreadyScheduled(for: merchantType)
-        guard !isScheduled else { return }
-        guard isCountryEligible() else { return }

-        // For current merchants, also check if they've opened POS at least once
-        if merchantType == .currentMerchant {
-            let hasOpenedPOS = await hasOpenedPOSAtLeastOnce()
-            guard hasOpenedPOS else { return }
-        }

        await scheduleLocalNotification(for: merchantType)
    }
```
- Run the app and enter POS
- AppCoordinator automatically requests the current-merchant notification during startup, if you add a debug print in line 129 you already should see the URL with UTM:
```
POS survey URL: https://automattic.survey.fm/pos-survey-existing-users?woo-mobile-platform=ios&app-version=25.5.0.0&site-id=215063064&store-id=c5bd46cc-1804-4f7b-badb-bb98c449127f&store-url=https://indiemelon.mystagingwebsite.com
🔵 Tracked local_notification_scheduled, properties: [blog_id: 215063064, is_jetpack_installed: true, is_jetpack_cp_connected: false, is_jetpack_connected: true, site_url: https://indiemelon.mystagingwebsite.com, type: woo_pos_survey_current_user_survey, is_wpcom_store: false, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f]
```
- Relaunch the app
- Wait 5 seconds and tap the notification, fill the survey and send it over
- Log into CrowdSignal's a8c account, observe UTM details have been logged in your response

## Screenshots

<img width="1122" height="486" alt="Screenshot 2026-08-25 at 17 16 37" src="https://github.com/user-attachments/assets/1c02cb62-2615-4bac-8a42-2a62ac68881c" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
