### PR TITLE
Make Product Form favorite menu synchronous

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -193,6 +193,14 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         viewModel.refreshProduct()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Task { @MainActor [weak self] in
+            await self?.viewModel.refreshFavoriteStatus()
+        }
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
@@ -348,15 +356,13 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     /// More Options button action
     ///
     @objc func didTapMoreOptions(_ sender: UIBarButtonItem) {
-        Task { @MainActor in
-            await presentMoreOptionsActionSheet(sender)
-        }
+        presentMoreOptionsActionSheet(sender)
     }
 
     /// Present More Options Action Sheet
     ///
     @MainActor
-    func presentMoreOptionsActionSheet(_ moreOptionsButton: UIBarButtonItem) async {
+    func presentMoreOptionsActionSheet(_ moreOptionsButton: UIBarButtonItem) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
@@ -387,7 +393,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         }
 
         if viewModel.canFavoriteProduct() {
-            if await viewModel.isFavorite() {
+            if viewModel.isFavorite() {
                 actionSheet.addDefaultActionWithTitle(ActionSheetStrings.Favorite.removeFromFavorite) { [weak self] _ in
                     ServiceLocator.analytics.track(event: .ProductForm.productDetailRemoveFromFavoriteButtonTapped())
                     self?.viewModel.removeFromFavorite()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -222,6 +222,9 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let favoriteProductsUseCase: FavoriteProductsUseCase
 
+    private var isFavoriteProduct = false
+    private var favoriteStatusRevision = 0
+
     /// Assign this closure to be notified when a new product is saved remotely
     ///
     var onProductCreated: (Product) -> Void = { _ in }
@@ -911,17 +914,32 @@ private extension ProductFormViewModel {
 
 // MARK: Favorite
 //
+@MainActor
 extension ProductFormViewModel {
-    @MainActor
-    func isFavorite() async -> Bool {
-        await favoriteProductsUseCase.isFavorite(productID: product.productID)
+    func refreshFavoriteStatus() async {
+        favoriteStatusRevision += 1
+        let revision = favoriteStatusRevision
+        let persistedFavoriteStatus = await favoriteProductsUseCase.isFavorite(productID: product.productID)
+
+        guard revision == favoriteStatusRevision else {
+            return
+        }
+        isFavoriteProduct = persistedFavoriteStatus
+    }
+
+    func isFavorite() -> Bool {
+        isFavoriteProduct
     }
 
     func markAsFavorite() {
+        favoriteStatusRevision += 1
+        isFavoriteProduct = true
         favoriteProductsUseCase.markAsFavorite(productID: product.productID)
     }
 
     func removeFromFavorite() {
+        favoriteStatusRevision += 1
+        isFavoriteProduct = false
         favoriteProductsUseCase.removeFromFavorite(productID: product.productID)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -201,10 +201,16 @@ protocol ProductFormViewModelProtocol {
 
     // Favorite actions
 
-    func isFavorite() async -> Bool
+    @MainActor
+    func refreshFavoriteStatus() async
 
+    @MainActor
+    func isFavorite() -> Bool
+
+    @MainActor
     func markAsFavorite()
 
+    @MainActor
     func removeFromFavorite()
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -509,7 +509,12 @@ extension ProductVariationFormViewModel {
 
 // MARK: Favorite
 //
+@MainActor
 extension ProductVariationFormViewModel {
+    func refreshFavoriteStatus() async {
+        // no-op
+    }
+
     func isFavorite() -> Bool {
         false
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFavoriteProductsUseCase.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFavoriteProductsUseCase.swift
@@ -7,6 +7,7 @@ final class MockFavoriteProductsUseCase: FavoriteProductsUseCase {
 
     var isFavoriteCalledForProductID: Int64?
     var isFavoriteValue = false
+    var onIsFavorite: (@MainActor () -> Void)?
 
     var favoriteProductIDsCalled = false
     var favoriteProductIDsValue: [Int64] = []
@@ -21,6 +22,7 @@ final class MockFavoriteProductsUseCase: FavoriteProductsUseCase {
 
     func isFavorite(productID: Int64) async -> Bool {
         isFavoriteCalledForProductID = productID
+        await onIsFavorite?()
         return isFavoriteValue
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -259,7 +259,50 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canFavoriteProduct())
     }
 
-    func test_markAsFavorite_marks_product_as_favorite() async {
+    @MainActor
+    func test_refreshFavoriteStatus_updates_cached_state() async {
+        // Given
+        let product = Product.fake()
+        let mockUseCase = MockFavoriteProductsUseCase()
+        mockUseCase.isFavoriteValue = true
+        let viewModel = createViewModel(product: product,
+                                        formType: .edit,
+                                        stores: stores,
+                                        favoriteProductsUseCase: mockUseCase)
+
+        // When
+        await viewModel.refreshFavoriteStatus()
+
+        // Then
+        XCTAssertTrue(viewModel.isFavorite())
+        XCTAssertEqual(mockUseCase.isFavoriteCalledForProductID, product.productID)
+    }
+
+    @MainActor
+    func test_refreshFavoriteStatus_does_not_override_newer_favorite_state() async {
+        // Given
+        let product = Product.fake()
+        let mockUseCase = MockFavoriteProductsUseCase()
+        mockUseCase.isFavoriteValue = false
+        var viewModel: ProductFormViewModel!
+        mockUseCase.onIsFavorite = {
+            viewModel.markAsFavorite()
+        }
+        viewModel = createViewModel(product: product,
+                                    formType: .edit,
+                                    stores: stores,
+                                    favoriteProductsUseCase: mockUseCase)
+
+        // When
+        await viewModel.refreshFavoriteStatus()
+        mockUseCase.onIsFavorite = nil
+
+        // Then
+        XCTAssertTrue(viewModel.isFavorite())
+    }
+
+    @MainActor
+    func test_markAsFavorite_marks_product_as_favorite_and_updates_cached_state() {
         // Given
         let product = Product.fake()
         let mockUseCase = MockFavoriteProductsUseCase()
@@ -272,22 +315,27 @@ final class ProductFormViewModelTests: XCTestCase {
         viewModel.markAsFavorite()
 
         // Then
+        XCTAssertTrue(viewModel.isFavorite())
         XCTAssertEqual(mockUseCase.markAsFavoriteCalledForProductID, product.productID)
     }
 
-    func test_removeFromFavorite_removes_product_as_favorite() async {
+    @MainActor
+    func test_removeFromFavorite_removes_product_as_favorite_and_updates_cached_state() async {
         // Given
         let product = Product.fake()
         let mockUseCase = MockFavoriteProductsUseCase()
+        mockUseCase.isFavoriteValue = true
         let viewModel = createViewModel(product: product,
                                         formType: .edit,
                                         stores: stores,
                                         favoriteProductsUseCase: mockUseCase)
+        await viewModel.refreshFavoriteStatus()
 
         // When
         viewModel.removeFromFavorite()
 
         // Then
+        XCTAssertFalse(viewModel.isFavorite())
         XCTAssertEqual(mockUseCase.removeFromFavoriteCalledForProductID, product.productID)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -178,6 +178,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canFavoriteProduct())
     }
 
+    @MainActor
     func test_isFavorite_is_false() {
         // Given
         let product = ProductVariation.fake().copy(status: .published)


### PR DESCRIPTION
## Description

This improvement came out of the review of #17776. The iOS 26 UIKit presentation issue addressed there is real and reproducible: the system can present the More Options menu and another modal at the same time, leaving the modal undismissable or causing a crash.

During the review, we noticed an additional avoidable timing window in the Product Form. `presentMoreOptionsActionSheet` awaited the favorite state before presenting the menu, giving the user more time to tap `...` again. This async call is not necessarily the root cause of the iOS 26 issue, but it may make the issue more prevalent.

This PR loads the product favorite state asynchronously when the Product Form appears and caches it in the view model. More Options can then be assembled and presented synchronously, while mark and remove actions update the cache immediately and continue persisting through the existing Yosemite-backed favorite-products mechanism.

This is a focused improvement and does not claim to fully resolve the underlying iOS 26 UIKit regression.

## Test Steps

1. Open a product, choose More Options, and mark it as a favorite.
2. Reopen the product and confirm More Options shows Remove from favorite.
3. Remove the product from favorites, reopen it, and confirm More Options shows Mark as favorite.
4. Mark a product in one store, switch stores and verify favorite state is site-specific, then switch back and confirm the original store retains its state.
5. Log out and back in, then confirm favorite state follows the current clearing behavior.
6. Tap More Options rapidly and repeatedly, dismissing between presentations, and confirm each menu shows only the expected Mark as favorite or Remove from favorite action.

The repeated-tap check validates the expected menu behavior in this refactor. It does not claim to resolve the separate iOS 26 UIKit regression.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
