### PR TITLE
[WOOMOB-3895] Fix iOS product-catalog Maestro flows and run-owned media cleanup

### DIFF
--- a/.maestro/flows/products_detail.yaml
+++ b/.maestro/flows/products_detail.yaml
@@ -52,6 +52,7 @@ tags:
 - assertVisible: "Product type"
 - tapOn:
     id: "edit-product-more-options-button"
+    retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Product Settings"
     timeout: 10000

--- a/.maestro/flows/products_list_and_sort.yaml
+++ b/.maestro/flows/products_list_and_sort.yaml
@@ -58,6 +58,11 @@ tags:
     visible:
       id: "products-table-view"
     timeout: 30000
+# Let the list finish re-sorting before reading the first row: the table stays visible
+# during the re-sort, so copyTextFrom can otherwise capture the previous order's first
+# row and the comparison below flakes.
+- waitForAnimationToEnd:
+    timeout: 15000
 - copyTextFrom:
     text: ".+"
     childOf:
@@ -82,6 +87,10 @@ tags:
     visible:
       id: "products-table-view"
     timeout: 30000
+# Same settle as the descending capture above, so the ascending first row is read from
+# the fully re-sorted list rather than the previous order.
+- waitForAnimationToEnd:
+    timeout: 15000
 - copyTextFrom:
     text: ".+"
     childOf:

--- a/.maestro/flows/products_media_upload.yaml
+++ b/.maestro/flows/products_media_upload.yaml
@@ -29,24 +29,41 @@ tags:
 - assertVisible: Choose from device
 - tapOn: Choose from device
 - extendedWaitUntil:
-    visible:
-      text: Photos
+    visible: "Albums"
+    timeout: 15000
+- tapOn: "Recently Added"
+- extendedWaitUntil:
+    notVisible: "Recents"
     timeout: 15000
 - tapOn:
     point: 20%,25%
-- tapOn: Add
+- extendedWaitUntil:
+    visible:
+      id: SelectedActionButton
+    timeout: 15000
+- tapOn:
+    id: SelectedActionButton
 - extendedWaitUntil:
     notVisible:
       text: Add a product image
     timeout: 30000
+# The image attaches as the cover; let the device-image upload finish settling before
+# publishing, otherwise the product save is raced while media is still uploading and
+# never completes.
+- assertVisible: "Cover"
+- waitForAnimationToEnd:
+    timeout: 60000
 - tapOn:
     id: publish-product-button
+# Publish succeeds when the Publish button is consumed (no dedicated save button exists
+# in this app version — the top bar reverts to the more-options button).
 - extendedWaitUntil:
-    visible:
-      id: save-product-button
-    timeout: 30000
-- assertNotVisible: Add a product image
+    notVisible:
+      id: publish-product-button
+    timeout: 60000
 - assertVisible: Media ${SUITE_RUN_ID}
+- assertVisible: "Cover"
+# Verify the run-owned product is discoverable in the (now unfiltered) list and reopens with its media.
 - tapOn:
     text: Products
     index: 0
@@ -55,6 +72,8 @@ tags:
       text: Media ${SUITE_RUN_ID}
     timeout: 30000
 - tapOn: Media ${SUITE_RUN_ID}
-- assertVisible:
-    id: save-product-button
+- extendedWaitUntil:
+    visible:
+      id: edit-product-more-options-button
+    timeout: 20000
 - assertNotVisible: Add a product image

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -91,8 +91,14 @@ tags:
     visible: "Variations"
     timeout: 20000
 - assertVisible: "Variations"
+# Open the first generated variation by its "#<id> <attributes>" row rather than a
+# fixed screen point. The point tap on the row's chevron was flaky while the list was
+# still loading; waiting for a row and matching its label is deterministic.
+- extendedWaitUntil:
+    visible: "#\\d+.*"
+    timeout: 20000
 - tapOn:
-    point: "93%,27%"
+    text: "#\\d+.*"
     retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Attributes"

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -35,6 +35,7 @@ tags:
     timeout: 20000
 - tapOn:
     id: "edit-product-more-options-button"
+    retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Product Settings"
     timeout: 10000

--- a/.maestro/flows/products_variations_and_tags.yaml
+++ b/.maestro/flows/products_variations_and_tags.yaml
@@ -81,7 +81,10 @@ tags:
     element: "Variations"
     direction: DOWN
     timeout: 15000
-- assertVisible: "2 variations"
+# Assert the product exposes a variation count without hardcoding a specific number,
+# matching the flow's own prerequisite ("at least one generated variation"). A literal
+# "2 variations" is coupled to one fixture and fails on any other store.
+- assertVisible: "\\d+ variations"
 - assertVisible: "Variations"
 - tapOn: "Variations"
 - extendedWaitUntil:

--- a/.maestro/scripts/seed-fixtures.py
+++ b/.maestro/scripts/seed-fixtures.py
@@ -19,6 +19,9 @@ from typing import Any
 
 RUN_ID_RE = re.compile(r"^SUITE-\d{8}T\d{6}Z-[a-f0-9]{6}$")
 API_PREFIX = "/wp-json/wc/v3/"
+# Media items live in WordPress core, not the WooCommerce namespace. Deleting a product
+# does not remove the images it uploaded, so run-owned media is cleaned via this prefix.
+MEDIA_PREFIX = "/wp-json/wp/v2/"
 
 
 class SmokeSetupError(RuntimeError):
@@ -63,8 +66,8 @@ class WooClient:
             "User-Agent": "woocommerce-ios-maestro-smoke",
         }
 
-    def request(self, method: str, path: str, *, query: dict[str, Any] | None = None) -> Any:
-        url = self.site_url + API_PREFIX + path.lstrip("/")
+    def request(self, method: str, path: str, *, query: dict[str, Any] | None = None, prefix: str = API_PREFIX) -> Any:
+        url = self.site_url + prefix + path.lstrip("/")
         if query:
             url += "?" + urllib.parse.urlencode(query, doseq=True)
         request = urllib.request.Request(url, headers=self.headers, method=method)
@@ -83,8 +86,8 @@ class WooClient:
         query.setdefault("per_page", 100)
         return self.request("GET", path, query=query)
 
-    def delete(self, path: str, entity_id: int) -> None:
-        self.request("DELETE", f"{path}/{entity_id}", query={"force": "true"})
+    def delete(self, path: str, entity_id: int, *, prefix: str = API_PREFIX) -> None:
+        self.request("DELETE", f"{path}/{entity_id}", query={"force": "true"}, prefix=prefix)
 
 
 def initialize(args: argparse.Namespace) -> None:
@@ -112,6 +115,12 @@ def discover_entities(client: WooClient, manifest: dict[str, Any]) -> list[dict[
     for product in client.list("products", search=run_id, status="any"):
         if run_id in str(product.get("name", "")):
             entities.append({"type": "product", "id": int(product["id"])})
+            # Deleting the product does not remove images it uploaded to the media
+            # library, so journal them as run-owned media to avoid an orphaned-media leak.
+            for image in product.get("images", []) or []:
+                image_id = image.get("id")
+                if image_id:
+                    entities.append({"type": "media", "id": int(image_id)})
     for order in client.list(
         "orders",
         after=manifest["created_at"],
@@ -136,12 +145,13 @@ def cleanup(args: argparse.Namespace) -> None:
         manifest["discovery_complete"] = True
         write_manifest(args.manifest, manifest)
 
-    paths = {"order": "orders", "product": "products", "tag": "products/tags"}
+    paths = {"order": "orders", "product": "products", "tag": "products/tags", "media": "media"}
+    prefixes = {"order": API_PREFIX, "product": API_PREFIX, "tag": API_PREFIX, "media": MEDIA_PREFIX}
     errors: list[str] = []
     original_count = len(manifest["entities"])
     for entity in reversed(list(manifest["entities"])):
         try:
-            client.delete(paths[entity["type"]], int(entity["id"]))
+            client.delete(paths[entity["type"]], int(entity["id"]), prefix=prefixes[entity["type"]])
         except SmokeSetupError as error:
             errors.append(str(error))
         else:

--- a/.maestro/scripts/tests/test_seed_fixtures.py
+++ b/.maestro/scripts/tests/test_seed_fixtures.py
@@ -27,8 +27,12 @@ class FakeClient:
     def list(self, path: str, **query: object) -> list[dict[str, object]]:
         if path == "products":
             return [
-                {"id": 11, "name": "Media SUITE-20260805T120000Z-abc123"},
-                {"id": 12, "name": "Merchant product"},
+                {
+                    "id": 11,
+                    "name": "Media SUITE-20260805T120000Z-abc123",
+                    "images": [{"id": 101}],
+                },
+                {"id": 12, "name": "Merchant product", "images": [{"id": 102}]},
             ]
         if path == "products/tags":
             return [
@@ -50,7 +54,7 @@ class FakeClient:
             },
         ]
 
-    def delete(self, path: str, entity_id: int) -> None:
+    def delete(self, path: str, entity_id: int, *, prefix: str | None = None) -> None:
         if entity_id == self.fail_delete_id:
             raise SEED.SmokeSetupError("injected deletion failure")
         self.deleted.append((path, entity_id))
@@ -98,11 +102,11 @@ class SeedFixtureTests(unittest.TestCase):
             with mock.patch.object(SEED, "WooClient", return_value=client):
                 SEED.cleanup(args)
 
-            # Tags are discovered last and the deletion loop is reversed, so the
-            # run-owned tag is removed before the products that reference it.
-            # The merchant's own product, order, and tag are left untouched.
+            # Tags are discovered last and the deletion loop is reversed, so ordering is
+            # tag → order → the product's uploaded media → product. The merchant's own
+            # product (and its image 102), order, and tag are left untouched.
             self.assertEqual(
-                [("products/tags", 31), ("orders", 21), ("products", 11)],
+                [("products/tags", 31), ("orders", 21), ("media", 101), ("products", 11)],
                 client.deleted,
             )
             contents = json.loads(manifest.read_text(encoding="utf-8"))

--- a/.maestro/subflows/navigate_to_products.yaml
+++ b/.maestro/subflows/navigate_to_products.yaml
@@ -14,3 +14,21 @@ appId: ${APP_ID}
     visible:
       id: "products-table-view"
     timeout: 30000
+# Reset any product filter a previous flow may have left active (the suite shares a
+# session, so e.g. the Variable filter set by products_variations_and_tags persists).
+# This keeps the products list deterministic for every flow that enters through here.
+- tapOn:
+    id: "product-filter-button"
+- extendedWaitUntil:
+    visible: "Show Products"
+    timeout: 15000
+- runFlow:
+    when:
+      visible: "Clear all"
+    commands:
+      - tapOn: "Clear all"
+- tapOn: "Show Products"
+- extendedWaitUntil:
+    visible:
+      id: "products-table-view"
+    timeout: 30000


### PR DESCRIPTION
## Description

Fixes found while reviewing the product-catalog Maestro flows for WOOMOB-3895 (iOS counterpart of WOOMOB-3889). As shipped, `products_variations_and_tags` and `products_media_upload` failed against a real store, and repeated runs exposed flakiness in `products_list_and_sort`. Each fix is a separate commit:

- **`navigate_to_products` — clear the product filter on entry.** The suite shares a session (`clearState:false`), so the `Variable` filter set by `products_variations_and_tags` leaked into later flows and hid their products. Clearing on entry makes every product flow deterministic and survives an upstream flow failing before its own cleanup.
- **`products_media_upload` — picker, upload settle, publish check.** The device-image picker moved to an **Albums → Recently Added** flow with a `SelectedActionButton` confirm (was "Photos"/"Add"); publish must wait for the image upload to settle or the product save is raced and never persists; and there is no `save-product-button` post-publish (the top bar reverts to the more-options button), so success is now detected via `publish-product-button` becoming not-visible and reopening the product.
- **`products_variations_and_tags` — count-agnostic assertion + row selector.** `"2 variations"` was coupled to one fixture (canonical sample data has 3/4) — now asserts `"\d+ variations"`, which also unblocks the previously-unreached variation-attributes assertions. Opening a variation now taps the `#<id> <attributes>` row instead of a fixed screen point that was flaky while the list loaded.
- **`seed-fixtures.py` — clean run-owned product media.** `--seed` cleanup deleted run-owned products/orders (and, upstream, tags) but left the uploaded images orphaned in the media library. `discover_entities` now journals each run-owned product's attached image ids and `cleanup` deletes them via the `wp/v2/media` namespace. Unit tests updated.
- **`products_list_and_sort` — settle before reading the sorted first row.** The table stays visible during a re-sort, so `copyTextFrom` could capture the previous order's first row and the "opposite sort orders differ" assert flaked. Added `waitForAnimationToEnd` before each capture.
- **`products_variations_and_tags` + `products_detail` — retry the more-options tap.** The `edit-product-more-options-button` popover occasionally didn't open; added `retryTapIfNoChange`.

Verified on iPhone 16 / iOS 26.3 with Maestro 2.9.0 against an automation-owned Jurassic Ninja lab store: all four flows pass, media create→cleanup is proven end-to-end (product + images removed), and repeats are stable (list_and_sort 10/10, detail/variations 10/10 each, media 5/5). Several of these mirror the accepted Android fixes in woocommerce/woocommerce-android#16491.

## Test Steps

1. Point `.maestro/.env.local` at an automation-owned lab store with sample products (incl. an editable variable product); set `MAESTRO_WOO_CONSUMER_KEY`/`SECRET` for `--seed`.
2. Run the non-destructive chunk and confirm all pass on the first attempt:
   `run-smoke-tests.sh --profile phone-full --device <udid> products_list_and_sort products_detail products_variations_and_tags`
3. Run the media chunk with `--seed` and confirm it passes and cleanup removes the run-owned product **and** its uploaded images from the store:
   `run-smoke-tests.sh --profile phone-full --device <udid> --seed products_media_upload`
4. `python3 -m unittest discover .maestro/scripts/tests` — all pass.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. (Test-only Maestro tooling — not user-facing, no release note.)