### PR TITLE
[TEMP] Smoke-test build warning guard

### DIFF
--- a/Modules/Sources/Yosemite/TemporaryBuildWarningFixtures.swift
+++ b/Modules/Sources/Yosemite/TemporaryBuildWarningFixtures.swift
@@ -1,0 +1,15 @@
+// Temporary CI fixtures for the build warning guard. Do not merge.
+#warning("[TEMP] Explicit compiler warning for the build warning guard smoke test")
+#warning("[TEMP] Literal formatting: `code` | [link](https://example.invalid) </details> & @warning-guard-fixture")
+
+private enum TemporaryBuildWarningFixtures {
+    static func emitWarnings() {
+        let temporaryUnusedValue = 1
+        var temporaryNeverMutatedValue = 2
+        _ = temporaryNeverMutatedValue
+        deprecatedWarningFixture()
+    }
+
+    @available(*, deprecated, message: "[TEMP] Deprecated call for the build warning guard smoke test")
+    private static func deprecatedWarningFixture() {}
+}


### PR DESCRIPTION
## Description

**Temporary CI smoke test for #17456. Do not merge.**

Includes the latest fixes from `codex/build-warning-increase-guard` at `94fe8d2118` and targets that branch, so the PR uses the updated warning guard.

Adds one isolated SwiftPM source file with five deliberate compiler diagnostics:

- An explicit compiler warning.
- A warning containing backticks, a pipe, Markdown link syntax, HTML, an ampersand, and a mention-like token.
- An unused `let`.
- A never-mutated `var`.
- A deprecated function call.

The fixture method is never called, so it does not change runtime behavior. No user-facing release notes are needed for this disposable test PR.

## Test Steps

1. Let Buildkite run the Build, Build Warning Baseline, and Build Warning Count steps.
2. Check that the warning comment lists all five distinct fixture diagnostics under `Modules/Sources/Yosemite/TemporaryBuildWarningFixtures.swift`.
3. Confirm the formatting diagnostic appears literally, without an active link or mention, broken table cells, or a prematurely closed details section.
4. Confirm the comment identifies this PR's tested commit and links the current CI build. The baseline should resolve to `94fe8d2118` on the warning-guard branch.
5. Inspect `build-warnings.json` and `base-build-warnings.json` in Buildkite artifacts. Raw occurrence counts may exceed five if the compiler repeats diagnostics across targets or architectures.

Local verification: the standalone Swift 5-mode type check succeeds with exactly five warnings; the warning parser identifies all five as owned Yosemite warnings and renders their exact details against an empty synthetic baseline. The full iOS build and live GitHub comment delivery are left to CI.

After validation, close this temporary PR without merging it.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
