### PR TITLE
Fix unstable order-row capture in orders_list_and_search flow

### DIFF
--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -13,9 +13,23 @@ tags:
 - assertVisible:
     id: "orders-table-view"
 
+# The table view is present before its rows carry text, so reading row content
+# immediately races the first fetch and yields an empty string on a cold cache.
+# Wait for a real order number to render before capturing anything.
+- extendedWaitUntil:
+    visible:
+      text: "#.*"
+      childOf:
+        id: "orders-table-view"
+    timeout: 30000
+
 # Capture the first live order title (for example, "#560 Pamela Nguyen").
+# Match the order-number shape rather than ".+": the table also exposes section
+# headers ("YESTERDAY"), row dates ("Sep 7"), status chips ("Completed") and
+# amounts ("$135.26"), and which of those lands at index 0 is not stable between
+# runs.
 - copyTextFrom:
-    text: ".+"
+    text: "#.*"
     childOf:
       id: "orders-table-view"
     index: 0
@@ -31,7 +45,7 @@ tags:
 - scroll
 - scroll
 - copyTextFrom:
-    text: ".+"
+    text: "#.*"
     childOf:
       id: "orders-table-view"
     index: 0


### PR DESCRIPTION
## Description

`orders_list_and_search` failed on the first attempt and passed on retry, so the suite reported it as flaky rather than broken. Two real defects were behind that.

The table view becomes visible before its rows carry any text, so a cold run could read an empty string — one run captured the list rendered with entirely blank rows.

More importantly, `copyTextFrom text: ".+"` at `index: 0` matches far more than the order title. The table also exposes the section header ("YESTERDAY"), row dates ("Sep 7"), status chips ("Completed", "POS", "Pending payment") and amounts ("$135.26"). Which of those occupies index 0 depends on accessibility-tree ordering and is not stable between runs — two runs with pixel-identical screenshots produced opposite results.

This waits for an order number to render, then matches `#.*` instead of `.+` in both capture steps. The second capture feeds the pagination comparison, so leaving it on `.+` would have kept that assertion resting on the same unstable selector.

The wait is deliberately in the flow rather than in `subflows/navigate_to_orders.yaml`: seven flows use that subflow and most tap "new order" immediately without reading list text, so a wait there would impose a "store must contain at least one order" precondition on flows that do not need one.

Found while reviewing [WOOMOB-3893](https://linear.app/a8c/issue/WOOMOB-3893/ios-maestro-review-i36-order-outcomes-and-system-surfaces).

## Test Steps

Run on a **cold** simulator — a warm cache passes either way, so it proves nothing:

1. Force a cold start: `xcrun simctl uninstall <udid> com.automattic.woocommerce`
2. Run the flow:
   ```
   .maestro/scripts/run-smoke-tests.sh --app <WooCommerce.app> \
     --profile phone-full --device <udid> \
     .maestro/flows/orders_list_and_search.yaml
   ```
3. Expect **PASS on attempt 1** with no retry.

Three prior cold runs failed on attempt 1 at this step (`Assertion is false: false is true`); after the change it passes cold in a single attempt. Verified on iPhone 16 Pro, iOS 18.3, Maestro 2.9.0.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

`.maestro/` is developer tooling and not user-facing, so no release note is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKubbokWePvCgtYThjwkxT
