### PR TITLE
[Woo POS] Match the platform push when the split view slides on a phone

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -29,10 +29,13 @@ struct POSOrdersView: View {
         case (.empty, false):
             emptyView()
         default:
-            POSNavigationSplitView(selection: Binding(
-                get: { orderListModel.ordersController.selectedOrder },
-                set: { selectOrder($0) }
-            )) { _ in
+            POSNavigationSplitView(
+                selection: Binding(
+                    get: { orderListModel.ordersController.selectedOrder },
+                    set: { selectOrder($0) }
+                ),
+                isCompactBackGestureEnabled: activeRefundSelectionOrderID == nil
+            ) { _ in
                 POSOrderListView(
                     isSearching: $isSearching,
                     searchTerm: $searchTerm,

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -29,13 +29,10 @@ struct POSOrdersView: View {
         case (.empty, false):
             emptyView()
         default:
-            POSNavigationSplitView(
-                selection: Binding(
-                    get: { orderListModel.ordersController.selectedOrder },
-                    set: { selectOrder($0) }
-                ),
-                isCompactBackGestureEnabled: activeRefundSelectionOrderID == nil
-            ) { _ in
+            POSNavigationSplitView(selection: Binding(
+                get: { orderListModel.ordersController.selectedOrder },
+                set: { selectOrder($0) }
+            )) { _ in
                 POSOrderListView(
                     isSearching: $isSearching,
                     searchTerm: $searchTerm,

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
@@ -20,6 +20,10 @@ struct POSEdgeSwipePolicy {
     /// Used when the container has not reported a width yet. Without it the threshold would be
     /// zero, and a strict comparison against zero never completes however far the merchant swipes.
     static let fallbackCompletionDistance: CGFloat = 60
+    /// How far the outgoing screen travels, as a fraction of the incoming screen's travel. UIKit
+    /// moves the screen being left by roughly a third of the width, so it drifts under the arriving
+    /// screen rather than sliding away with it.
+    static let outgoingParallaxFraction: CGFloat = 0.3
 
     let layoutDirection: LayoutDirection
 
@@ -57,6 +61,28 @@ struct POSEdgeSwipePolicy {
 
     func completionDistance(totalWidth: CGFloat) -> CGFloat {
         totalWidth > 0 ? totalWidth * Self.completionThreshold : Self.fallbackCompletionDistance
+    }
+
+    // MARK: - Container-owned transition
+
+    /// How far the incoming screen has travelled: `1` when it fully covers the outgoing screen,
+    /// `0` when the outgoing screen is fully back.
+    func incomingProgress(dragTranslation: CGFloat, totalWidth: CGFloat) -> CGFloat {
+        guard totalWidth > 0 else { return 1 }
+        return 1 - min(max(dragTranslation / totalWidth, 0), 1)
+    }
+
+    /// Moves a container holding both screens side by side, so the incoming one arrives from the
+    /// trailing edge and covers the full width.
+    func incomingOffset(progress: CGFloat, totalWidth: CGFloat) -> CGFloat {
+        -progress * totalWidth * direction
+    }
+
+    /// Cancels most of the container's travel for the outgoing screen, leaving it the parallax
+    /// fraction. Without this the two screens move as one sheet, which reads as the outgoing screen
+    /// being dragged in from the side rather than revealed underneath.
+    func outgoingParallaxOffset(progress: CGFloat, totalWidth: CGFloat) -> CGFloat {
+        progress * totalWidth * (1 - Self.outgoingParallaxFraction) * direction
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSEdgeSwipeBackAction.swift
@@ -74,15 +74,21 @@ struct POSEdgeSwipePolicy {
 
     /// Moves a container holding both screens side by side, so the incoming one arrives from the
     /// trailing edge and covers the full width.
+    ///
+    /// Deliberately not multiplied by `direction`. SwiftUI already mirrors this for right-to-left
+    /// layouts, so applying `direction` here flips it a second time: the container travels the wrong
+    /// way and the incoming screen leaves the screen instead of covering it.
     func incomingOffset(progress: CGFloat, totalWidth: CGFloat) -> CGFloat {
-        -progress * totalWidth * direction
+        -progress * totalWidth
     }
 
     /// Cancels most of the container's travel for the outgoing screen, leaving it the parallax
     /// fraction. Without this the two screens move as one sheet, which reads as the outgoing screen
     /// being dragged in from the side rather than revealed underneath.
+    /// Mirrored by SwiftUI for right-to-left layouts, so no `direction` here either — see
+    /// `incomingOffset`.
     func outgoingParallaxOffset(progress: CGFloat, totalWidth: CGFloat) -> CGFloat {
-        progress * totalWidth * (1 - Self.outgoingParallaxFraction) * direction
+        progress * totalWidth * (1 - Self.outgoingParallaxFraction)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -15,6 +15,10 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     /// Distance the in-progress back drag has travelled towards the sidebar, always positive
     /// however the layout runs. Zero whenever no drag is in flight.
     @State private var dragTranslation: CGFloat = 0
+    @State private var dragPhase: DragPhase = .idle
+    /// Resets itself when the drag ends *or is cancelled*, which is the only signal a cancelled
+    /// drag gives us. See `DragPhase`.
+    @GestureState private var isDragActive = false
 
     private let sidebar: (Binding<SelectionValue?>) -> Sidebar
     private let detail: (SelectionValue, Binding<NavigationPath>) -> Detail
@@ -105,14 +109,25 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
             }
             .offset(x: edgeSwipePolicy.incomingOffset(progress: progress, totalWidth: totalWidth))
             .simultaneousGesture(
-                compactBackGesture(
-                    totalWidth: totalWidth,
-                    globalFrame: geometry.frame(in: .global)
-                ),
+                compactBackGesture(totalWidth: totalWidth),
                 isEnabled: isCompactBackGestureActive
             )
         }
+        // Anchors the gesture's coordinates to this view rather than to the window. `.global` is
+        // only the same thing as "this split view" when the window fills the screen, which is why
+        // measuring the edge against it worked on a phone and failed in a collapsed iPad window.
+        .coordinateSpace(.named(Constants.coordinateSpaceName))
         .animation(Constants.paneTransition, value: selection != nil)
+        .onChange(of: isDragActive) { _, isActive in
+            // A cancelled drag delivers no `onEnded`, so nothing else will put the panes back.
+            // Still `.dragging` here means `onEnded` never ran and this is that case; any other
+            // phase means it did run and has already decided what happens next.
+            guard !isActive, dragPhase == .dragging else { return }
+            dragPhase = .idle
+            withAnimation(Constants.paneTransition) {
+                dragTranslation = 0
+            }
+        }
         .onAppear {
             if isRegular, selection == nil {
                 setDefaultValue?()
@@ -167,27 +182,43 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
         .allowsHitTesting(false)
     }
 
+    /// Where a back drag is in its life cycle.
+    ///
+    /// `onEnded` is not guaranteed to arrive: a drag that is cancelled rather than ended delivers
+    /// no callback at all. Tracking the phase lets a cancelled drag be told apart from one that
+    /// `onEnded` has already taken responsibility for, so the panes are never left stranded
+    /// part-way across.
+    private enum DragPhase {
+        case idle
+        case dragging
+        case completing
+    }
+
     private var isCompactBackGestureActive: Bool {
         !isRegular && selection != nil && detailNavigationPath.isEmpty && isCompactBackGestureEnabled
     }
 
-    private func compactBackGesture(totalWidth: CGFloat, globalFrame: CGRect) -> some Gesture {
+    private func compactBackGesture(totalWidth: CGFloat) -> some Gesture {
         DragGesture(
             minimumDistance: POSEdgeSwipePolicy.minimumDragDistance,
-            coordinateSpace: .global
+            coordinateSpace: .named(Constants.coordinateSpaceName)
         )
+        .updating($isDragActive) { _, isActive, _ in
+            isActive = true
+        }
         .onChanged { value in
-            guard startsAtLeadingEdge(value.startLocation.x, globalFrame: globalFrame),
+            guard edgeSwipePolicy.startsAtLeadingEdge(value.startLocation.x, totalWidth: totalWidth),
                   edgeSwipePolicy.isPredominantlyHorizontal(value.translation) else {
                 return
             }
+            dragPhase = .dragging
             dragTranslation = edgeSwipePolicy.clampedTranslation(
                 value.translation.width,
                 totalWidth: totalWidth
             )
         }
         .onEnded { value in
-            guard startsAtLeadingEdge(value.startLocation.x, globalFrame: globalFrame) else { return }
+            guard edgeSwipePolicy.startsAtLeadingEdge(value.startLocation.x, totalWidth: totalWidth) else { return }
             let shouldNavigateBack = edgeSwipePolicy.isPredominantlyHorizontal(value.translation)
                 && edgeSwipePolicy.shouldComplete(
                     translation: value.translation.width,
@@ -196,6 +227,7 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                 )
 
             if shouldNavigateBack {
+                dragPhase = .completing
                 withAnimation(Constants.paneTransition, completionCriteria: .logicallyComplete) {
                     dragTranslation = totalWidth
                 } completion: {
@@ -208,8 +240,10 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                         selection = nil
                         dragTranslation = 0
                     }
+                    dragPhase = .idle
                 }
             } else {
+                dragPhase = .idle
                 withAnimation(Constants.paneTransition) {
                     dragTranslation = 0
                 }
@@ -220,15 +254,12 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     private var edgeSwipePolicy: POSEdgeSwipePolicy {
         POSEdgeSwipePolicy(layoutDirection: layoutDirection)
     }
-
-    /// The gesture tracks in global space, because the container it is attached to is itself
-    /// offset. Rebase onto the container before asking the policy about the edge.
-    private func startsAtLeadingEdge(_ xPosition: CGFloat, globalFrame: CGRect) -> Bool {
-        edgeSwipePolicy.startsAtLeadingEdge(xPosition - globalFrame.minX, totalWidth: globalFrame.width)
-    }
 }
 
 private enum Constants {
+    /// Names this split view's own coordinate space, so the back gesture can measure the leading
+    /// edge against the view it belongs to instead of against the window.
+    static let coordinateSpaceName = "POSNavigationSplitView"
     static let sidebarWidthFraction: CGFloat = 0.35
     static let sidebarDimOpacity: CGFloat = 0.12
     static let leadingEdgeShadowWidth: CGFloat = 12

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -24,11 +24,9 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     private let detail: (SelectionValue, Binding<NavigationPath>) -> Detail
     private let detailPlaceholderView: () -> DetailPlaceholder
     private let setDefaultValue: (() -> Void)?
-    private let isCompactBackGestureEnabled: Bool
 
     init(
         selection: Binding<SelectionValue?> = .constant(nil),
-        isCompactBackGestureEnabled: Bool = true,
         @ViewBuilder sidebar: @escaping (Binding<SelectionValue?>) -> Sidebar,
         @ViewBuilder detail: @escaping (SelectionValue, Binding<NavigationPath>) -> Detail,
         @ViewBuilder detailPlaceholderView: @escaping () -> DetailPlaceholder,
@@ -39,7 +37,6 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
         self.detail = detail
         self.detailPlaceholderView = detailPlaceholderView
         self.setDefaultValue = setDefaultValue
-        self.isCompactBackGestureEnabled = isCompactBackGestureEnabled
     }
 
     private var isRegular: Bool {
@@ -195,7 +192,9 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     }
 
     private var isCompactBackGestureActive: Bool {
-        !isRegular && selection != nil && detailNavigationPath.isEmpty && isCompactBackGestureEnabled
+        // A non-empty detail path means a sub-screen is pushed and owns its own back affordance,
+        // so the container must not also swipe the whole pane away.
+        !isRegular && selection != nil && detailNavigationPath.isEmpty
     }
 
     private func compactBackGesture(totalWidth: CGFloat) -> some Gesture {

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -9,16 +9,20 @@ import SwiftUI
 /// presented sheets, @Environment objects) when horizontalSizeClass flickers during background transitions.
 struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: View, SelectionValue: Hashable & Identifiable>: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.layoutDirection) private var layoutDirection
     @Binding private var selection: SelectionValue?
     @State private var detailNavigationPath = NavigationPath()
+    @State private var compactBackDragOffset: CGFloat = 0
 
     private let sidebar: (Binding<SelectionValue?>) -> Sidebar
     private let detail: (SelectionValue, Binding<NavigationPath>) -> Detail
     private let detailPlaceholderView: () -> DetailPlaceholder
     private let setDefaultValue: (() -> Void)?
+    private let isCompactBackGestureEnabled: Bool
 
     init(
         selection: Binding<SelectionValue?> = .constant(nil),
+        isCompactBackGestureEnabled: Bool = true,
         @ViewBuilder sidebar: @escaping (Binding<SelectionValue?>) -> Sidebar,
         @ViewBuilder detail: @escaping (SelectionValue, Binding<NavigationPath>) -> Detail,
         @ViewBuilder detailPlaceholderView: @escaping () -> DetailPlaceholder,
@@ -29,6 +33,7 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
         self.detail = detail
         self.detailPlaceholderView = detailPlaceholderView
         self.setDefaultValue = setDefaultValue
+        self.isCompactBackGestureEnabled = isCompactBackGestureEnabled
     }
 
     private var isRegular: Bool {
@@ -70,7 +75,14 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                 }
                 .frame(width: detailWidth(for: geometry.size.width))
             }
-            .offset(x: compactOffset(for: geometry.size.width))
+            .offset(x: compactOffset(for: geometry.size.width) + compactBackDragOffset)
+            .simultaneousGesture(
+                compactBackGesture(
+                    totalWidth: geometry.size.width,
+                    globalFrame: geometry.frame(in: .global)
+                ),
+                isEnabled: isCompactBackGestureActive
+            )
         }
         .animation(.default, value: selection != nil)
         .onAppear {
@@ -101,7 +113,65 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
 
     private func compactOffset(for totalWidth: CGFloat) -> CGFloat {
         guard !isRegular, selection != nil else { return 0 }
-        return -totalWidth
+        return -totalWidth * edgeSwipePolicy.direction
+    }
+
+    private var isCompactBackGestureActive: Bool {
+        !isRegular && selection != nil && detailNavigationPath.isEmpty && isCompactBackGestureEnabled
+    }
+
+    private func compactBackGesture(totalWidth: CGFloat, globalFrame: CGRect) -> some Gesture {
+        DragGesture(
+            minimumDistance: POSEdgeSwipePolicy.minimumDragDistance,
+            coordinateSpace: .global
+        )
+        .onChanged { value in
+            guard startsAtLeadingEdge(value.startLocation.x, globalFrame: globalFrame) else { return }
+            compactBackDragOffset = edgeSwipePolicy.clampedTranslation(
+                value.translation.width,
+                totalWidth: totalWidth
+            ) * edgeSwipePolicy.direction
+        }
+        .onEnded { value in
+            guard startsAtLeadingEdge(value.startLocation.x, globalFrame: globalFrame) else { return }
+            let shouldNavigateBack = edgeSwipePolicy.shouldComplete(
+                translation: value.translation.width,
+                predictedEndTranslation: value.predictedEndTranslation.width,
+                totalWidth: totalWidth
+            )
+
+            if shouldNavigateBack {
+                withAnimation(.snappy, completionCriteria: .logicallyComplete) {
+                    compactBackDragOffset = totalWidth * edgeSwipePolicy.direction
+                } completion: {
+                    var transaction = Transaction(animation: nil)
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        selection = nil
+                        compactBackDragOffset = 0
+                    }
+                }
+            } else {
+                withAnimation(.snappy) {
+                    compactBackDragOffset = 0
+                }
+            }
+        }
+    }
+
+    private var edgeSwipePolicy: POSEdgeSwipePolicy {
+        POSEdgeSwipePolicy(layoutDirection: layoutDirection)
+    }
+
+    private func startsAtLeadingEdge(_ xPosition: CGFloat, globalFrame: CGRect) -> Bool {
+        switch layoutDirection {
+        case .leftToRight:
+            xPosition <= globalFrame.minX + POSEdgeSwipePolicy.activationWidth
+        case .rightToLeft:
+            xPosition >= globalFrame.maxX - POSEdgeSwipePolicy.activationWidth
+        @unknown default:
+            xPosition <= globalFrame.minX + POSEdgeSwipePolicy.activationWidth
+        }
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -173,7 +173,7 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
             endPoint: .trailing
         )
         .frame(width: Constants.leadingEdgeShadowWidth)
-        .offset(x: -Constants.leadingEdgeShadowWidth * edgeSwipePolicy.direction)
+        .offset(x: -Constants.leadingEdgeShadowWidth)
         .opacity(progress)
         .ignoresSafeArea()
         .allowsHitTesting(false)

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -12,7 +12,9 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     @Environment(\.layoutDirection) private var layoutDirection
     @Binding private var selection: SelectionValue?
     @State private var detailNavigationPath = NavigationPath()
-    @State private var compactBackDragOffset: CGFloat = 0
+    /// Distance the in-progress back drag has travelled towards the sidebar, always positive
+    /// however the layout runs. Zero whenever no drag is in flight.
+    @State private var dragTranslation: CGFloat = 0
 
     private let sidebar: (Binding<SelectionValue?>) -> Sidebar
     private let detail: (SelectionValue, Binding<NavigationPath>) -> Detail
@@ -54,9 +56,23 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
 
     var body: some View {
         GeometryReader { geometry in
+            let totalWidth = geometry.size.width
+            let progress = detailProgress(for: totalWidth)
+
             HStack(spacing: 0) {
                 sidebar(sidebarSelection)
-                    .frame(width: sidebarWidth(for: geometry.size.width))
+                    .frame(width: sidebarWidth(for: totalWidth))
+                    .offset(x: edgeSwipePolicy.outgoingParallaxOffset(progress: progress, totalWidth: totalWidth))
+                    // The panes lay out inside the safe area, so anything drawn over them stops at
+                    // the status bar and the home indicator. A dim that stops short of those leaves
+                    // undimmed bands of list showing above and below it, which reads as banding
+                    // rather than as one screen sliding under another.
+                    .overlay {
+                        Color.black
+                            .opacity(Constants.sidebarDimOpacity * progress)
+                            .ignoresSafeArea()
+                            .allowsHitTesting(false)
+                    }
 
                 NavigationStack(path: $detailNavigationPath) {
                     VStack {
@@ -70,21 +86,33 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                                 .transition(.opacity)
                         }
                     }
-                    .animation(.default, value: selection != nil)
+                    // Cross-fading the placeholder into the detail only makes sense side by side,
+                    // where the merchant is looking at the pane while it changes. In compact the
+                    // pane is off-screen until it slides in, so the fade would only make the
+                    // arriving screen translucent for the length of the slide.
+                    .animation(isRegular ? .default : nil, value: selection != nil)
                     .navigationBarHidden(true)
                 }
-                .frame(width: detailWidth(for: geometry.size.width))
+                .frame(width: detailWidth(for: totalWidth))
+                // The stack has no backdrop of its own, so without this any moment where the
+                // detail is not yet drawn shows the host's background instead. It has to reach into
+                // the safe areas too, because the sidebar now passes behind this pane rather than
+                // leaving the screen, and would otherwise show through above and below it.
+                .background(Color.posSurface.ignoresSafeArea())
+                .overlay(alignment: .leading) {
+                    leadingEdgeShadow(progress: progress)
+                }
             }
-            .offset(x: compactOffset(for: geometry.size.width) + compactBackDragOffset)
+            .offset(x: edgeSwipePolicy.incomingOffset(progress: progress, totalWidth: totalWidth))
             .simultaneousGesture(
                 compactBackGesture(
-                    totalWidth: geometry.size.width,
+                    totalWidth: totalWidth,
                     globalFrame: geometry.frame(in: .global)
                 ),
                 isEnabled: isCompactBackGestureActive
             )
         }
-        .animation(.default, value: selection != nil)
+        .animation(Constants.paneTransition, value: selection != nil)
         .onAppear {
             if isRegular, selection == nil {
                 setDefaultValue?()
@@ -111,9 +139,32 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
         isRegular ? totalWidth * (1 - Constants.sidebarWidthFraction) : totalWidth
     }
 
-    private func compactOffset(for totalWidth: CGFloat) -> CGFloat {
+    /// How far the detail pane has travelled over the sidebar: `1` when it covers it, `0` when the
+    /// sidebar is fully back. Zero in regular width, where both panes are on screen at once and
+    /// nothing slides — which makes every transition modifier above inert there.
+    private func detailProgress(for totalWidth: CGFloat) -> CGFloat {
         guard !isRegular, selection != nil else { return 0 }
-        return -totalWidth * edgeSwipePolicy.direction
+        return edgeSwipePolicy.incomingProgress(dragTranslation: dragTranslation, totalWidth: totalWidth)
+    }
+
+    /// A soft edge on the detail pane's leading side, drawn just outside it so it falls on the
+    /// sidebar. A `shadow` on the pane itself would blur a full-screen view on every frame of a drag.
+    ///
+    /// Kept in the hierarchy at all times and faded by `progress`, rather than inserted and removed.
+    /// A view removed part-way through a transition gets a removal transition of its own, and SwiftUI
+    /// stops updating its position while that plays — so a fast swipe left the shadow behind, hanging
+    /// mid-screen and fading out on its own while the pane carried on without it.
+    private func leadingEdgeShadow(progress: CGFloat) -> some View {
+        LinearGradient(
+            colors: [.clear, .black.opacity(Constants.leadingEdgeShadowOpacity)],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        .frame(width: Constants.leadingEdgeShadowWidth)
+        .offset(x: -Constants.leadingEdgeShadowWidth * edgeSwipePolicy.direction)
+        .opacity(progress)
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
     }
 
     private var isCompactBackGestureActive: Bool {
@@ -126,34 +177,41 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
             coordinateSpace: .global
         )
         .onChanged { value in
-            guard startsAtLeadingEdge(value.startLocation.x, globalFrame: globalFrame) else { return }
-            compactBackDragOffset = edgeSwipePolicy.clampedTranslation(
+            guard startsAtLeadingEdge(value.startLocation.x, globalFrame: globalFrame),
+                  edgeSwipePolicy.isPredominantlyHorizontal(value.translation) else {
+                return
+            }
+            dragTranslation = edgeSwipePolicy.clampedTranslation(
                 value.translation.width,
                 totalWidth: totalWidth
-            ) * edgeSwipePolicy.direction
+            )
         }
         .onEnded { value in
             guard startsAtLeadingEdge(value.startLocation.x, globalFrame: globalFrame) else { return }
-            let shouldNavigateBack = edgeSwipePolicy.shouldComplete(
-                translation: value.translation.width,
-                predictedEndTranslation: value.predictedEndTranslation.width,
-                totalWidth: totalWidth
-            )
+            let shouldNavigateBack = edgeSwipePolicy.isPredominantlyHorizontal(value.translation)
+                && edgeSwipePolicy.shouldComplete(
+                    translation: value.translation.width,
+                    predictedEndTranslation: value.predictedEndTranslation.width,
+                    totalWidth: totalWidth
+                )
 
             if shouldNavigateBack {
-                withAnimation(.snappy, completionCriteria: .logicallyComplete) {
-                    compactBackDragOffset = totalWidth * edgeSwipePolicy.direction
+                withAnimation(Constants.paneTransition, completionCriteria: .logicallyComplete) {
+                    dragTranslation = totalWidth
                 } completion: {
+                    // Clearing the selection is what actually ends the navigation, but it also
+                    // resets the progress the animation just drove to zero. Doing both without a
+                    // transaction would animate the panes a second time, back the way they came.
                     var transaction = Transaction(animation: nil)
                     transaction.disablesAnimations = true
                     withTransaction(transaction) {
                         selection = nil
-                        compactBackDragOffset = 0
+                        dragTranslation = 0
                     }
                 }
             } else {
-                withAnimation(.snappy) {
-                    compactBackDragOffset = 0
+                withAnimation(Constants.paneTransition) {
+                    dragTranslation = 0
                 }
             }
         }
@@ -163,18 +221,23 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
         POSEdgeSwipePolicy(layoutDirection: layoutDirection)
     }
 
+    /// The gesture tracks in global space, because the container it is attached to is itself
+    /// offset. Rebase onto the container before asking the policy about the edge.
     private func startsAtLeadingEdge(_ xPosition: CGFloat, globalFrame: CGRect) -> Bool {
-        switch layoutDirection {
-        case .leftToRight:
-            xPosition <= globalFrame.minX + POSEdgeSwipePolicy.activationWidth
-        case .rightToLeft:
-            xPosition >= globalFrame.maxX - POSEdgeSwipePolicy.activationWidth
-        @unknown default:
-            xPosition <= globalFrame.minX + POSEdgeSwipePolicy.activationWidth
-        }
+        edgeSwipePolicy.startsAtLeadingEdge(xPosition - globalFrame.minX, totalWidth: globalFrame.width)
     }
 }
 
 private enum Constants {
     static let sidebarWidthFraction: CGFloat = 0.35
+    static let sidebarDimOpacity: CGFloat = 0.12
+    static let leadingEdgeShadowWidth: CGFloat = 12
+    static let leadingEdgeShadowOpacity: CGFloat = 0.18
+    /// Shared by the tap-driven push and by the release of an interactive drag, so a pane that
+    /// arrives from a tap and one that arrives from a swipe travel at the same rate.
+    ///
+    /// A spring rather than an ease: it front-loads the movement, which is what makes a platform
+    /// push feel immediate. `.default` here read as sluggish next to the pushes inside the detail
+    /// pane, which are real `NavigationStack` transitions.
+    static let paneTransition: Animation = .snappy(duration: 0.3)
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCard.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct POSSettingsCard: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     let title: String
     let subtitle: String
     let isSelected: Bool
@@ -11,6 +13,12 @@ struct POSSettingsCard: View {
         self.subtitle = subtitle
         self.isSelected = isSelected
         self.action = action
+    }
+
+    /// On phone the selected detail replaces the list, so retaining a selection border on the
+    /// off-screen row adds no information and makes the stroke visible during an interactive pop.
+    private var showsSelectionBorder: Bool {
+        isSelected && horizontalSizeClass == .regular
     }
 
     var body: some View {
@@ -29,7 +37,7 @@ struct POSSettingsCard: View {
             .dynamicTypeSize(...DynamicTypeSize.accessibility2)
             .posItemCardBorderStyles()
             .overlay {
-                if isSelected {
+                if showsSelectionBorder {
                     RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value)
                         .stroke(Color.posOnSurface, lineWidth: 2)
                 }

--- a/Modules/Sources/PointOfSale/Utils/POSShadowStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSShadowStyle.swift
@@ -113,6 +113,13 @@ private class MultiShadowView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        // SwiftUI can update a representable's frame repeatedly while an ancestor is being dragged.
+        // Core Animation otherwise interpolates these layer changes independently of the SwiftUI
+        // transform, which makes card shadows appear to lag behind their rows during interactive navigation.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+
         layer.sublayers?.removeAll(where: { $0.name == "posShadowLayer" })
         for (index, shadow) in shadowLayers.enumerated() {
             let shadowLayer = CALayer()

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
@@ -142,13 +142,25 @@ struct POSEdgeSwipePolicyTests {
 
     @Test func test_incomingOffset_when_fully_navigated_then_moves_the_container_a_full_width() {
         // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When / Then
+        #expect(policy.incomingOffset(progress: 1, totalWidth: 400) == -400)
+        #expect(policy.incomingOffset(progress: 0, totalWidth: 400) == 0)
+    }
+
+    @Test func test_incomingOffset_when_right_to_left_then_is_not_flipped_a_second_time() {
+        // Given SwiftUI already mirrors an offset for right-to-left layouts, the policy must return
+        // the same value for both directions. Applying `direction` here flipped it twice, which sent
+        // the incoming screen off the edge instead of over the outgoing one.
         let leftToRight = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
         let rightToLeft = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
 
         // When / Then
-        #expect(leftToRight.incomingOffset(progress: 1, totalWidth: 400) == -400)
-        #expect(rightToLeft.incomingOffset(progress: 1, totalWidth: 400) == 400)
-        #expect(leftToRight.incomingOffset(progress: 0, totalWidth: 400) == 0)
+        #expect(rightToLeft.incomingOffset(progress: 1, totalWidth: 400)
+                == leftToRight.incomingOffset(progress: 1, totalWidth: 400))
+        #expect(rightToLeft.outgoingParallaxOffset(progress: 1, totalWidth: 400)
+                == leftToRight.outgoingParallaxOffset(progress: 1, totalWidth: 400))
     }
 
     @Test func test_outgoingParallaxOffset_when_combined_with_the_container_then_leaves_only_the_parallax_travel() {
@@ -163,19 +175,6 @@ struct POSEdgeSwipePolicyTests {
 
         // Then
         #expect(netTravel == -totalWidth * POSEdgeSwipePolicy.outgoingParallaxFraction)
-    }
-
-    @Test func test_outgoingParallaxOffset_when_right_to_left_then_travel_mirrors() {
-        // Given
-        let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
-        let totalWidth: CGFloat = 400
-
-        // When
-        let netTravel = policy.incomingOffset(progress: 1, totalWidth: totalWidth)
-            + policy.outgoingParallaxOffset(progress: 1, totalWidth: totalWidth)
-
-        // Then
-        #expect(netTravel == totalWidth * POSEdgeSwipePolicy.outgoingParallaxFraction)
     }
 
     @Test func test_isPredominantlyHorizontal_when_drag_is_mostly_vertical_then_returns_false() {

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSEdgeSwipePolicyTests.swift
@@ -120,6 +120,64 @@ struct POSEdgeSwipePolicyTests {
         #expect(!policy.startsAtLeadingEdge(0, totalWidth: 400))
     }
 
+    @Test func test_incomingProgress_when_drag_is_in_flight_then_falls_from_one_to_zero() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When / Then
+        #expect(policy.incomingProgress(dragTranslation: 0, totalWidth: 400) == 1)
+        #expect(policy.incomingProgress(dragTranslation: 100, totalWidth: 400) == 0.75)
+        #expect(policy.incomingProgress(dragTranslation: 400, totalWidth: 400) == 0)
+    }
+
+    @Test func test_incomingProgress_when_drag_runs_past_the_edges_then_clamps() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+
+        // When / Then
+        #expect(policy.incomingProgress(dragTranslation: -50, totalWidth: 400) == 1)
+        #expect(policy.incomingProgress(dragTranslation: 900, totalWidth: 400) == 0)
+        #expect(policy.incomingProgress(dragTranslation: 0, totalWidth: 0) == 1)
+    }
+
+    @Test func test_incomingOffset_when_fully_navigated_then_moves_the_container_a_full_width() {
+        // Given
+        let leftToRight = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+        let rightToLeft = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
+
+        // When / Then
+        #expect(leftToRight.incomingOffset(progress: 1, totalWidth: 400) == -400)
+        #expect(rightToLeft.incomingOffset(progress: 1, totalWidth: 400) == 400)
+        #expect(leftToRight.incomingOffset(progress: 0, totalWidth: 400) == 0)
+    }
+
+    @Test func test_outgoingParallaxOffset_when_combined_with_the_container_then_leaves_only_the_parallax_travel() {
+        // Given the outgoing screen sits in the same container as the incoming one, its own offset
+        // has to cancel all but the parallax fraction of the container's travel.
+        let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)
+        let totalWidth: CGFloat = 400
+
+        // When
+        let netTravel = policy.incomingOffset(progress: 1, totalWidth: totalWidth)
+            + policy.outgoingParallaxOffset(progress: 1, totalWidth: totalWidth)
+
+        // Then
+        #expect(netTravel == -totalWidth * POSEdgeSwipePolicy.outgoingParallaxFraction)
+    }
+
+    @Test func test_outgoingParallaxOffset_when_right_to_left_then_travel_mirrors() {
+        // Given
+        let policy = POSEdgeSwipePolicy(layoutDirection: .rightToLeft)
+        let totalWidth: CGFloat = 400
+
+        // When
+        let netTravel = policy.incomingOffset(progress: 1, totalWidth: totalWidth)
+            + policy.outgoingParallaxOffset(progress: 1, totalWidth: totalWidth)
+
+        // Then
+        #expect(netTravel == totalWidth * POSEdgeSwipePolicy.outgoingParallaxFraction)
+    }
+
     @Test func test_isPredominantlyHorizontal_when_drag_is_mostly_vertical_then_returns_false() {
         // Given
         let policy = POSEdgeSwipePolicy(layoutDirection: .leftToRight)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.6
 -----
 - [*] Shipping Labels: Fixed purchased labels disappearing when an unfinished label has no carrier information. [https://github.com/woocommerce/woocommerce-ios/pull/17766]
+- [*] POS: On iPhone, opening an order or a settings section now slides in the way the rest of iOS does, and can be swiped back with the list tracking your finger. [https://github.com/woocommerce/woocommerce-ios/pull/17790]
 - [*] POS: On iPhone, you can now swipe from the left edge to go back, across search, checkout, the payment screens, refunds and hardware settings. [https://github.com/woocommerce/woocommerce-ios/pull/17789]
 - [***] POS: On stores running WooCommerce 11.1.0 or newer, refund totals are now calculated by the store instead of on the device. [https://github.com/woocommerce/woocommerce-ios/pull/17741]
 - [*] Orders: Product search results in the order form are now scrollable and selectable on iPhone in landscape. [https://github.com/woocommerce/woocommerce-ios/pull/17693]


### PR DESCRIPTION
## Description

**Second of two stacked PRs** adding back-swipe gestures to POS on phone. Based on #17789 — review that one first.

`POSNavigationSplitView` backs both Orders and Settings. On a phone it holds the list and the detail side by side in one `HStack` and moved the whole thing with a single offset, so both panes travelled together. That looks like the list being dragged in from the left rather than revealed underneath the detail.

Now:
- the container still moves a full width, so the detail arrives from the trailing edge and covers the screen
- the sidebar takes a counter-offset cancelling all but ~30% of that travel, so it drifts under the arriving pane the way a UIKit push does
- a dim over the sidebar and a narrow gradient just outside the detail's leading edge complete it

The same value drives the interactive back gesture. All of it is inert in regular width, where the value is zero because both panes are on screen and nothing slides. The arithmetic lives on `POSEdgeSwipePolicy` so it is unit-tested rather than trapped in a view.

Unfortunately, we can only apply this where the two views are in the same tree, in the same container, so not all spots can have the interactive gesture without further work... and probably bringing in more UIKit.

## Test Steps

On a phone, in POS's **Orders** and **Settings**:

1. Tap a row. The detail should cover the screen from the trailing edge while the list drifts ~30% and dims, with a soft edge falling on it. Not the two moving as one sheet.
2. No blank or white frame at any point.
3. Swipe back from the leading edge — the list should track the finger and the detail slide away over it. Release past ~35% completes; release short of it springs back.
4. **Swipe quickly across.** The edge shading should stay attached to the pane, not hang mid-screen.
5. Tap-driven pushes and swipe-driven ones should move at the same rate.

On an **iPad**:

6. **In a collapsed (Split View / Slide Over) window** — the back swipe should work, not stall after a few points. This is the case the coordinate-space change fixes.
7. Full width: side-by-side layout unchanged, no gesture active, no dim or edge shading.

## Screenshots

These videos cover the changes from both this PR, and #17789 

iPadOS 18

https://github.com/user-attachments/assets/94632458-2287-4591-a253-49def62ff5c6

iPadOS 26

https://github.com/user-attachments/assets/a25255f3-561e-4107-97ea-0fd1e3103efa

iOS 26

https://github.com/user-attachments/assets/1b56344c-164f-4473-9807-3b2b056d3cbf


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
