### PR TITLE
Revert "Match WooCommerce core when deciding if an order can be refunded"

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,7 +17,6 @@
 - [*] Payments: Update card reader's statement descriptor validation rules [https://github.com/woocommerce/woocommerce-ios/pull/17751]
 - [*] Settings: Fixed the bottom of the settings list being cut off behind the tab bar on iOS 26. [https://github.com/woocommerce/woocommerce-ios/pull/17765]
 - [Internal] POS: Refund submission events now use the POS Tracks prefix when issued from POS. [https://github.com/woocommerce/woocommerce-ios/pull/17744]
-- [*] Order Details: Orders paid offline can now be refunded from the app, matching the behavior on the web. [https://github.com/woocommerce/woocommerce-ios/pull/17764]
 - [*] Order creation: the Add Shipping button now stays above the keyboard after returning from the shipping method picker. [https://github.com/woocommerce/woocommerce-ios/pull/17767]
 - [Internal] POS: Removed the WooCommerce 10.5.0 sunset warning banner that promised an August 1st requirement that is not enforced. [https://github.com/woocommerce/woocommerce-ios/pull/17763]
 - [Internal] Payments: Added the card reader discovery and connection Tracks events that iOS was missing, for parity with Android. [PR_URL]

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -51,14 +51,9 @@ final class OrderDetailsDataSource: NSObject {
         return order.datePaid == nil
     }
 
-    /// Whether the order has anything left to refund.
-    ///
-    /// This deliberately does not check whether the order was paid. WooCommerce core gates its own Refund button on
-    /// the same question (`woocommerce_admin_order_should_render_refunds`), because nothing in the API reliably says
-    /// that money arrived: `date_paid` is only set by `payment_complete()`, so an order paid offline never gets one.
-    ///
     var isEligibleForRefund: Bool {
         guard !isRefundedStatus,
+              order.datePaid != nil,
               refundableOrderItemsDeterminer.isAnythingToRefund(from: order, with: refunds, currencyFormatter: currencyFormatter) else {
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -163,10 +163,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(issueRefundRow)
     }
 
-    func test_refund_button_is_visible_when_there_is_no_date_paid() throws {
+    func test_refund_button_is_not_visible_when_there_is_no_date_paid() throws {
         // Given
-        // Orders paid offline never go through `payment_complete()`, so they have no `date_paid`. WooCommerce core
-        // refunds them all the same, gating only on whether anything is left to refund.
         let order = makeOrder().copy(datePaid: .some(nil))
         let orderRefundsOptionsDeterminer = MockOrderRefundsOptionsDeterminer(isAnythingToRefund: true)
         let dataSource = OrderDetailsDataSource(order: order,
@@ -181,7 +179,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         let issueRefundRow = row(row: .issueRefundButton, in: paymentSection)
-        XCTAssertNotNil(issueRefundRow)
+        XCTAssertNil(issueRefundRow)
     }
 
     func test_refund_button_is_not_visible_when_the_order_status_is_refunded() throws {


### PR DESCRIPTION
Pauses WOOMOB-3593. Reverts #17764.

## Description

This puts back the `datePaid != nil` condition in `isEligibleForRefund`, restores the original expectation in `OrderDetailsDataSourceTests`, and drops the release note. The unused `Experiments` import that #17764 removed stays removed.

This is a temporary pause, not a rejection of the fix. We are waiting for the decision on Core to be taken so we can align with it.

Two things changed since #17764 merged:

1. **Its justification does not hold.** The PR said an order completed by hand never gets a `date_paid`. It does. Core's `WC_Order::set_status()` calls `maybe_set_date_paid()`, which stamps one on any transition to the order's payment-complete status, manual changes included. Verified against WooCommerce 10.7.0. The orders that genuinely lack one are those left pending, on hold, failed or cancelled.
2. **Core is treating the behaviour we aligned with as a bug.** WOOPLUG-7524 tracks the Refund button showing on unpaid and pending orders in wp-admin, with the expected behaviour being that it should not appear on orders that were never paid. That is a product decision still pending. Until it lands, matching wp-admin means matching something core plans to change.

The Android counterpart (woocommerce/woocommerce-android#16510) was stopped for the same reason and never merged.

## Test Steps

1. Open a Pending or On hold order with no payment recorded. Issue Refund is hidden, as it was in 25.5.
2. Open a Completed or Processing order paid by card. Issue Refund is still shown and refunding still works.
3. Open a fully refunded order. Issue Refund is still hidden.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.