### PR TITLE
[Woo POS] Add edge-swipe back gestures on phone

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -186,6 +186,7 @@ struct ItemListView: View {
             guard oldStage == .finalizing, newStage == .building, posModel.cart.isEmpty else { return }
             navigationResetID += 1
         }
+        .posEdgeSwipeBackAction(isEnabled: isSearching, onBack: dismissSearch)
     }
 
     private var searchItemsController: PointOfSaleSearchingItemsControllerProtocol {
@@ -376,6 +377,7 @@ struct ItemListView: View {
             .barcodeScanning(enabled: isBarcodeScanningEnabled) { scannedCode in
                 posModel.barcodeScanned(scannedCode)
             }
+            .posEdgeSwipeBackAction()
         default:
             EmptyView()
         }
@@ -395,6 +397,7 @@ struct ItemListView: View {
         // (matches how `ChildItemList` handles the variations push).
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
+        .posEdgeSwipeBackAction(onBack: { isAddingCustomAmount = false })
     }
 }
 
@@ -424,9 +427,7 @@ private extension ItemListView {
                             searchable: POSProductSearchable(itemListType: selectedItemListType,
                                                              itemsController: searchItemsController,
                                                              searchHistoryProvider: posModel.searchHistoryService),
-                            onBack: {
-                                setSearch(false)
-                            }
+                            onBack: dismissSearch
                         )
                         .transition(.opacity.combined(with: .move(edge: .trailing)))
                     } else {
@@ -597,6 +598,11 @@ private extension ItemListView {
         case .coupons:
             selectedItemListType = .coupons(search: isSearching)
         }
+    }
+
+    private func dismissSearch() {
+        searchTerm = ""
+        setSearch(false)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -68,9 +68,7 @@ struct POSOrderListView: View {
                         POSSearchField(
                             searchTerm: $searchTerm,
                             searchable: POSOrderSearchable(ordersController: orderListModel.ordersController),
-                            onBack: {
-                                setSearch(false)
-                            }
+                            onBack: { setSearch(false) }
                         )
                         .posSearchTextFieldUnfocusedBorderColor(.posOutlineVariant)
                         .transition(.asymmetric(
@@ -115,6 +113,7 @@ struct POSOrderListView: View {
             analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersListPullToRefresh())
             await orderListModel.ordersController.refreshOrders()
         }
+        .posEdgeSwipeBackAction(isEnabled: isSearching, onBack: { setSearch(false) })
     }
 
     @ViewBuilder

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -35,6 +35,10 @@ struct POSRefundConfirmationView: View {
         }
         .background(backgroundColor)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
+        .posEdgeSwipeBackAction(
+            isEnabled: headerBackAction != nil,
+            onBack: headerBackAction
+        )
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -246,6 +246,7 @@ struct POSRefundModalContentView: View {
             onCancel: dismissAfterError,
             onClose: dismissAfterError
         )
+        .posEdgeSwipeBackAction(onBack: dismissAfterError)
     }
 
     /// `true` when the card-present refund itself failed, rather than the store rejecting the request.

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReaderDisconnectedView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReaderDisconnectedView.swift
@@ -33,6 +33,7 @@ struct POSRefundReaderDisconnectedView: View {
         }
         .background(Color.posSurfaceBright)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
+        .posEdgeSwipeBackAction(onBack: onBack)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReaderDisconnectedView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReaderDisconnectedView.swift
@@ -41,7 +41,7 @@ private extension POSRefundReaderDisconnectedView {
     var headerView: some View {
         HStack {
             Button(action: onBack) {
-                Text(Image(systemName: "chevron.left"))
+                Text(Image(systemName: "chevron.backward"))
                     .font(.posButtonSymbolLarge)
             }
             .accessibilityLabel(Localization.backButtonAccessibilityLabel)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -24,6 +24,7 @@ struct POSRefundReviewView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurfaceBright)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
+        .posEdgeSwipeBackAction(onBack: onClose)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
@@ -48,6 +48,7 @@ struct POSRefundSelectionFlowView: View {
             .background(Color.posSurfaceBright)
             .ignoresSafeArea(.container, edges: .bottom)
             .posHidesFloatingControl()
+            .posEdgeSwipeBackAction(onBack: onDismiss)
     }
 
     @ViewBuilder

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -94,12 +94,7 @@ struct POSNavigationDestinationMarkAsPaidView: View {
                     }
                 }
             },
-            onCancel: {
-                Task { @MainActor in
-                    await paymentModel.cancelMarkAsPaidPayment()
-                    router.pop()
-                }
-            }
+            onCancel: cancelMarkAsPaidPayment
         )
         .toolbar(.hidden, for: .navigationBar)
         // Fill the right pane so the visual transition reads as "totals → confirmation → totals"
@@ -109,6 +104,17 @@ struct POSNavigationDestinationMarkAsPaidView: View {
         // Asks the dashboard to hide the floating control overlay (`…` menu, reader chip)
         // so the merchant can focus on the confirmation step without distractions.
         .posHidesFloatingControl()
+        .posEdgeSwipeBackAction(
+            isEnabled: paymentModel.paymentState.markAsPaid != .processing,
+            onBack: cancelMarkAsPaidPayment
+        )
+    }
+
+    private func cancelMarkAsPaidPayment() {
+        Task { @MainActor in
+            await paymentModel.cancelMarkAsPaidPayment()
+            router.pop()
+        }
     }
 
     private enum Localization {
@@ -132,6 +138,7 @@ struct POSNavigationDestinationEmailReceiptView: View {
             try await paymentModel.sendReceipt(to: email)
         }
         .toolbar(.hidden, for: .navigationBar)
+        .posEdgeSwipeBackAction(onBack: { router.pop() })
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -67,7 +67,8 @@ struct POSNavigationDestinationScanToPayView: View {
 /// alert. Hosting it inside the `NavigationStack` gives us:
 ///
 /// - the same in-pane navigation pattern as cash and scan-to-pay (no special-case modifier)
-/// - "back" semantics for free (chevron-back, edge swipe)
+/// - the same "back" affordances as cash and scan-to-pay: a chevron-back, plus the module's own
+///   `posEdgeSwipeBackAction`, since a hidden navigation bar rules out UIKit's interactive pop
 /// - the same `navigationPath`-based check used to hide floating dashboard controls
 /// - no modal-stack optics (no "sheet → alert" chain, no auto-dismiss binding hack)
 ///

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -69,13 +69,7 @@ struct PointOfSaleCollectCashView: View {
                     POSPageHeaderView(title: Localization.backNavigationTitle,
                                       subtitle: formattedOrderTotal,
                                       backButtonConfiguration: .init(state: isLoading ? .disabled: .enabled,
-                                                                     action: {
-                        isTextFieldFocused = false
-                        Task { @MainActor in
-                            await paymentModel.cancelCashPayment()
-                            router.popToRoot()
-                        }
-                    }))
+                                                                     action: cancelCashPayment))
 
                     VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
                         Spacer()
@@ -144,6 +138,7 @@ struct PointOfSaleCollectCashView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea([])
+        .posEdgeSwipeBackAction(isEnabled: !isLoading, onBack: cancelCashPayment)
     }
 
     private func markComplete() async throws {
@@ -154,6 +149,14 @@ struct PointOfSaleCollectCashView: View {
 }
 
 private extension PointOfSaleCollectCashView {
+    private func cancelCashPayment() {
+        isTextFieldFocused = false
+        Task { @MainActor in
+            await paymentModel.cancelCashPayment()
+            router.popToRoot()
+        }
+    }
+
     private func submitCashAmount() async {
         analytics.track(.pointOfSaleCashPaymentTapped)
         isLoading = true

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -373,6 +373,10 @@ struct PointOfSaleDashboardView: View {
         }
         .background(Color.posSurface)
         .toolbar(.hidden, for: .navigationBar)
+        .posEdgeSwipeBackAction(
+            isEnabled: canExitFinalizingOnPhone,
+            onBack: { posModel.addMoreToCart() }
+        )
     }
 
     @State private var showOrders: Bool = false

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleScanToPayView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleScanToPayView.swift
@@ -71,12 +71,7 @@ struct PointOfSaleScanToPayView: View {
                         title: Localization.title,
                         subtitle: String.localizedStringWithFormat(Localization.subtitle, orderTotal),
                         backButtonConfiguration: .init(state: isLoading ? .disabled : .enabled,
-                                                       action: {
-                                                           Task { @MainActor in
-                                                               await paymentModel.cancelScanToPayPayment()
-                                                               router.popToRoot()
-                                                           }
-                                                       }))
+                                                       action: cancelScanToPayPayment))
 
                     Spacer()
 
@@ -113,6 +108,14 @@ struct PointOfSaleScanToPayView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurface)
+        .posEdgeSwipeBackAction(isEnabled: !isLoading, onBack: cancelScanToPayPayment)
+    }
+
+    private func cancelScanToPayPayment() {
+        Task { @MainActor in
+            await paymentModel.cancelScanToPayPayment()
+            router.popToRoot()
+        }
     }
 
     @ViewBuilder

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// Shared policy for POS leading-edge back gestures.
+struct POSEdgeSwipePolicy {
+    static let activationWidth: CGFloat = 24
+    static let minimumDragDistance: CGFloat = 8
+    static let completionThreshold: CGFloat = 0.35
+
+    let layoutDirection: LayoutDirection
+
+    var edgeAlignment: Alignment {
+        layoutDirection == .leftToRight ? .leading : .trailing
+    }
+
+    var direction: CGFloat {
+        layoutDirection == .leftToRight ? 1 : -1
+    }
+
+    func normalized(_ horizontalTranslation: CGFloat) -> CGFloat {
+        horizontalTranslation * direction
+    }
+
+    func clampedTranslation(_ horizontalTranslation: CGFloat, totalWidth: CGFloat) -> CGFloat {
+        min(max(normalized(horizontalTranslation), 0), totalWidth)
+    }
+
+    func shouldComplete(translation: CGFloat, predictedEndTranslation: CGFloat, totalWidth: CGFloat) -> Bool {
+        let current = normalized(translation)
+        let projected = normalized(predictedEndTranslation)
+        return max(projected, current) > totalWidth * Self.completionThreshold
+    }
+}
+
+/// Recognizes a phone-style leading-edge swipe and invokes the screen's real back action.
+///
+/// This is intentionally an action gesture rather than an interactive transition. SwiftUI can
+/// host a destination and its parent in different presentation containers, and a modifier on the
+/// destination cannot reveal content owned by another container. Moving only the destination
+/// exposes that container's empty background.
+///
+/// Use native interactive pop for genuine `NavigationStack` pushes and a container-owned
+/// transition, such as `POSNavigationSplitView`, when both screens are available to render.
+private struct POSEdgeSwipeBackAction: ViewModifier {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.layoutDirection) private var layoutDirection
+
+    let isEnabled: Bool
+    let onBack: (() -> Void)?
+
+    func body(content: Content) -> some View {
+        GeometryReader { geometry in
+            ZStack(alignment: policy.edgeAlignment) {
+                content
+
+                if isEnabled, horizontalSizeClass == .compact {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .frame(width: POSEdgeSwipePolicy.activationWidth)
+                        .frame(maxHeight: .infinity)
+                        .gesture(backGesture(totalWidth: geometry.size.width))
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+    }
+
+    private var policy: POSEdgeSwipePolicy {
+        POSEdgeSwipePolicy(layoutDirection: layoutDirection)
+    }
+
+    private func backGesture(totalWidth: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: POSEdgeSwipePolicy.minimumDragDistance)
+            .onEnded { value in
+                guard policy.shouldComplete(
+                    translation: value.translation.width,
+                    predictedEndTranslation: value.predictedEndTranslation.width,
+                    totalWidth: totalWidth
+                ) else {
+                    return
+                }
+
+                if let onBack {
+                    onBack()
+                } else {
+                    dismiss()
+                }
+            }
+    }
+}
+
+extension View {
+    func posEdgeSwipeBackAction(isEnabled: Bool = true, onBack: (() -> Void)? = nil) -> some View {
+        modifier(POSEdgeSwipeBackAction(isEnabled: isEnabled, onBack: onBack))
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
@@ -2,8 +2,19 @@ import SwiftUI
 
 /// Shared policy for POS leading-edge back gestures.
 struct POSEdgeSwipePolicy {
-    /// How far in from the leading edge a drag may start and still count as an edge swipe.
-    static let activationWidth: CGFloat = 24
+    /// How far in from the leading edge a drag may start and still count as a back swipe.
+    ///
+    /// iOS 26 dropped the edge requirement for its own back gesture — a swipe can begin anywhere.
+    /// POS cannot follow that yet: this is a `simultaneousGesture`, which recognises alongside
+    /// whatever else claims the touch and has no way to yield to a horizontal scroll view the way
+    /// UIKit's recognizer does. An unrestricted swipe would both scroll and navigate on the header
+    /// scroller (`POSPageHeaderView`) and the search-history chips (`POSPreSearchView`), which sit
+    /// on the very screens this is enabled for. Matching iOS 26 properly needs a UIKit gesture that
+    /// can `require(toFail:)` those recognizers.
+    ///
+    /// A touch-target's width rather than the old hairline, so the region is reachable without
+    /// reaching so far in that the scrollers become hard to use.
+    static let activationWidth: CGFloat = 44
     static let minimumDragDistance: CGFloat = 8
     static let completionThreshold: CGFloat = 0.35
     /// Used when the container has not reported a width yet. Without it the threshold would be

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
@@ -2,20 +2,22 @@ import SwiftUI
 
 /// Shared policy for POS leading-edge back gestures.
 struct POSEdgeSwipePolicy {
+    /// How far in from the leading edge a drag may start and still count as an edge swipe.
     static let activationWidth: CGFloat = 24
     static let minimumDragDistance: CGFloat = 8
     static let completionThreshold: CGFloat = 0.35
+    /// Used when the container has not reported a width yet. Without it the threshold would be
+    /// zero, and a strict comparison against zero never completes however far the merchant swipes.
+    static let fallbackCompletionDistance: CGFloat = 60
 
     let layoutDirection: LayoutDirection
 
-    var edgeAlignment: Alignment {
-        layoutDirection == .leftToRight ? .leading : .trailing
-    }
-
+    /// `1` when a back swipe travels in the positive x direction, `-1` when it travels the other way.
     var direction: CGFloat {
-        layoutDirection == .leftToRight ? 1 : -1
+        layoutDirection == .rightToLeft ? -1 : 1
     }
 
+    /// Restates a horizontal translation as distance travelled *towards back*, whichever way that is.
     func normalized(_ horizontalTranslation: CGFloat) -> CGFloat {
         horizontalTranslation * direction
     }
@@ -24,10 +26,26 @@ struct POSEdgeSwipePolicy {
         min(max(normalized(horizontalTranslation), 0), totalWidth)
     }
 
+    func startsAtLeadingEdge(_ xPosition: CGFloat, totalWidth: CGFloat) -> Bool {
+        layoutDirection == .rightToLeft
+            ? xPosition >= totalWidth - Self.activationWidth
+            : xPosition <= Self.activationWidth
+    }
+
+    /// Rejects a drag that is mostly vertical, so a scroll that begins near the edge and wanders
+    /// sideways does not read as a back swipe.
+    func isPredominantlyHorizontal(_ translation: CGSize) -> Bool {
+        abs(translation.width) > abs(translation.height)
+    }
+
     func shouldComplete(translation: CGFloat, predictedEndTranslation: CGFloat, totalWidth: CGFloat) -> Bool {
         let current = normalized(translation)
         let projected = normalized(predictedEndTranslation)
-        return max(projected, current) > totalWidth * Self.completionThreshold
+        return max(projected, current) > completionDistance(totalWidth: totalWidth)
+    }
+
+    func completionDistance(totalWidth: CGFloat) -> CGFloat {
+        totalWidth > 0 ? totalWidth * Self.completionThreshold : Self.fallbackCompletionDistance
     }
 }
 
@@ -38,45 +56,48 @@ struct POSEdgeSwipePolicy {
 /// destination cannot reveal content owned by another container. Moving only the destination
 /// exposes that container's empty background.
 ///
-/// Use native interactive pop for genuine `NavigationStack` pushes and a container-owned
-/// transition, such as `POSNavigationSplitView`, when both screens are available to render.
+/// Native interactive pop is not an alternative: POS hides the navigation bar on every screen,
+/// which switches off UIKit's `interactivePopGestureRecognizer`. Where one container owns both
+/// screens — as `POSNavigationSplitView` does — prefer its transition, which does track the finger.
+///
+/// The gesture attaches to the content rather than to an overlay strip. An overlay that is
+/// hit-testable enough to receive a drag also becomes the hit target for taps, which would kill
+/// every tap along the leading edge; `simultaneousGesture` recognizes alongside the content's own
+/// gestures instead of competing with them. Attaching to the content also keeps the modifier
+/// layout-neutral, which matters because several callers apply it to intrinsically sized cards.
 private struct POSEdgeSwipeBackAction: ViewModifier {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.layoutDirection) private var layoutDirection
+    @State private var totalWidth: CGFloat = 0
 
     let isEnabled: Bool
     let onBack: (() -> Void)?
 
     func body(content: Content) -> some View {
-        GeometryReader { geometry in
-            ZStack(alignment: policy.edgeAlignment) {
-                content
+        content
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.width }) { totalWidth = $0 }
+            .simultaneousGesture(backGesture, isEnabled: isActive)
+    }
 
-                if isEnabled, horizontalSizeClass == .compact {
-                    Color.clear
-                        .contentShape(Rectangle())
-                        .frame(width: POSEdgeSwipePolicy.activationWidth)
-                        .frame(maxHeight: .infinity)
-                        .gesture(backGesture(totalWidth: geometry.size.width))
-                        .accessibilityHidden(true)
-                }
-            }
-        }
+    private var isActive: Bool {
+        isEnabled && horizontalSizeClass == .compact
     }
 
     private var policy: POSEdgeSwipePolicy {
         POSEdgeSwipePolicy(layoutDirection: layoutDirection)
     }
 
-    private func backGesture(totalWidth: CGFloat) -> some Gesture {
+    private var backGesture: some Gesture {
         DragGesture(minimumDistance: POSEdgeSwipePolicy.minimumDragDistance)
             .onEnded { value in
-                guard policy.shouldComplete(
-                    translation: value.translation.width,
-                    predictedEndTranslation: value.predictedEndTranslation.width,
-                    totalWidth: totalWidth
-                ) else {
+                guard policy.startsAtLeadingEdge(value.startLocation.x, totalWidth: totalWidth),
+                      policy.isPredominantlyHorizontal(value.translation),
+                      policy.shouldComplete(
+                        translation: value.translation.width,
+                        predictedEndTranslation: value.predictedEndTranslation.width,
+                        totalWidth: totalWidth
+                      ) else {
                     return
                 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -372,6 +372,7 @@ private struct POSSettingsDetailPage<Content: View>: View {
         }
         .background(backgroundColor)
         .navigationBarBackButtonHidden(true)
+        .posEdgeSwipeBackAction(onBack: onBack)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -365,7 +365,9 @@ private struct POSSettingsDetailPage<Content: View>: View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
                 title: title,
-                backButtonConfiguration: .init(state: .enabled, action: onBack, buttonIcon: "chevron.left"))
+                // No `buttonIcon` override: the default is `chevron.backward`, which mirrors itself
+                // in right-to-left layouts. `chevron.left` does not, and pointed the wrong way.
+                backButtonConfiguration: .init(state: .enabled, action: onBack))
             .foregroundColor(.posSurface)
 
             content()

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import Testing
+@testable import PointOfSale
+
+struct POSEdgeSwipePolicyTests {
+    @Test func normalized_translation_when_left_to_right_then_positive_translation_moves_back() {
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        #expect(policy.normalized(40) == 40)
+        #expect(policy.normalized(-40) == -40)
+    }
+
+    @Test func normalized_translation_when_right_to_left_then_negative_translation_moves_back() {
+        let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
+
+        #expect(policy.normalized(-40) == 40)
+        #expect(policy.normalized(40) == -40)
+    }
+
+    @Test func clamped_translation_when_drag_exceeds_bounds_then_clamps_to_view_width() {
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        #expect(policy.clampedTranslation(-10, totalWidth: 100) == 0)
+        #expect(policy.clampedTranslation(50, totalWidth: 100) == 50)
+        #expect(policy.clampedTranslation(120, totalWidth: 100) == 100)
+    }
+
+    @Test func should_complete_when_current_translation_crosses_threshold_then_returns_true() {
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        #expect(policy.shouldComplete(translation: 36, predictedEndTranslation: 36, totalWidth: 100))
+    }
+
+    @Test func should_complete_when_projected_translation_crosses_threshold_then_returns_true() {
+        let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
+
+        #expect(policy.shouldComplete(translation: -10, predictedEndTranslation: -40, totalWidth: 100))
+    }
+
+    @Test func should_complete_when_drag_moves_away_from_leading_edge_then_returns_false() {
+        let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
+
+        #expect(!policy.shouldComplete(translation: 40, predictedEndTranslation: 60, totalWidth: 100))
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
@@ -3,43 +3,130 @@ import Testing
 @testable import PointOfSale
 
 struct POSEdgeSwipePolicyTests {
-    @Test func normalized_translation_when_left_to_right_then_positive_translation_moves_back() {
+    @Test func test_normalized_when_left_to_right_then_positive_translation_moves_back() {
+        // Given
         let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
 
+        // When / Then
         #expect(policy.normalized(40) == 40)
         #expect(policy.normalized(-40) == -40)
     }
 
-    @Test func normalized_translation_when_right_to_left_then_negative_translation_moves_back() {
+    @Test func test_normalized_when_right_to_left_then_negative_translation_moves_back() {
+        // Given
         let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
 
+        // When / Then
         #expect(policy.normalized(-40) == 40)
         #expect(policy.normalized(40) == -40)
     }
 
-    @Test func clamped_translation_when_drag_exceeds_bounds_then_clamps_to_view_width() {
+    @Test func test_clampedTranslation_when_drag_exceeds_bounds_then_clamps_to_view_width() {
+        // Given
         let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
 
+        // When / Then
         #expect(policy.clampedTranslation(-10, totalWidth: 100) == 0)
         #expect(policy.clampedTranslation(50, totalWidth: 100) == 50)
         #expect(policy.clampedTranslation(120, totalWidth: 100) == 100)
     }
 
-    @Test func should_complete_when_current_translation_crosses_threshold_then_returns_true() {
+    @Test func test_shouldComplete_when_current_translation_crosses_threshold_then_returns_true() {
+        // Given
         let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
 
-        #expect(policy.shouldComplete(translation: 36, predictedEndTranslation: 36, totalWidth: 100))
+        // When
+        let result = policy.shouldComplete(translation: 36, predictedEndTranslation: 36, totalWidth: 100)
+
+        // Then
+        #expect(result)
     }
 
-    @Test func should_complete_when_projected_translation_crosses_threshold_then_returns_true() {
+    @Test func test_shouldComplete_when_projected_translation_crosses_threshold_then_returns_true() {
+        // Given
         let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
 
-        #expect(policy.shouldComplete(translation: -10, predictedEndTranslation: -40, totalWidth: 100))
+        // When
+        let result = policy.shouldComplete(translation: -10, predictedEndTranslation: -40, totalWidth: 100)
+
+        // Then
+        #expect(result)
     }
 
-    @Test func should_complete_when_drag_moves_away_from_leading_edge_then_returns_false() {
+    @Test func test_shouldComplete_when_drag_moves_away_from_leading_edge_then_returns_false() {
+        // Given
         let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
 
-        #expect(!policy.shouldComplete(translation: 40, predictedEndTranslation: 60, totalWidth: 100))
+        // When
+        let result = policy.shouldComplete(translation: 40, predictedEndTranslation: 60, totalWidth: 100)
+
+        // Then
+        #expect(!result)
+    }
+
+    @Test func test_shouldComplete_when_translation_sits_exactly_on_threshold_then_returns_false() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When
+        let result = policy.shouldComplete(translation: 35, predictedEndTranslation: 35, totalWidth: 100)
+
+        // Then
+        #expect(!result)
+    }
+
+    @Test func test_completionDistance_when_width_is_unknown_then_falls_back_to_a_fixed_distance() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When
+        let distance = policy.completionDistance(totalWidth: 0)
+
+        // Then
+        #expect(distance == POSEdgeSwipePolicy.fallbackCompletionDistance)
+    }
+
+    @Test func test_shouldComplete_when_width_is_unknown_then_a_long_swipe_still_completes() {
+        // Given a container that has not reported its width, a strict comparison against a zero
+        // threshold would never complete however far the merchant swipes.
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When
+        let result = policy.shouldComplete(translation: 120, predictedEndTranslation: 120, totalWidth: 0)
+
+        // Then
+        #expect(result)
+    }
+
+    @Test func test_startsAtLeadingEdge_when_left_to_right_then_only_the_left_edge_qualifies() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When / Then
+        #expect(policy.startsAtLeadingEdge(0, totalWidth: 400))
+        #expect(policy.startsAtLeadingEdge(POSEdgeSwipePolicy.activationWidth, totalWidth: 400))
+        #expect(!policy.startsAtLeadingEdge(POSEdgeSwipePolicy.activationWidth + 1, totalWidth: 400))
+        #expect(!policy.startsAtLeadingEdge(400, totalWidth: 400))
+    }
+
+    @Test func test_startsAtLeadingEdge_when_right_to_left_then_only_the_right_edge_qualifies() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
+
+        // When / Then
+        #expect(policy.startsAtLeadingEdge(400, totalWidth: 400))
+        #expect(policy.startsAtLeadingEdge(400 - POSEdgeSwipePolicy.activationWidth, totalWidth: 400))
+        #expect(!policy.startsAtLeadingEdge(400 - POSEdgeSwipePolicy.activationWidth - 1, totalWidth: 400))
+        #expect(!policy.startsAtLeadingEdge(0, totalWidth: 400))
+    }
+
+    @Test func test_isPredominantlyHorizontal_when_drag_is_mostly_vertical_then_returns_false() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When / Then
+        #expect(policy.isPredominantlyHorizontal(CGSize(width: 60, height: 20)))
+        #expect(!policy.isPredominantlyHorizontal(CGSize(width: 20, height: 60)))
+        #expect(!policy.isPredominantlyHorizontal(CGSize(width: 40, height: 40)))
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.6
 -----
 - [*] Shipping Labels: Fixed purchased labels disappearing when an unfinished label has no carrier information. [https://github.com/woocommerce/woocommerce-ios/pull/17766]
+- [*] POS: On iPhone, you can now swipe from the left edge to go back, across search, checkout, the payment screens, refunds and hardware settings. [https://github.com/woocommerce/woocommerce-ios/pull/17789]
 - [***] POS: On stores running WooCommerce 11.1.0 or newer, refund totals are now calculated by the store instead of on the device. [https://github.com/woocommerce/woocommerce-ios/pull/17741]
 - [*] Orders: Product search results in the order form are now scrollable and selectable on iPhone in landscape. [https://github.com/woocommerce/woocommerce-ios/pull/17693]
 - [*] Fixed the swipe-back gesture sometimes failing when returning from detail screens. [https://github.com/woocommerce/woocommerce-ios/pull/17749]


### PR DESCRIPTION
## Description

**First of two stacked PRs.** Targets `trunk`; #17790 stacks on top of it. Reviewable and mergeable on its own, but it's probably fine to just test on #17790 if you prefer.

This PR adds a back-swipe gesture to phone (and compact iPad) POS screens where it's appropriate.

Where practical, this is an interactive back-swipe gesture, like the system's built in gesture. We don't get that for free because we hide the system nav bar. However, because many POS screens aren't in navigation controllers at all, many are a simpler non-interactive edge swipe.

The new `POSEdgeSwipePolicy`, holds the shared geometry and mirrors it for right-to-left layouts, and a `posEdgeSwipeBackAction` modifier that runs a screen's back action on swipe. 

Applied at 15 sites: 
 - item search 
 - orders search
 - variations detail 
 - custom amounts 
 - cash, 
 - scan to pay, 
 - mark as paid, 
 - email receipt, 
 - five refund screens, 
 - checkout, and 
 - settings hardware sub-pages.

The gesture attaches to the content via `simultaneousGesture`. An overlay would become the hit target for taps, which would swallow every tap along the leading edge too.

**iOS 26 replaced edge-based back gesture swipes with full-screen, so a system-gesture swipe can start anywhere on screen.** However, this wasn't a clean implementation, especially when it's not interactive, so I've chosen to keep it as an edge based swipe, which is a compromise but a lot better than no gesture.

We can't use `require(toFail` in Swift UI gestures, which prevents us from safely having an edge swipe co-exist with other horizontal gestures.

## Test Steps (optional, perhaps best tested on #17790 

On an iPhone running iOS 26, or iPad in compact Split View on iOS 18/26

1. Items list → tap search → swipe from the leading edge. Search should close and the keyboard should dismiss.
2. Same in Orders search.
3. Cart → Checkout → swipe back. Should return to the cart, and be inert mid-payment.
4. Cash, scan to pay, mark as paid, email receipt — swipe back should run the same cancellation that the back button does, not just dismiss the screen.
5. Refund flow: selection, review, confirmation, reader-disconnected, error.
6. Settings → Hardware → Card readers / Scanners / Printers.
7. **Tap targets:** tap the far-left edge of an order row, a settings card and an item card. All
   must register — an earlier revision of this work swallowed them.

## Screenshots

See #17790 for combined screenshots

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
