### PR TITLE
Fix analytics site enrichment dropping caller-supplied `store_id` / `cached_woo_core_version`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,6 +23,7 @@
 - [Internal] Payments: Added the card reader discovery and connection Tracks events that iOS was missing, for parity with Android. [PR_URL]
 - [*] Order Creation: Scanning a subscription or bookable product now explains why it can't be added to an order instead of adding it. [https://github.com/woocommerce/woocommerce-ios/pull/17710]
 - [*] Orders paid via Scan to Pay or Mark as Paid now show their actual payment method instead of "Other". [https://github.com/woocommerce/woocommerce-ios/pull/17470]
+- [Internal] Analytics: Site enrichment no longer drops caller-supplied properties when the session cache is still empty [https://github.com/woocommerce/woocommerce-ios/pull/WOOMOB-3994]
 
 25.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,7 +23,7 @@
 - [Internal] Payments: Added the card reader discovery and connection Tracks events that iOS was missing, for parity with Android. [PR_URL]
 - [*] Order Creation: Scanning a subscription or bookable product now explains why it can't be added to an order instead of adding it. [https://github.com/woocommerce/woocommerce-ios/pull/17710]
 - [*] Orders paid via Scan to Pay or Mark as Paid now show their actual payment method instead of "Other". [https://github.com/woocommerce/woocommerce-ios/pull/17470]
-- [Internal] Analytics: Site enrichment no longer drops caller-supplied properties when the session cache is still empty [https://github.com/woocommerce/woocommerce-ios/pull/WOOMOB-3994]
+- [Internal] Analytics: Site enrichment no longer drops caller-supplied properties when the session cache is still empty [https://github.com/woocommerce/woocommerce-ios/pull/17809]
 
 25.5
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -233,8 +233,12 @@ fileprivate extension Analytics {
                 updatedProperties[key] = value
             }
         }
-        updatedProperties[PropertyKeys.storeID] = ServiceLocator.stores.sessionManager.defaultStoreUUID
-        updatedProperties[PropertyKeys.cachedWooCommerceVersionKey] = ServiceLocator.stores.sessionManager.cachedWooCommerceVersion
+        if let storeUUID = ServiceLocator.stores.sessionManager.defaultStoreUUID {
+            updatedProperties[PropertyKeys.storeID] = storeUUID
+        }
+        if let cachedWooCommerceVersion = ServiceLocator.stores.sessionManager.cachedWooCommerceVersion {
+            updatedProperties[PropertyKeys.cachedWooCommerceVersionKey] = cachedWooCommerceVersion
+        }
         return updatedProperties
     }
 

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -233,10 +233,10 @@ fileprivate extension Analytics {
                 updatedProperties[key] = value
             }
         }
-        if let storeUUID = ServiceLocator.stores.sessionManager.defaultStoreUUID {
+        if let storeUUID = ServiceLocator.stores.sessionManager.defaultStoreUUID, !storeUUID.isEmpty {
             updatedProperties[PropertyKeys.storeID] = storeUUID
         }
-        if let cachedWooCommerceVersion = ServiceLocator.stores.sessionManager.cachedWooCommerceVersion {
+        if let cachedWooCommerceVersion = ServiceLocator.stores.sessionManager.cachedWooCommerceVersion, !cachedWooCommerceVersion.isEmpty {
             updatedProperties[PropertyKeys.cachedWooCommerceVersionKey] = cachedWooCommerceVersion
         }
         return updatedProperties

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -428,6 +428,37 @@ class WooAnalyticsTests: XCTestCase {
         }
         XCTAssertNil(receivedProperties["store_id"])
     }
+
+    func test_track_by_raw_stat_name_when_session_values_are_nil_then_keeps_caller_supplied_store_and_version_properties() {
+        // Given
+        guard let testingProvider else {
+            return XCTFail("Testing provider not available")
+        }
+        // Session values are `nil` until the system information sync completes after login / cold start.
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                   defaultSite: Site.fake().copy(
+                                                                    siteID: sampleSiteID,
+                                                                    url: sampleSiteURL),
+                                                                   defaultStoreUUID: nil,
+                                                                   cachedWooCommerceVersion: nil))
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        let callerProperties: [AnyHashable: Any] = [
+            "cached_woo_core_version": "9.8.0",
+            "store_id": "caller_store_uuid"
+        ]
+
+        // When
+        analytics.track(WooAnalyticsStat.pointOfSaleLocalCatalogSyncFailed.rawValue, properties: callerProperties, error: nil)
+
+        // Then
+        guard let receivedProperties = testingProvider.receivedProperties.first else {
+            return XCTFail("No properties found")
+        }
+        XCTAssertEqual(receivedProperties["cached_woo_core_version"] as? String, "9.8.0")
+        XCTAssertEqual(receivedProperties["store_id"] as? String, "caller_store_uuid")
+        XCTAssertEqual(receivedProperties["blog_id"] as? Int64, sampleSiteID)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -459,6 +459,36 @@ class WooAnalyticsTests: XCTestCase {
         XCTAssertEqual(receivedProperties["store_id"] as? String, "caller_store_uuid")
         XCTAssertEqual(receivedProperties["blog_id"] as? Int64, sampleSiteID)
     }
+
+    func test_track_by_raw_stat_name_when_session_and_caller_both_have_values_then_session_values_win() {
+        // Given
+        guard let testingProvider else {
+            return XCTFail("Testing provider not available")
+        }
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                   defaultSite: Site.fake().copy(
+                                                                    siteID: sampleSiteID,
+                                                                    url: sampleSiteURL),
+                                                                   defaultStoreUUID: "session_store_uuid",
+                                                                   cachedWooCommerceVersion: "10.0"))
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        let callerProperties: [AnyHashable: Any] = [
+            "cached_woo_core_version": "9.8.0",
+            "store_id": "caller_store_uuid"
+        ]
+
+        // When
+        analytics.track(WooAnalyticsStat.pointOfSaleLocalCatalogSyncFailed.rawValue, properties: callerProperties, error: nil)
+
+        // Then
+        guard let receivedProperties = testingProvider.receivedProperties.first else {
+            return XCTFail("No properties found")
+        }
+        XCTAssertEqual(receivedProperties["cached_woo_core_version"] as? String, "10.0")
+        XCTAssertEqual(receivedProperties["store_id"] as? String, "session_store_uuid")
+        XCTAssertEqual(receivedProperties["blog_id"] as? Int64, sampleSiteID)
+    }
 }
 
 


### PR DESCRIPTION
Closes WOOMOB-3994

## Description

Analytics `appendSiteProperties` assigns `defaultStoreUUID` and `cachedWooCommerceVersion` straight into the event dictionary., however, both are `nil` until the system information sync finishes after login or cold start. This means that assigning `nil` through a dictionary subscript removes the key

`POSCatalogSyncCoordinator` had already attached `cached_woo_core_version` from plugin storage, so the enrichment deleted it exactly in the window where first syncs and their failures happen.

This PR only overwrites those two keys when the session has a value, keeping whatever the caller supplied otherwise. `blog_id` and the other site properties are unchanged.

## Test Steps
CI should pass

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
