### PR TITLE
[WOOMOB-3891] Improve Maestro login recovery and preflight

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -38,6 +38,12 @@ stores artifacts under `~/woocommerce-maestro-output/` by default.
 When exactly one built `WooCommerce.app` exists in the repository or Xcode
 DerivedData, `--app` is optional; multiple candidates fail with an explicit list.
 
+The selected simulator's first Preferred Language must be English (`en`, with
+any region). The doctor and runner fail before app installation or Maestro
+execution when another language is primary; they never change simulator
+settings automatically. The side-effect-free doctor does not boot a simulator,
+so boot the selected device before using it to validate language settings.
+
 ## Profiles
 
 ```bash

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -64,7 +64,9 @@ Run one flow or rerun failures:
 .maestro/scripts/run-smoke-tests.sh --app /path/to/WooCommerce.app --rerun-failed ~/woocommerce-maestro-output/SUITE-.../report.xml
 ```
 
-Each failed non-destructive flow is retried once; destructive mutation failures
+Each failed non-destructive flow is retried once. A pass on retry is reported as
+a passing flaky result: it does not fail the runner or JUnit, but remains visible
+in reports and selectable through `--rerun-failed`. Destructive mutation failures
 remain failed and proceed to cleanup without a blind retry. The final directory contains combined JUnit,
 HTML with direct artifact links and a faithful rerun command, per-attempt logs,
 screenshots, hierarchy/debug evidence, and a redacted JSON summary with final

--- a/.maestro/flows/login_no_jetpack.yaml
+++ b/.maestro/flows/login_no_jetpack.yaml
@@ -75,10 +75,7 @@ tags:
     commands:
       - tapOn: "Save"
 - runFlow:
-    when:
-      visible: "Save Password?"
-    commands:
-      - tapOn: "Not Now"
+    file: ../subflows/dismiss_save_password_prompt.yaml
 - extendedWaitUntil:
     visible: "Manage Privacy|Save Password\\?|Orders"
     timeout: 30000
@@ -88,10 +85,7 @@ tags:
     commands:
       - tapOn: "Save"
 - runFlow:
-    when:
-      visible: "Save Password?"
-    commands:
-      - tapOn: "Not Now"
+    file: ../subflows/dismiss_save_password_prompt.yaml
 - extendedWaitUntil:
     visible:
       id: "tab-bar-orders-item"

--- a/.maestro/flows/login_not_woo_store.yaml
+++ b/.maestro/flows/login_not_woo_store.yaml
@@ -92,10 +92,7 @@ tags:
             - tapOn:
                 id: "Continue Button"
       - runFlow:
-          when:
-            visible: "Save Password?"
-          commands:
-            - tapOn: "Not Now"
+          file: ../subflows/dismiss_save_password_prompt.yaml
 - extendedWaitUntil:
     visible: '.*is not a WooCommerce site\.'
     timeout: 60000

--- a/.maestro/flows/login_not_wp_site.yaml
+++ b/.maestro/flows/login_not_wp_site.yaml
@@ -26,4 +26,14 @@ tags:
     timeout: 30000
 - assertVisible: "Enter Another Store"
 - assertVisible: "Log In With Another Account"
+
+- tapOn: "Enter Another Store"
+- extendedWaitUntil:
+    visible:
+      id: "Site address"
+    timeout: 15000
+- assertVisible:
+    id: "Site address"
+    text: "https://google.com"
+    label: "Verify the last entered site address is preserved"
 - takeScreenshot: login_not_wp_site

--- a/.maestro/flows/login_wrong_account.yaml
+++ b/.maestro/flows/login_wrong_account.yaml
@@ -53,10 +53,7 @@ tags:
       - tapOn:
           id: "Continue Button"
 - runFlow:
-    when:
-      visible: "Save Password?"
-    commands:
-      - tapOn: "Not Now"
+    file: ../subflows/dismiss_save_password_prompt.yaml
 - extendedWaitUntil:
     visible: '.*is connected to a different account\.'
     timeout: 60000

--- a/.maestro/flows/login_wrong_credentials.yaml
+++ b/.maestro/flows/login_wrong_credentials.yaml
@@ -57,10 +57,7 @@ tags:
       - tapOn:
           id: "Continue Button"
 - runFlow:
-    when:
-      visible: "Save Password?"
-    commands:
-      - tapOn: "Not Now"
+    file: ../subflows/dismiss_save_password_prompt.yaml
 - extendedWaitUntil:
     visible:
       id: "Password Error"

--- a/.maestro/scripts/device_locale.py
+++ b/.maestro/scripts/device_locale.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate that an iOS simulator uses English as its primary language."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+
+LOCALE_RE = re.compile(r"^[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{1,8})*$")
+
+
+class SimulatorLocaleError(RuntimeError):
+    """Raised when the simulator language cannot be read or is not English."""
+
+
+@dataclass(frozen=True)
+class SimulatorLocale:
+    primary: str
+
+    @property
+    def message(self) -> str:
+        return f"simulator primary language {self.primary} is English (AppleLanguages)"
+
+
+CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def parse_primary_locale(value: str) -> str | None:
+    for line in value.splitlines():
+        candidate = line.strip().rstrip(",").strip()
+        if len(candidate) >= 2 and candidate[0] == candidate[-1] == '"':
+            candidate = candidate[1:-1]
+        if LOCALE_RE.fullmatch(candidate):
+            return candidate.replace("_", "-")
+    return None
+
+
+def read_simulator_locale(
+    device: str,
+    command_runner: CommandRunner = run_command,
+) -> SimulatorLocale:
+    command = [
+        "xcrun",
+        "simctl",
+        "spawn",
+        device,
+        "defaults",
+        "read",
+        "NSGlobalDomain",
+        "AppleLanguages",
+    ]
+    result = command_runner(command)
+    if result.returncode != 0:
+        details = [line.strip() for line in result.stderr.splitlines() if line.strip()]
+        reason = details[-1] if details else "AppleLanguages could not be read"
+        raise SimulatorLocaleError(
+            f"could not determine the primary language for simulator {device}: {reason}"
+        )
+    primary = parse_primary_locale(result.stdout)
+    if primary is None:
+        raise SimulatorLocaleError(
+            f"could not parse the primary language for simulator {device}"
+        )
+    return SimulatorLocale(primary=primary)
+
+
+def ensure_english_simulator_locale(
+    device: str,
+    command_runner: CommandRunner = run_command,
+) -> SimulatorLocale:
+    locale = read_simulator_locale(device, command_runner)
+    language = locale.primary.split("-", maxsplit=1)[0].lower()
+    if language != "en":
+        raise SimulatorLocaleError(
+            f"simulator {device} primary language is {locale.primary}; Maestro flows require English. "
+            "Make English the first Preferred Language in the simulator's Language & Region settings, "
+            "then rerun pre-flight"
+        )
+    return locale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Require an English primary language on an iOS simulator."
+    )
+    parser.add_argument("--device", required=True, help="iOS simulator UDID")
+    args = parser.parse_args()
+
+    try:
+        locale = ensure_english_simulator_locale(args.device)
+    except SimulatorLocaleError as error:
+        print(f"Setup error: {error}", file=sys.stderr)
+        return 1
+    print(locale.message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.maestro/scripts/doctor.py
+++ b/.maestro/scripts/doctor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 RUNNER_PATH = SCRIPT_DIR / "run-smoke-tests.py"
 CHECK_TOOLCHAIN = SCRIPT_DIR / "check-toolchain.py"
+DEVICE_LOCALE = SCRIPT_DIR / "device_locale.py"
 SPEC = importlib.util.spec_from_file_location("woo_maestro_runner", RUNNER_PATH)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError(f"Cannot load {RUNNER_PATH}")
@@ -36,6 +37,22 @@ def check_toolchain() -> tuple[bool, str]:
     details = [line.strip() for line in result.stderr.splitlines() if line.strip()]
     reason = details[-1] if details else "toolchain check failed"
     return False, f"toolchain: {reason}"
+
+
+def check_simulator_locale(device: str) -> tuple[bool, str]:
+    result = subprocess.run(
+        [sys.executable, str(DEVICE_LOCALE), "--device", device],
+        cwd=RUNNER.REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        details = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        return True, details[-1] if details else "simulator primary language is English"
+    details = [line.strip() for line in result.stderr.splitlines() if line.strip()]
+    reason = details[-1] if details else "simulator language check failed"
+    return False, f"simulator language: {reason}"
 
 
 def main() -> int:
@@ -71,6 +88,7 @@ def main() -> int:
     try:
         simulator = RUNNER.resolve_simulator(args.device, family, boot=False)
         checks.append((True, f"simulator: {simulator['name']} ({simulator['udid']})"))
+        checks.append(check_simulator_locale(simulator["udid"]))
     except (SystemExit, subprocess.SubprocessError) as error:
         checks.append((False, f"simulator: {error}"))
 

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -31,6 +31,7 @@ ENV_FILE = MAESTRO_DIR / ".env.local"
 CONFIG_FILE = MAESTRO_DIR / "config.yaml"
 LINT_ENV = SCRIPT_DIR / "lint-env.py"
 CHECK_TOOLCHAIN = SCRIPT_DIR / "check-toolchain.py"
+DEVICE_LOCALE = SCRIPT_DIR / "device_locale.py"
 OUTPUT_DEFAULT = Path.home() / "woocommerce-maestro-output"
 NOT_WOO_STORE_FLOW = "login_not_woo_store.yaml"
 NO_JETPACK_FLOW = "login_no_jetpack.yaml"
@@ -667,6 +668,13 @@ def main() -> int:
     validate_environment(flows, values, seed=args.seed)
     values = normalized_flow_environment(flows, values)
     simulator = resolve_simulator(args.device, family)
+    locale = run(
+        [sys.executable, str(DEVICE_LOCALE), "--device", simulator["udid"]],
+        capture=False,
+        check=False,
+    )
+    if locale.returncode:
+        return locale.returncode
     run(["xcrun", "simctl", "install", simulator["udid"], str(app)])
     summary = {
         "run_id": run_id, "profile": args.profile, "app": str(app), "app_id": app_id,

--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -72,7 +72,7 @@ ENV_REFERENCE_RE = re.compile(r"\$\{(MAESTRO_[A-Z0-9_]+)\}")
 SUBFLOW_REFERENCE_RE = re.compile(r"(?:file:|runFlow:)\s*([^\s#]+\.ya?ml)")
 STATUS_EXIT_CODES = {
     "PASS": 0,
-    "FLAKY": 1,
+    "FLAKY": 0,
     "FAIL": 1,
     "SETUP_ERROR": 2,
     "TIMED_OUT": 124,
@@ -279,7 +279,9 @@ def failed_flow_stems(report: Path) -> set[str]:
     root = ET.parse(report).getroot()
     stems: set[str] = set()
     for case in root.iter("testcase"):
-        if case.find("failure") is None and case.find("error") is None:
+        status = case.find("./properties/property[@name='maestro.status']")
+        is_flaky = status is not None and status.get("value") == "FLAKY"
+        if case.find("failure") is None and case.find("error") is None and not is_flaky:
             continue
         haystack = " ".join([case.get("name", ""), case.get("classname", ""), case.get("file", "")])
         stems.update(path.stem for path in FLOWS_DIR.glob("*.yaml") if path.stem in haystack)
@@ -459,18 +461,53 @@ def sanitize_artifacts(root: Path, values: dict[str, str], *, remove_images: boo
 def write_combined_junit(attempts: list[Attempt], destination: Path) -> tuple[int, int, int]:
     suites = ET.Element("testsuites")
     tests = failures = skipped = 0
+    attempts_by_execution: dict[tuple[Path, int], list[int]] = {}
     for attempt in attempts:
+        attempts_by_execution.setdefault((attempt.flow, attempt.repeat), []).append(
+            attempt.returncode
+        )
+    for attempt in attempts:
+        status = flow_status(attempts_by_execution[(attempt.flow, attempt.repeat)])
         if not attempt.junit.exists():
-            suite = ET.SubElement(suites, "testsuite", name=f"{attempt.flow.stem}-attempt-{attempt.number}", tests="1", failures="1")
+            is_flaky = status == "FLAKY"
+            suite = ET.SubElement(
+                suites,
+                "testsuite",
+                name=f"{attempt.flow.stem}-attempt-{attempt.number}",
+                tests="1",
+                failures="0" if is_flaky else "1",
+            )
             case = ET.SubElement(suite, "testcase", name=attempt.flow.stem, file=str(attempt.flow.relative_to(REPO_ROOT)))
-            ET.SubElement(case, "failure", message="Maestro did not produce JUnit output")
+            if is_flaky:
+                properties = ET.SubElement(case, "properties")
+                ET.SubElement(properties, "property", name="maestro.status", value="FLAKY")
+            else:
+                ET.SubElement(case, "failure", message="Maestro did not produce JUnit output")
             tests += 1
-            failures += 1
+            failures += int(not is_flaky)
             continue
         root = ET.parse(attempt.junit).getroot()
         children = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
         for suite in children:
             suite.set("name", f"{suite.get('name', attempt.flow.stem)} [run {attempt.repeat} attempt {attempt.number}]")
+            if status == "FLAKY":
+                suite.set("failures", "0")
+                suite.set("errors", "0")
+                for case in suite.iter("testcase"):
+                    for result in list(case):
+                        if result.tag in {"failure", "error"}:
+                            case.remove(result)
+                    properties = case.find("properties")
+                    if properties is None:
+                        properties = ET.Element("properties")
+                        case.insert(0, properties)
+                    existing = properties.find("property[@name='maestro.status']")
+                    if existing is None:
+                        ET.SubElement(properties, "property", name="maestro.status", value="FLAKY")
+                    else:
+                        existing.set("value", "FLAKY")
+            for case in suite.iter("testcase"):
+                case.set("file", str(attempt.flow.relative_to(REPO_ROOT)))
             suites.append(suite)
             tests += int(suite.get("tests", len(suite.findall("testcase"))))
             failures += int(suite.get("failures", "0")) + int(suite.get("errors", "0"))
@@ -796,8 +833,8 @@ def main() -> int:
         flow_timeout_seconds=args.flow_timeout_seconds,
     )
     sanitize_artifacts(output, values)
-    passed = statuses.count("PASS")
     flaky = statuses.count("FLAKY")
+    passed = statuses.count("PASS") + flaky
     failed = statuses.count("FAIL")
     timed_out = statuses.count("TIMED_OUT")
     suite_duration = round(time.monotonic() - suite_started)
@@ -810,7 +847,7 @@ def main() -> int:
     print(f"Simulator: {simulator['name']} ({simulator['udid']})")
     print(f"Bundle identifier: {app_id}")
     print(
-        f"Result: {passed} passed, {flaky} flaky, {failed} failed, {timed_out} timed out "
+        f"Result: {passed} passed ({flaky} flaky), {failed} failed, {timed_out} timed out "
         f"out of {total_runs} executions ({suite_duration}s)"
     )
     print(f"Overall status: {result.status}")

--- a/.maestro/scripts/tests/test_device_locale.py
+++ b/.maestro/scripts/tests/test_device_locale.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "device_locale.py"
+SPEC = importlib.util.spec_from_file_location("device_locale", SCRIPT)
+assert SPEC and SPEC.loader
+DEVICE_LOCALE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = DEVICE_LOCALE
+SPEC.loader.exec_module(DEVICE_LOCALE)
+
+
+class DeviceLocaleTests(unittest.TestCase):
+    def test_parse_primary_locale_reads_the_first_preferred_language(self) -> None:
+        output = '(\n    "en-ES",\n    "es-ES"\n)\n'
+
+        self.assertEqual("en-ES", DEVICE_LOCALE.parse_primary_locale(output))
+
+    def test_parse_primary_locale_accepts_unquoted_and_underscore_values(self) -> None:
+        self.assertEqual("en-US", DEVICE_LOCALE.parse_primary_locale("(\n    en_US\n)"))
+
+    def test_read_simulator_locale_uses_apple_languages(self) -> None:
+        commands: list[list[str]] = []
+
+        def command_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, '(\n    "en-GB"\n)\n', "")
+
+        locale = DEVICE_LOCALE.read_simulator_locale("sim-1", command_runner)
+
+        self.assertEqual("en-GB", locale.primary)
+        self.assertEqual(
+            [
+                "xcrun",
+                "simctl",
+                "spawn",
+                "sim-1",
+                "defaults",
+                "read",
+                "NSGlobalDomain",
+                "AppleLanguages",
+            ],
+            commands[0],
+        )
+
+    def test_english_region_is_accepted(self) -> None:
+        def command_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(command, 0, '(\n    "en-AU"\n)\n', "")
+
+        locale = DEVICE_LOCALE.ensure_english_simulator_locale("sim-1", command_runner)
+
+        self.assertEqual("en-AU", locale.primary)
+
+    def test_non_english_primary_language_is_rejected(self) -> None:
+        def command_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(command, 0, '(\n    "es-ES",\n    "en-ES"\n)\n', "")
+
+        with self.assertRaisesRegex(
+            DEVICE_LOCALE.SimulatorLocaleError,
+            "primary language is es-ES; Maestro flows require English",
+        ):
+            DEVICE_LOCALE.ensure_english_simulator_locale("sim-1", command_runner)
+
+    def test_unavailable_simulator_language_is_reported(self) -> None:
+        def command_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(command, 2, "", "Unable to boot device")
+
+        with self.assertRaisesRegex(
+            DEVICE_LOCALE.SimulatorLocaleError,
+            "Unable to boot device",
+        ):
+            DEVICE_LOCALE.read_simulator_locale("sim-1", command_runner)
+
+    def test_runner_checks_language_before_installing_the_app(self) -> None:
+        runner = (SCRIPT.parent / "run-smoke-tests.py").read_text(encoding="utf-8")
+
+        locale_check = runner.index("str(DEVICE_LOCALE)")
+        app_install = runner.index('["xcrun", "simctl", "install"')
+
+        self.assertLess(locale_check, app_install)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.maestro/scripts/tests/test_doctor.py
+++ b/.maestro/scripts/tests/test_doctor.py
@@ -17,6 +17,26 @@ SPEC.loader.exec_module(DOCTOR)
 
 
 class DoctorTests(unittest.TestCase):
+    def test_reports_non_english_simulator_language(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["device_locale.py"],
+            1,
+            stdout="",
+            stderr=(
+                "Setup error: simulator sim-1 primary language is es-ES; "
+                "Maestro flows require English\n"
+            ),
+        )
+        with mock.patch.object(DOCTOR.subprocess, "run", return_value=completed):
+            passed, message = DOCTOR.check_simulator_locale("sim-1")
+
+        self.assertFalse(passed)
+        self.assertEqual(
+            "simulator language: Setup error: simulator sim-1 primary language is es-ES; "
+            "Maestro flows require English",
+            message,
+        )
+
     def test_reports_repository_toolchain_mismatch(self) -> None:
         completed = subprocess.CompletedProcess(
             ["check-toolchain.py"],

--- a/.maestro/scripts/tests/test_login_contract.py
+++ b/.maestro/scripts/tests/test_login_contract.py
@@ -9,6 +9,29 @@ MAESTRO_ROOT = REPO_ROOT / ".maestro"
 
 
 class MaestroLoginContractTests(unittest.TestCase):
+    def test_login_flows_share_password_prompt_dismissal(self) -> None:
+        flow_paths = [
+            MAESTRO_ROOT / "flows" / name
+            for name in (
+                "login_no_jetpack.yaml",
+                "login_not_woo_store.yaml",
+                "login_wrong_account.yaml",
+                "login_wrong_credentials.yaml",
+            )
+        ]
+
+        for path in flow_paths:
+            with self.subTest(path=path):
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("../subflows/dismiss_save_password_prompt.yaml", source)
+                self.assertNotIn('visible: "Save Password?"', source)
+
+        shared_login = (MAESTRO_ROOT / "subflows" / "login.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("file: dismiss_save_password_prompt.yaml", shared_login)
+        self.assertNotIn('visible: "Save Password?"', shared_login)
+
     def test_non_wordpress_recovery_preserves_the_entered_address(self) -> None:
         source = (MAESTRO_ROOT / "flows" / "login_not_wp_site.yaml").read_text(
             encoding="utf-8"

--- a/.maestro/scripts/tests/test_login_contract.py
+++ b/.maestro/scripts/tests/test_login_contract.py
@@ -9,6 +9,21 @@ MAESTRO_ROOT = REPO_ROOT / ".maestro"
 
 
 class MaestroLoginContractTests(unittest.TestCase):
+    def test_non_wordpress_recovery_preserves_the_entered_address(self) -> None:
+        source = (MAESTRO_ROOT / "flows" / "login_not_wp_site.yaml").read_text(
+            encoding="utf-8"
+        )
+
+        recovery = source.index('- tapOn: "Enter Another Store"')
+        preserved_address = source.index(
+            '- assertVisible:\n'
+            '    id: "Site address"\n'
+            '    text: "https://google.com"\n'
+            '    label: "Verify the last entered site address is preserved"'
+        )
+
+        self.assertLess(recovery, preserved_address)
+
     def test_site_address_entry_waits_for_qr_fallback_or_legacy_form(self) -> None:
         source = (MAESTRO_ROOT / "subflows" / "open_site_address_login.yaml").read_text(
             encoding="utf-8"

--- a/.maestro/scripts/tests/test_runner.py
+++ b/.maestro/scripts/tests/test_runner.py
@@ -168,7 +168,7 @@ class RunnerTests(unittest.TestCase):
     def test_setup_error_has_a_distinct_nonzero_exit_code(self) -> None:
         self.assertEqual(2, RUNNER.status_exit_code("SETUP_ERROR"))
 
-    def test_flaky_retry_is_visible_in_junit_and_returns_nonzero(self) -> None:
+    def test_flaky_retry_is_a_passing_rerunnable_junit_result(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             flow = RUNNER.FLOWS_DIR / "dashboard_stats.yaml"
@@ -192,13 +192,19 @@ class RunnerTests(unittest.TestCase):
             result = RUNNER.finalize_suite(attempts, report)
 
             self.assertEqual("FLAKY", result.status)
-            self.assertEqual(1, result.exit_code)
+            self.assertEqual(0, result.exit_code)
             self.assertEqual(2, result.tests)
-            self.assertEqual(1, result.failures)
+            self.assertEqual(0, result.failures)
             suites = ET.parse(report).getroot().findall("testsuite")
             self.assertEqual(2, len(suites))
             self.assertIn("attempt 1", suites[0].get("name", ""))
             self.assertIn("attempt 2", suites[1].get("name", ""))
+            self.assertNotIn("<failure", report.read_text(encoding="utf-8"))
+            statuses = ET.parse(report).getroot().findall(
+                ".//property[@name='maestro.status']"
+            )
+            self.assertEqual(["FLAKY", "FLAKY"], [item.get("value") for item in statuses])
+            self.assertEqual({"dashboard_stats"}, RUNNER.failed_flow_stems(report))
 
     def test_completed_run_summary_records_final_status_and_attempts(self) -> None:
         flow = RUNNER.FLOWS_DIR / "dashboard_stats.yaml"

--- a/.maestro/subflows/dismiss_save_password_prompt.yaml
+++ b/.maestro/subflows/dismiss_save_password_prompt.yaml
@@ -1,0 +1,8 @@
+# Dismiss the iOS password-save prompt when it appears after authentication.
+appId: ${APP_ID}
+---
+- runFlow:
+    when:
+      visible: "Save Password?"
+    commands:
+      - tapOn: "Not Now"

--- a/.maestro/subflows/login.yaml
+++ b/.maestro/subflows/login.yaml
@@ -48,10 +48,7 @@ appId: ${APP_ID}
     visible: "Continue|Manage Privacy|Save Password.*|My store"
     timeout: 15000
 - runFlow:
-    when:
-      visible: "Save Password?"
-    commands:
-      - tapOn: "Not Now"
+    file: dismiss_save_password_prompt.yaml
 - extendedWaitUntil:
     visible: "Continue|Manage Privacy|My store"
     timeout: 15000


### PR DESCRIPTION
Part of: WOOMOB-3891

## Description

Ports the applicable authentication and session improvements identified while reviewing the Android Maestro login suite:

- Verifies that recovering from the non-WordPress error preserves the entered site address.
- Centralizes dismissal of the iOS password-save prompt across login flows.
- Requires English as the simulator's primary language in both the doctor and runner without modifying simulator settings automatically.
- Treats a non-destructive flow that passes on retry as a passing flaky result while retaining its diagnostics, JUnit status, and `--rerun-failed` eligibility.

The seven quarantined login flows remain excluded from release cadence until the WOOMOB-3891 manual runs provide first-attempt and repeated stability evidence.

## Test Steps

1. Run `python3 -m unittest discover .maestro/scripts/tests` and verify all tests pass.
2. Run `python3 .maestro/scripts/check-smoke-coverage.py` and verify the 98-item coverage snapshot passes.
3. Run `python3 -m py_compile .maestro/scripts/*.py` and `bash -n .maestro/scripts/*.sh`.
4. Boot an iPhone simulator with English as its first Preferred Language and run `.maestro/scripts/device_locale.py --device <simulator-udid>`; verify the detected `en` locale passes.
5. Make a non-English language primary and rerun the locale check; verify it fails with instructions to restore English. Restore English afterward.
6. Run `python3 .maestro/scripts/run-smoke-tests.py --plan --profile phone-full --include-tags login` and verify all eight login flows are selected.

## Screenshots

N/A — Maestro tooling and flow assertions only.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


