### PR TITLE
Fix run-owned order cleanup, which never deleted anything

### DIFF
--- a/.maestro/scripts/run-smoke-tests.py
+++ b/.maestro/scripts/run-smoke-tests.py
@@ -757,6 +757,19 @@ def main() -> int:
                 env=values,
             )
             cleanup_status = "PASS" if cleanup_result.returncode == 0 else "FAIL"
+            # Surface cleanup output even when it succeeds. It reports orders it
+            # could not attribute to this run and therefore left on the store,
+            # which is exactly the case a PASS would otherwise hide.
+            cleanup_output = redact(
+                "\n".join(
+                    part.strip()
+                    for part in (cleanup_result.stdout, cleanup_result.stderr)
+                    if part and part.strip()
+                ),
+                values,
+            )
+            if cleanup_output:
+                print(cleanup_output, flush=True)
             if cleanup_result.returncode:
                 cleanup_error = redact(
                     (cleanup_result.stderr or cleanup_result.stdout).strip()

--- a/.maestro/scripts/seed-fixtures.py
+++ b/.maestro/scripts/seed-fixtures.py
@@ -32,6 +32,22 @@ def required_environment(name: str) -> str:
     return value
 
 
+def rest_datetime(value: str) -> str:
+    """Convert a manifest timestamp into the form the WooCommerce REST API accepts.
+
+    `created_at` is stored as a full ISO 8601 UTC timestamp, e.g.
+    `2026-09-09T05:29:41.207439+00:00`. The API's `after`/`before` filters reject
+    that: the same query returns zero rows with the offset present and the real
+    rows once it is removed. Everything is UTC, so dropping the offset and the
+    microseconds is lossless here.
+    """
+    text = str(value).strip()
+    for separator in ("+", "Z"):
+        head, _, _ = text.partition(separator)
+        text = head or text
+    return text.split(".", 1)[0]
+
+
 def strict_run_id(value: str) -> str:
     if not RUN_ID_RE.fullmatch(value):
         raise SmokeSetupError(f"Invalid suite run ID: {value!r}")
@@ -102,6 +118,9 @@ def initialize(args: argparse.Namespace) -> None:
 def order_contains_run_id(order: dict[str, Any], run_id: str) -> bool:
     candidates = [str(order.get("customer_note", ""))]
     candidates.extend(str(item.get("name", "")) for item in order.get("line_items", []))
+    # Custom amounts are stored as fee lines rather than line items, so an order
+    # whose only run-id marker is a custom amount name is invisible without this.
+    candidates.extend(str(item.get("name", "")) for item in order.get("fee_lines", []))
     candidates.extend(str(item.get("value", "")) for item in order.get("meta_data", []))
     return any(run_id in candidate for candidate in candidates)
 
@@ -112,14 +131,51 @@ def discover_entities(client: WooClient, manifest: dict[str, Any]) -> list[dict[
     for product in client.list("products", search=run_id, status="any"):
         if run_id in str(product.get("name", "")):
             entities.append({"type": "product", "id": int(product["id"])})
+    seen_orders: set[int] = set()
     for order in client.list(
         "orders",
-        after=manifest["created_at"],
+        after=rest_datetime(manifest["created_at"]),
         status="any",
         order="asc",
     ):
         if order_contains_run_id(order, run_id):
+            seen_orders.add(int(order["id"]))
             entities.append({"type": "order", "id": int(order["id"])})
+
+    # `status=any` excludes auto-draft in the WooCommerce REST API, and every order
+    # the UI flows create begins as an auto-draft. Querying only `any` therefore
+    # reports a successful cleanup while leaving run-owned drafts behind.
+    #
+    # Drafts are still matched by run id, never by age alone. A draft that carries
+    # the id is ours; one that does not may be a merchant part-way through writing
+    # an order in another window, and deleting it would destroy their work.
+    unmatched_drafts = 0
+    for order in client.list(
+        "orders",
+        after=rest_datetime(manifest["created_at"]),
+        status="auto-draft",
+        order="asc",
+    ):
+        order_id = int(order["id"])
+        if order_id in seen_orders:
+            continue
+        if order_contains_run_id(order, run_id):
+            seen_orders.add(order_id)
+            entities.append({"type": "order", "id": order_id})
+        else:
+            unmatched_drafts += 1
+
+    # A flow that fails before it finishes creating an order leaves a draft that
+    # never received the run id, so it cannot be attributed and is not deleted.
+    # Surface the count rather than reporting a clean run, because these
+    # accumulate: the lab store had roughly 430 of them when this was written.
+    if unmatched_drafts:
+        print(
+            f"warning: {unmatched_drafts} auto-draft order(s) created during this run "
+            "carry no run ID and were left in place. They are most likely abandoned "
+            "by a failed flow, but cannot be told apart from a merchant's own draft.",
+            file=sys.stderr,
+        )
     for tag in client.list("products/tags", search=run_id):
         if run_id in str(tag.get("name", "")):
             entities.append({"type": "tag", "id": int(tag["id"])})

--- a/.maestro/scripts/tests/test_seed_fixtures.py
+++ b/.maestro/scripts/tests/test_seed_fixtures.py
@@ -85,6 +85,85 @@ class SeedFixtureTests(unittest.TestCase):
             self.assertEqual([], contents["entities"])
             self.assertIn("created_at", contents)
 
+    def test_rest_datetime_strips_offset_and_microseconds(self) -> None:
+        """The API's `after` filter returns nothing when the offset is present.
+
+        `created_at` is written as a full ISO 8601 UTC timestamp, which the
+        WooCommerce REST API rejects for date filtering. Measured against a live
+        store: 0 rows with the offset, 5 rows without it.
+        """
+        self.assertEqual(
+            "2026-09-09T05:29:41",
+            SEED.rest_datetime("2026-09-09T05:29:41.207439+00:00"),
+        )
+        self.assertEqual("2026-09-09T05:29:41", SEED.rest_datetime("2026-09-09T05:29:41Z"))
+        self.assertEqual("2026-09-09T05:29:41", SEED.rest_datetime("2026-09-09T05:29:41"))
+
+    def test_cleanup_collects_run_owned_auto_drafts_but_leaves_unattributed_ones(self) -> None:
+        """`status=any` excludes auto-draft, so drafts need their own query.
+
+        A draft carrying the run ID is ours. One without it cannot be told apart
+        from a merchant part-way through writing an order, so it is left alone.
+        """
+        run_id = "SUITE-20260805T120000Z-abc123"
+
+        class StatusAwareClient(FakeClient):
+            def list(self, path: str, **query: object) -> list[dict[str, object]]:
+                if path != "orders":
+                    return []
+                if query.get("status") == "auto-draft":
+                    return [
+                        {
+                            "id": 41,
+                            "customer_note": "",
+                            "line_items": [],
+                            "fee_lines": [{"name": f"QR {run_id}"}],
+                            "meta_data": [],
+                        },
+                        {
+                            "id": 42,
+                            "customer_note": "",
+                            "line_items": [],
+                            "fee_lines": [],
+                            "meta_data": [],
+                        },
+                    ]
+                return []
+
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            args = argparse.Namespace(run_id=run_id, manifest=manifest)
+            SEED.initialize(args)
+            client = StatusAwareClient()
+
+            with mock.patch.object(SEED, "WooClient", return_value=client):
+                SEED.cleanup(args)
+
+            # 41 carries the run ID in a fee line; 42 is unattributable.
+            self.assertEqual([("orders", 41)], client.deleted)
+
+    def test_order_contains_run_id_matches_custom_amount_fee_lines(self) -> None:
+        """Custom amounts are fee lines, not line items.
+
+        The QR and share-payment flows stamp the run ID only on a custom amount,
+        so without this those orders can never be attributed.
+        """
+        run_id = "SUITE-20260805T120000Z-abc123"
+        order = {
+            "customer_note": "",
+            "line_items": [],
+            "fee_lines": [{"name": f"Share {run_id}"}],
+            "meta_data": [],
+        }
+
+        self.assertTrue(SEED.order_contains_run_id(order, run_id))
+        self.assertFalse(
+            SEED.order_contains_run_id(
+                {"customer_note": "", "line_items": [], "fee_lines": [{"name": "Gift wrap"}], "meta_data": []},
+                run_id,
+            )
+        )
+
     def test_cleanup_deletes_only_exact_run_owned_entities(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             manifest = Path(directory) / "manifest.json"


### PR DESCRIPTION
## Description

Every seeded run in this chunk reported `cleanup_status: PASS` with an empty journal, while the lab store accumulated roughly **430 orphaned auto-draft orders**. Three separate causes.

**The date filter never matched.** `initialize` writes `created_at` as a full ISO 8601 UTC timestamp with microseconds and a `+00:00` offset, and the WooCommerce REST API's `after` filter returns nothing for that form. Measured against the live store:

| `after` value | rows |
|---|---|
| `2026-09-09T05:29:41.207439+00:00` (what we sent) | **0** |
| `2026-09-09T05:29:41.207439` | 5 |
| `2026-09-09T05:29:41` | 5 |

Both order queries in `discover_entities` used the manifest value directly, so **no order has ever been discovered, regardless of status.** This is the main reason cleanup has never worked.

**`status=any` excludes auto-draft.** Every order the UI flows create begins as an auto-draft, so even with a working date filter these would have stayed invisible. Auto-drafts are now queried separately and matched **by run ID, not by age** — a draft carrying the ID is ours, while one without it may be a merchant part-way through writing an order in another window, and deleting that would destroy their work. The existing test `test_cleanup_deletes_only_exact_run_owned_entities` catches this, and caught it when I first tried the age-based approach. Drafts that cannot be attributed are counted and reported rather than silently left.

**Custom amounts are fee lines, not line items.** The QR and share-payment flows stamp the run ID only on a custom amount name, so those orders could never be attributed. `order_contains_run_id` now searches fee lines too.

The runner also discarded cleanup output unless cleanup exited non-zero, hiding exactly the case a `PASS` should not hide. It now echoes cleanup output whenever there is any.

Found while reviewing [WOOMOB-3893](https://linear.app/a8c/issue/WOOMOB-3893/ios-maestro-review-i36-order-outcomes-and-system-surfaces).

## Test Steps

```
python3 -m unittest discover .maestro/scripts/tests     # 65 tests
.maestro/scripts/run-smoke-tests.sh --app <WooCommerce.app> \
  --profile phone-full --device <iphone-udid> --seed \
  .maestro/flows/orders_cash_payment.yaml
```

Before: `cleanup_status: PASS`, `run-manifest.json` entities `[]`, nothing deleted, nothing reported.

After, against the lab store:

```
Cleaned 1 run-owned entities
warning: 5 auto-draft order(s) created during this run carry no run ID and were
left in place. They are most likely abandoned by a failed flow, but cannot be
told apart from a merchant's own draft.
```

Three new unit tests cover the timestamp conversion, auto-draft attribution, and fee-line matching.

## Known limitations

- Orders created by the app on this store stay `auto-draft` server-side and never receive the run ID, so they still cannot be attributed. That is app or store behaviour rather than a cleanup defect; the new warning makes it visible instead of hiding it behind a `PASS`.
- The ~430 auto-drafts already on the lab store need clearing separately. This PR stops the bleeding but does not clean up the backlog.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

`.maestro/` is developer tooling and not user-facing, so no release note is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKubbokWePvCgtYThjwkxT
