### PR TITLE
Assert order search excludes non-matching orders

### DIFF
--- a/.maestro/flows/orders_list_and_search.yaml
+++ b/.maestro/flows/orders_list_and_search.yaml
@@ -53,6 +53,10 @@ tags:
 - assertTrue:
     condition: ${output.afterScrollOrderTitle.length > 0 && output.afterScrollOrderTitle !== output.initialOrderTitle}
     label: Orders list exposes an additional row after scrolling
+# Keep this second, different order number. The search below asserts it is gone
+# from the results, which is what distinguishes a real search from a list that
+# ignored the query.
+- evalScript: ${output.excludedOrderNumber = output.afterScrollOrderTitle.split(' ')[0].replace('#', '')}
 - takeScreenshot: orders_list_scrolled
 
 - tapOn:
@@ -73,6 +77,13 @@ tags:
     timeout: 30000
 - assertVisible:
     text: "#${output.orderSearchText}.*"
+    childOf:
+      id: "updated-search-results-table-view"
+# Presence alone is weak: the searched order was already on screen before the
+# search ran, so a list that ignored the query entirely would also satisfy it.
+# Assert a known non-matching order has gone.
+- assertNotVisible:
+    text: "#${output.excludedOrderNumber}.*"
     childOf:
       id: "updated-search-results-table-view"
 - takeScreenshot: orders_search_results


### PR DESCRIPTION
## Description

`orders_list_and_search` asserted only that the searched order was visible in the results. That order was already on screen before the search ran, so a list that ignored the query entirely would satisfy the assertion too.

The flow already captures a second, different order number when it scrolls, and asserts the two differ. This reuses it as a known non-match and asserts it has gone from the results.

Fails safe: if the captured number were ever empty, the pattern collapses to `#.*`, which matches the visible result and fails the assertion rather than passing vacuously.

Android made the same change in woocommerce-android#16500 after finding the same weakness — that comparison is what surfaced it here.

Found while reviewing [WOOMOB-3893](https://linear.app/a8c/issue/WOOMOB-3893/ios-maestro-review-i36-order-outcomes-and-system-surfaces). `orders.search` was downgraded to verified-partial because of this; it can go back to verified-full with this change.

## Test Steps

```
.maestro/scripts/run-smoke-tests.sh --app <WooCommerce.app> \
  --profile phone-full --device <iphone-udid> \
  .maestro/flows/orders_list_and_search.yaml
```

3 of 3 runs pass on attempt 1, including a cold run with the app uninstalled first. The Maestro log confirms the new assertion executes rather than being skipped:

```
Assert that "#${output.excludedOrderNumber}.*", Child of: id: updated-search-results-table-view is not visible  COMPLETED
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

`.maestro/` is developer tooling and not user-facing, so no release note is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKubbokWePvCgtYThjwkxT
