### PR TITLE
[Swift 6] Update `swift-tools-version` to 6.0 + pin modules per language mode + migrate initial modules

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -145,7 +145,7 @@ let package = Package(
         .target(
             name: "Codegen",
             exclude: ["README.md", "Sourcery"], // Relative to sources path
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .target(
             name: "Experiments",
@@ -153,7 +153,7 @@ let package = Package(
                 "WooFoundationCore",
                 .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
             ],
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .target(
             name: "Fakes",
@@ -267,7 +267,7 @@ let package = Package(
         .target(
             name: "WPMediaPicker",
             resources: [.process("Resources")],
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .target(
             name: "Yosemite",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -1,6 +1,12 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
+
+// Explicit Swift language mode per target. Tools version 6.0 defaults every target to
+// language mode 6, so targets that are not migrated yet must be pinned to .v5.
+// A target moves to `swift6` once it compiles cleanly under complete concurrency checking.
+let swift5: [SwiftSetting] = [.swiftLanguageMode(.v5)]
+let swift6: [SwiftSetting] = [.swiftLanguageMode(.v6)]
 
 let package = Package(
     name: "Modules",
@@ -133,18 +139,21 @@ let package = Package(
     targets: XcodeSupport.targets + [
         .target(
             name: "APIMocks",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "Codegen",
-            exclude: ["README.md", "Sourcery"] // Relative to sources path
+            exclude: ["README.md", "Sourcery"], // Relative to sources path
+            swiftSettings: swift5
         ),
         .target(
             name: "Experiments",
             dependencies: [
                 "WooFoundationCore",
                 .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
             name: "Fakes",
@@ -153,7 +162,8 @@ let package = Package(
                 "Hardware",
                 "Networking",
                 "Yosemite"
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
             name: "Hardware",
@@ -163,7 +173,8 @@ let package = Package(
                 .product(name: "StripeTerminal", package: "stripe-terminal-ios"),
                 .product(name: "StarIO10", package: "StarXpand-SDK-iOS")
             ],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "Networking",
@@ -176,7 +187,8 @@ let package = Package(
                 .product(name: "Aztec", package: "AztecEditor-iOS"),
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                 .product(name: "KeychainAccess", package: "KeychainAccess"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
             name: "NetworkingCore",
@@ -186,7 +198,8 @@ let package = Package(
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                 .product(name: "HTMLParser", package: "AztecEditor-iOS"),
                 .product(name: "KeychainAccess", package: "KeychainAccess"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
             name: "Storage",
@@ -196,18 +209,21 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift")
             ],
             exclude: ["Model/Migrations.md"],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "TestKit",
-            dependencies: ["Difference", "Nimble"]
+            dependencies: ["Difference", "Nimble"],
+            swiftSettings: swift5
         ),
         .target(
             name: "UITestsFoundation",
             dependencies: [
                 .product(name: "ScreenObject", package: "ScreenObject"),
                 .product(name: "XCUITestHelpers", package: "ScreenObject"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
             name: "WooFoundation",
@@ -215,7 +231,8 @@ let package = Package(
                 "WooFoundationCore",
                 .product(name: "Kingfisher", package: "Kingfisher")
             ],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "WooFoundationCore",
@@ -223,28 +240,34 @@ let package = Package(
                 "Codegen",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
             ],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "WordPressShared",
             dependencies: [
                 .target(name: "WordPressSharedObjC"),
             ],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "WordPressSharedObjC",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
-        .target(name: "WordPressUIObjC"),
+        .target(name: "WordPressUIObjC",
+                swiftSettings: swift5),
         .target(
             name: "WordPressUI",
             dependencies: [.target(name: "WordPressUIObjC")],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "WPMediaPicker",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "Yosemite",
@@ -261,17 +284,20 @@ let package = Package(
                 .product(name: "KeychainAccess", package: "KeychainAccess"),
                 .product(name: "StripeTerminal", package: "stripe-terminal-ios"),
                 .product(name: "WordPressEditor", package: "AztecEditor-iOS"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
             name: "YosemiteTestHelpers",
-            dependencies: ["Yosemite"]
+            dependencies: ["Yosemite"],
+            swiftSettings: swift5
         ),
         .target(
             name: "ParcelFittingCheck",
             dependencies: [
                 "EventHorizonSDK",
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
             name: "PointOfSale",
@@ -284,7 +310,8 @@ let package = Package(
                 .product(name: "Shimmer", package: "SwiftUI-Shimmer"),
                 .product(name: "Kingfisher", package: "Kingfisher"),
             ],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .target(
             name: "WooAIAssistant",
@@ -292,28 +319,33 @@ let package = Package(
                 "WooFoundation",
                 "NetworkingCore",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .target(
-            name: "StoreDesignSystem"
+            name: "StoreDesignSystem",
+            swiftSettings: swift5
         ),
         .target(
             name: "NetworkingTestsResponsesFixtures",
             path: "Tests/NetworkingTestsResponsesFixtures",
-            resources: [.process("Responses")]
+            resources: [.process("Responses")],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "ExperimentsTests",
             dependencies: [
                 "Experiments",
                 .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "HardwareTests",
             dependencies: [
                 "Hardware"
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "NetworkingTests",
@@ -326,7 +358,8 @@ let package = Package(
                 "WooFoundation",
                 "WordPressShared",
                 .product(name: "KeychainAccess", package: "KeychainAccess"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "StorageTests",
@@ -334,24 +367,29 @@ let package = Package(
                 "Storage",
                 "TestKit"
             ],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "WooFoundationTests",
-            dependencies: ["TestKit", .target(name: "WooFoundation")]
+            dependencies: ["TestKit", .target(name: "WooFoundation")],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "WordPressUITests",
-            dependencies: [.target(name: "WordPressUI")]
+            dependencies: [.target(name: "WordPressUI")],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "WordPressSharedTests",
-            dependencies: [.target(name: "WordPressShared")]
+            dependencies: [.target(name: "WordPressShared")],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "WordPressSharedObjCTests",
             dependencies: [.target(name: "WordPressShared")],
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "YosemiteTests",
@@ -367,7 +405,8 @@ let package = Package(
             ],
             resources: [
                 .process("Resources"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "PointOfSaleTests",
@@ -377,24 +416,28 @@ let package = Package(
                 "Fakes",
                 "TestKit",
                 "WooFoundation"
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "WooAIAssistantTests",
             dependencies: [
                 .target(name: "WooAIAssistant"),
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "ParcelFittingCheckTests",
             dependencies: [
                 .target(name: "ParcelFittingCheck"),
                 "EventHorizonSDK",
-            ]
+            ],
+            swiftSettings: swift5
         ),
         .testTarget(
             name: "StoreDesignSystemTests",
-            dependencies: ["StoreDesignSystem"]
+            dependencies: ["StoreDesignSystem"],
+            swiftSettings: swift5
         ),
         .binaryTarget(
             name: "EventHorizonSDK",
@@ -598,7 +641,8 @@ extension Target {
         .target(
             name: name.supportingName,
             dependencies: dependencies,
-            path: "Sources/XcodeSupport/\(name.replacing(" ", with: "-").supportingName)"
+            path: "Sources/XcodeSupport/\(name.replacing(" ", with: "-").supportingName)",
+            swiftSettings: swift5
         )
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1469,7 +1469,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.automattic.alpha.woocommerce";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -2246,7 +2245,6 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "WooCommerce Development";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "WooCommerce Catalyst Development";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -2273,7 +2271,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.automattic.woocommerce";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";

--- a/config/WooCommerce.common.xcconfig
+++ b/config/WooCommerce.common.xcconfig
@@ -4,3 +4,7 @@
 // This is App Store account id.
 // Build configurations that need the Enterprise account should override in their dedicated xcconfig.
 DEVELOPMENT_TEAM = PZYM8XX95Q
+
+// Single source of truth for concurrency checking in ordinary builds.
+// Targets already migrated to Swift 6 are enforced by the compiler instead.
+SWIFT_STRICT_CONCURRENCY = minimal


### PR DESCRIPTION
## Description
Closes WOOMOB-4008
Closes WOOMOB-4009

First infrastructure step of the incremental Swift 6 migration:
- No feature code.
- Concurrency checking is unchanged for existing code.
- The Danger warning telling us to resolve packages is a false positive, `swift package resolve` does nothing because there is nothing to do.

## Changes
- Centralize `SWIFT_STRICT_CONCURRENCY`. It was set on the app target only, which silently overrides anything set higher up. At this point the effective value is still `minimal` everywhere.
- Bump `Modules/Package.swift` to tools version 6.0, so targets can be moved to Swift 6 one at a time.
- Move `Codegen`, `Experiments` and `WPMediaPicker` to Swift 6. Measured zero warnings under complete concurrency checking so can be moved as initial pass.

## Test Steps
- CI should pass

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
