### PR TITLE
[Swift 6] Adapt `StoreDesignSystem` to Swift 6

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -324,7 +324,7 @@ let package = Package(
         ),
         .target(
             name: "StoreDesignSystem",
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .target(
             name: "NetworkingTestsResponsesFixtures",
@@ -437,7 +437,7 @@ let package = Package(
         .testTarget(
             name: "StoreDesignSystemTests",
             dependencies: ["StoreDesignSystem"],
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .binaryTarget(
             name: "EventHorizonSDK",

--- a/Modules/Sources/StoreDesignSystem/Components/Badge/StoreBadgeTone.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Badge/StoreBadgeTone.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// - Note: A closed type holding the color roles per tone; `background` and `border` are optional
 ///   (`nil` means no fill / no border). Caution and Warning map to their like-named container
 ///   tokens, matching the Android `WooBadge`.
-public struct StoreBadgeTone {
+public struct StoreBadgeTone: Sendable {
     struct Appearance {
         let background: Color?
         let foreground: Color

--- a/Modules/Sources/StoreDesignSystem/Components/Button/StoreButtonSize.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Button/StoreButtonSize.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 /// - Note: A closed type — only the design sizes exist, each carrying its own typography, icon
 ///   size, padding, and corner radius, so there are no per-size branches at the call site or style.
-public struct StoreButtonSize {
+public struct StoreButtonSize: Sendable {
     let textStyle: StoreTextStyle
     let iconSize: StoreIconSize
     let horizontalPadding: CGFloat

--- a/Modules/Sources/StoreDesignSystem/Components/Button/StoreButtonVariant.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Button/StoreButtonVariant.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 /// - Note: A closed type holding only the enabled color roles; the disabled presentation is derived
 ///   uniformly by ``StoreButtonStyle`` from the state-layer rule, so it isn't duplicated per variant.
-public struct StoreButtonVariant {
+public struct StoreButtonVariant: Sendable {
     /// The enabled-state color roles. `background` and `border` are optional: `nil` means
     /// the variant has no fill / no border.
     struct Appearance {

--- a/Modules/Sources/StoreDesignSystem/Components/Checkbox/StoreCheckboxVariant.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Checkbox/StoreCheckboxVariant.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// - Note: A closed type holding the enabled accent and its `on`-color (the mark tint); the disabled
 ///   presentation is derived uniformly by ``StoreCheckboxStyle`` from the state-layer rule, so it
 ///   isn't duplicated per tone.
-public struct StoreCheckboxVariant {
+public struct StoreCheckboxVariant: Sendable {
     let accent: Color
     let onColor: Color
 

--- a/Modules/Sources/StoreDesignSystem/Components/Divider/StoreDividerVariant.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Divider/StoreDividerVariant.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 ///
 /// - Note: A closed type holding the horizontal inset per variant. `full` spans edge to edge;
 ///   `inset` aligns the line with inset content.
-public struct StoreDividerVariant {
+public struct StoreDividerVariant: Sendable {
     let horizontalInset: CGFloat
 
     private init(horizontalInset: CGFloat) {

--- a/Modules/Sources/StoreDesignSystem/Components/IconContainer/StoreIconContainerTone.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/IconContainer/StoreIconContainerTone.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 /// - Note: A closed type holding the background and foreground color roles per tone. The tones map
 ///   to the Woo palette ramps, matching the Android `WooIconContainerTone`.
-public struct StoreIconContainerTone {
+public struct StoreIconContainerTone: Sendable {
     struct Appearance {
         let background: Color
         let foreground: Color

--- a/Modules/Sources/StoreDesignSystem/Components/NoticeBanner/StoreNoticeBannerTone.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/NoticeBanner/StoreNoticeBannerTone.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 /// - Note: A closed type holding the color roles for one tone. `background` and `border` are
 ///   optional (`nil` means no fill / no border); only the neutral-outlined tone is bordered.
-public struct StoreNoticeBannerTone {
+public struct StoreNoticeBannerTone: Sendable {
     /// The tone's color roles. `background` and `border` are optional: `nil` means no fill / no border.
     struct Appearance {
         let background: Color?

--- a/Modules/Sources/StoreDesignSystem/Tokens/Icons/StoreIconImage.swift
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Icons/StoreIconImage.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct StoreIconImage {
+public struct StoreIconImage: Sendable {
     private let assetName: String
 
     init(_ assetName: String) {

--- a/Modules/Sources/StoreDesignSystem/Tokens/Icons/StoreIconSize.swift
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Icons/StoreIconSize.swift
@@ -5,7 +5,7 @@ import CoreGraphics
 /// CGFloat parameters, icon size is a closed type: its only consumer is our own
 /// `StoreIconImage.image(size:)`, so typing it blocks arbitrary sizes and enables
 /// dot-shorthand (`.image(size: .medium)`).
-public struct StoreIconSize {
+public struct StoreIconSize: Sendable {
     let value: CGFloat
 
     private init(_ value: CGFloat) {

--- a/Modules/Sources/StoreDesignSystem/Tokens/Typography/StoreTextStyle.swift
+++ b/Modules/Sources/StoreDesignSystem/Tokens/Typography/StoreTextStyle.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct StoreTextStyle: Equatable {
+public struct StoreTextStyle: Equatable, Sendable {
     public let size: CGFloat
     public let lineHeight: CGFloat
     public let tracking: CGFloat


### PR DESCRIPTION
Closes WOOMOB-4024

## Description
Adds checked `Sendable` to the ten public token and variant types in StoreDesignSystem, which clears all 221 strict-concurrency warnings in the module.

With the module and its test target both at zero, this also flips them to `swiftSettings: swift6` in `Modules/Package.swift`.

No behaviour change: `Sendable` is compile-time only.

## Test Steps (Optional)
1. Settings > Debug (Debug/Alpha builds only) > Design System.
2. Browse the catalog. Everything should render as before.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
