### PR TITLE
Fix POS refunds failing with "Invalid refund amount" on tax-inclusive stores

### DIFF
--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -699,11 +699,15 @@ public extension OrdersRemote {
     /// - Returns: The loaded Order.
     /// - Throws: Network or parsing errors.
     func loadPOSOrder(siteID: Int64, orderID: Int64) async throws -> Order {
+        let parameters: RequestParameterConvertibleDictionary = [
+            ParameterKeys.decimalPlaces: OrdersRemote.Defaults.decimalPoints
+        ]
         let path = "\(Constants.ordersPath)/\(orderID)"
         let request = JetpackRequest(wooApiVersion: .mark3,
                                    method: .get,
                                    siteID: siteID,
                                    path: path,
+                                   parameters: parameters,
                                    availableAsRESTRequest: true)
         let mapper = OrderMapper(siteID: siteID)
 

--- a/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -1170,6 +1170,18 @@ final class OrdersRemoteTests: XCTestCase {
         XCTAssertFalse(fields.contains("meta_data"))
     }
 
+    func test_loadPOSOrder_requests_full_precision_amounts() async throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+
+        // When
+        _ = try? await remote.loadPOSOrder(siteID: sampleSiteID, orderID: sampleOrderID)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        XCTAssertEqual(request.parameters["dp"] as? String, "8")
+    }
+
     func test_loadPOSOrders_by_orderIDs_excludes_meta_data_from_fields() async throws {
         // Given
         let remote = OrdersRemote(network: network)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.7
 -----
+- [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax.
 
 
 25.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 25.7
 -----
-- [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax.
+- [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax. [https://github.com/woocommerce/woocommerce-ios/pull/17827]
 
 
 25.6

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -153,7 +153,7 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         case .fallbackToLocal:
             serverPreviewTotals[selectionKey] = nil
             let components = refundMapping.refundComponents(from: selectedItems, context: context)
-            let values = refundMapping.refundValues(items: components.items, fees: components.fees)
+            let values = refundMapping.refundValues(items: components.items, fees: components.fees, order: context.order)
             return reviewData(subtotal: values.subtotal,
                               tax: values.tax,
                               total: values.total,
@@ -205,7 +205,7 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         }
 
         let components = refundMapping.refundComponents(from: selectedItems, context: context)
-        let values = refundMapping.refundValues(items: components.items, fees: components.fees)
+        let values = refundMapping.refundValues(items: components.items, fees: components.fees, order: context.order)
         // A server-computed create is only allowed when this exact selection was previewed
         // successfully; otherwise the classic v3 create path is used.
         let serverPreviewTotal = serverPreviewTotals[SelectionKey(orderID: preparation.orderID,

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
@@ -145,12 +145,20 @@ struct POSRefundSubmissionMapping {
         return productLines + feeLines
     }
 
-    func refundValues(items: [RefundableOrderItem], fees: [OrderFeeLine]) -> (subtotal: Decimal, tax: Decimal, total: Decimal) {
+    func refundValues(items: [RefundableOrderItem],
+                      fees: [OrderFeeLine],
+                      order: Order) -> (subtotal: Decimal, tax: Decimal, total: Decimal) {
         let itemValues = RefundItemsValuesCalculationUseCase(refundItems: items, currencyFormatter: currencyFormatter).calculateRefundValues()
         let feeValues = RefundFeesCalculationUseCase(fees: fees, currencyFormatter: currencyFormatter).calculateRefundValues()
         let subtotal = itemValues.subtotal + feeValues.subtotal
         let tax = itemValues.tax + feeValues.tax
-        return (subtotal, tax, subtotal + tax)
+        var total = subtotal + tax
+
+        if let maxRefundableAmount = maxRefundableAmount(for: order) {
+            total = min(total, maxRefundableAmount)
+        }
+
+        return (subtotal, tax, total)
     }
 
     func apiAmountString(for amount: Decimal) -> String {
@@ -187,6 +195,14 @@ struct POSRefundSubmissionMapping {
 }
 
 private extension POSRefundSubmissionMapping {
+    func maxRefundableAmount(for order: Order) -> Decimal? {
+        guard let orderTotal = currencyFormatter.convertToDecimal(order.total) as Decimal? else {
+            return nil
+        }
+        let totalRefunded = TotalRefundedCalculationUseCase(order: order, currencyFormatter: currencyFormatter).totalRefunded().decimalValue
+        return max(orderTotal + totalRefunded, .zero)
+    }
+
     /// The tax-inclusive amount to request for a fee line, or nil for a zero-total fee.
     /// Zero lines must be dropped from both the preview and the computed create: the server
     /// rejects a gross line refund of zero with `invalid_refund_total`, and a zero line

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionAdaptorTests.swift
@@ -265,12 +265,70 @@ struct POSRefundSubmissionAdaptorTests {
                                                reason: nil)
         }
     }
+
+    @Test func prepareReviewData_when_rounded_tax_inclusive_line_sums_above_order_total_then_shows_order_total() async throws {
+        // Given a tax-inclusive line whose rounded total and rounded tax sum to 10.00 on a 9.99 order
+        let sut = makeSUT(previewResult: nil, flagEnabled: false, order: taxInclusiveRoundedUpOrder())
+        let preparation = try await sut.adaptor.prepareRefund(for: posOrder())
+
+        // When
+        let reviewData = try await sut.adaptor.prepareReviewData(for: posOrder(),
+                                                                 preparation: preparation,
+                                                                 selectedItems: preparation.selectableItems,
+                                                                 reason: nil)
+
+        // Then the reviewed total is capped at what the order can still refund
+        #expect(reviewData.formattedRefundTotal == "$9.99")
+        #expect(reviewData.calculationFlow == .local)
+    }
+
+    @Test func submitRefund_when_rounded_tax_inclusive_line_sums_above_order_total_then_submits_order_total() async throws {
+        // Given the same order, reviewed on the local path
+        let sut = makeSUT(previewResult: nil, flagEnabled: false, order: taxInclusiveRoundedUpOrder())
+        let preparation = try await sut.adaptor.prepareRefund(for: posOrder())
+        _ = try await sut.adaptor.prepareReviewData(for: posOrder(),
+                                                    preparation: preparation,
+                                                    selectedItems: preparation.selectableItems,
+                                                    reason: nil)
+
+        // When
+        try await sut.adaptor.submitRefund(for: posOrder(),
+                                           preparation: preparation,
+                                           selectedItems: preparation.selectableItems,
+                                           reason: nil)
+
+        // Then the amount the server would reject as "Invalid refund amount" is never sent
+        #expect(sut.spy.classicCreateAmount == "9.99")
+    }
+
+    @Test func submitRefund_when_order_is_partly_refunded_then_caps_amount_at_the_remaining_total() async throws {
+        // Given an $11.00 order with $10.00 already refunded, and a selection worth $11.00
+        let refund = OrderRefundCondensed(refundID: 1, reason: nil, total: "-10.00")
+        let sut = makeSUT(previewResult: nil,
+                          flagEnabled: false,
+                          order: order().copy(total: "11.00", refunds: [refund]))
+        let preparation = try await sut.adaptor.prepareRefund(for: posOrder())
+        _ = try await sut.adaptor.prepareReviewData(for: posOrder(),
+                                                    preparation: preparation,
+                                                    selectedItems: preparation.selectableItems,
+                                                    reason: nil)
+
+        // When
+        try await sut.adaptor.submitRefund(for: posOrder(),
+                                           preparation: preparation,
+                                           selectedItems: preparation.selectableItems,
+                                           reason: nil)
+
+        // Then
+        #expect(sut.spy.classicCreateAmount == "1")
+    }
 }
 
 private extension POSRefundSubmissionAdaptorTests {
 
     final class RefundActionSpy {
         var dispatchedClassicCreate = false
+        var classicCreateAmount: String?
     }
 
     /// `RefundServiceProtocol` mock pinned to the main actor so the manual-resolution list and the
@@ -350,6 +408,7 @@ private extension POSRefundSubmissionAdaptorTests {
             switch action {
             case .createRefund(_, _, let refund, let onCompletion):
                 spy.dispatchedClassicCreate = true
+                spy.classicCreateAmount = refund.amount
                 onCompletion(refund, nil)
             case .retrieveRefund(_, _, _, let onCompletion):
                 onCompletion(.fake(), nil)
@@ -416,6 +475,24 @@ private extension POSRefundSubmissionAdaptorTests {
                                                         subtotal: "10.00",
                                                         total: "10.00",
                                                         totalTax: "1.00")],
+                          refunds: [])
+    }
+
+    /// A tax-inclusive line whose money strings the API already rounded up: 8.325 -> "8.33" and
+    /// 1.665 -> "1.67". Summing them gives 10.00, a penny above the 9.99 order total.
+    func taxInclusiveRoundedUpOrder() -> Order {
+        Order.fake().copy(siteID: siteID,
+                          orderID: orderID,
+                          currency: "USD",
+                          total: "9.99",
+                          items: [OrderItem.fake().copy(itemID: 10,
+                                                        quantity: 1,
+                                                        price: NSDecimalNumber(string: "8.325"),
+                                                        subtotal: "8.33",
+                                                        subtotalTax: "1.67",
+                                                        taxes: [OrderItemTax(taxID: 1, subtotal: "1.67", total: "1.67")],
+                                                        total: "8.33",
+                                                        totalTax: "1.67")],
                           refunds: [])
     }
 


### PR DESCRIPTION
## Description

Fixes [WOOMOB-3966](https://linear.app/a8c/issue/WOOMOB-3966). On a store that enters prices inclusive of tax, a POS refund fails with `woocommerce_rest_cannot_create_order_refund: Invalid refund amount`, and the review screen shows a total a penny above the order total.

This is [WOOMOB-3514](https://linear.app/a8c/issue/WOOMOB-3514) recurring in the POS path. That fix landed in `IssueRefundViewModel` only, so the main app's refund flow was protected and POS was not.

### What happens

`OrdersRemote.loadPOSOrder` sent no `dp`, so WooCommerce formatted every money string at the store's 2 decimals. For a £9.99 line at 20% inclusive VAT:

| Field | API returned | True value |
| -- | -- | -- |
| `line_items[0].total` | `"8.33"` | 8.325 |
| `line_items[0].taxes[0].total` | `"1.67"` | 1.665 |

The local refund calculation sums the two and gets 10.00. `wc_create_refund()` rejects anything above the remaining refundable amount, which is 9.99.

### The fix

1. `loadPOSOrder` now sends `dp=8`, so the line and tax totals arrive at full precision and sum to exactly 9.99. The POS order create and update POSTs already send `dp=8` — this GET was the only one that did not. This removes the cause rather than capping the symptom, and it is the only part that fixes a **partial** refund: refunding 1 of 3 such units asks for 10.00 against 29.97 remaining, which is under the cap, so a clamp alone would let it through and over-refund by a penny.

2. `POSRefundSubmissionMapping.refundValues` clamps the total to `order.total - alreadyRefunded`, mirroring `IssueRefundViewModel.calculateRefundTotal`. Both `prepareReviewData`'s `.fallbackToLocal` branch and `submitRefund` read the same clamped value, so the displayed total and the submitted amount stay equal and the app cannot send an amount the server will reject.

The server-calculated path (WooCommerce 11.1.0+) is untouched — it already replaces the local total with the preview total.

### Unit tests

All passing:

- `POSRefundSubmissionAdaptorTests` — three new cases over a line with `total: "8.33"`, `taxes: [total: "1.67"]`, `price: 8.325` against a `9.99` order: the reviewed total is `$9.99`, the submitted amount is `"9.99"` not `"10"`, and a partly refunded order caps at the remaining total.
- `OrdersRemoteTests.test_loadPOSOrder_requests_full_precision_amounts` — the GET sends `dp=8`.

Also ran the existing `POSRefundSubmissionAdaptorTests`, `POSRefundSubmissionMappingTests`, `POSRefundFlowResolverTests`, `POSServerRefundPreviewUseCaseTests` and `RefundItemsValuesCalculationUseCaseTests` — 39 tests, no failures. SwiftLint is clean.

## Test Steps

**Device verification is still outstanding.** It needs a store with prices entered inclusive of tax, "round tax at subtotal level" off, a 20% rate, and a product priced so the split lands on a half-penny (9.99 → 8.325 + 1.665), on WooCommerce below 11.1.0 so the local path is used.

1. On such a store, sell one unit of the 9.99 product in POS and take payment.
2. POS → Orders → that order → Issue refund → select the item → Refund.
3. The review screen shows 9.99, not 10.00, and the refund succeeds.
4. Repeat with 3 units in the order and refund 1: the refund is 9.99, and the order's remaining refundable drops by exactly 9.99.

## Screenshots

No layout or copy changes. The only visible difference is the refund total on the POS refund review screen, 10.00 before and 9.99 after, which needs the tax setup above to reproduce. Screenshots to follow with device verification.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
