### PR TITLE
Remove duplicate import in POS analytics

### DIFF
--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -11,7 +11,6 @@ import enum Yosemite.CardReaderServiceError
 import enum Yosemite.PaymentMethod
 import enum Yosemite.RefundAPIError
 import struct WooFoundation.WooAnalyticsEvent
-import protocol WooFoundation.WooAnalyticsEventPropertyType
 
 extension WooAnalyticsEvent {
     public enum PointOfSale {


### PR DESCRIPTION
## Description

`WooAnalyticsEvent+PointOfSale.swift` imported `WooAnalyticsEventPropertyType` twice — #17716 and #17745 each added the line independently, so both were clean alone and only the merge was duplicated. This fails `swiftlint --strict`, which is currently blocking every PR branched from trunk.

## Test Steps

CI SwiftLint passes.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.