### PR TITLE
[WOOMOB-3896] Automate lab store provisioning for the Maestro suite

### DIFF
--- a/.claude/skills/setup-test-stores/SKILL.md
+++ b/.claude/skills/setup-test-stores/SKILL.md
@@ -22,9 +22,26 @@ hand against a site created in a browser.
 - `expect` on PATH (ships with macOS) for password-based SSH.
 - A **WordPress.com test account with two-factor authentication disabled**. The OAuth
   password grant used to connect Jetpack cannot answer a 2FA challenge non-interactively.
-  Never use a personal or production account.
+  Never use a personal or production account. The account is read from `.env.local`, or
+  from `MAESTRO_WOO_LAB_WPCOM_EMAIL` / `MAESTRO_WOO_LAB_WPCOM_PASSWORD` in the
+  environment; see step 0.
 
 ## Steps
+
+0. **Make sure the WordPress.com account is available.** The script needs a test account
+   to connect Jetpack to, and it cannot prompt when run by an agent because there is no
+   terminal attached; it will exit with a message naming what is missing.
+
+   If `.env.local` has no `MAESTRO_WOO_LAB_WPCOM_EMAIL` / `MAESTRO_WOO_LAB_WPCOM_PASSWORD`,
+   stop and ask the user to either add those two lines themselves, or run the script
+   directly in their own terminal, where it prompts without echoing:
+
+   ```bash
+   .maestro/scripts/setup-jn-store.sh --site <domain>.jurassic.ninja
+   ```
+
+   Do not ask the user to paste a password into the conversation, and never pass one as a
+   command-line argument.
 
 1. **Check whether setup is already usable.** If `.maestro/.env.local` exists, read
    `MAESTRO_WOO_LAB_JETPACK_STORE_URL` and the consumer key/secret, then probe:
@@ -67,9 +84,8 @@ hand against a site created in a browser.
    finish installing), connects Jetpack, creates the API keys, and writes
    `.maestro/.env.local`.
 
-   If `.env.local` has no WordPress.com account yet, the script prompts for it
-   interactively. Let it prompt: do not collect the password yourself and do not pass it
-   as an argument.
+   This assumes `.env.local` already has `MAESTRO_WOO_LAB_WPCOM_EMAIL` and
+   `MAESTRO_WOO_LAB_WPCOM_PASSWORD`. If it does not, see step 0.
 
 5. **Report** the store URL and blog ID. Do not print any credential.
 

--- a/.claude/skills/setup-test-stores/SKILL.md
+++ b/.claude/skills/setup-test-stores/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: setup-test-stores
+description: Provision a disposable Jurassic Ninja store for the Maestro smoke suite, connect Jetpack to the developer's own WordPress.com test account, create WooCommerce API keys, and write .maestro/.env.local. Use when Maestro setup is missing, when .env.local points at an expired store, or when a clean store is wanted.
+user-invocable: true
+allowed-tools: "Bash, Read, mcp__context-a8c__context-a8c-load-provider, mcp__context-a8c__context-a8c-execute-tool"
+argument-hint: "[--fresh]"
+---
+
+# Set up a Maestro test store
+
+Provisions a Jurassic Ninja (JN) site and configures it as the Maestro lab store.
+Site creation is only possible through the `jurassic-ninja` ContextA8C MCP, so this
+skill drives that part; everything after "site exists and its password is known" is
+handled by `.maestro/scripts/setup-jn-store.sh`, which a developer can also run by
+hand against a site created in a browser.
+
+## Prerequisites
+
+- ContextA8C MCP configured with the `jurassic-ninja` provider (see `.agents/rules/context-a8c.md`).
+- App credentials present at `~/.configure/woocommerce-ios/secrets/woo_app_credentials.json`.
+  If missing, run `rake dependencies`.
+- `expect` on PATH (ships with macOS) for password-based SSH.
+- A **WordPress.com test account with two-factor authentication disabled**. The OAuth
+  password grant used to connect Jetpack cannot answer a 2FA challenge non-interactively.
+  Never use a personal or production account.
+
+## Steps
+
+1. **Check whether setup is already usable.** If `.maestro/.env.local` exists, read
+   `MAESTRO_WOO_LAB_JETPACK_STORE_URL` and the consumer key/secret, then probe:
+
+   ```bash
+   curl -s -o /dev/null -w '%{http_code}' -u "$CK:$CS" "$STORE/wp-json/wc/v3/products?per_page=1"
+   ```
+
+   A `200` means the store is alive and the keys work; report that and stop, unless the
+   user passed `--fresh`. Anything else means the store is gone or expired: continue, and
+   reuse the existing WP.com account lines rather than asking for them again.
+
+2. **Provision a site.**
+
+   ```
+   provision-site  features: {"woocommerce":"true","woocommerce-import-sample-data":"true","jetpack":"true"}
+   ```
+
+   Note the returned `domain`.
+
+3. **Fetch its password.**
+
+   ```
+   list-sites  domain: <domain>, include_passwords: true, include_config: true
+   ```
+
+   `JN_PASSWORD` in the returned config is both the wp-admin and the SSH password. The
+   admin username is `demo`.
+
+   Do not echo this value in your reply.
+
+4. **Configure the store.** Pass the password through the environment so it never lands
+   in `ps` output:
+
+   ```bash
+   JN_SSH_PASS='<JN_PASSWORD>' .maestro/scripts/setup-jn-store.sh --site <domain>
+   ```
+
+   The script waits for JN to finish provisioning (it answers HTTP before its plugins
+   finish installing), connects Jetpack, creates the API keys, and writes
+   `.maestro/.env.local`.
+
+   If `.env.local` has no WordPress.com account yet, the script prompts for it
+   interactively. Let it prompt: do not collect the password yourself and do not pass it
+   as an argument.
+
+5. **Report** the store URL and blog ID. Do not print any credential.
+
+## Verifying
+
+```bash
+.maestro/scripts/lint-env.py
+.maestro/scripts/doctor.sh --app "$APP" --include-tags products --exclude-tags "" --seed --device "$UDID"
+```
+
+The doctor should report all credentials present. Scoping by tag is deliberate: with
+`--profile phone-full` it also demands the negative-login fixtures, which this skill does
+not yet provision, and reports them missing.
+
+## What the provisioned store supports
+
+A fresh store has the WooCommerce sample products, and is known-good for the products
+flows and basic dashboard flows.
+
+It has **no orders, customers, or coupons**, and its onboarding profile is unset, so these
+are expected to fail against it: `orders_list_and_search`, `dashboard_view_all_analytics`,
+`orders_create` (needs `MAESTRO_WOO_EXISTING_CUSTOMER_SEARCH`), and the coupon flows.
+Seeding that data is not yet automated.
+
+The negative-login fixtures (`MAESTRO_WOO_NO_JETPACK_*`, `MAESTRO_WOO_NOT_A_WOO_STORE_*`,
+`MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL`) are also not provisioned yet, so the login flows
+that need them remain unconfigured.
+
+## Notes
+
+- JN sites expire after 7 days of inactivity. Re-run this skill when a store stops
+  responding; it reuses the WordPress.com account already in `.env.local`.
+- Only test stores and test accounts. Destructive flows publish and delete real data.
+- The previous `.env.local` is backed up outside the repository, because `.gitignore`
+  matches `.env.local` exactly and a sibling backup file would not be ignored.

--- a/.maestro/CONTRACT.md
+++ b/.maestro/CONTRACT.md
@@ -39,6 +39,10 @@ fixtures and optional for self-hosted fixtures. Set both or leave both blank.
 The runner removes a trailing `/wp-admin` or `/wp-admin/` from the no-Jetpack
 site URL before passing it to the app.
 
+Variables written by store-setup tooling (`MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_USERNAME`
+and `MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_PASSWORD`) are never required by a flow and are
+never forwarded to Maestro; they exist so a provisioned store can be reconfigured later.
+
 `MAESTRO_WOO_CONSUMER_KEY` and `MAESTRO_WOO_CONSUMER_SECRET` are optional and
 are validated only when explicit REST seeding or cleanup is requested. Local
 runs may load `.maestro/.env.local`; CI injects protected environment variables

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -24,6 +24,9 @@ release archive into the workspace, verifies the SHA-256 in
 3. Copy `env.example` to `.env.local` and fill it locally.
    WordPress.com-hosted not-Woo fixtures require the dedicated WP.com pair.
    Jurassic Ninja `/wp-admin` or `/wp-admin/` URLs are normalized to the site root.
+
+   The lab store can be provisioned instead of filled in by hand. See
+   [Provisioning a lab store](#provisioning-a-lab-store) below.
 4. Run the linter and side-effect-free doctor without printing values or
    booting a simulator:
 
@@ -37,6 +40,50 @@ compatible simulator, installs the app, generates a unique `SUITE_RUN_ID`, and
 stores artifacts under `~/woocommerce-maestro-output/` by default.
 When exactly one built `WooCommerce.app` exists in the repository or Xcode
 DerivedData, `--app` is optional; multiple candidates fail with an explicit list.
+
+## Provisioning a lab store
+
+`.maestro/scripts/setup-jn-store.sh` turns a Jurassic Ninja site into the lab store:
+it connects Jetpack to your own WordPress.com test account, creates WooCommerce REST
+API keys, and writes the matching `.env.local` entries. Everything site-side runs over
+SSH and wp-cli; only the two WordPress.com calls go over HTTP. No Jetpack partner
+credentials are involved.
+
+The quickest path is the `/setup-test-stores` skill, which creates the site through the
+`jurassic-ninja` ContextA8C MCP and then runs the script. To do it by hand instead,
+create a site at
+`https://jurassic.ninja/create/?woocommerce&woocommerce-import-sample-data`, take the
+admin password from the notice the site shows in `/wp-admin`, and run:
+
+```bash
+.maestro/scripts/setup-jn-store.sh --site your-site.jurassic.ninja
+```
+
+The script prompts for anything it cannot find in `.env.local`, so a later run against a
+new site needs only `--site`. Passwords are prompted rather than passed as flags, because
+command-line arguments are written to shell history and are visible in `ps` output. For
+non-interactive use, supply the site password via the `JN_SSH_PASS` environment variable.
+
+Requirements: `expect` (ships with macOS), app credentials at
+`~/.configure/woocommerce-ios/secrets/woo_app_credentials.json` (`rake dependencies`), and
+a **WordPress.com test account with two-factor authentication disabled** — the OAuth
+password grant cannot answer a 2FA challenge non-interactively. Use test accounts only.
+
+### What a provisioned store covers
+
+It ships with the WooCommerce sample products and is known-good for the products flows
+and the basic dashboard flows.
+
+It has no orders, customers, or coupons, and an unset onboarding profile, so
+`orders_list_and_search`, `dashboard_view_all_analytics`, `orders_create` and the coupon
+flows are expected to fail against it until that data is seeded, which is not yet
+automated. The negative-login fixtures (`MAESTRO_WOO_NO_JETPACK_*`,
+`MAESTRO_WOO_NOT_A_WOO_STORE_*`, `MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL`) are not
+provisioned either and still need to be supplied by hand.
+
+Jurassic Ninja sites expire after 7 days of inactivity. Re-run the script or the skill
+against a new site when that happens; the WordPress.com account already in `.env.local`
+is reused.
 
 ## Profiles
 

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -59,10 +59,24 @@ admin password from the notice the site shows in `/wp-admin`, and run:
 .maestro/scripts/setup-jn-store.sh --site your-site.jurassic.ninja
 ```
 
-The script prompts for anything it cannot find in `.env.local`, so a later run against a
-new site needs only `--site`. Passwords are prompted rather than passed as flags, because
-command-line arguments are written to shell history and are visible in `ps` output. For
-non-interactive use, supply the site password via the `JN_SSH_PASS` environment variable.
+### Supplying the WordPress.com account
+
+The first run needs a test account for Jetpack to connect to. Supply it either by filling
+`MAESTRO_WOO_LAB_WPCOM_EMAIL` and `MAESTRO_WOO_LAB_WPCOM_PASSWORD` in `.env.local`
+beforehand, or by letting the script prompt when you run it in a terminal. Once the account
+is in `.env.local`, later runs against new sites reuse it and need only `--site`.
+
+Passwords are prompted rather than passed as flags, because command-line arguments are
+written to shell history and are visible in `ps` output. When there is no terminal to
+prompt on — an agent, or CI — supply them through the environment instead:
+
+```bash
+JN_SSH_PASS=… MAESTRO_WOO_LAB_WPCOM_EMAIL=… MAESTRO_WOO_LAB_WPCOM_PASSWORD=… \
+  .maestro/scripts/setup-jn-store.sh --site your-site.jurassic.ninja
+```
+
+Run without a terminal and without credentials, the script exits immediately naming what
+is missing rather than failing further in.
 
 Requirements: `expect` (ships with macOS), app credentials at
 `~/.configure/woocommerce-ios/secrets/woo_app_credentials.json` (`rake dependencies`), and

--- a/.maestro/env.example
+++ b/.maestro/env.example
@@ -38,6 +38,13 @@ MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL=
 MAESTRO_WOO_CONSUMER_KEY=
 MAESTRO_WOO_CONSUMER_SECRET=
 
+# Written and consumed by .maestro/scripts/setup-jn-store.sh only; no flow
+# reads these. The site-admin password doubles as the SSH password (user is the
+# site domain, host is sftp.wp.com) so a store can be reconfigured later
+# without looking the credentials up again.
+MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_USERNAME=
+MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_PASSWORD=
+
 # Optional flow-specific data. Values must belong to the configured iOS store.
 MAESTRO_WOO_TEST_COUPON_CODE=
 MAESTRO_WOO_TEST_RECEIPT_EMAIL=

--- a/.maestro/scripts/setup-jn-store.sh
+++ b/.maestro/scripts/setup-jn-store.sh
@@ -87,14 +87,30 @@ prompt_secret() {
   printf -v "$__var" '%s' "$__value"
 }
 
+# Resolution order per value: flag, then environment, then .env.local, then an
+# interactive prompt.
 [ -n "$SITE_PASS" ]   || SITE_PASS="${JN_SSH_PASS:-}"
 [ -n "$SITE_PASS" ]   || SITE_PASS="$(env_value MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_PASSWORD)"
+[ -n "$WPCOM_USER" ]  || WPCOM_USER="${MAESTRO_WOO_LAB_WPCOM_EMAIL:-}"
 [ -n "$WPCOM_USER" ]  || WPCOM_USER="$(env_value MAESTRO_WOO_LAB_WPCOM_EMAIL)"
+[ -n "$WPCOM_PASS" ]  || WPCOM_PASS="${MAESTRO_WOO_LAB_WPCOM_PASSWORD:-}"
 [ -n "$WPCOM_PASS" ]  || WPCOM_PASS="$(env_value MAESTRO_WOO_LAB_WPCOM_PASSWORD)"
 
+# Prompting needs a terminal. Without one (an agent, a pipeline) the reads would
+# take EOF and fail several steps later with a misleading message, so say
+# exactly what is missing and how to supply it.
 if [ -z "$SITE_PASS" ] || [ -z "$WPCOM_USER" ] || [ -z "$WPCOM_PASS" ]; then
+  if [ ! -t 0 ]; then
+    printf 'error: missing credentials and no terminal to prompt on.\n' >&2
+    [ -n "$SITE_PASS" ]  || printf '  site admin password: pass --site-password or set JN_SSH_PASS\n' >&2
+    [ -n "$WPCOM_USER" ] || printf '  WordPress.com account: set MAESTRO_WOO_LAB_WPCOM_EMAIL or add it to %s\n' "$(basename "$ENV_OUT")" >&2
+    [ -n "$WPCOM_PASS" ] || printf '  WordPress.com password: set MAESTRO_WOO_LAB_WPCOM_PASSWORD or add it to %s\n' "$(basename "$ENV_OUT")" >&2
+    printf 'Or run this script directly in a terminal and it will prompt.\n' >&2
+    exit 1
+  fi
   printf '\nCredentials not found in %s, enter them now.\n' "$(basename "$ENV_OUT")"
 fi
+
 [ -n "$SITE_PASS" ] || prompt_secret SITE_PASS "site admin password for $SITE"
 if [ -z "$WPCOM_USER" ]; then
   printf '  WordPress.com test account email: ' >&2

--- a/.maestro/scripts/setup-jn-store.sh
+++ b/.maestro/scripts/setup-jn-store.sh
@@ -158,7 +158,7 @@ remote_php() {
 
 # JN provisions asynchronously and answers HTTP well before its plugins finish
 # installing, so poll for the state actually needed rather than for a 200.
-step 1/7 "Waiting for $SITE to finish provisioning"
+step 1/6 "Waiting for $SITE to finish provisioning"
 DEADLINE=$(( $(date +%s) + 900 ))
 STATE=""
 while :; do
@@ -181,7 +181,7 @@ echo "USER:" . ( get_user_by( "id", __ADMIN_ID__ ) ? "ok" : "MISSING" ) . "\n";'
 done
 ok "site is up, WooCommerce and Jetpack active"
 
-step 2/7 "Checking SSH and admin user"
+step 2/6 "Checking SSH and admin user"
 if ! printf '%s' "$STATE" | grep -q "WPCLI:ok"; then
   printf '  remote output: %s\n' "$(printf '%s' "$STATE" | head -3 | tr '\n' ' ')" >&2
   die "could not run wp-cli over SSH. Check the site admin password."
@@ -189,15 +189,10 @@ fi
 printf '%s' "$STATE" | grep -q "USER:ok" || die "no user with id $ADMIN_ID (try --admin-id)"
 ok "ssh and wp-cli working, admin user id $ADMIN_ID present"
 
-# Jetpack matches the local user to the WordPress.com account by email. The
-# Jetpack e2e suite does the same before provisioning a connection.
-step 3/7 "Aligning the site admin's email with $WPCOM_USER"
-remote "wp user update $ADMIN_ID --user_email='$WPCOM_USER' --quiet" >/dev/null
-ok "admin email aligned"
 
 # rest_do_request runs as an authenticated admin inside wp-cli, so no cookie or
 # REST nonce is needed for the two site-side Jetpack calls.
-step 4/7 "Registering the site with Jetpack"
+step 3/6 "Registering the site with Jetpack"
 REG="$(remote_php '<?php
 wp_set_current_user( __ADMIN_ID__ );
 $res = rest_do_request( new WP_REST_Request( "POST", "/jetpack/v4/connection/register" ) );
@@ -210,7 +205,7 @@ BLOG_ID="$(printf '%s' "$REG" | sed -n 's/^BLOGID:\([0-9][0-9]*\).*/\1/p' | head
 [ -n "$BLOG_ID" ] || die "could not register the site: $(printf '%s' "$REG" | head -3)"
 ok "registered, blogID=$BLOG_ID"
 
-step 5/7 "Provisioning the user connection"
+step 4/6 "Provisioning the user connection"
 PROV="$(remote_php '<?php
 wp_set_current_user( __ADMIN_ID__ );
 $res = rest_do_request( new WP_REST_Request( "POST", "/jetpack/v4/remote_provision" ) );
@@ -228,7 +223,7 @@ ok "scope and secret obtained (the secret is short-lived)"
 # --data-urlencode is required, not stylistic: curl -d sends the body raw, so a
 # plus-alias address arrives with the + decoded as a space and the grant fails
 # with a misleading "Incorrect username or password".
-step 6/7 "Connecting Jetpack to $WPCOM_USER"
+step 5/6 "Connecting Jetpack to $WPCOM_USER"
 CID="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['dotcom_app_id'])" "$APP_CREDS")"
 CSEC="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['dotcom_secret'])" "$APP_CREDS")"
 TOKRESP="$(curl -s -X POST https://public-api.wordpress.com/oauth2/token \
@@ -259,7 +254,7 @@ ok "isUserConnected=yes, hasConnectedOwner=yes"
 
 # WooCommerce exposes no REST endpoint for API keys, so insert the row the same
 # way its own admin-ajax handler does.
-step 7/7 "Creating WooCommerce API keys and writing $(basename "$ENV_OUT")"
+step 6/6 "Creating WooCommerce API keys and writing $(basename "$ENV_OUT")"
 KEYS="$(remote_php '<?php
 $ck = "ck_" . wc_rand_hash();
 $cs = "cs_" . wc_rand_hash();

--- a/.maestro/scripts/setup-jn-store.sh
+++ b/.maestro/scripts/setup-jn-store.sh
@@ -1,0 +1,325 @@
+#!/bin/bash
+# Configure a Jurassic Ninja site as the Maestro lab store.
+#
+# Connects Jetpack to your own WordPress.com test account, creates WooCommerce
+# REST API keys, and writes .maestro/.env.local. Everything site-side runs over
+# SSH + wp-cli; only the two WordPress.com calls go over HTTP.
+#
+# Provision the site first. Either use the /setup-test-stores skill, which does
+# this and then calls this script, or create one yourself at
+# https://jurassic.ninja/create/?woocommerce&woocommerce-import-sample-data and
+# take the admin password from the wp-admin notice the site displays.
+#
+# Usage:
+#   setup-jn-store.sh --site <domain> [--site-password <password>]
+#
+# Credentials are resolved in this order, so a second run needs no arguments
+# beyond --site:
+#   1. command-line flags
+#   2. existing values in .maestro/.env.local
+#   3. an interactive prompt (never echoed, never in shell history)
+#
+# The WordPress.com account must not have two-factor authentication enabled:
+# the OAuth password grant cannot answer a challenge non-interactively.
+
+set -uo pipefail
+
+SITE="" SITE_PASS="" WPCOM_USER="" WPCOM_PASS=""
+ADMIN_USER="demo"
+ADMIN_ID="1"
+ENV_OUT=""
+APP_CREDS="$HOME/.configure/woocommerce-ios/secrets/woo_app_credentials.json"
+
+die() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+step() { printf '\n\033[1m[%s]\033[0m %s\n' "$1" "$2"; }
+ok() { printf '  \033[32mok\033[0m %s\n' "$*"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --site) SITE="$2"; shift 2 ;;
+    --site-password) SITE_PASS="$2"; shift 2 ;;
+    --wpcom-user) WPCOM_USER="$2"; shift 2 ;;
+    --admin-user) ADMIN_USER="$2"; shift 2 ;;
+    --admin-id) ADMIN_ID="$2"; shift 2 ;;
+    --env-out) ENV_OUT="$2"; shift 2 ;;
+    --app-creds) APP_CREDS="$2"; shift 2 ;;
+    -h|--help) sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$SITE" ] || die "--site is required"
+command -v expect >/dev/null || die "expect is required for password-based SSH"
+command -v python3 >/dev/null || die "python3 is required"
+[ -f "$APP_CREDS" ] || die "app credentials not found: $APP_CREDS (run 'rake dependencies')"
+
+if [ -z "$ENV_OUT" ]; then
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel 2>/dev/null)" || REPO_ROOT=""
+  ENV_OUT="${REPO_ROOT:-.}/.maestro/.env.local"
+fi
+
+# Read one value out of an env file, tolerating quoting and inline comments.
+env_value() {
+  [ -f "$ENV_OUT" ] || return 0
+  ENV_FILE="$ENV_OUT" ENV_KEY="$1" python3 -c '
+import os, re, shlex
+path, key = os.environ["ENV_FILE"], os.environ["ENV_KEY"]
+for line in open(path, encoding="utf-8"):
+    m = re.match(r"\s*" + re.escape(key) + r"=(.*)$", line)
+    if m:
+        raw = m.group(1).strip()
+        try:
+            parts = shlex.split(raw, comments=True)
+        except ValueError:
+            parts = [raw]
+        print(parts[0] if parts else "")
+        break
+'
+}
+
+# Secrets are prompted rather than accepted as flags: command-line arguments are
+# recorded in shell history and are visible to any process that can run `ps`.
+prompt_secret() {
+  local __var="$1" __label="$2" __value=""
+  printf '  %s: ' "$__label" >&2
+  read -rs __value
+  printf '\n' >&2
+  printf -v "$__var" '%s' "$__value"
+}
+
+[ -n "$SITE_PASS" ]   || SITE_PASS="${JN_SSH_PASS:-}"
+[ -n "$SITE_PASS" ]   || SITE_PASS="$(env_value MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_PASSWORD)"
+[ -n "$WPCOM_USER" ]  || WPCOM_USER="$(env_value MAESTRO_WOO_LAB_WPCOM_EMAIL)"
+[ -n "$WPCOM_PASS" ]  || WPCOM_PASS="$(env_value MAESTRO_WOO_LAB_WPCOM_PASSWORD)"
+
+if [ -z "$SITE_PASS" ] || [ -z "$WPCOM_USER" ] || [ -z "$WPCOM_PASS" ]; then
+  printf '\nCredentials not found in %s, enter them now.\n' "$(basename "$ENV_OUT")"
+fi
+[ -n "$SITE_PASS" ] || prompt_secret SITE_PASS "site admin password for $SITE"
+if [ -z "$WPCOM_USER" ]; then
+  printf '  WordPress.com test account email: ' >&2
+  read -r WPCOM_USER
+fi
+[ -n "$WPCOM_PASS" ] || prompt_secret WPCOM_PASS "WordPress.com password for $WPCOM_USER"
+
+[ -n "$SITE_PASS" ]  || die "no site admin password supplied"
+[ -n "$WPCOM_USER" ] || die "no WordPress.com account supplied"
+[ -n "$WPCOM_PASS" ] || die "no WordPress.com password supplied"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+chmod 700 "$WORK"
+
+cat > "$WORK/ssh.exp" <<'EXP'
+#!/usr/bin/expect -f
+set timeout 120
+set site [lindex $argv 0]
+set pass $env(JN_SSH_PASS)
+set cmd  [lindex $argv 1]
+log_user 0
+spawn ssh -o StrictHostKeyChecking=accept-new -o PubkeyAuthentication=no \
+          -o NumberOfPasswordPrompts=1 $site@sftp.wp.com $cmd
+expect {
+  -re {[Pp]assword:} { send "$pass\r"; log_user 1; exp_continue }
+  eof
+}
+EXP
+chmod +x "$WORK/ssh.exp"
+
+# The password goes through the environment rather than argv so it never
+# appears in `ps` output.
+remote() { JN_SSH_PASS="$SITE_PASS" "$WORK/ssh.exp" "$SITE" "$1" 2>/dev/null | tr -d '\r'; }
+
+# Run PHP on the site. The source is base64-encoded so quoting survives the
+# shell/ssh/wp-cli layers, and staged as a file because `wp eval-file -` does
+# not read stdin in the wp-cli build JN ships.
+remote_php() {
+  local php b64
+  php="${1//__ADMIN_ID__/$ADMIN_ID}"
+  b64="$(printf '%s' "$php" | base64 | tr -d '\n')"
+  remote "echo $b64 | base64 -d > /tmp/.jnsetup.php && wp eval-file /tmp/.jnsetup.php; rm -f /tmp/.jnsetup.php"
+}
+
+# JN provisions asynchronously and answers HTTP well before its plugins finish
+# installing, so poll for the state actually needed rather than for a 200.
+step 1/7 "Waiting for $SITE to finish provisioning"
+DEADLINE=$(( $(date +%s) + 900 ))
+STATE=""
+while :; do
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "https://$SITE/wp-json/" || echo 000)"
+  if [ "$code" = "200" ]; then
+    STATE="$(remote_php '<?php
+echo "WPCLI:ok\n";
+echo "WC:" . ( function_exists( "wc_rand_hash" ) ? "active" : "pending" ) . "\n";
+echo "JP:" . ( class_exists( "Jetpack" ) ? "active" : "pending" ) . "\n";
+echo "USER:" . ( get_user_by( "id", __ADMIN_ID__ ) ? "ok" : "MISSING" ) . "\n";')"
+    printf '%s' "$STATE" | grep -q "WC:active" \
+      && printf '%s' "$STATE" | grep -q "JP:active" && break
+  fi
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    printf '  last state: http=%s %s\n' "$code" "$(printf '%s' "$STATE" | tr '\n' ' ')" >&2
+    die "site did not finish provisioning within 15 minutes"
+  fi
+  printf '  still provisioning (http=%s), waiting...\n' "$code"
+  sleep 15
+done
+ok "site is up, WooCommerce and Jetpack active"
+
+step 2/7 "Checking SSH and admin user"
+if ! printf '%s' "$STATE" | grep -q "WPCLI:ok"; then
+  printf '  remote output: %s\n' "$(printf '%s' "$STATE" | head -3 | tr '\n' ' ')" >&2
+  die "could not run wp-cli over SSH. Check the site admin password."
+fi
+printf '%s' "$STATE" | grep -q "USER:ok" || die "no user with id $ADMIN_ID (try --admin-id)"
+ok "ssh and wp-cli working, admin user id $ADMIN_ID present"
+
+# Jetpack matches the local user to the WordPress.com account by email. The
+# Jetpack e2e suite does the same before provisioning a connection.
+step 3/7 "Aligning the site admin's email with $WPCOM_USER"
+remote "wp user update $ADMIN_ID --user_email='$WPCOM_USER' --quiet" >/dev/null
+ok "admin email aligned"
+
+# rest_do_request runs as an authenticated admin inside wp-cli, so no cookie or
+# REST nonce is needed for the two site-side Jetpack calls.
+step 4/7 "Registering the site with Jetpack"
+REG="$(remote_php '<?php
+wp_set_current_user( __ADMIN_ID__ );
+$res = rest_do_request( new WP_REST_Request( "POST", "/jetpack/v4/connection/register" ) );
+$d = $res->get_data();
+if ( $res->is_error() ) { echo "ERR:" . json_encode( $d ) . "\n"; exit( 1 ); }
+$q = array();
+parse_str( (string) parse_url( $d["authorizeUrl"], PHP_URL_QUERY ), $q );
+echo "BLOGID:" . ( isset( $q["client_id"] ) ? $q["client_id"] : "" ) . "\n";')"
+BLOG_ID="$(printf '%s' "$REG" | sed -n 's/^BLOGID:\([0-9][0-9]*\).*/\1/p' | head -1)"
+[ -n "$BLOG_ID" ] || die "could not register the site: $(printf '%s' "$REG" | head -3)"
+ok "registered, blogID=$BLOG_ID"
+
+step 5/7 "Provisioning the user connection"
+PROV="$(remote_php '<?php
+wp_set_current_user( __ADMIN_ID__ );
+$res = rest_do_request( new WP_REST_Request( "POST", "/jetpack/v4/remote_provision" ) );
+$d = $res->get_data();
+if ( $res->is_error() ) { echo "ERR:" . json_encode( $d ) . "\n"; exit( 1 ); }
+echo "UID:"    . $d["user_id"] . "\n";
+echo "SCOPE:"  . $d["scope"]   . "\n";
+echo "SECRET:" . $d["secret"]  . "\n";')"
+EXT_UID="$(printf '%s' "$PROV" | sed -n 's/^UID:\(.*\)$/\1/p'    | head -1)"
+SCOPE="$(printf   '%s' "$PROV" | sed -n 's/^SCOPE:\(.*\)$/\1/p'  | head -1)"
+SECRET="$(printf  '%s' "$PROV" | sed -n 's/^SECRET:\(.*\)$/\1/p' | head -1)"
+[ -n "$SECRET" ] || die "remote_provision failed: $(printf '%s' "$PROV" | head -3)"
+ok "scope and secret obtained (the secret is short-lived)"
+
+# --data-urlencode is required, not stylistic: curl -d sends the body raw, so a
+# plus-alias address arrives with the + decoded as a space and the grant fails
+# with a misleading "Incorrect username or password".
+step 6/7 "Connecting Jetpack to $WPCOM_USER"
+CID="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['dotcom_app_id'])" "$APP_CREDS")"
+CSEC="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['dotcom_secret'])" "$APP_CREDS")"
+TOKRESP="$(curl -s -X POST https://public-api.wordpress.com/oauth2/token \
+  --data-urlencode "client_id=$CID" --data-urlencode "client_secret=$CSEC" \
+  -d grant_type=password \
+  --data-urlencode "username=$WPCOM_USER" --data-urlencode "password=$WPCOM_PASS" \
+  -d wpcom_supports_2fa=true -d with_auth_types=true)"
+TOKEN="$(printf '%s' "$TOKRESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null)"
+if [ -z "$TOKEN" ]; then
+  printf '%s\n' "$TOKRESP" | python3 -m json.tool 2>/dev/null | head -6 >&2
+  die "could not obtain a WordPress.com token. The account must exist and have 2FA disabled."
+fi
+
+curl -s -o /dev/null -X POST "https://public-api.wordpress.com/wpcom/v2/sites/$BLOG_ID/jetpack-remote-connect-user" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-urlencode "secret=$SECRET" --data-urlencode "scope=$SCOPE" \
+  --data-urlencode "external_user_id=$EXT_UID" --data-urlencode "redirect_uri=https://$SITE"
+
+# That call can return remote_request_timeout and still have succeeded, so
+# trust the site's own connection state rather than the response body.
+CONN="$(remote_php '<?php
+wp_set_current_user( __ADMIN_ID__ );
+$d = rest_do_request( new WP_REST_Request( "GET", "/jetpack/v4/connection" ) )->get_data();
+echo "USERCONNECTED:" . ( ! empty( $d["isUserConnected"] ) ? "yes" : "no" ) . "\n";
+echo "OWNER:" . ( ! empty( $d["hasConnectedOwner"] ) ? "yes" : "no" ) . "\n";')"
+printf '%s' "$CONN" | grep -q "USERCONNECTED:yes" || die "the Jetpack user connection did not complete"
+ok "isUserConnected=yes, hasConnectedOwner=yes"
+
+# WooCommerce exposes no REST endpoint for API keys, so insert the row the same
+# way its own admin-ajax handler does.
+step 7/7 "Creating WooCommerce API keys and writing $(basename "$ENV_OUT")"
+KEYS="$(remote_php '<?php
+$ck = "ck_" . wc_rand_hash();
+$cs = "cs_" . wc_rand_hash();
+global $wpdb;
+$ok = $wpdb->insert( $wpdb->prefix . "woocommerce_api_keys", array(
+  "user_id"         => __ADMIN_ID__,
+  "description"     => "maestro-smoke",
+  "permissions"     => "read_write",
+  "consumer_key"    => wc_api_hash( $ck ),
+  "consumer_secret" => $cs,
+  "truncated_key"   => substr( $ck, -7 ),
+), array( "%d", "%s", "%s", "%s", "%s", "%s" ) );
+if ( ! $ok ) { echo "ERR:insert failed\n"; exit( 1 ); }
+echo "CK:" . $ck . "\n" . "CS:" . $cs . "\n";')"
+CK="$(printf '%s' "$KEYS" | sed -n 's/^CK:\(.*\)$/\1/p' | head -1)"
+CS="$(printf '%s' "$KEYS" | sed -n 's/^CS:\(.*\)$/\1/p' | head -1)"
+[ -n "$CK" ] && [ -n "$CS" ] || die "could not create API keys: $(printf '%s' "$KEYS" | head -3)"
+
+VERIFY="$(curl -s -o /dev/null -w '%{http_code}' -u "$CK:$CS" "https://$SITE/wp-json/wc/v3/products?per_page=1")"
+[ "$VERIFY" = "200" ] || die "the API keys do not authenticate (http=$VERIFY)"
+ok "keys created and verified as read_write"
+
+if [ -f "$ENV_OUT" ]; then
+  BACKUP_DIR="${TMPDIR:-/tmp}"; BACKUP_DIR="${BACKUP_DIR%/}/maestro-env-backups"
+  mkdir -p "$BACKUP_DIR"; chmod 700 "$BACKUP_DIR"
+  BACKUP="$BACKUP_DIR/$(basename "$ENV_OUT").$(date +%Y%m%d-%H%M%S).$$"
+  cp "$ENV_OUT" "$BACKUP"; chmod 600 "$BACKUP"
+  # Deliberately outside the repository: .gitignore matches "**/.env.local"
+  # only, so a ".env.local.bak" sibling would not be ignored and could be
+  # committed with credentials in it.
+  ok "backed up the previous env file to $BACKUP"
+fi
+
+mkdir -p "$(dirname "$ENV_OUT")"
+SITE="$SITE" ADMIN_USER="$ADMIN_USER" WPCOM_USER="$WPCOM_USER" WPCOM_PASS="$WPCOM_PASS" \
+SITE_PASS="$SITE_PASS" CK="$CK" CS="$CS" \
+python3 - "$ENV_OUT" <<'PY'
+import os, re, sys, pathlib
+
+path = pathlib.Path(sys.argv[1])
+values = {
+    "MAESTRO_WOO_LAB_JETPACK_STORE_URL": "https://" + os.environ["SITE"],
+    "MAESTRO_WOO_LAB_WPCOM_EMAIL": os.environ["WPCOM_USER"],
+    "MAESTRO_WOO_LAB_WPCOM_PASSWORD": os.environ["WPCOM_PASS"],
+    "MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_USERNAME": os.environ["ADMIN_USER"],
+    "MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_PASSWORD": os.environ["SITE_PASS"],
+    "MAESTRO_WOO_CONSUMER_KEY": os.environ["CK"],
+    "MAESTRO_WOO_CONSUMER_SECRET": os.environ["CS"],
+}
+
+def quote(value):
+    if re.search(r"[\s()\"'!$&|;<>`\\#]", value):
+        return "'" + value.replace("'", "'\\''") + "'"
+    return value
+
+# Rewrite in place so hand-maintained lines and comments survive.
+lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+seen, out = set(), []
+for line in lines:
+    match = re.match(r"^([A-Z_]+)=", line)
+    if match and match.group(1) in values:
+        out.append(f"{match.group(1)}={quote(values[match.group(1)])}")
+        seen.add(match.group(1))
+    else:
+        out.append(line)
+missing = [k for k in values if k not in seen]
+if missing:
+    if out and out[-1].strip():
+        out.append("")
+    out.append("# Written by .maestro/scripts/setup-jn-store.sh")
+    out.extend(f"{k}={quote(values[k])}" for k in missing)
+path.write_text("\n".join(out).rstrip() + "\n", encoding="utf-8")
+path.chmod(0o600)
+PY
+ok "wrote $ENV_OUT (mode 600)"
+
+printf '\n\033[32mDone.\033[0m Lab store ready: https://%s (blogID %s)\n' "$SITE" "$BLOG_ID"
+printf 'Verify with:\n'
+printf '  .maestro/scripts/doctor.sh --app "$APP" --include-tags products --exclude-tags "" --seed --device "$UDID"\n'


### PR DESCRIPTION
## Description

Getting a Jetpack-connected test store and filling in `.env.local` by hand was reported on the P2 as the biggest friction point of the smoke-test effort. This PR automates it. You end up with a Jurassic Ninja store connected to your own WordPress.com test account, WooCommerce REST API keys, and a filled-in `.maestro/.env.local`.

Because each developer connects a store to their own account, we no longer need the shared test account. That account currently gets flagged for logins from different locations and has to be unblocked by hand each time.

### Before you start

You need a WordPress.com test account with two-factor authentication disabled. The OAuth password grant used to connect Jetpack cannot answer a 2FA challenge non-interactively. Do not use a personal or production account.

Give the script that account in one of two ways:

- Fill `MAESTRO_WOO_LAB_WPCOM_EMAIL` and `MAESTRO_WOO_LAB_WPCOM_PASSWORD` in `.maestro/.env.local` before running anything. This is required if you use the skill, because an agent has no terminal to prompt on.
- Run the script yourself in a terminal and let it prompt. The prompt does not echo.

The account is written to `.env.local` on the first run. Later runs against new sites reuse it and need only `--site`.

You also need `expect` (ships with macOS) and the app credentials at `~/.configure/woocommerce-ios/secrets/woo_app_credentials.json`. Run `rake dependencies` if that file is missing.

### Usage

With the account in place, either run the skill, which creates the site through the `jurassic-ninja` ContextA8C MCP and then runs the script:

```
/setup-test-stores
```

Or create a site yourself at `https://jurassic.ninja/create/?woocommerce&woocommerce-import-sample-data`, take the admin password from the notice it shows in `/wp-admin`, and run the script in a terminal. It prompts for the site admin password and, on the first run, for the WordPress.com account:

```
.maestro/scripts/setup-jn-store.sh --site <domain>.jurassic.ninja
```

Passwords are prompted rather than accepted as flags, because arguments land in shell history and `ps` output. Where there is no terminal, such as an agent or CI, pass them through the environment instead: `JN_SSH_PASS` for the site admin password, plus the two `MAESTRO_WOO_LAB_WPCOM_*` variables. If anything is missing and there is no terminal, the script exits immediately and names what it needs.

The script waits for Jurassic Ninja to finish provisioning, connects Jetpack, creates WooCommerce REST API keys with `read_write` permissions, and writes `.env.local`. Site-side work goes over SSH and wp-cli. Two calls go to WordPress.com over HTTP. An existing `.env.local` is backed up outside the repository before it is rewritten.

### New variables

`MAESTRO_WOO_LAB_JETPACK_SITE_ADMIN_USERNAME` and `_PASSWORD` are added to `env.example`. They are owned by the tooling: no flow references them, so `required_environment()` never demands them and they are never forwarded to Maestro. The site admin password doubles as the SSH password, so a store can be reconfigured later without looking it up again. `CONTRACT.md` gains a sentence noting the category exists.

### Known gaps

A fresh store has no orders, customers, or coupons, and its onboarding profile is unset. `orders_list_and_search`, `dashboard_view_all_analytics`, `orders_create` and the coupon flows cannot run against it yet. The negative-login fixtures (`MAESTRO_WOO_NO_JETPACK_*`, `MAESTRO_WOO_NOT_A_WOO_STORE_*`, `MAESTRO_WOO_WRONG_ACCOUNT_STORE_URL`) are not provisioned either. Both are documented in the README and the skill and are the obvious follow-ups.

Jurassic Ninja sites expire after 7 days of inactivity. When that happens, run the skill or the script again against a new site.

## Test Steps

1. Run `python3 -m unittest discover .maestro/scripts/tests` and verify all 62 tests pass.
2. Run `python3 .maestro/scripts/check-smoke-coverage.py` and verify the 98-item snapshot passes.
3. Run `python3 -m py_compile .maestro/scripts/*.py` and `bash -n .maestro/scripts/*.sh`.
4. Provision a store, either with `/setup-test-stores` or by creating one at `https://jurassic.ninja/create/?woocommerce&woocommerce-import-sample-data` and running the script in a terminal, letting it prompt for the passwords:
   ```
   .maestro/scripts/setup-jn-store.sh --site <domain>.jurassic.ninja
   ```
   Expect all 6 steps to report `ok`, ending with `isUserConnected=yes` and keys verified as `read_write`.
5. Run `.maestro/scripts/lint-env.py` and verify it reports OK with no unknown-variable warnings.
6. Confirm the store is genuinely connected from the account side — it should appear in the WordPress.com account's own site list with `jetpack: true`.
7. Run a flow against it to confirm it is usable:
   ```
   .maestro/scripts/run-smoke-tests.sh --app "$APP" --profile phone-full \
     --device "$UDID" --seed .maestro/flows/products_create.yaml
   ```
   Expect `PASS`.
8. Re-run step 4 against a second fresh site and confirm it needs only `--site`, reusing the WordPress.com account already in `.env.local`.

Validated on four freshly provisioned sites; `products_create.yaml` passed against one of them.

## Screenshots

N/A — tooling only.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. Test tooling only; no release note is required.




