### PR TITLE
Let Product Search coordinator own navigation bar visibility

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -101,7 +101,6 @@ private extension ProductsSplitViewCoordinator {
                 }, onCancel: { [weak self] in
                     guard let self else { return }
                     primaryNavigationController.viewControllers = [productsViewController]
-                    primaryNavigationController.setNavigationBarHiddenIfNeeded(false, animated: false)
                 })
                 let searchViewController = SearchViewController(storeID: siteID,
                                                                 command: searchCommand,
@@ -292,10 +291,14 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
         if didNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode(navigationController, didShow: viewController, animated: animated) {
             let dismissedProduct = productShownInSecondaryContent()
             DispatchQueue.main.async { [weak self] in
-                self?.clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
+                guard let self else { return }
+                clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
+                updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
             }
             return
         }
+
+        updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
 
         // The goal here is to detect when the user pops a view controller in the secondary navigation stack like from tapping the back button,
         // so that the secondary content types state can be updated accordingly.
@@ -316,6 +319,17 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
 }
 
 private extension ProductsSplitViewCoordinator {
+    /// Updates the primary navigation bar only after its navigation controller has finished showing a view controller.
+    /// In a collapsed layout, UIKit temporarily wraps the secondary navigation stack in the primary one. Updating the bar
+    /// from the search view controller's lifecycle can force layout while navigation items are still changing owners.
+    func updatePrimaryNavigationBarVisibility(afterShowing viewController: UIViewController, in navigationController: UINavigationController) {
+        guard navigationController == primaryNavigationController else {
+            return
+        }
+        let isShowingProductSearch = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
+        primaryNavigationController.setNavigationBarHiddenIfNeeded(isShowingProductSearch, animated: false)
+    }
+
     /// In the collapsed mode, the secondary navigation controller is added to the primary navigation stack and the primary navigation stack is shown.
     /// When the user taps the back button to leave the last secondary view controller (e.g. product form), we want to reset `contentTypes`
     /// while there is no proper callback that I can find other than observing the primary navigation controller's `didShow`.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -322,9 +322,8 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
 
 private extension ProductsSplitViewCoordinator {
     /// The split-view coordinator owns these updates because, in a collapsed layout, UIKit temporarily wraps the secondary
-    /// navigation stack in the primary one. Updating from the search view controller's lifecycle can force layout while
-    /// navigation items are changing owners. Updating in `willShow` lets UIKit animate the bar with the transition, while
-    /// the `didShow` update reconciles its actual presentation after interactive or split-view transitions.
+    /// navigation controller in the primary navigation stack. Updating from the search view controller's lifecycle can
+    /// force layout while the product detail item still belongs to the secondary bar.
     func requestPrimaryNavigationBarVisibility(for viewController: UIViewController,
                                                in navigationController: UINavigationController,
                                                animated: Bool) {
@@ -332,6 +331,22 @@ private extension ProductsSplitViewCoordinator {
             return
         }
         let isShowingProductSearch = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
+
+        // UIKit does not scrub a navigation-bar visibility animation with an interactive pop. Starting that animation in
+        // `willShow` can therefore leave the product detail bar visible briefly after the swipe finishes. Wait until UIKit
+        // knows whether the gesture will finish or cancel, then hide the bar immediately only for a completed pop.
+        if isShowingProductSearch,
+           let transitionCoordinator = navigationController.transitionCoordinator,
+           transitionCoordinator.isInteractive {
+            transitionCoordinator.notifyWhenInteractionChanges { [weak self] context in
+                guard !context.isCancelled else {
+                    return
+                }
+                self?.primaryNavigationController.setNavigationBarHiddenIfNeeded(true, animated: false)
+            }
+            return
+        }
+
         primaryNavigationController.setNavigationBarHiddenIfNeeded(isShowingProductSearch, animated: animated)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -290,15 +290,15 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if didNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode(navigationController, didShow: viewController, animated: animated) {
             let dismissedProduct = productShownInSecondaryContent()
-            updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
+                updatePrimaryNavigationBarVisibility(for: viewController, in: navigationController, animated: false)
             }
             return
         }
 
-        updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
+        updatePrimaryNavigationBarVisibility(for: viewController, in: navigationController, animated: false)
 
         // The goal here is to detect when the user pops a view controller in the secondary navigation stack like from tapping the back button,
         // so that the secondary content types state can be updated accordingly.
@@ -312,6 +312,8 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
         }
     }
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        updatePrimaryNavigationBarVisibility(for: viewController, in: navigationController, animated: animated)
+
         if let tabNavigationController = navigationController as? WooTabNavigationController {
             tabNavigationController.navigationController(navigationController, willShow: viewController, animated: animated)
         }
@@ -319,15 +321,18 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
 }
 
 private extension ProductsSplitViewCoordinator {
-    /// Updates the primary navigation bar only after its navigation controller has finished showing a view controller.
-    /// In a collapsed layout, UIKit temporarily wraps the secondary navigation stack in the primary one. Updating the bar
-    /// from the search view controller's lifecycle can force layout while navigation items are still changing owners.
-    func updatePrimaryNavigationBarVisibility(afterShowing viewController: UIViewController, in navigationController: UINavigationController) {
+    /// The split-view coordinator owns these updates because, in a collapsed layout, UIKit temporarily wraps the secondary
+    /// navigation stack in the primary one. Updating from the search view controller's lifecycle can force layout while
+    /// navigation items are changing owners. Updating in `willShow` lets UIKit animate the bar with the transition, while
+    /// the guarded `didShow` update reconciles the final state after cancellations or split-view column changes.
+    func updatePrimaryNavigationBarVisibility(for viewController: UIViewController,
+                                              in navigationController: UINavigationController,
+                                              animated: Bool) {
         guard navigationController == primaryNavigationController else {
             return
         }
         let isShowingProductSearch = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
-        primaryNavigationController.setNavigationBarHiddenIfNeeded(isShowingProductSearch, animated: false)
+        primaryNavigationController.setNavigationBarHiddenIfNeeded(isShowingProductSearch, animated: animated)
     }
 
     /// In the collapsed mode, the secondary navigation controller is added to the primary navigation stack and the primary navigation stack is shown.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -292,8 +292,7 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
             let dismissedProduct = productShownInSecondaryContent()
             reconcilePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
             DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
+                self?.clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
             }
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -290,10 +290,10 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if didNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode(navigationController, didShow: viewController, animated: animated) {
             let dismissedProduct = productShownInSecondaryContent()
+            updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
-                updatePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
             }
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -77,6 +77,17 @@ final class ProductsSplitViewCoordinator: NSObject {
         productsViewController.startProductCreation()
     }
 
+    /// Returns the primary column to the product list when the user cancels Product Search.
+    ///
+    /// Replacing the navigation stack is not an animated transition, so UIKit is not guaranteed to send a
+    /// `willShow`/`didShow` pair to this delegate. The navigation bar that Product Search hid is restored here
+    /// rather than through those callbacks. Both calls are idempotent, so nothing breaks if UIKit does deliver them.
+    func cancelProductSearch() {
+        primaryNavigationController.viewControllers = [productsViewController]
+        requestPrimaryNavigationBarVisibility(for: productsViewController, in: primaryNavigationController, animated: false)
+        reconcilePrimaryNavigationBarVisibility(afterShowing: productsViewController, in: primaryNavigationController)
+    }
+
     /// Returns the product form of the given product ID being displayed on the secondary column if available.
     func currentProductForm(for productID: Int64) -> ProductFormViewController<ProductFormViewModel>? {
         if let contentType = contentTypes.last,
@@ -99,8 +110,7 @@ private extension ProductsSplitViewCoordinator {
                 let searchCommand = ProductSearchUICommand(siteID: siteID, onProductSelection: { [weak self] product in
                     self?.showProductFormIfNoUnsavedChanges(product: product)
                 }, onCancel: { [weak self] in
-                    guard let self else { return }
-                    primaryNavigationController.viewControllers = [productsViewController]
+                    self?.cancelProductSearch()
                 })
                 let searchViewController = SearchViewController(storeID: siteID,
                                                                 command: searchCommand,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -290,15 +290,15 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if didNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode(navigationController, didShow: viewController, animated: animated) {
             let dismissedProduct = productShownInSecondaryContent()
+            reconcilePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 clearSecondaryContentIfStillShowingProductListInCollapsedMode(dismissedProduct: dismissedProduct)
-                updatePrimaryNavigationBarVisibility(for: viewController, in: navigationController, animated: false)
             }
             return
         }
 
-        updatePrimaryNavigationBarVisibility(for: viewController, in: navigationController, animated: false)
+        reconcilePrimaryNavigationBarVisibility(afterShowing: viewController, in: navigationController)
 
         // The goal here is to detect when the user pops a view controller in the secondary navigation stack like from tapping the back button,
         // so that the secondary content types state can be updated accordingly.
@@ -312,7 +312,7 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
         }
     }
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        updatePrimaryNavigationBarVisibility(for: viewController, in: navigationController, animated: animated)
+        requestPrimaryNavigationBarVisibility(for: viewController, in: navigationController, animated: animated)
 
         if let tabNavigationController = navigationController as? WooTabNavigationController {
             tabNavigationController.navigationController(navigationController, willShow: viewController, animated: animated)
@@ -324,15 +324,30 @@ private extension ProductsSplitViewCoordinator {
     /// The split-view coordinator owns these updates because, in a collapsed layout, UIKit temporarily wraps the secondary
     /// navigation stack in the primary one. Updating from the search view controller's lifecycle can force layout while
     /// navigation items are changing owners. Updating in `willShow` lets UIKit animate the bar with the transition, while
-    /// the guarded `didShow` update reconciles the final state after cancellations or split-view column changes.
-    func updatePrimaryNavigationBarVisibility(for viewController: UIViewController,
-                                              in navigationController: UINavigationController,
-                                              animated: Bool) {
+    /// the `didShow` update reconciles its actual presentation after interactive or split-view transitions.
+    func requestPrimaryNavigationBarVisibility(for viewController: UIViewController,
+                                               in navigationController: UINavigationController,
+                                               animated: Bool) {
         guard navigationController == primaryNavigationController else {
             return
         }
         let isShowingProductSearch = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
         primaryNavigationController.setNavigationBarHiddenIfNeeded(isShowingProductSearch, animated: animated)
+    }
+
+    /// An interactive transition can finish with `isNavigationBarHidden` already set to the requested value while the bar's
+    /// presentation is still visible. Compare the actual bar after `didShow` so that state is corrected only when necessary.
+    func reconcilePrimaryNavigationBarVisibility(afterShowing viewController: UIViewController,
+                                                 in navigationController: UINavigationController) {
+        guard navigationController == primaryNavigationController else {
+            return
+        }
+        let shouldHideNavigationBar = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
+        guard primaryNavigationController.navigationBar.isHidden != shouldHideNavigationBar else {
+            return
+        }
+        primaryNavigationController.navigationBar.layer.removeAllAnimations()
+        primaryNavigationController.navigationBar.isHidden = shouldHideNavigationBar
     }
 
     /// In the collapsed mode, the secondary navigation controller is added to the primary navigation stack and the primary navigation stack is shown.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -88,6 +88,17 @@ final class ProductsSplitViewCoordinator: NSObject {
         reconcilePrimaryNavigationBarVisibility(afterShowing: productsViewController, in: primaryNavigationController)
     }
 
+    /// Hides the primary navigation bar once an interactive pop back to Product Search commits.
+    ///
+    /// A cancelled gesture leaves the bar alone, because Product Detail stays on screen and keeps needing it.
+    /// Extracted from the transition coordinator callback so the completed and cancelled cases can be tested.
+    func hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: Bool) {
+        guard !isCancelled else {
+            return
+        }
+        primaryNavigationController.setNavigationBarHiddenIfNeeded(true, animated: false)
+    }
+
     /// Returns the product form of the given product ID being displayed on the secondary column if available.
     func currentProductForm(for productID: Int64) -> ProductFormViewController<ProductFormViewModel>? {
         if let contentType = contentTypes.last,
@@ -353,10 +364,7 @@ private extension ProductsSplitViewCoordinator {
            let transitionCoordinator = navigationController.transitionCoordinator,
            transitionCoordinator.isInteractive {
             transitionCoordinator.notifyWhenInteractionChanges { [weak self] context in
-                guard !context.isCancelled else {
-                    return
-                }
-                self?.primaryNavigationController.setNavigationBarHiddenIfNeeded(true, animated: false)
+                self?.hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: context.isCancelled)
             }
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -335,6 +335,11 @@ private extension ProductsSplitViewCoordinator {
         // UIKit does not scrub a navigation-bar visibility animation with an interactive pop. Starting that animation in
         // `willShow` can therefore leave the product detail bar visible briefly after the swipe finishes. Wait until UIKit
         // knows whether the gesture will finish or cancel, then hide the bar immediately only for a completed pop.
+        //
+        // IMPORTANT: This intentionally leaves navigation-bar-sized space above Product Search briefly after a back swipe.
+        // Do not remove that gap by hiding the bar or forcing Search to lay out earlier in the transition. In a collapsed
+        // split view, the product detail navigation item can still belong to the secondary navigation bar at that point.
+        // Forcing the primary bar to lay it out caused NSInternalInconsistencyException crashes (Sentry issue 7669931391).
         if isShowingProductSearch,
            let transitionCoordinator = navigationController.transitionCoordinator,
            transitionCoordinator.isInteractive {

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -18,8 +18,8 @@ final class ProductSearchUICommand: SearchUICommand {
 
     let cancelButtonAccessibilityIdentifier = "product-search-screen-cancel-button"
 
-    /// The split-view coordinator owns the primary navigation bar because it knows when UIKit has finished transferring
-    /// navigation items between the primary and secondary navigation controllers in a collapsed layout.
+    /// The split-view coordinator owns the primary navigation bar because it can coordinate visibility with the collapsed
+    /// split-view transition that presents the secondary navigation controller from the primary navigation stack.
     let hideNavigationBar = false
 
     var reloadUIRequests: AnyPublisher<Void, Never> {

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -18,10 +18,9 @@ final class ProductSearchUICommand: SearchUICommand {
 
     let cancelButtonAccessibilityIdentifier = "product-search-screen-cancel-button"
 
-    /// Product search replaces the primary navigation stack of a split view, unlike Order search, which is presented
-    /// in its own modal navigation controller. Avoid animating the navigation bar while UIKit transfers presentation
-    /// to the secondary navigation stack in a collapsed layout.
-    let animateNavigationBarVisibilityChanges = false
+    /// The split-view coordinator owns the primary navigation bar because it knows when UIKit has finished transferring
+    /// navigation items between the primary and secondary navigation controllers in a collapsed layout.
+    let hideNavigationBar = false
 
     var reloadUIRequests: AnyPublisher<Void, Never> {
         reloadUINeeded.eraseToAnyPublisher()

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -191,7 +191,9 @@ where Cell.SearchModel == Command.CellViewModel {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        navigationController?.setNavigationBarHiddenIfNeeded(false, animated: searchUICommand.animateNavigationBarVisibilityChanges)
+        if searchUICommand.hideNavigationBar {
+            navigationController?.setNavigationBarHiddenIfNeeded(false, animated: searchUICommand.animateNavigationBarVisibilityChanges)
+        }
     }
 
     // MARK: - UITableViewDataSource Conformance

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -104,6 +104,32 @@ struct ProductsSplitViewCoordinatorTests {
     }
 
     @Test
+    func test_hidePrimaryNavigationBarWhenInteractionCompletes_when_swipe_completes_then_hides_the_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+
+        // When
+        sut.hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: false)
+
+        // Then
+        #expect(primaryNavigationController.isNavigationBarHidden)
+    }
+
+    @Test
+    func test_hidePrimaryNavigationBarWhenInteractionCompletes_when_swipe_is_cancelled_then_leaves_the_bar_visible() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+
+        // When
+        sut.hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: true)
+
+        // Then
+        #expect(primaryNavigationController.isNavigationBarHidden == false)
+    }
+
+    @Test
     func test_cancelProductSearch_when_navigation_bar_is_hidden_then_restores_it() throws {
         // Given
         let (sut, primaryNavigationController, _) = try makeSUT()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -104,6 +104,59 @@ struct ProductsSplitViewCoordinatorTests {
     }
 
     @Test
+    func test_cancelProductSearch_when_navigation_bar_is_hidden_then_restores_it() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        primaryNavigationController.setNavigationBarHidden(true, animated: false)
+
+        // When
+        sut.cancelProductSearch()
+
+        // Then
+        #expect(primaryNavigationController.isNavigationBarHidden == false)
+        #expect(primaryNavigationController.navigationBar.isHidden == false)
+    }
+
+    @Test
+    func test_cancelProductSearch_when_navigation_bar_state_is_out_of_sync_then_shows_the_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+        // Mimics an interrupted hide animation, where the bar view is still hidden while the navigation
+        // controller already reports the bar as visible.
+        primaryNavigationController.navigationBar.isHidden = true
+
+        // When
+        sut.cancelProductSearch()
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden == false)
+    }
+
+    @Test
+    func test_cancelProductSearch_then_shows_the_product_list_in_the_primary_column() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        let productListViewController = try #require(primaryNavigationController.topViewController)
+        let command = ProductSearchUICommand(siteID: 123,
+                                             isSearchProductsBySKUEnabled: false,
+                                             onProductSelection: { _ in },
+                                             onCancel: {})
+        let searchViewController = SearchViewController(storeID: 123,
+                                                        command: command,
+                                                        cellType: ProductsTabProductTableViewCell.self,
+                                                        cellSeparator: .none)
+        primaryNavigationController.setViewControllers([searchViewController], animated: false)
+
+        // When
+        sut.cancelProductSearch()
+
+        // Then
+        #expect(primaryNavigationController.viewControllers.count == 1)
+        #expect(primaryNavigationController.topViewController === productListViewController)
+    }
+
+    @Test
     func test_navigationController_didShow_secondary_content_then_does_not_change_primary_navigation_bar() throws {
         // Given
         let (sut, primaryNavigationController, secondaryNavigationController) = try makeSUT()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -27,7 +27,7 @@ struct ProductsSplitViewCoordinatorTests {
     }
 
     @Test
-    func test_navigationController_didShow_productSearch_in_collapsed_layout_then_hides_primary_navigation_bar_synchronously() throws {
+    func test_navigationController_willShow_productSearch_in_collapsed_layout_then_hides_primary_navigation_bar_for_transition() throws {
         // Given
         let splitViewController = CollapsedSplitViewController(style: .doubleColumn)
         let (sut, primaryNavigationController, _) = try makeSUT(splitViewController: splitViewController)
@@ -43,10 +43,24 @@ struct ProductsSplitViewCoordinatorTests {
         primaryNavigationController.setNavigationBarHidden(false, animated: false)
 
         // When
-        sut.navigationController(primaryNavigationController, didShow: searchViewController, animated: true)
+        sut.navigationController(primaryNavigationController, willShow: searchViewController, animated: true)
 
         // Then
-        #expect(primaryNavigationController.navigationBar.isHidden)
+        #expect(primaryNavigationController.isNavigationBarHidden)
+    }
+
+    @Test
+    func test_navigationController_willShow_secondary_content_in_collapsed_layout_then_shows_primary_navigation_bar_for_transition() throws {
+        // Given
+        let splitViewController = CollapsedSplitViewController(style: .doubleColumn)
+        let (sut, primaryNavigationController, _) = try makeSUT(splitViewController: splitViewController)
+        primaryNavigationController.setNavigationBarHidden(true, animated: false)
+
+        // When
+        sut.navigationController(primaryNavigationController, willShow: UIViewController(), animated: true)
+
+        // Then
+        #expect(primaryNavigationController.isNavigationBarHidden == false)
     }
 
     @Test

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -64,6 +64,32 @@ struct ProductsSplitViewCoordinatorTests {
     }
 
     @Test
+    func test_navigationController_didShow_productSearch_when_animated_bar_is_still_visible_then_hides_it_immediately() throws {
+        // Given
+        let splitViewController = CollapsedSplitViewController(style: .doubleColumn)
+        let (sut, primaryNavigationController, _) = try makeSUT(splitViewController: splitViewController)
+        let command = ProductSearchUICommand(siteID: 123,
+                                             isSearchProductsBySKUEnabled: false,
+                                             onProductSelection: { _ in },
+                                             onCancel: {})
+        let searchViewController = SearchViewController(storeID: 123,
+                                                        command: command,
+                                                        cellType: ProductsTabProductTableViewCell.self,
+                                                        cellSeparator: .none)
+        primaryNavigationController.setViewControllers([searchViewController], animated: false)
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+        sut.navigationController(primaryNavigationController, willShow: searchViewController, animated: true)
+        #expect(primaryNavigationController.isNavigationBarHidden)
+        #expect(primaryNavigationController.navigationBar.isHidden == false)
+
+        // When
+        sut.navigationController(primaryNavigationController, didShow: searchViewController, animated: true)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden)
+    }
+
+    @Test
     func test_navigationController_didShow_productList_then_shows_primary_navigation_bar() throws {
         // Given
         let (sut, primaryNavigationController, _) = try makeSUT()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import UIKit
+
+@testable import WooCommerce
+
+@MainActor
+struct ProductsSplitViewCoordinatorTests {
+    @Test
+    func test_navigationController_didShow_productSearch_then_hides_primary_navigation_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        let command = ProductSearchUICommand(siteID: 123,
+                                             isSearchProductsBySKUEnabled: false,
+                                             onProductSelection: { _ in },
+                                             onCancel: {})
+        let searchViewController = SearchViewController(storeID: 123,
+                                                        command: command,
+                                                        cellType: ProductsTabProductTableViewCell.self,
+                                                        cellSeparator: .none)
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+
+        // When
+        sut.navigationController(primaryNavigationController, didShow: searchViewController, animated: false)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden)
+    }
+
+    @Test
+    func test_navigationController_didShow_productList_then_shows_primary_navigation_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        let productListViewController = try #require(primaryNavigationController.topViewController)
+        primaryNavigationController.setNavigationBarHidden(true, animated: false)
+
+        // When
+        sut.navigationController(primaryNavigationController, didShow: productListViewController, animated: false)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden == false)
+    }
+
+    @Test
+    func test_navigationController_didShow_secondary_content_then_does_not_change_primary_navigation_bar() throws {
+        // Given
+        let (sut, primaryNavigationController, secondaryNavigationController) = try makeSUT()
+        primaryNavigationController.setNavigationBarHidden(true, animated: false)
+
+        // When
+        sut.navigationController(secondaryNavigationController, didShow: UIViewController(), animated: false)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden)
+    }
+}
+
+private extension ProductsSplitViewCoordinatorTests {
+    func makeSUT() throws -> (ProductsSplitViewCoordinator, UINavigationController, UINavigationController) {
+        let splitViewController = UISplitViewController(style: .doubleColumn)
+        let sut = ProductsSplitViewCoordinator(siteID: 123, splitViewController: splitViewController)
+        sut.start()
+        let primaryNavigationController = try #require(splitViewController.viewController(for: .primary) as? UINavigationController)
+        let secondaryNavigationController = try #require(splitViewController.viewController(for: .secondary) as? UINavigationController)
+        return (sut, primaryNavigationController, secondaryNavigationController)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -27,6 +27,29 @@ struct ProductsSplitViewCoordinatorTests {
     }
 
     @Test
+    func test_navigationController_didShow_productSearch_in_collapsed_layout_then_hides_primary_navigation_bar_synchronously() throws {
+        // Given
+        let splitViewController = CollapsedSplitViewController(style: .doubleColumn)
+        let (sut, primaryNavigationController, _) = try makeSUT(splitViewController: splitViewController)
+        let command = ProductSearchUICommand(siteID: 123,
+                                             isSearchProductsBySKUEnabled: false,
+                                             onProductSelection: { _ in },
+                                             onCancel: {})
+        let searchViewController = SearchViewController(storeID: 123,
+                                                        command: command,
+                                                        cellType: ProductsTabProductTableViewCell.self,
+                                                        cellSeparator: .none)
+        primaryNavigationController.setViewControllers([searchViewController], animated: false)
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+
+        // When
+        sut.navigationController(primaryNavigationController, didShow: searchViewController, animated: true)
+
+        // Then
+        #expect(primaryNavigationController.navigationBar.isHidden)
+    }
+
+    @Test
     func test_navigationController_didShow_productList_then_shows_primary_navigation_bar() throws {
         // Given
         let (sut, primaryNavigationController, _) = try makeSUT()
@@ -55,12 +78,17 @@ struct ProductsSplitViewCoordinatorTests {
 }
 
 private extension ProductsSplitViewCoordinatorTests {
-    func makeSUT() throws -> (ProductsSplitViewCoordinator, UINavigationController, UINavigationController) {
-        let splitViewController = UISplitViewController(style: .doubleColumn)
+    func makeSUT(
+        splitViewController: UISplitViewController = UISplitViewController(style: .doubleColumn)
+    ) throws -> (ProductsSplitViewCoordinator, UINavigationController, UINavigationController) {
         let sut = ProductsSplitViewCoordinator(siteID: 123, splitViewController: splitViewController)
         sut.start()
         let primaryNavigationController = try #require(splitViewController.viewController(for: .primary) as? UINavigationController)
         let secondaryNavigationController = try #require(splitViewController.viewController(for: .secondary) as? UINavigationController)
         return (sut, primaryNavigationController, secondaryNavigationController)
     }
+}
+
+private final class CollapsedSplitViewController: UISplitViewController {
+    override var isCollapsed: Bool { true }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
@@ -182,12 +182,12 @@ final class ProductSearchUICommandTests: XCTestCase {
 
     // MARK: - Split view support
 
-    func test_animateNavigationBarVisibilityChanges_when_using_product_search_then_is_false() {
+    func test_hideNavigationBar_when_using_product_search_then_is_false() {
         // Given
         let command = ProductSearchUICommand(siteID: sampleSiteID, isSearchProductsBySKUEnabled: true)
 
         // Then
-        XCTAssertFalse(command.animateNavigationBarVisibilityChanges)
+        XCTAssertFalse(command.hideNavigationBar)
     }
 
     func test_didSelectSearchResult_ends_editing_before_invoking_onProductSelection() {


### PR DESCRIPTION
Closes: WOOMOB-3881

## Description

This PR addresses the Product Search navigation bar crash tracked in Sentry issue 7669931391, with additional handling for interactive back navigation.

Product Search is displayed by the split view’s primary navigation controller, while Product Detail uses its secondary navigation controller. In a compact layout, UIKit presents those columns as a single navigation flow, although each navigation controller still has its own navigation bar. 

The search controller doesn't show a navigation bar, while the product details do. That requires us to change bar visibility from SearchViewController lifecycle callbacks, which could force a layout during that transition. 

The theory, from the breadcrumbs in Sentry, is that the crash occurred when UIKit tried to lay out the Product Detail navigation item in one bar while it still belonged to the other.

Product Search now opts out of the generic search controller's navigation bar handling. `ProductsSplitViewCoordinator`, which owns both navigation controllers, coordinates the primary bar through the navigation controller delegate. For ordinary navigation it starts the visibility change in `willShow` and reconciles it in `didShow`. For an interactive back swipe, it waits until UIKit knows whether the gesture will finish or cancel, then hides the bar only when the pop commits. Secondary-stack cleanup remains deferred until after the transition callback.

This back swipe behaviour does mean that there's a temporary visual glitch, but as far as I can tell that's unavoidable with our set up, and it's better than crashing.

## Test Steps

1. On an iPhone, open **Products** and enter Product Search. Confirm the search screen has no navigation bar.
2. Search for and select a product. Confirm Product Detail has its normal navigation bar.
3. Navigate back to Search, then repeat selecting a product and returning several times.
4. Cancel Product Search and confirm the Products navigation bar is restored.
5. Repeat with a variable product and after editing and saving a product.
6. On iPad, repeat while switching between collapsed and expanded split-view layouts.

## Screenshots



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release note is needed for this internal crash fix.
