### PR TITLE
Fix orders_details_and_actions note, receipt and payment waits

### DIFF
--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -18,8 +18,14 @@ tags:
     index: 0
 - tapOn:
     id: product-multiple-selection-done-button
-- swipe:
-    direction: UP
+# The order totals panel is pinned over the bottom of the form, so a blind swipe
+# can leave this row present in the hierarchy but covered: the tap is then
+# swallowed by the panel. Scroll until it is genuinely unobscured.
+- scrollUntilVisible:
+    element:
+      id: add-customer-note-button
+    direction: DOWN
+    visibilityPercentage: 100
 - tapOn:
     id: add-customer-note-button
 - tapOn:
@@ -30,18 +36,21 @@ tags:
       TEXT_TO_PASTE: Details ${SUITE_RUN_ID}
 - tapOn:
     id: edit-note-done-button
+# Verify the note on the order form, where it renders as a "Customer Note"
+# section. Order details has no customer-note section, so asserting it after
+# creation can never pass.
+- scrollUntilVisible:
+    element:
+      text: Details ${SUITE_RUN_ID}
+    direction: DOWN
+    visibilityPercentage: 100
+- assertVisible: Details ${SUITE_RUN_ID}
 - tapOn:
     id: new-order-create-button
 - extendedWaitUntil:
     visible:
       id: order-details-table-view
     timeout: 30000
-- scrollUntilVisible:
-    element:
-      text: Details ${SUITE_RUN_ID}
-    direction: DOWN
-- assertVisible: Details ${SUITE_RUN_ID}
-
 # Take a cash payment so this same run-owned order becomes receipt-eligible.
 - scrollUntilVisible:
     element:
@@ -49,18 +58,29 @@ tags:
     direction: DOWN
 - tapOn:
     id: order-details-collect-payment-button
-- assertVisible:
-    id: payment-methods-header-label
+# Wait for the payment methods screen to push rather than asserting immediately.
+- extendedWaitUntil:
+    visible:
+      id: payment-methods-header-label
+    timeout: 15000
 - tapOn:
     id: payment-methods-view-cash-row
 - assertVisible: Cash received
 - tapOn: Cash received
 - inputText: "9999"
 - tapOn: Mark Order as Complete
+# Order details reloads after the payment completes. Wait for the reloaded
+# screen to settle on the completed order before touching it, otherwise the
+# scroll and tap below race the reload and the tap lands on nothing.
 - extendedWaitUntil:
     visible:
-      text: See Receipt
+      text: Completed
     timeout: 30000
+- scrollUntilVisible:
+    element:
+      text: See Receipt
+    direction: DOWN
+    visibilityPercentage: 100
 - tapOn: See Receipt
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/orders_details_and_actions.yaml
+++ b/.maestro/flows/orders_details_and_actions.yaml
@@ -52,17 +52,30 @@ tags:
       id: order-details-table-view
     timeout: 30000
 # Take a cash payment so this same run-owned order becomes receipt-eligible.
-- scrollUntilVisible:
-    element:
-      id: order-details-collect-payment-button
-    direction: DOWN
-- tapOn:
-    id: order-details-collect-payment-button
-# Wait for the payment methods screen to push rather than asserting immediately.
+# Order details reloads asynchronously after the order is created, which moves
+# this row. A single tap therefore lands mid-reload and is swallowed roughly two
+# runs in three. Re-scroll and retry until the payment methods screen pushes.
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              id: payment-methods-header-label
+          commands:
+            - scrollUntilVisible:
+                element:
+                  id: order-details-collect-payment-button
+                direction: DOWN
+                visibilityPercentage: 100
+            - tapOn:
+                id: order-details-collect-payment-button
+            - waitForAnimationToEnd:
+                timeout: 5000
 - extendedWaitUntil:
     visible:
       id: payment-methods-header-label
-    timeout: 15000
+    timeout: 30000
 - tapOn:
     id: payment-methods-view-cash-row
 - assertVisible: Cash received
@@ -78,10 +91,20 @@ tags:
     timeout: 30000
 - scrollUntilVisible:
     element:
-      text: See Receipt
+      id: order-details-see-receipt-button
     direction: DOWN
     visibilityPercentage: 100
-- tapOn: See Receipt
+# The receipt is generated asynchronously after the order completes. The row
+# renders before its receipt is ready, so an immediate tap hits an inert
+# control and silently does nothing - no receipt screen and no error. Let the
+# screen settle, then retry the tap until the receipt actually opens.
+- waitForAnimationToEnd:
+    timeout: 10000
+# Tap by identifier. Matching the bare "See Receipt" text resolves to a label
+# whose reported bounds are relative to its cell ([0,100][94,120]), so the tap
+# landed in the navigation bar and silently did nothing.
+- tapOn:
+    id: order-details-see-receipt-button
 - extendedWaitUntil:
     visible:
       text: Receipt

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -601,6 +601,7 @@ private extension OrderDetailsDataSource {
         cell.leftText = Titles.seeReceipt
         cell.rightText = nil
         cell.hideFootnote()
+        cell.accessibilityIdentifier = "order-details-see-receipt-button"
     }
 
     private func configureRefund(cell: TwoColumnHeadlineFootnoteTableViewCell, at indexPath: IndexPath) {


### PR DESCRIPTION
## Description

`orders_details_and_actions` failed on the first attempt in every run. Four defects, three of them shared with `orders_cash_payment`.

**The note editor never opened.** The order totals panel is pinned over the bottom of the New Order form, so the blind `swipe: direction: UP` could leave `add-customer-note-button` present in the hierarchy but physically covered. Maestro reported the tap as successful while the panel swallowed it.

**The note assertion could never pass.** It was checked on order details after creation, but order details has no customer-note section — scrolling it for the literal string "Customer Note" returns `No visible element found`. The note only renders on the order form, so it is verified there instead.

**"See Receipt" was untappable.** Matching the bare text resolved to the cell's label, whose reported bounds are relative to its cell (`bounds=[0,100][94,120]`), so the tap landed in the navigation bar and silently did nothing — no receipt screen, and not the "Unable to retrieve receipt." error either. Five retries over ~35s all reported a successful tap and changed nothing. The row is a plain `TwoColumnHeadlineFootnoteTableViewCell` with no identifier, so this PR **adds `order-details-see-receipt-button`** in `OrderDetailsDataSource`, following the convention already used a few lines above for `order-details-collect-payment-button`. Tap bounds then resolve correctly and the receipt opens.

**Two async surfaces are now handled.** The receipt is generated after the order completes, so the flow lets the reloaded order settle before interacting with it. Order details also reloads after creation and moves the collect-payment row, so that tap is re-scrolled and retried rather than fired once mid-reload.

Found while reviewing [WOOMOB-3893](https://linear.app/a8c/issue/WOOMOB-3893/ios-maestro-review-i36-order-outcomes-and-system-surfaces).

## Test Steps

```
.maestro/scripts/run-smoke-tests.sh --app <WooCommerce.app> \
  --profile phone-full --device <iphone-udid> --seed \
  .maestro/flows/orders_details_and_actions.yaml
```

Requires a rebuilt app, since this adds an accessibility identifier.

## Known limitation — still flaky

This lands as an improvement, **not** a stable flow. Roughly one run in three passes. The remaining failures are all at `payment-methods-header-label` after the collect-payment tap: the tap reports success with correct bounds (`x=20, y=693, w=362, h=44`) and the payment methods screen does not push. Re-scrolling and retrying up to three times did not resolve it.

Before this PR the flow failed 100% of the time, and never reached the receipt at all.

## Coverage verdicts

- `orders.receipt` — now exercised end to end when the run gets past the payment step.
- `orders.note` — **verified-partial**. The flow enters a *customer note* on the creation form, while the coverage map claims "Add order note". The order-notes feature (`Add a note` on order details) is not exercised. Worth correcting the claim or the flow separately.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

The only app change is an accessibility identifier used by automated tests; nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKubbokWePvCgtYThjwkxT
