### PR TITLE
[Swift 6] Make payment gateway models sendable

### DIFF
--- a/Modules/Sources/Networking/Model/PaymentGateway.swift
+++ b/Modules/Sources/Networking/Model/PaymentGateway.swift
@@ -3,11 +3,11 @@ import Codegen
 
 /// Represents a Payment Gateway.
 ///
-public struct PaymentGateway: Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct PaymentGateway: Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
 
     /// Features for payment gateway.
     ///
-    public enum Feature: Equatable {
+    public enum Feature: Equatable, Sendable {
         case products
         case refunds
         case custom(raw: String)
@@ -15,7 +15,7 @@ public struct PaymentGateway: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// Setting for a payment gateway
     ///
-    public struct Setting: Equatable, GeneratedCopiable, GeneratedFakeable {
+    public struct Setting: Equatable, Sendable, GeneratedCopiable, GeneratedFakeable {
         public let settingID: String
         public let value: String
 

--- a/Modules/Sources/Networking/Model/PaymentGatewayAccount.swift
+++ b/Modules/Sources/Networking/Model/PaymentGatewayAccount.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Payment Gateway Account.
 ///
-public struct PaymentGatewayAccount: Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct PaymentGatewayAccount: Equatable, Sendable, GeneratedCopiable, GeneratedFakeable {
 
     /// Site identifier.
     ///

--- a/Modules/Sources/Networking/Model/WCPayCardBrand.swift
+++ b/Modules/Sources/Networking/Model/WCPayCardBrand.swift
@@ -7,7 +7,7 @@ import Codegen
 /// The endpoint returns a thin wrapper around the Stripe object, so
 /// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-brand)
 ///
-public enum WCPayCardBrand: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public enum WCPayCardBrand: String, Codable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case amex
     case cartesBancaires = "cartes_bancaires"
     case diners

--- a/Modules/Sources/Networking/Model/WCPayCardFunding.swift
+++ b/Modules/Sources/Networking/Model/WCPayCardFunding.swift
@@ -9,7 +9,7 @@ import Codegen
 ///
 /// e.g. `credit`, `debit`, `prepaid`
 ///
-public enum WCPayCardFunding: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public enum WCPayCardFunding: String, Codable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case credit
     case debit
     case prepaid

--- a/Modules/Sources/Networking/Model/WCPayCardPaymentDetails.swift
+++ b/Modules/Sources/Networking/Model/WCPayCardPaymentDetails.swift
@@ -7,7 +7,7 @@ import Codegen
 /// The endpoint returns a thin wrapper around the Stripe object, so
 /// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card)
 ///
-public struct WCPayCardPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public struct WCPayCardPaymentDetails: Codable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The brand of the card used to pay, e.g. `amex`, `mastercard`, `visa`
     public let brand: WCPayCardBrand
 

--- a/Modules/Sources/Networking/Model/WCPayCardPresentPaymentDetails.swift
+++ b/Modules/Sources/Networking/Model/WCPayCardPresentPaymentDetails.swift
@@ -7,7 +7,7 @@ import Codegen
 /// The endpoint returns a thin wrapper around the Stripe object, so
 /// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present)
 ///
-public struct WCPayCardPresentPaymentDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public struct WCPayCardPresentPaymentDetails: Codable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The brand of the card, e.g. `amex`, `mastercard`, `visa`, etc
     public let brand: WCPayCardBrand
 

--- a/Modules/Sources/Networking/Model/WCPayCardPresentReceiptDetails.swift
+++ b/Modules/Sources/Networking/Model/WCPayCardPresentReceiptDetails.swift
@@ -9,7 +9,7 @@ import Codegen
 ///
 /// Custom receipt field details can be found in [Stripe's documentation](https://stripe.com/docs/terminal/features/receipts#custom)
 ///
-public struct WCPayCardPresentReceiptDetails: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public struct WCPayCardPresentReceiptDetails: Codable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The funding method for the account used to pay, e.g. `credit`, `debit`, `prepaid`, `unknown`
     public let accountType: WCPayCardFunding
 

--- a/Modules/Sources/Networking/Model/WCPayCharge.swift
+++ b/Modules/Sources/Networking/Model/WCPayCharge.swift
@@ -7,7 +7,7 @@ import Codegen
 /// The endpoint returns a thin wrapper around the Stripe object, so
 /// [these docs are relevant](https://stripe.com/docs/api/charges/object)
 ///
-public struct WCPayCharge: Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public struct WCPayCharge: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The siteID of the site that the charge relates to
     public let siteID: Int64
 

--- a/Modules/Sources/Networking/Model/WCPayChargeStatus.swift
+++ b/Modules/Sources/Networking/Model/WCPayChargeStatus.swift
@@ -7,7 +7,7 @@ import Codegen
 /// The endpoint returns a thin wrapper around the Stripe object, so
 /// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-status)
 ///
-public enum WCPayChargeStatus: String, Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public enum WCPayChargeStatus: String, Decodable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case succeeded
     case pending
     case failed

--- a/Modules/Sources/Networking/Model/WCPayPaymentMethodDetails.swift
+++ b/Modules/Sources/Networking/Model/WCPayPaymentMethodDetails.swift
@@ -7,7 +7,7 @@ import Codegen
 /// The endpoint returns a thin wrapper around the Stripe object, so
 /// [these docs are relevant](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details)
 ///
-public enum WCPayPaymentMethodDetails: Decodable, GeneratedCopiable, GeneratedFakeable, Equatable {
+public enum WCPayPaymentMethodDetails: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case unknown
 
     /// A card payment, with `details`. This represents a payment made online, rather than in-person


### PR DESCRIPTION
Closes WOOMOB-4017

## Description
Adds checked `Sendable` to `WCPayCharge`, `PaymentGateway`, `PaymentGatewayAccount` and the payload types they hold. 

No behaviour change.

## Test Steps (optional)
1. Open an order paid by card and view its payment/receipt detail. Card brand, last 4 digits, funding type and so on should render as before.
2. Settings > Payments loads the gateway list.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
