### PR TITLE
Add job-level timeouts to the screenshots workflow

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -12,7 +12,7 @@ jobs:
       github.event.pull_request.head.repo.fork != true &&
       contains(github.event.pull_request.labels.*.name, 'generate screenshots')
     runs-on: macos-latest
-    timeout-minutes: 25
+    timeout-minutes: 60
 
     steps:
     - name: "Check out Project"
@@ -43,7 +43,7 @@ jobs:
     name: Capture
     needs: build
     runs-on: macos-latest
-    timeout-minutes: 110
+    timeout-minutes: 120
 
     strategy:
       # Don't let one locale's flaky accessibility-hierarchy timeout cancel the other locales'
@@ -91,7 +91,7 @@ jobs:
     name: "Process Screenshots"
     needs: capture
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       # Push the generated-screenshots branch
       contents: write

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -12,6 +12,7 @@ jobs:
       github.event.pull_request.head.repo.fork != true &&
       contains(github.event.pull_request.labels.*.name, 'generate screenshots')
     runs-on: macos-latest
+    timeout-minutes: 25
 
     steps:
     - name: "Check out Project"
@@ -42,6 +43,7 @@ jobs:
     name: Capture
     needs: build
     runs-on: macos-latest
+    timeout-minutes: 110
 
     strategy:
       # Don't let one locale's flaky accessibility-hierarchy timeout cancel the other locales'
@@ -89,6 +91,7 @@ jobs:
     name: "Process Screenshots"
     needs: capture
     runs-on: macos-latest
+    timeout-minutes: 20
     permissions:
       # Push the generated-screenshots branch
       contents: write


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (last 30 days) | Max (last 30 days) | `timeout-minutes` |
| -- | -- | -- | -- |
| `build` — Build Application | 19.9 min | 20.5 min | 60 |
| `capture` — Capture | 26.8 min | 93.3 min | 120 |
| `process` — Process Screenshots | 15.0 min | 17.0 min | 30 |

Part of TESTOPS-272
