### PR TITLE
[Swift 6] Make POS card reader value types Sendable

### DIFF
--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentCardReader.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentCardReader.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CardPresentPaymentCardReader: Equatable {
+public struct CardPresentPaymentCardReader: Equatable, Sendable {
     let name: String
 
     /// The reader's battery level, if available.

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentReaderConnectionResult.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentReaderConnectionResult.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum CardPresentPaymentReaderConnectionResult {
+public enum CardPresentPaymentReaderConnectionResult: Sendable {
     case connected(CardPresentPaymentCardReader)
     case canceled
 }


### PR DESCRIPTION
Closes WOOMOB-4018

## Description
Removes 13 strict-concurrency warnings in the POS card-present payment flow by explicitely declaring these as `Sendable`. No behaviour change.

## Test Steps (optional)
1. On iPad, open the POS tab and connect a card reader.
2. Reader name and battery level show as before. 
3. Processing and cancelling a payment works normally.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
