### PR TITLE
Liquid Glass: (Try) Fix Order Details refresh-control crash on iOS 26

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 
 25.5
 -----
-- [*] Orders: Fixed a rare crash when opening order details on iOS 26. [PR_URL]
+- [*] Orders: Fixed a rare crash when opening order details on iOS 26. [https://github.com/woocommerce/woocommerce-ios/pull/17813]
 - [*] Orders: Fixed new orders not appearing automatically after push notifications when logged in with site credentials. [https://github.com/woocommerce/woocommerce-ios/pull/17736]
 - [*] Fixed in-app notices appearing too far above the keyboard or tab bar on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17743]
 - [Internal] POS: Fixed `waiting_time` reporting a Unix timestamp instead of an elapsed duration, restored site properties (`store_id`, `blog_id`, `site_url`) on events tracked by raw name, and added a `search_method` discriminator to the remote search event. [https://github.com/woocommerce/woocommerce-ios/pull/17731]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,6 @@
 
 25.5
 -----
-- [*] Orders: Fixed a rare crash when opening order details on iOS 26. [https://github.com/woocommerce/woocommerce-ios/pull/17813]
 - [*] Orders: Fixed new orders not appearing automatically after push notifications when logged in with site credentials. [https://github.com/woocommerce/woocommerce-ios/pull/17736]
 - [*] Fixed in-app notices appearing too far above the keyboard or tab bar on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17743]
 - [Internal] POS: Fixed `waiting_time` reporting a Unix timestamp instead of an elapsed duration, restored site properties (`store_id`, `blog_id`, `site_url`) on events tracked by raw name, and added a `search_method` discriminator to the remote search event. [https://github.com/woocommerce/woocommerce-ios/pull/17731]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.5
 -----
+- [*] Orders: Fixed a rare crash when opening order details on iOS 26. [PR_URL]
 - [*] Orders: Fixed new orders not appearing automatically after push notifications when logged in with site credentials. [https://github.com/woocommerce/woocommerce-ios/pull/17736]
 - [*] Fixed in-app notices appearing too far above the keyboard or tab bar on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17743]
 - [Internal] POS: Fixed `waiting_time` reporting a Unix timestamp instead of an elapsed duration, restored site properties (`store_id`, `blog_id`, `site_url`) on events tracked by raw name, and added a `search_method` discriminator to the remote search event. [https://github.com/woocommerce/woocommerce-ios/pull/17731]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -141,7 +141,13 @@ private extension OrderDetailsViewController {
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.refreshControl = refreshControl
+        if #available(iOS 26.0, *) {
+            // Work around WOOMOB-3694 by avoiding the navigation controller's refresh-control host, which can enter a recursive layout cycle.
+            // Order Details does not use large titles, so direct subview attachment preserves pull-to-refresh without that integration.
+            tableView.addSubview(refreshControl)
+        } else {
+            tableView.refreshControl = refreshControl
+        }
 
         tableView.dataSource = viewModel.dataSource
         tableView.accessibilityIdentifier = "order-details-table-view"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
@@ -9,6 +9,32 @@ import YosemiteTestHelpers
 
 final class OrderDetailsViewControllerTests: XCTestCase {
     @MainActor
+    func test_refresh_control_when_view_loads_on_iOS26_then_is_attached_as_subview() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("Requires iOS 26")
+        }
+
+        // Given
+        let storageManager = MockStorageManager()
+        let order = MockOrders().sampleOrder()
+        let storesManager = OrderDetailStoreManagerFactory.createManager(order: order)
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager)
+        let viewController = OrderDetailsViewController(viewModel: viewModel)
+
+        // When
+        viewController.loadViewIfNeeded()
+
+        // Then
+        let tableView = try Self.mirror(of: viewController).tableView
+        let refreshControls = tableView.subviews.compactMap { $0 as? UIRefreshControl }
+        let refreshControl = try XCTUnwrap(refreshControls.first)
+        XCTAssertEqual(refreshControls.count, 1)
+        XCTAssertNil(tableView.refreshControl)
+        XCTAssertTrue(refreshControl.isHidden)
+        XCTAssertFalse(refreshControl.isEnabled)
+    }
+
+    @MainActor
     func test_products_cell_is_not_visible_on_order_with_no_items() throws {
         // Given
         let storageManager = MockStorageManager()


### PR DESCRIPTION
Part of: WOOMOB-3694

## Description

We have Liquid Glass -related crashes. However, I wasn't able to reproduce them. According to the logs, iOS 26 can enter a recursive UIKit layout cycle through `_UINavigationControllerRefreshControlHost`, refresh-control visible height, scroll notifications, navigation layout, and safe-area updates.

The native stack does not identify the app-owned table. Sampled breadcrumbs repeatedly show Order Details active with requests completing shortly before the crash, so this targets that likely subtype. This is a speculative fix.

Confirmed crashes continued after #17611 deferred safe-area updates and #17742 attached the Order Details refresh control through:

```swift
tableView.refreshControl = refreshControl
```

Other investigated ways to reduce the cycle included removing explicit bottom scroll registration:

```swift
setContentScrollView(tableView, for: .bottom)
```

and changing refresh-control state or ownership around loading and navigation:

```swift
refreshControl.isHidden = false
refreshControl.isEnabled = true
tableView.refreshControl = nil
```

Those options affect more layout or lifecycle behavior than is appropriate for the `release/25.5` patch.

This patch makes one iOS 26-specific change:

```swift
tableView.addSubview(refreshControl)
```

This is an old way to add refresh control to tableView which is not recommended for views that use large titles. However, Order Details doesn't use it. The speculative guess is that using an old way of adding refreshControl will break some internal UIKit cycles of `tableView.refreshControl` which result in a crash.

Codex analysis:

```
UIKit’s iOS 26.5 implementation only enables _UINavigationControllerRefreshControlHost when scrollView.refreshControl is non-nil, while a directly added control installs the ordinary scroll-view refresh host. That confirms the patch targets the intended mechanism rather than merely changing syntax
```

## Test Steps

1. On iOS 26, open Order Details and wait for initial synchronization.
2. Pull to refresh. Confirm synchronization starts and the spinner stops.
3. Complete and cancel an edge-swipe back gesture while refreshing.
4. Navigate back, switch tabs, change window size (if on iPad)
5. On iOS 18, confirm Order Details pull-to-refresh is unchanged.

## Screenshots

https://github.com/user-attachments/assets/f8714423-80eb-48d1-a5c2-62ded8ec9d89


https://github.com/user-attachments/assets/0908fa4f-221e-4960-acaa-4ee2fd2be54c

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
