### PR TITLE
Fix orders_refund and make cell-hosted buttons tappable by UI automation

### DIFF
--- a/.maestro/flows/orders_refund.yaml
+++ b/.maestro/flows/orders_refund.yaml
@@ -18,8 +18,14 @@ tags:
     index: 0
 - tapOn:
     id: product-multiple-selection-done-button
-- swipe:
-    direction: UP
+# The order totals panel is pinned over the bottom of the form, so a blind swipe
+# can leave this row present in the hierarchy but covered, and the tap is then
+# swallowed by the panel.
+- scrollUntilVisible:
+    element:
+      id: add-customer-note-button
+    direction: DOWN
+    visibilityPercentage: 100
 - tapOn:
     id: add-customer-note-button
 - tapOn:
@@ -30,29 +36,70 @@ tags:
       TEXT_TO_PASTE: Refund ${SUITE_RUN_ID}
 - tapOn:
     id: edit-note-done-button
+# Verify the note here, where it renders as a "Customer Note" section. Order
+# details has no customer-note section, so asserting it after creation cannot
+# pass.
+- scrollUntilVisible:
+    element:
+      text: Refund ${SUITE_RUN_ID}
+    direction: DOWN
+    visibilityPercentage: 100
+- assertVisible: Refund ${SUITE_RUN_ID}
 - tapOn:
     id: new-order-create-button
 - extendedWaitUntil:
     visible:
       id: order-details-table-view
     timeout: 30000
-- scrollUntilVisible:
-    element:
-      id: order-details-collect-payment-button
-    direction: DOWN
-- tapOn:
-    id: order-details-collect-payment-button
+# Order details reloads after creation, so a single tap is swallowed. Retry
+# until the payment methods screen pushes.
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              id: payment-methods-header-label
+          commands:
+            - scrollUntilVisible:
+                element:
+                  id: order-details-collect-payment-button
+                direction: DOWN
+                visibilityPercentage: 100
+            - tapOn:
+                id: order-details-collect-payment-button
+            - waitForAnimationToEnd:
+                timeout: 5000
+- extendedWaitUntil:
+    visible:
+      id: payment-methods-header-label
+    timeout: 30000
 - tapOn:
     id: payment-methods-view-cash-row
+- extendedWaitUntil:
+    visible: "Cash received"
+    timeout: 15000
 - tapOn: Cash received
 - inputText: "9999"
 - tapOn: Mark Order as Complete
+# Tap by identifier. Matching the bare "Issue Refund" text resolves to the
+# button's label, whose reported bounds are relative to its cell
+# (bounds=[0,100][346,128]), so the tap landed in the navigation bar and
+# silently did nothing.
 - extendedWaitUntil:
     visible:
-      text: Issue Refund
+      id: order-details-issue-refund-button
     timeout: 30000
-- tapOn: Issue Refund
-- assertVisible: Select all
+- scrollUntilVisible:
+    element:
+      id: order-details-issue-refund-button
+    direction: DOWN
+    visibilityPercentage: 100
+- tapOn:
+    id: order-details-issue-refund-button
+- extendedWaitUntil:
+    visible: "Select all"
+    timeout: 15000
 - tapOn: Select all
 - tapOn: Next
 - extendedWaitUntil:
@@ -60,13 +107,18 @@ tags:
       text: Refund
     timeout: 15000
 - tapOn: Refund
+# Issuing a refund raises a confirmation alert ("Are you sure you want to issue
+# a refund? This can't be undone.") with Cancel / Refund. Without confirming it
+# the refund is never submitted, so the flow waited for a result that could not
+# arrive.
+- waitForAnimationToEnd:
+    timeout: 10000
+- tapOn:
+    text: Refund
+    index: 0
+# The refunded section header is rendered upper-cased, and Maestro matches text
+# case-sensitively, so "Refunded Products" never matched.
 - extendedWaitUntil:
-    visible:
-      text: Refunded Products
+    visible: "(?i)refunded products"
     timeout: 30000
-- assertVisible: Refunded Products
-- scrollUntilVisible:
-    element:
-      text: Refund ${SUITE_RUN_ID}
-    direction: DOWN
-- assertVisible: Refund ${SUITE_RUN_ID}
+- assertVisible: "(?i)refunded products"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.swift
@@ -36,6 +36,7 @@ private extension IssueRefundTableViewCell {
     func configureIssueRefundButton() {
         issueRefundButton.applySecondaryButtonStyle()
         issueRefundButton.setTitle(Localization.buttonTitle, for: .normal)
+        accessibilityIdentifier = "order-details-issue-refund-button"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -51,7 +51,11 @@ final class ButtonTableViewCell: UITableViewCell {
         apply(style: style)
         button.setTitle(title, for: .normal)
         button.setImage(image, for: .normal)
-        button.accessibilityIdentifier = accessibilityIdentifier
+        // Identify the cell rather than the button it contains. A control nested in
+        // a cell reports its frame relative to that cell, so UI automation resolves
+        // an on-screen position that does not match the button and the tap lands
+        // elsewhere.
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.onButtonTouchUp = onButtonTouchUp
 
         topConstraint.constant = topSpacing


### PR DESCRIPTION
## Description

`orders_refund` failed on the first attempt in every run, for four reasons.

**Buttons inside table view cells were untappable.** A control nested in a cell reports its frame relative to that cell, so UI automation resolves an on-screen position that does not match the button. Tapping "Issue Refund" reported `bounds=[0,100][346,128]` and landed in the navigation bar, silently doing nothing.

The same applies to **every** button configured through `ButtonTableViewCell`, which set the supplied identifier on its inner button. That is why `order-details-collect-payment-button` failed roughly two runs in three — a flakiness that also affects `orders_cash_payment`, `orders_details_and_actions`, `orders_mark_complete`, `orders_qr_payment` and `orders_share_payment_link`. Both cells now carry the identifier themselves, and the resolved bounds become real screen coordinates. After this change the collect-payment step succeeded in 6 of 6 runs, where it had blocked 3 of 3 immediately before.

**The refund was never confirmed.** Issuing a refund raises an alert — "Are you sure you want to issue a refund? This can't be undone." with Cancel and Refund. The flow never dismissed it, so the refund was never submitted and it waited for a result that could not arrive.

**The final assertion could not match.** The refunded section header is rendered upper-cased and Maestro matches text case-sensitively, so `Refunded Products` never matched even once the refund had gone through. It now matches case-insensitively.

It also applies the two fixes already landed on the sibling flows: scrolling the customer-note row fully into view before tapping it, since the pinned totals panel otherwise swallows the tap, and asserting the note on the order form rather than order details, which has no customer-note section.

Found while reviewing [WOOMOB-3893](https://linear.app/a8c/issue/WOOMOB-3893/ios-maestro-review-i36-order-outcomes-and-system-surfaces).

## Test Steps

```
.maestro/scripts/run-smoke-tests.sh --app <WooCommerce.app> \
  --profile phone-full --device <iphone-udid> --seed \
  .maestro/flows/orders_refund.yaml
```

Requires a rebuilt app. The resulting order shows `Paid $29.99` and `Refunded -$29.99`, so the refund genuinely lands.

## Results

2 of 3 consecutive runs pass on attempt 1, against none before. The remaining failure is the final refund assertion, not the payment step, which now succeeds consistently.

The `ButtonTableViewCell` change is worth reviewing carefully since it affects every cell-hosted button, not just refunds. Only Maestro flows reference `order-details-collect-payment-button`; no XCUITest depends on it resolving as a button.

## Coverage verdict

`orders.refund` — exercised end to end, with a real refund committed against a run-owned order.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

The app changes are accessibility identifiers used by automated tests; nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKubbokWePvCgtYThjwkxT
