### PR TITLE
Fix order list last updated text truncation in larger sizes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
@@ -26,7 +26,7 @@
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLu-fm-bTC" userLabel="Last Updated Label">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLu-fm-bTC" userLabel="Last Updated Label">
                                     <rect key="frame" x="0.0" y="24.5" width="261" height="26.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>


### PR DESCRIPTION
Closes WOOMOB-901 (only item remaining in the list, the rest are solved or no longer valid)

## Description
Updates the Orders header so the complete `Last Updated` timestamp remains visible at large accessibility text sizes.

| Before | After |
|--------|--------|
| <img width="1488" height="2266" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-08-26 at 19 35 05" src="https://github.com/user-attachments/assets/3d968efb-65d2-4e66-983e-bd751dbe6a47" /> | <img width="1488" height="2266" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-08-26 at 19 55 18" src="https://github.com/user-attachments/assets/76e777dc-02f5-4285-b6a8-8e3f3db14a1b" /> | 


| Before | After |
|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-08-26 at 20 01 01" src="https://github.com/user-attachments/assets/d55bd8eb-8a86-4636-a2d7-2907e40372de" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-08-26 at 19 58 28" src="https://github.com/user-attachments/assets/c1e03c85-da89-4666-af93-fd98f37f6ca1" /> | 

## Test Steps (optional)
- Go to order list, increase font size to max
- Observe `Last Updated` is no longer cut off

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
