### PR TITLE
Remove splitViewInProductsTab feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -45,8 +45,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .scanToUpdateInventory:
             return true
-        case .splitViewInProductsTab:
-            return true
         case .pointOfSale:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .googleAdsCampaignCreationOnWebView:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -115,10 +115,6 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case scanToUpdateInventory
 
-    /// Displays the Products tab in a split view
-    ///
-    case splitViewInProductsTab
-
     /// Enables the Point Of Sale when remote feature flag is disabled.
     ///
     case pointOfSale

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -142,13 +142,6 @@ final class MainTabBarController: UITabBarController {
 
     private let productsContainerController = TabContainerController()
 
-    /// Unfortunately, we can't use the above container to directly hold a WooTabNavigationController, due to
-    /// a longstanding bug where a black bar equal to the tab bar height is shown when a nav controller
-    /// is shown as an embedded vc in a tab. See link for details, but the solutions don't work here.
-    /// https://stackoverflow.com/questions/28608817/uinavigationcontroller-embedded-in-a-container-view-displays-a-table-view-contr
-    /// remove when .splitViewInProductsTab is removed.
-    private let productsNavigationController = WooTabNavigationController()
-
     private let posContainerController = TabContainerController()
     private var posTabCoordinator: POSTabCoordinator?
 
@@ -191,8 +184,6 @@ final class MainTabBarController: UITabBarController {
     private var isPOSTabVisible: Bool = false
     private var isBookingsTabVisible: Bool = false
     private var isBookingsFeatureAvailable: Bool = false
-
-    private lazy var isProductsSplitViewFeatureFlagOn = featureFlagService.isFeatureFlagEnabled(.splitViewInProductsTab)
 
     /// periphery: ignore - used in tests
     init?(coder: NSCoder,
@@ -951,7 +942,7 @@ private extension MainTabBarController {
             case .orders:
                 return ordersContainerController
             case .products:
-                return isProductsSplitViewFeatureFlagOn ? productsContainerController: productsNavigationController
+                return productsContainerController
             case .bookings:
                 return bookingsContainerController
             case .hubMenu:
@@ -1017,13 +1008,7 @@ private extension MainTabBarController {
 
         ordersContainerController.wrappedController = createOrdersViewController(siteID: siteID)
 
-        if isProductsSplitViewFeatureFlagOn {
-            productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: siteID)
-        } else {
-            productsNavigationController.viewControllers = [ProductsViewController(siteID: siteID,
-                                                                                   selectedProduct: Empty().eraseToAnyPublisher(),
-                                                                                   navigateToContent: { _ in })]
-        }
+        productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: siteID)
 
         // Configure hub menu tab coordinator once per logged in session potentially with multiple sites.
         if hubMenuTabCoordinator == nil {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -155,8 +155,7 @@ private extension ProductFormViewController {
     func displayInProgressView(title: String, message: String) {
         let viewProperties = InProgressViewProperties(title: title, message: message)
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
-        inProgressViewController.modalPresentationStyle = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInProductsTab) ?
-            .overFullScreen: .overCurrentContext
+        inProgressViewController.modalPresentationStyle = .overFullScreen
 
         navigationController?.present(inProgressViewController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1,4 +1,3 @@
-import Experiments
 import UIKit
 import SwiftUI
 import WordPressUI
@@ -220,13 +219,10 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     private var subscriptions: Set<AnyCancellable> = []
 
-    private var addProductCoordinator: AddProductCoordinator?
-
     /// Tracks if the swipe actions have been glanced to the user.
     ///
     private var swipeActionsGlanced = false
 
-    private let isSplitViewEnabled: Bool
     private let navigateToContent: (NavigationContentType) -> Void
     private let selectedProduct: AnyPublisher<Product?, Never>
     private let onTableViewEditingEnd: PassthroughSubject<Void, Never> = .init()
@@ -240,12 +236,10 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     init(siteID: Int64,
          selectedProduct: AnyPublisher<Product?, Never>,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          navigateToContent: @escaping (NavigationContentType) -> Void) {
         self.siteID = siteID
         self.viewModel = .init(siteID: siteID, stores: ServiceLocator.stores)
         self.selectedProduct = selectedProduct
-        self.isSplitViewEnabled = featureFlagService.isFeatureFlagEnabled(.splitViewInProductsTab)
         self.navigateToContent = navigateToContent
         self.paginationTracker = PaginationTracker()
         super.init(nibName: type(of: self).nibName, bundle: nil)
@@ -432,23 +426,6 @@ private extension ProductsViewController {
         guard let sourceView else {
             return
         }
-        guard isSplitViewEnabled else {
-            guard let navigationController else {
-                return
-            }
-
-            let source: AddProductCoordinator.Source = .productsTab
-            let coordinatingController = AddProductCoordinator(siteID: siteID,
-                                                               source: source,
-                                                               sourceView: sourceView,
-                                                               sourceNavigationController: navigationController,
-                                                               isFirstProduct: isFirstProduct)
-
-            coordinatingController.start()
-            self.addProductCoordinator = coordinatingController
-            return
-        }
-
         navigateToContent(.addProduct(sourceView: sourceView, isFirstProduct: isFirstProduct))
     }
 }
@@ -1294,7 +1271,7 @@ extension ProductsViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if (splitViewController?.isCollapsed == true || !isSplitViewEnabled) &&
+        if splitViewController?.isCollapsed == true &&
             !tableView.isEditing {
             tableView.deselectRow(at: indexPath, animated: true)
         }
@@ -1390,12 +1367,6 @@ extension ProductsViewController: UITableViewDelegate {
 
 private extension ProductsViewController {
     func didSelectProduct(product: Product) {
-        guard isSplitViewEnabled else {
-            let viewController = ProductDetailNavigator.shared.makeDestination(product: product,
-                                                                               isReadOnly: false)
-            navigationController?.pushViewController(viewController, animated: true)
-            return
-        }
         navigateToContent(.productForm(product: product))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
@@ -33,7 +33,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
         assertThat(tabBarController.tabRootViewController(tab: .orders, isPOSTabVisible: false),
                    isAnInstanceOf: OrdersSplitViewWrapperController.self)
         assertThat(tabBarController.tabRootViewController(tab: .products, isPOSTabVisible: false),
-                   isAnInstanceOf: ProductsViewController.self)
+                   isAnInstanceOf: ProductsSplitViewWrapperController.self)
 
         let hubMenuNavigationController = try XCTUnwrap(tabBarController.tabRootViewController(tab: .hubMenu, isPOSTabVisible: false) as? UINavigationController)
         assertThat(hubMenuNavigationController.topViewController,
@@ -73,7 +73,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
         assertThat(tabBarController.tabRootViewController(tab: .orders, isPOSTabVisible: true),
                    isAnInstanceOf: OrdersSplitViewWrapperController.self)
         assertThat(tabBarController.tabRootViewController(tab: .products, isPOSTabVisible: true),
-                   isAnInstanceOf: ProductsViewController.self)
+                   isAnInstanceOf: ProductsSplitViewWrapperController.self)
         assertThat(tabBarController.tabRootViewController(tab: .pointOfSale, isPOSTabVisible: true),
                    isAnInstanceOf: POSTabViewController.self)
 
@@ -115,7 +115,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
         assertThat(tabBarController.tabRootViewController(tab: .orders, isPOSTabVisible: false),
                    isAnInstanceOf: OrdersSplitViewWrapperController.self)
         assertThat(tabBarController.tabRootViewController(tab: .products, isPOSTabVisible: false),
-                   isAnInstanceOf: ProductsViewController.self)
+                   isAnInstanceOf: ProductsSplitViewWrapperController.self)
 
         let hubMenuNavigationController = try XCTUnwrap(tabBarController.tabRootViewController(tab: .hubMenu, isPOSTabVisible: false) as? UINavigationController)
         assertThat(hubMenuNavigationController.topViewController,
@@ -200,7 +200,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
             tab: .products,
             isPOSTabVisible: false,
             isBookingsTabVisible: true
-        ), isAnInstanceOf: ProductsViewController.self)
+        ), isAnInstanceOf: ProductsSplitViewWrapperController.self)
         assertThat(tabBarController.tabRootViewController(
             tab: .bookings,
             isPOSTabVisible: false,
@@ -258,7 +258,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
             tab: .products,
             isPOSTabVisible: false,
             isBookingsTabVisible: false
-        ), isAnInstanceOf: ProductsViewController.self)
+        ), isAnInstanceOf: ProductsSplitViewWrapperController.self)
 
         let hubMenuNavigationController = try XCTUnwrap(tabBarController.tabRootViewController(
             tab: .hubMenu,

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -511,7 +511,7 @@ final class MainTabBarControllerTests: XCTestCase {
         assertThat(tabBarController.tabRootViewController(tab: .orders, isPOSTabVisible: false),
                    isAnInstanceOf: OrdersSplitViewWrapperController.self)
         assertThat(tabBarController.tabRootViewController(tab: .products, isPOSTabVisible: false),
-                   isAnInstanceOf: ProductsViewController.self)
+                   isAnInstanceOf: ProductsSplitViewWrapperController.self)
 
         let hubMenuNavigationController = try XCTUnwrap(tabBarController.tabRootViewController(tab: .hubMenu, isPOSTabVisible: false) as? UINavigationController)
         assertThat(hubMenuNavigationController.topViewController,


### PR DESCRIPTION
Closes WOOMOB-3945

## Description
`splitViewInProductsTab` has been hardcoded to `true` since the Products split view fully shipped on 2024. The flag no longer gates anything, so this PR removes it along with the legacy non-split-view code paths:

## Test Steps (optional)
1. On iPad: open the Products tab, tap a product. Confirm it opens in the secondary split-view pane.
2. Tap + to add a product; verify the creation flow opens.
3. Edit and save a product; verify the in-progress overlay covers the full screen.
4. On iPhone (collapsed split view): tap a product and verify it pushes and the row deselects on return.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
