### PR TITLE
Fix orders_cash_payment note handling and obscured tap

### DIFF
--- a/.maestro/flows/orders_cash_payment.yaml
+++ b/.maestro/flows/orders_cash_payment.yaml
@@ -18,8 +18,14 @@ tags:
     index: 0
 - tapOn:
     id: product-multiple-selection-done-button
-- swipe:
-    direction: UP
+# The order totals panel is pinned over the bottom of the form, so a blind swipe
+# can leave this row present in the hierarchy but covered: the tap is then
+# swallowed by the panel. Scroll until it is genuinely unobscured.
+- scrollUntilVisible:
+    element:
+      id: add-customer-note-button
+    direction: DOWN
+    visibilityPercentage: 100
 - tapOn:
     id: add-customer-note-button
 - tapOn:
@@ -30,6 +36,15 @@ tags:
       TEXT_TO_PASTE: Cash ${SUITE_RUN_ID}
 - tapOn:
     id: edit-note-done-button
+# Verify the note on the order form, where it is rendered as a "Customer Note"
+# section. The order details screen has no customer-note section at all, so the
+# original post-creation assertion could never pass.
+- scrollUntilVisible:
+    element:
+      text: Cash ${SUITE_RUN_ID}
+    direction: DOWN
+    visibilityPercentage: 100
+- assertVisible: Cash ${SUITE_RUN_ID}
 - tapOn:
     id: new-order-create-button
 - extendedWaitUntil:
@@ -56,8 +71,3 @@ tags:
       text: Completed
     timeout: 30000
 - assertVisible: Completed
-- scrollUntilVisible:
-    element:
-      text: Cash ${SUITE_RUN_ID}
-    direction: DOWN
-- assertVisible: Cash ${SUITE_RUN_ID}


### PR DESCRIPTION
## Description

`orders_cash_payment` failed on the first attempt in five consecutive runs, at two separate points.

**The note editor never opened.** The order totals panel is pinned over the bottom of the New Order form, so the blind `swipe: direction: UP` could leave `add-customer-note-button` present in the view hierarchy but physically covered. Maestro found the element and reported the tap as successful while the panel swallowed it. Scrolling until the row is fully visible fixes it.

**The note assertion could never pass.** The flow looked for the note text on the order details screen after creation, but order details has no customer-note section at all. Scrolling details for the literal string "Customer Note" returns `No visible element found`, and scrolling to the top shows the sections are header, Products, Custom Fields, Shipping Labels and Payment Totals. The note is only rendered on the order *form*, as a "Customer Note" section, so it is verified there instead — before the order is created.

Nothing is weakened by the move. The cash payment path itself was already sound and is untouched: collect payment, cash row, amount entry, change due, mark order as complete, and the resulting `Completed` status are all still asserted. The note assertion is a run-ownership marker, not part of the `orders.collect-payment.cash` claim.

Found while reviewing [WOOMOB-3893](https://linear.app/a8c/issue/WOOMOB-3893/ios-maestro-review-i36-order-outcomes-and-system-surfaces). Verdict for `orders.collect-payment.cash`: **verified-full** after this change.

## Test Steps

```
.maestro/scripts/run-smoke-tests.sh --app <WooCommerce.app> \
  --profile phone-full --device <iphone-udid> --seed \
  .maestro/flows/orders_cash_payment.yaml
```

Expect **PASS on attempt 1**. Before the change the same command failed on attempt 1 with `Element not found: edit-note-text-editor`, and after the tap was fixed, with `No visible element found: "Cash <RUN_ID>"`.

Verified on iPhone 16 Pro, iOS 18.3, Maestro 2.9.0, against an automation lab store. Passes in 58s.

## Notes for reviewers

The remaining three destructive flows in this chunk (`orders_details_and_actions`, `orders_mark_complete`, `orders_refund`) share the same impossible post-creation note assertion and are being fixed separately, one flow per PR.

Two findings from this investigation are **not** addressed here and need their own decisions:

- Orders created by these flows are not visible to the WooCommerce REST API used by `seed-fixtures.py` (`status=any` returns nothing newer than an order from the previous day, while ~430 `auto-draft` orders have accumulated on the lab store). Cleanup therefore reports `PASS` while journaling nothing.
- `custom-amount-fixed-button` is declared in the app but never reaches the accessibility hierarchy, which blocks `orders_qr_payment` and `orders_share_payment_link` entirely.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

`.maestro/` is developer tooling and not user-facing, so no release note is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKubbokWePvCgtYThjwkxT
