### PR TITLE
Fix orders_mark_complete status editing and mark-complete preconditions

### DIFF
--- a/.maestro/flows/orders_mark_complete.yaml
+++ b/.maestro/flows/orders_mark_complete.yaml
@@ -18,13 +18,18 @@ tags:
     index: 0
 - tapOn:
     id: product-multiple-selection-done-button
-- tapOn:
-    id: order-status-section-edit-button
-- assertVisible:
-    id: order-status-list
-- tapOn: Processing
-- swipe:
-    direction: UP
+# The order status section is only rendered when the order form is in editing
+# flow (`OrderForm.swift:282`, `.renderedIf(flow == .editing)`), so it does not
+# exist while creating an order. The status is set below, on order details.
+#
+# The order totals panel is pinned over the bottom of the form, so a blind swipe
+# can leave this row present in the hierarchy but covered, and the tap is then
+# swallowed by the panel.
+- scrollUntilVisible:
+    element:
+      id: add-customer-note-button
+    direction: DOWN
+    visibilityPercentage: 100
 - tapOn:
     id: add-customer-note-button
 - tapOn:
@@ -35,16 +40,101 @@ tags:
       TEXT_TO_PASTE: Complete ${SUITE_RUN_ID}
 - tapOn:
     id: edit-note-done-button
+# Verify the note here, where it renders as a "Customer Note" section. Order
+# details has no customer-note section, so asserting it after creation cannot
+# pass.
+- scrollUntilVisible:
+    element:
+      text: Complete ${SUITE_RUN_ID}
+    direction: DOWN
+    visibilityPercentage: 100
+- assertVisible: Complete ${SUITE_RUN_ID}
 - tapOn:
     id: new-order-create-button
 - extendedWaitUntil:
     visible:
       id: order-details-table-view
     timeout: 30000
+# "Mark Order Complete" is only offered when the order is processing AND not
+# eligible for payment (`OrderDetailsDataSource.swift:1232`, the
+# `(true, false, false)` case). A freshly created unpaid order is always
+# eligible for payment, so the button never renders until the order is paid.
+# Take the cash payment first, then move the paid order back to processing.
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              id: payment-methods-header-label
+          commands:
+            - scrollUntilVisible:
+                element:
+                  id: order-details-collect-payment-button
+                direction: DOWN
+                visibilityPercentage: 100
+            - tapOn:
+                id: order-details-collect-payment-button
+            - waitForAnimationToEnd:
+                timeout: 5000
+- extendedWaitUntil:
+    visible:
+      id: payment-methods-header-label
+    timeout: 30000
+- tapOn:
+    id: payment-methods-view-cash-row
+- extendedWaitUntil:
+    visible: "Cash received"
+    timeout: 15000
+- tapOn: Cash received
+- inputText: "9999"
+- tapOn: Mark Order as Complete
+- extendedWaitUntil:
+    visible:
+      text: Completed
+    timeout: 30000
+
+# Put the now-paid run-owned order into Processing from order details, which is
+# where the status editor lives.
+# Order details reloads, so a single tap here is swallowed. Retry until the
+# status list opens.
+- waitForAnimationToEnd:
+    timeout: 10000
+- repeat:
+    times: 4
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              id: order-status-list
+          commands:
+            - tapOn:
+                id: summary-table-view-cell-update-status-button
+            - waitForAnimationToEnd:
+                timeout: 5000
+- extendedWaitUntil:
+    visible:
+      id: order-status-list
+    timeout: 15000
+- tapOn: Processing
+- runFlow:
+    when:
+      visible:
+        id: order-status-list-apply-button
+    commands:
+      - tapOn:
+          id: order-status-list-apply-button
+- extendedWaitUntil:
+    visible:
+      text: Processing
+    timeout: 30000
+
+# Now transition the processing order to completed.
 - scrollUntilVisible:
     element:
       text: Mark Order Complete
     direction: DOWN
+    visibilityPercentage: 100
 - tapOn: Mark Order Complete
 - assertVisible: Review Order
 - tapOn: Mark Order Complete
@@ -53,8 +143,3 @@ tags:
       text: Completed
     timeout: 30000
 - assertVisible: Completed
-- scrollUntilVisible:
-    element:
-      text: Complete ${SUITE_RUN_ID}
-    direction: DOWN
-- assertVisible: Complete ${SUITE_RUN_ID}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -108,6 +108,7 @@ private extension SummaryTableViewCell {
 
     func configureIcon() {
         updateStatusButton.applyIconButtonStyle(icon: .pencilImage)
+        updateStatusButton.accessibilityIdentifier = "summary-table-view-cell-update-status-button"
 
         updateStatusButton.addTarget(self, action: #selector(editWasTapped), for: .touchUpInside)
 


### PR DESCRIPTION
## Description

`orders_mark_complete` failed on the first attempt in every run. Two of its assumptions about the app were wrong.

**The status could not be set during order creation.** The flow tapped `order-status-section-edit-button` on the New Order form, but the status section is only rendered in the editing flow — `OrderForm.swift:282`, `.renderedIf(flow == .editing)`. It does not exist while creating an order. The status is now set from order details, which is where the status editor lives.

**"Mark Order Complete" never rendered.** That button is only offered when the order is processing *and* not eligible for payment — `OrderDetailsDataSource.swift:1232`, the `(true, false, false)` case. A freshly created unpaid order is always eligible for payment, so the button was never on screen. The flow now takes the cash payment first, then moves the paid order back to processing, which is the only state in which the app offers the action this coverage item claims to test.

The status pencil on order details had no accessibility identifier, so this adds `summary-table-view-cell-update-status-button`, alongside the identifiers already assigned in that cell.

It also applies the two fixes already landed on the sibling flows: scrolling the customer-note row fully into view before tapping it, since the pinned order totals panel otherwise swallows the tap, and asserting the note on the order form rather than on order details, which has no customer-note section.

Found while reviewing [WOOMOB-3893](https://linear.app/a8c/issue/WOOMOB-3893/ios-maestro-review-i36-order-outcomes-and-system-surfaces).

## Test Steps

```
.maestro/scripts/run-smoke-tests.sh --app <WooCommerce.app> \
  --profile phone-full --device <iphone-udid> --seed \
  .maestro/flows/orders_mark_complete.yaml
```

Requires a rebuilt app, since this adds an accessibility identifier.

The order notes on the resulting order show the real transitions: "Order status changed from Pending payment to Processing", then completion.

## Known limitation — still flaky

Passes on attempt 1, but roughly one run in three. The failures are always at `payment-methods-header-label` after the collect-payment tap — the same instability documented in #17834, not introduced here. Before this PR the flow failed 100% of the time.

## Coverage verdict

`orders.mark-complete` — exercised end to end when a run gets past the payment step. Worth noting the coverage map claims this as full while the flow could not previously reach the button at all.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

The only app change is an accessibility identifier used by automated tests; nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKubbokWePvCgtYThjwkxT
