### PR TITLE
Fix POS tab flashing in the tab bar on a new store

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.6
 -----
 - [***] POS: On stores running WooCommerce 11.1.0 or newer, refund totals are now calculated by the store instead of on the device. [https://github.com/woocommerce/woocommerce-ios/pull/17741]
+- [*] POS: Fixed the POS tab briefly flashing into the tab bar while the app loads a store that is not eligible for POS. [https://github.com/woocommerce/woocommerce-ios/pull/17791]
 - [*] Orders: Product search results in the order form are now scrollable and selectable on iPhone in landscape. [https://github.com/woocommerce/woocommerce-ios/pull/17693]
 - [*] Fixed the swipe-back gesture sometimes failing when returning from detail screens. [https://github.com/woocommerce/woocommerce-ios/pull/17749]
 - [*] Analytics Hub: Fixed the interactive swipe-back gesture not working when opened from the Dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/17755]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -182,7 +182,9 @@ private extension POSTabVisibilityChecker {
             }
             return siteSettings.settings
         }
-        // If we get here, the stream completed without yielding any values for our site ID which is unexpected.
+        // The settings stream never completes on its own (it is backed by a CurrentValueSubject), so
+        // reaching this point means the surrounding task was cancelled, which ends the async iteration.
+        // Callers must treat the resulting verdict as indeterminate rather than acting on it.
         return []
     }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -915,6 +915,9 @@ private extension MainTabBarController {
         posEligibilityCheckTask = Task { @MainActor [weak self] in
             guard let self, let posTabVisibilityChecker = self.posTabVisibilityChecker else { return }
             let isPOSTabVisible = await posTabVisibilityChecker.checkVisibility()
+            // Cancellation ends the checker's site-settings wait early, so a superseded task resumes
+            // with an indeterminate verdict — it must not cache it or rebuild the tab bar (WOOMOB-3915).
+            guard !Task.isCancelled else { return }
             analytics.track(.pointOfSaleTabVisibilityChecked, withProperties: ["is_visible": isPOSTabVisible])
             cachePOSTabVisibility(siteID: siteID, isPOSTabVisible: isPOSTabVisible)
             let isBookingsTabVisible = shouldShowBookingsTab(isPOSTabVisible: isPOSTabVisible,

--- a/WooCommerce/WooCommerceTests/Mocks/MockPOSTabVisibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPOSTabVisibilityChecker.swift
@@ -5,12 +5,27 @@ final class MockPOSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     var initialVisibility: Bool = false
     var visibility: Bool = false
 
+    /// When `true`, `checkVisibility` suspends until the surrounding task is cancelled before
+    /// returning `visibility`, mimicking the real checker's site-settings wait being cut short
+    /// by cancellation and resuming with an indeterminate verdict.
+    var resolvesVisibilityOnlyOnCancellation: Bool = false
+
+    private(set) var visibilityCheckStarted = false
+    private(set) var visibilityCheckResolved = false
+
     func checkInitialVisibility() -> Bool {
         initialVisibility
     }
 
     @MainActor
     func checkVisibility() async -> Bool {
-        visibility
+        visibilityCheckStarted = true
+        if resolvesVisibilityOnlyOnCancellation {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        visibilityCheckResolved = true
+        return visibility
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
@@ -367,6 +367,55 @@ final class MainTabBarController_TabsTests: XCTestCase {
         XCTAssertEqual(viewControllersBeforeSiteChange, viewControllersAfterSiteChange)
     }
 
+    func test_pos_tab_is_not_inserted_when_superseded_visibility_check_resolves_after_cancellation() throws {
+        // Given a check that resolves `true` only once its task is cancelled, mimicking the
+        // indeterminate verdict a superseded checker produces when cancellation cuts its
+        // site-settings wait short (WOOMOB-3915).
+        let supersededChecker = MockPOSTabVisibilityChecker()
+        supersededChecker.resolvesVisibilityOnlyOnCancellation = true
+        supersededChecker.visibility = true
+
+        // The replacement check never resolves, so only the superseded check could alter the tab bar.
+        let pendingChecker = MockPOSTabVisibilityChecker()
+        pendingChecker.resolvesVisibilityOnlyOnCancellation = true
+
+        var factoryCallCount = 0
+        let storesManager = MockStoresManager(sessionManager: .makeForTesting())
+        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
+            return MainTabBarController(coder: coder,
+                                        featureFlagService: MockFeatureFlagService(),
+                                        stores: storesManager,
+                                        posTabVisibilityCheckerFactory: { _ in
+                                            factoryCallCount += 1
+                                            return factoryCallCount == 1 ? supersededChecker : pendingChecker
+                                        })
+        }) else {
+            return
+        }
+
+        // Trigger `viewDidLoad`
+        XCTAssertNotNil(tabBarController.view)
+
+        let siteID: Int64 = 3915
+        storesManager.updateDefaultStore(storeID: siteID)
+        storesManager.updateDefaultStore(.fake().copy(siteID: siteID))
+        waitUntil {
+            supersededChecker.visibilityCheckStarted
+        }
+
+        // When a second site emission supersedes the in-flight check, cancelling its task
+        storesManager.updateDefaultStore(.fake().copy(siteID: siteID))
+        waitUntil {
+            supersededChecker.visibilityCheckResolved
+        }
+        // Drains the superseded task's remaining main-actor continuation before asserting.
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        // Then the cancelled check's `true` verdict is discarded and the POS tab is never inserted
+        XCTAssertEqual(tabBarController.tabRootViewControllers.count, 4)
+        withExtendedLifetime(tabBarController) {}
+    }
+
     func test_pos_visibility_and_eligibility_are_rechecked_when_app_enters_foreground() throws {
         // Given
         let mockPOSVisibilityChecker = MockPOSTabVisibilityChecker()


### PR DESCRIPTION
WOOMOB-3915

## Description
On a freshly created store, the tab bar rendered without POS, briefly inserted the POS tab, then removed it again while My Store loaded. The cause is a task-cancellation race: `stores.site` emits more than once during login, and each emission restarts the POS visibility check while cancelling the previous check's task — but cancellation only ends the checker's `for await` over the site-settings stream, so the superseded task resumes with empty settings, skips the country check, and lets the feature flag alone report the tab as visible. That bogus verdict was applied to the tab bar, cached per site (making the next launch flash too), and tracked in analytics before the live check resolved the real answer and removed the tab. This PR makes superseded checks inert so the tab bar settles once, on the verdict of the newest check. Note that the blink is hard to notice in the iOS Simulator or with the debugger attached — it shows clearly on a real device running detached from Xcode.

- Discard a superseded visibility check's result in `MainTabBarController` (`guard !Task.isCancelled` after `checkVisibility()`), so it can no longer rebuild the tab bar, poison the cached visibility, or track a wrong `pointOfSaleTabVisibilityChecked` event.
- Correct the comment in `POSTabVisibilityChecker.waitForSiteSettingsRefresh()` — the settings stream never completes on its own, so reaching the empty fallback means the surrounding task was cancelled.
- Add a regression test that parks a visibility check until cancellation and verifies its late `true` verdict no longer inserts the POS tab (fails with 5 tabs instead of 4 without the fix).
- Extend `MockPOSTabVisibilityChecker` to optionally suspend until cancellation and expose check lifecycle flags for that test.

## Test Steps
⚠️ Test on a real device, launched detached from the debugger — the blink is not noticeable in the iOS Simulator or while the debugger is attached.

Verified reproduction flow (flashes on an unfixed build; the restart after installing Jetpack widens the race window because the site is re-synced while site settings are still refreshing):
1. Create a new Jurassic Ninja site with WooCommerce but no Jetpack, and log in to the app with site credentials.
2. Generate some products and orders (e.g. 100) with WC Smooth Generator (WP Admin → Tools → Smooth Generator).
3. Install Jetpack from the app (Menu → Settings → Install Jetpack).
4. Restart the app and watch the tab bar while My Store loads — it should settle once, with no POS tab flashing in and out.
5. Relaunch the app again and confirm the tab bar also settles once on subsequent launches (the cached visibility can no longer be poisoned by a superseded check).

Unit coverage: `MainTabBarController_TabsTests`, in particular `test_pos_tab_is_not_inserted_when_superseded_visibility_check_resolves_after_cancellation`.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

