### PR TITLE
[Woo POS] Show the refund selection in place instead of pushing it

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -8,14 +8,9 @@ import struct Yosemite.POSRefundItem
 import enum Yosemite.OrderStatusEnum
 import typealias Yosemite.OrderItemAttribute
 
-private enum POSOrderDetailsNavigationDestination: Hashable {
-    case refundSelection
-}
-
 struct POSOrderDetailsView: View {
     let order: POSOrder
     let onBack: () -> Void
-    @Binding private var detailNavigationPath: NavigationPath
     @Binding private var activeRefundSelectionOrderID: Int64?
     @State var autoStartNextRefundFlow: Bool = false
     var onRefundSuccess: (() -> Void)? = nil
@@ -44,7 +39,6 @@ struct POSOrderDetailsView: View {
 
     init(
         order: POSOrder,
-        detailNavigationPath: Binding<NavigationPath> = .constant(NavigationPath()),
         activeRefundSelectionOrderID: Binding<Int64?> = .constant(nil),
         onBack: @escaping () -> Void,
         autoStartNextRefundFlow: Bool = false,
@@ -53,7 +47,6 @@ struct POSOrderDetailsView: View {
     ) {
         self.order = order
         self.onBack = onBack
-        self._detailNavigationPath = detailNavigationPath
         self._activeRefundSelectionOrderID = activeRefundSelectionOrderID
         self._autoStartNextRefundFlow = State(initialValue: autoStartNextRefundFlow)
         self.onRefundSuccess = onRefundSuccess
@@ -65,59 +58,69 @@ struct POSOrderDetailsView: View {
         // refreshes refund details. Prefer the controller's live `selectedOrder` so the view
         // re-renders when refunds are loaded or the order is refetched after a refund.
         let order = orderListModel.ordersController.selectedOrder ?? self.order
-        VStack(spacing: POSSpacing.none) {
-            POSPageHeaderView(
-                title: POSOrderListView.Localization.orderTitle(order.number),
-                backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
-                trailingContent: {
-                    actionsSection(setup: availableActionsSetup)
-                },
-                bottomContent: {
-                    headerBottomContent(for: order)
-                }
-            )
-            .posHeaderBackButtonPadding(POSPadding.none)
-            .fixedSize(horizontal: false, vertical: true)
-            .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: POSSpacing.medium) {
-                    switch orderListModel.ordersController.orderDetailsItemsState {
-                    case .loading(let rowCount):
-                        ghostItemsSection(rowCount: rowCount)
-                        ghostRefundedProductsSection
-
-                    case .loaded(let lineItems, let customAmounts, let refundedItems):
-                        if !lineItems.isEmpty || !customAmounts.isEmpty {
-                            itemsSection(products: lineItems, customAmounts: customAmounts)
-                        }
-                        if !refundedItems.isEmpty {
-                            refundedProductsSection(refundedItems)
-                        }
+        ZStack {
+            VStack(spacing: POSSpacing.none) {
+                POSPageHeaderView(
+                    title: POSOrderListView.Localization.orderTitle(order.number),
+                    backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
+                    trailingContent: {
+                        actionsSection(setup: availableActionsSetup)
+                    },
+                    bottomContent: {
+                        headerBottomContent(for: order)
                     }
-                    POSTotalsSectionView(
-                        sectionTitle: Localization.totalsTitle,
-                        subtotalLabel: Localization.itemsLabel,
-                        subtotalAmount: order.formattedSubtotal,
-                        discountAmount: order.formattedDiscountTotal,
-                        taxAmount: order.formattedTotalTax,
-                        totalAmount: order.formattedTotal,
-                        paidAmount: order.formattedPaymentTotal,
-                        paymentMethodTitle: order.paymentMethodTitle,
-                        refunds: order.refunds,
-                        netAmount: order.formattedNetAmount,
-                        siteTimezone: siteTimezone,
-                        isLoadingRefundDetails: orderListModel.ordersController.isLoadingOrderRefunds,
-                        selectedRefundForDetail: $selectedRefundForDetail
-                    )
+                )
+                .posHeaderBackButtonPadding(POSPadding.none)
+                .fixedSize(horizontal: false, vertical: true)
+                .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: POSSpacing.medium) {
+                        switch orderListModel.ordersController.orderDetailsItemsState {
+                        case .loading(let rowCount):
+                            ghostItemsSection(rowCount: rowCount)
+                            ghostRefundedProductsSection
+
+                        case .loaded(let lineItems, let customAmounts, let refundedItems):
+                            if !lineItems.isEmpty || !customAmounts.isEmpty {
+                                itemsSection(products: lineItems, customAmounts: customAmounts)
+                            }
+                            if !refundedItems.isEmpty {
+                                refundedProductsSection(refundedItems)
+                            }
+                        }
+                        POSTotalsSectionView(
+                            sectionTitle: Localization.totalsTitle,
+                            subtotalLabel: Localization.itemsLabel,
+                            subtotalAmount: order.formattedSubtotal,
+                            discountAmount: order.formattedDiscountTotal,
+                            taxAmount: order.formattedTotalTax,
+                            totalAmount: order.formattedTotal,
+                            paidAmount: order.formattedPaymentTotal,
+                            paymentMethodTitle: order.paymentMethodTitle,
+                            refunds: order.refunds,
+                            netAmount: order.formattedNetAmount,
+                            siteTimezone: siteTimezone,
+                            isLoadingRefundDetails: orderListModel.ordersController.isLoadingOrderRefunds,
+                            selectedRefundForDetail: $selectedRefundForDetail
+                        )
+                    }
+                    .padding(.top, POSPadding.xSmall)
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.bottom, POSPadding.medium)
                 }
-                .padding(.top, POSPadding.xSmall)
-                .padding(.horizontal, POSPadding.medium)
-                .padding(.bottom, POSPadding.medium)
+            }
+            .allowsHitTesting(refundSelectionState == nil)
+            .accessibilityHidden(refundSelectionState != nil)
+
+            if let refundSelectionState {
+                refundSelectionView(state: refundSelectionState)
+                    .transition(.move(edge: .trailing))
+                    .zIndex(1)
             }
         }
+        .animation(.snappy, value: refundSelectionState != nil)
         .background(Color.posSurface)
-        .navigationBarHidden(true)
         .posModal(item: $selectedRefundForDetail) { refund in
             let sortedRefunds = order.refunds.sorted(by: { $0.refundID < $1.refundID })
             let index = (sortedRefunds.firstIndex(where: { $0.refundID == refund.refundID }) ?? 0) + 1
@@ -127,24 +130,6 @@ struct POSOrderDetailsView: View {
                 paymentMethodDescription: Localization.viaPaymentMethod(order.paymentMethodTitle),
                 onClose: { selectedRefundForDetail = nil }
             )
-        }
-        .navigationDestination(for: POSOrderDetailsNavigationDestination.self) { destination in
-            switch destination {
-            case .refundSelection:
-                if let refundSelectionState {
-                    POSRefundSelectionFlowView(
-                        state: refundSelectionState,
-                        errorStrings: refundErrorStrings,
-                        onDismiss: { dismissRefundFlow() },
-                        onRetryLoading: { initiateRefundFlow() },
-                        onRetryPreparation: {
-                            self.refundSelectionState = .itemSelection
-                        },
-                        onContinue: { navigateToRefundReview() },
-                        onRefreshItems: { refreshRefundSelection() }
-                    )
-                }
-            }
         }
         .posFullScreenCover(isPresented: isRefundModalPresented) {
             if let state = refundModalState {
@@ -707,7 +692,6 @@ private extension POSOrderDetailsView {
             return
         }
         activeRefundSelectionOrderID = order.id
-        detailNavigationPath.append(POSOrderDetailsNavigationDestination.refundSelection)
     }
 
     func dismissRefundSelectionIfNeeded() {
@@ -715,9 +699,20 @@ private extension POSOrderDetailsView {
             return
         }
         activeRefundSelectionOrderID = nil
-        if !detailNavigationPath.isEmpty {
-            detailNavigationPath.removeLast()
-        }
+    }
+
+    func refundSelectionView(state: RefundSelectionState) -> some View {
+        POSRefundSelectionFlowView(
+            state: state,
+            errorStrings: refundErrorStrings,
+            onDismiss: { dismissRefundFlow() },
+            onRetryLoading: { initiateRefundFlow() },
+            onRetryPreparation: {
+                refundSelectionState = .itemSelection
+            },
+            onContinue: { navigateToRefundReview() },
+            onRefreshItems: { refreshRefundSelection() }
+        )
     }
 
     var refundErrorStrings: POSRefundErrorStrings {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -41,10 +41,9 @@ struct POSOrdersView: View {
                     isPresented = false
                 }
                 .environment(orderListModel)
-            } detail: { selection, detailNavigationPath in
+            } detail: { selection, _ in
                 POSOrderDetailsView(
                     order: selection,
-                    detailNavigationPath: detailNavigationPath,
                     activeRefundSelectionOrderID: $activeRefundSelectionOrderID,
                     onBack: {
                         selectOrder(nil)

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -362,7 +362,12 @@ struct POSPaymentLoadingView: View {
                     .accessibilityFocused($isMessageFocused)
                     .matchedGeometryEffect(id: animation.messageTransitionId, in: animation.namespace, properties: .position)
             }
-            .transaction { $0.animation = nil }
+            // Swapping the strings as the flow advances should be instant rather than cross-faded.
+            // Keyed on the strings themselves so it suppresses only that: a bare `transaction` here
+            // strips the animation from every transaction reaching this subtree, including an
+            // ancestor's insertion transition, which left the text snapping to its final position
+            // while the screen behind it was still moving in.
+            .transaction(value: [title, message]) { $0.animation = nil }
         }
         .multilineTextAlignment(.center)
         .onAppear {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.6
 -----
+- [Internal] POS: The refund selection screen is now presented in place over the order details rather than pushed, so the order details pane can own its own back gesture. [https://github.com/woocommerce/woocommerce-ios/pull/17788]
 - [***] POS: On stores running WooCommerce 11.1.0 or newer, refund totals are now calculated by the store instead of on the device. [https://github.com/woocommerce/woocommerce-ios/pull/17741]
 - [*] Orders: Product search results in the order form are now scrollable and selectable on iPhone in landscape. [https://github.com/woocommerce/woocommerce-ios/pull/17693]
 - [*] Fixed the swipe-back gesture sometimes failing when returning from detail screens. [https://github.com/woocommerce/woocommerce-ios/pull/17749]


### PR DESCRIPTION
## Description

**First of three stacked PRs** adding back-swipe gestures to POS on phone. This one targets `trunk`;
PR 2 and PR 3 stack on top of it. Reviewable and mergeable on its own.

The refund selection screen was a `navigationDestination` pushed onto the detail pane's own
`NavigationPath`. That nests a navigation stack inside `POSNavigationSplitView`'s detail pane, which
the pane's own back affordances have no way to reach past — and it is what blocks the container from
owning a back gesture in PR 3.

It is now a `ZStack` overlay that moves in from the trailing edge, driven by the existing
`refundSelectionState`. The pushed screen and the overlay render the same
`POSRefundSelectionFlowView`, so the visual result is unchanged; only the containment differs.

**Most of the diff in `POSOrderDetailsView` is re-indentation** from wrapping the body in a `ZStack`.
The behavioural change is small: the `navigationDestination` and the `detailNavigationPath` binding
go away, and `refundSelectionView(state:)` appears.

### Why `POSPaymentContentView` is in here

Second commit, and it touches code shared with the card payment flow, so it deserves a look.

`POSPaymentLoadingView` suppressed animation on its title and message with a bare
`transaction { $0.animation = nil }`. The intent was local — the payment flow swaps those strings as
it advances and cross-fading them looks wrong — but `transaction` applies to *every* transaction
reaching that subtree and cannot tell "the text changed" from "an ancestor is being inserted".

Once the refund selection arrived as a SwiftUI transition instead of a navigation push, its subtree
took part in that transition and this block opted out: the title and message appeared instantly in
their final position while the screen behind them was still moving in. Keying the override to the
strings themselves fixes it without changing what it was written to do.

## Test Steps

On a phone:

1. Orders → open an order → **Issue refund**. The selection screen should move in over the details,
   not appear instantly.
2. The loading screen's title and message should travel **with** the screen, not land ahead of it.
3. Back returns to the order details.
4. With a refund selection open, tap a different order — the "Cancel this refund?" alert should
   still appear, and discarding should select the new order.
5. Complete a refund end to end.

**Please also exercise a card payment** — `POSPaymentLoadingView` is shared with the card flow's
idle-loading, `validatingOrder` and `preparingForPayment` states, and this PR changes it.

## Screenshots

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
