### PR TITLE
Prevent ExPlat login crash under Swift 6

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -153,7 +153,7 @@ let package = Package(
                 "WooFoundationCore",
                 .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
             ],
-            swiftSettings: swift6
+            swiftSettings: swift5
         ),
         .target(
             name: "Fakes",


### PR DESCRIPTION
## Description

PR #17815 moved the `Experiments` package target to Swift 6. During a normal login with analytics enabled,
`ABTest.start(for:)` is Main Actor-isolated, but Automattic Tracks 4.3.1 invokes the ExPlat refresh completion from the
URLSession delegate queue. Swift 6 detects the executor mismatch and traps in `_swift_task_checkIsolatedSwift`.

This PR temporarily moves only `Experiments` back to Swift 5. `Codegen` and `WPMediaPicker` remain on Swift 6.

Follow-up work should make the ExPlat callback safe to invoke from any queue, add a regression test that completes the
refresh from a background queue, and then re-enable Swift 6 for `Experiments`.

## Crash Trace

```text
Thread 44 Queue : com.apple.NSURLSession-delegate (serial)
#0  0x00000001068ef2a0 in _dispatch_assert_queue_fail ()
#1  0x00000001068f0a64 in dispatch_assert_queue$V2.cold.1 ()
#2  0x00000001068baaa0 in dispatch_assert_queue ()
#3  0x00000002378fa284 in _swift_task_checkIsolatedSwift ()
#4  0x00000002378c3768 in swift_task_isCurrentExecutorWithFlagsImpl ()
#5  0x000000011661e2c8 in closure #2 in closure #2 in static ABTest.start(for:) ()
#6  0x00000001165d2d20 in closure #1 in ExPlat.refresh(completion:) at Automattic-Tracks-iOS/Sources/Experiments/ExPlat.swift:128
#7  0x00000001165d71c8 in closure #1 in ExPlatService.getAssignments(completion:) at Automattic-Tracks-iOS/Sources/Experiments/ExPlatService.swift:82
```

## Test Steps

1. Open the  fresh app
2. Login
3. Observe no crash

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
