### PR TITLE
Fix settings list being clipped behind the Liquid Glass tab bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.5
 -----
+- [*] Settings: Fixed the bottom of the settings list being cut off behind the tab bar on iOS 26. [https://github.com/woocommerce/woocommerce-ios/pull/17769]
 - [*] Orders: Fixed new orders not appearing automatically after push notifications when logged in with site credentials. [https://github.com/woocommerce/woocommerce-ios/pull/17736]
 - [*] Fixed in-app notices appearing too far above the keyboard or tab bar on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17743]
 - [Internal] POS: Fixed `waiting_time` reporting a Unix timestamp instead of an elapsed duration, restored site properties (`store_id`, `blog_id`, `site_url`) on events tracked by raw name, and added a `search_method` discriminator to the remote search event. [https://github.com/woocommerce/woocommerce-ios/pull/17731]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -65,6 +65,7 @@ final class SettingsViewController: UIViewController {
         configureNavigation()
         configureMainView()
         configureTableView()
+        configureLiquidGlassTabBarUnderlap()
         configureTableViewFooter()
         registerTableViewCells()
         viewModel.onViewDidLoad()
@@ -101,6 +102,17 @@ private extension SettingsViewController {
 
         tableView.dataSource = self
         tableView.delegate = self
+    }
+
+    func configureLiquidGlassTabBarUnderlap() {
+        guard #available(iOS 26.0, *) else {
+            return
+        }
+
+        // Pairs with `.ignoresSafeArea` in `HubMenu.detailView` — either alone leaves the list clipped
+        // above the floating tab bar instead of scrolling under it.
+        setContentScrollView(tableView, for: .bottom)
+        view.pinSubviewBottomToBottomAnchorReplacingSafeArea(tableView)
     }
 
     func configureTableViewFooter() {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -135,6 +135,9 @@ private extension HubMenu {
             switch destination {
             case .settings:
                 ViewControllerContainer(SettingsViewController())
+                    // SwiftUI would otherwise size the representable to the safe area, hard-clipping
+                    // the list above the iOS 26 floating tab bar.
+                    .ignoresSafeArea(.container, edges: .bottom)
                     .navigationTitle(HubMenuViewModel.Localization.settings)
             case .payments:
                 paymentsView


### PR DESCRIPTION
WOOMOB-3913

## Description

On iOS 26, the Menu → Settings list is hard-clipped above the floating tab bar instead of scrolling under the glass, leaving the last rows — including Log Out — cut off behind it. There are two stacked causes and both fixes are needed: SwiftUI sizes the hosted view controller to the safe area, which stops above the tab bar, and the nib separately pins the table view's bottom to that same safe area. I verified each change independently and neither alone alters the rendering. The table view fix follows the pattern already used in `OrderDetailsViewController` and `ProductFormViewController`.

- `HubMenu.swift`: added `.ignoresSafeArea(.container, edges: .bottom)` to the Settings destination, so SwiftUI gives the hosted view controller the full height. Scoped to this one call site rather than to `ViewControllerContainer`, whose other users include a modal where this would be wrong.
- `SettingsViewController.swift`: added `configureLiquidGlassTabBarUnderlap()`, which calls `setContentScrollView(tableView, for: .bottom)` and extends the table view to the view's bottom edge, under an `#available(iOS 26.0, *)` guard.
- This is a 25.5 backport of #17765.

## Test Steps

Requires an iOS 26 device or simulator.

1. Open the Menu tab and tap Settings.
2. Scroll to a mid-list position, not all the way to the bottom — at rest the content settles above the bar either way, so the bug only shows mid-scroll.
3. Check the strip behind the tab bar. Before: a hard cut with a flat empty band. After: rows visible blurred through the glass.
4. Scroll to the bottom and confirm Log Out and the Automattic footer are fully visible and tappable above the tab bar.
5. Confirm the top of the list and the navigation bar are unchanged.

Verified on iPhone 17 / iOS 26.5, and sanity-checked on iOS 26.2 including at maximum Dynamic Type.

## Screenshots

Before | After
--- | ---
<img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/adb9d5f2-405d-4c08-9444-0de361a0ad72" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/2029d96d-98e8-4888-9aeb-8c935be833e6" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
