### PR TITLE
Fix device registration error in support chat

### DIFF
--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -469,7 +469,7 @@ final class SupportChatViewModel {
             }
         } catch {
             DDLogError("⛔️ Failed to execute action \(action): \(error)")
-            state = .error(errorMessage(for: error))
+            state = .error(errorMessage(for: error, whileExecuting: action))
         }
     }
 
@@ -924,6 +924,15 @@ final class SupportChatViewModel {
         return Localization.errorMessage
     }
 
+    private func errorMessage(for error: Error, whileExecuting action: SupportDiagnosticsService.Action) -> String {
+        switch action {
+        case .registerDevice:
+            return Localization.deviceRegistrationErrorMessage
+        default:
+            return errorMessage(for: error)
+        }
+    }
+
     /// Persists a local bookmark for the chat so it appears in the chat history UI.
     /// Fire-and-forget: we don't surface storage errors to the user.
     private func persistChatBookmark(wasNewChat: Bool,
@@ -1088,6 +1097,11 @@ private extension SupportChatViewModel {
             "supportChatViewModel.aiChatConnectionErrorMessage",
             value: "We couldn't connect to AI chat right now.",
             comment: "Generic error message shown when an AI support chat request fails"
+        )
+        static let deviceRegistrationErrorMessage = NSLocalizedString(
+            "supportChatViewModel.deviceRegistrationErrorMessage",
+            value: "We couldn't register your device for push notifications. Please try again.",
+            comment: "Error message shown when device registration for push notifications fails from support chat"
         )
         static let rateLimitErrorMessage = NSLocalizedString(
             "supportChatViewModel.rateLimitErrorMessage",

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -562,7 +562,11 @@ struct SupportChatViewModelTests {
         await sut.executeAction(.registerDevice)
 
         // Then
-        #expect(sut.state == .error("We couldn't register your device for push notifications. Please try again."))
+        #expect(sut.state == .error(NSLocalizedString(
+            "supportChatViewModel.deviceRegistrationErrorMessage",
+            value: "We couldn't register your device for push notifications. Please try again.",
+            comment: ""
+        )))
         #expect(sut.isExecutingAction == false)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -552,6 +552,20 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
+    @Test func test_executeAction_registerDevice_when_service_throws_then_state_is_device_registration_error() async {
+        // Given
+        let diagnosticsService = MockSupportDiagnosticsService { _ in [] }
+        diagnosticsService.registerDeviceError = NSError(domain: "TestDomain", code: 1)
+        let sut = makeSUT(diagnosticsService: diagnosticsService)
+
+        // When
+        await sut.executeAction(.registerDevice)
+
+        // Then
+        #expect(sut.state == .error("We couldn't register your device for push notifications. Please try again."))
+        #expect(sut.isExecutingAction == false)
+    }
+
     @Test func executeAction_setupJetpack_calls_onStartJetpackSetup() async {
         // Given
         var callbackCalled = false
@@ -2212,6 +2226,7 @@ private extension SupportChatViewModel.ChatMessage {
 @MainActor
 private final class MockSupportDiagnosticsService: SupportDiagnosticsServicing {
     var formattedSystemStatusReport: String?
+    var registerDeviceError: Error?
 
     private let resultProvider: ([SupportDiagnosticsService.Test]) -> [SupportDiagnosticsService.Result]
 
@@ -2225,7 +2240,11 @@ private final class MockSupportDiagnosticsService: SupportDiagnosticsServicing {
 
     func enableAnalytics() async throws {}
 
-    func registerDevice() async throws {}
+    func registerDevice() async throws {
+        if let registerDeviceError {
+            throw registerDeviceError
+        }
+    }
 
     func enableOrderNotifications(settings: NotificationSettings) async throws {}
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -552,7 +552,7 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
-    @Test func test_executeAction_registerDevice_when_service_throws_then_state_is_device_registration_error() async {
+    @Test func executeAction_registerDevice_when_service_throws_then_state_is_device_registration_error() async {
         // Given
         let diagnosticsService = MockSupportDiagnosticsService { _ in [] }
         diagnosticsService.registerDeviceError = NSError(domain: "TestDomain", code: 1)


### PR DESCRIPTION
WOOMOB-3380

## Description

When **Register Device** failed in Support Chat, its error went through the generic AI chat mapper and incorrectly said AI chat was unavailable.

This is a straightforward naive-fix to map the specific error into a more user-friendly error message. 

## Test Steps

1. On a physical device, open **Menu > Settings > Help & Support > Contact Support > Receiving push notifications**.
2. Tap **Register Device**.
3. If registration fails, confirm the alert says the device could not be registered for push notifications.

Expected result: a failed Register Device action shows “We couldn't register your device for push notifications. Please try again.” and does not show an AI chat connection error.

## Screenshots

| Before | After |
|---|---|
| ![AI chat error shown before the fix](https://github.com/user-attachments/assets/cbefb6ce-7fd2-4ae8-b134-d078fc5b6875) | ![Device registration error shown after the fix](https://github.com/user-attachments/assets/d9e61f57-7290-4ec1-9198-bbb9cc5d505a) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
