### PR TITLE
[WOOMOB-4006] Attribute push notification received events to the origin site

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1473,6 +1473,10 @@ extension WooAnalyticsStat {
         case .wooPushTokenRegisterSuccess, .wooPushTokenRegisterError,
              .wooPushTokenDeleteSuccess, .wooPushTokenDeleteError:
             return false
+        // Received/pressed push notification events attribute `blog_id` / `site_url` to the notification's
+        // origin site (read from the APNS payload) via a factory, so opt out of the default-site enrichment.
+        case .pushNotificationReceived, .pushNotificationAlertPressed:
+            return false
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 25.7
 -----
-- [Internal] Attribute push_notification_received/alert_pressed events to the notification's origin site instead of the selected site. [https://github.com/woocommerce/woocommerce-ios/pull/XXXXX]
+- [Internal] Attribute push_notification_received/alert_pressed events to the notification's origin site instead of the selected site. [https://github.com/woocommerce/woocommerce-ios/pull/17848]
 - [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax. [https://github.com/woocommerce/woocommerce-ios/pull/17827]
 - [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.7
 -----
+- [Internal] Attribute push_notification_received/alert_pressed events to the notification's origin site instead of the selected site. [https://github.com/woocommerce/woocommerce-ios/pull/XXXXX]
 - [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax. [https://github.com/woocommerce/woocommerce-ios/pull/17827]
 - [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
 

--- a/WooCommerce/Classes/Analytics/Site+AnalyticsProperties.swift
+++ b/WooCommerce/Classes/Analytics/Site+AnalyticsProperties.swift
@@ -18,7 +18,7 @@ extension Site {
         return properties
     }
 
-    private enum PropertyKeys {
+    enum PropertyKeys {
         static let blogID = "blog_id"
         static let siteURL = "site_url"
         static let isWPComStore = "is_wpcom_store"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
@@ -38,8 +38,9 @@ extension WooAnalyticsEvent {
                               error: error)
         }
 
-        /// Tracked when a push notification is received while the app is running. Attributes `blog_id` /
-        /// `site_url` to the notification's origin site rather than the currently selected one.
+        /// Tracked when a push notification arrives in any app state other than being opened from the
+        /// notification. Attributes `blog_id` / `site_url` to the notification's origin site rather than
+        /// the currently selected one.
         static func pushNotificationReceived(originSiteID: Int64?,
                                              originSite: Site?,
                                              properties: [String: WooAnalyticsEventPropertyType]) -> WooAnalyticsEvent {
@@ -58,13 +59,14 @@ extension WooAnalyticsEvent {
 
         /// Builds properties for an event about the notification's origin site. When the origin site isn't
         /// available locally (e.g. a store no longer in the account), `blog_id` still carries the payload's
-        /// site ID so the origin is never lost.
+        /// site ID so the origin is never lost. Note that `store_id` and `cached_woo_core_version` still
+        /// describe the selected session store, matching the token register/delete events.
         private static func originSiteProperties(originSiteID: Int64?,
                                                  originSite: Site?,
                                                  merging eventProperties: [String: WooAnalyticsEventPropertyType]) -> [String: WooAnalyticsEventPropertyType] {
             var properties = properties(for: originSite)
             if originSite == nil, let originSiteID {
-                properties[SitePropertyKeys.blogID] = originSiteID
+                properties[Site.PropertyKeys.blogID] = originSiteID
             }
             return properties.merging(eventProperties) { _, event in event }
         }
@@ -83,10 +85,6 @@ extension WooAnalyticsEvent {
                 properties[SessionPropertyKeys.cachedWooCoreVersion] = cachedWooCoreVersion
             }
             return properties
-        }
-
-        private enum SitePropertyKeys {
-            static let blogID = "blog_id"
         }
 
         private enum SessionPropertyKeys {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
@@ -38,6 +38,37 @@ extension WooAnalyticsEvent {
                               error: error)
         }
 
+        /// Tracked when a push notification is received while the app is running. Attributes `blog_id` /
+        /// `site_url` to the notification's origin site rather than the currently selected one.
+        static func pushNotificationReceived(originSiteID: Int64?,
+                                             originSite: Site?,
+                                             properties: [String: WooAnalyticsEventPropertyType]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pushNotificationReceived,
+                              properties: originSiteProperties(originSiteID: originSiteID, originSite: originSite, merging: properties))
+        }
+
+        /// Tracked when the user opens the app by tapping a push notification. Attributes `blog_id` /
+        /// `site_url` to the notification's origin site rather than the currently selected one.
+        static func pushNotificationAlertPressed(originSiteID: Int64?,
+                                                 originSite: Site?,
+                                                 properties: [String: WooAnalyticsEventPropertyType]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pushNotificationAlertPressed,
+                              properties: originSiteProperties(originSiteID: originSiteID, originSite: originSite, merging: properties))
+        }
+
+        /// Builds properties for an event about the notification's origin site. When the origin site isn't
+        /// available locally (e.g. a store no longer in the account), `blog_id` still carries the payload's
+        /// site ID so the origin is never lost.
+        private static func originSiteProperties(originSiteID: Int64?,
+                                                 originSite: Site?,
+                                                 merging eventProperties: [String: WooAnalyticsEventPropertyType]) -> [String: WooAnalyticsEventPropertyType] {
+            var properties = properties(for: originSite)
+            if originSite == nil, let originSiteID {
+                properties[SitePropertyKeys.blogID] = originSiteID
+            }
+            return properties.merging(eventProperties) { _, event in event }
+        }
+
         /// Combines the target site's analytics properties with session-level fields (`store_id`,
         /// `cached_woo_core_version`) that the default-site enrichment would normally attach.
         /// These events opt out of that enrichment to protect the target-site attribution, so the
@@ -52,6 +83,10 @@ extension WooAnalyticsEvent {
                 properties[SessionPropertyKeys.cachedWooCoreVersion] = cachedWooCoreVersion
             }
             return properties
+        }
+
+        private enum SitePropertyKeys {
+            static let blogID = "blog_id"
         }
 
         private enum SessionPropertyKeys {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -1236,12 +1236,15 @@ private extension PushNotificationsManager {
 
         // Attribute the event to the notification's origin site, not the currently selected one.
         let notificationSiteID = userInfo[APNSKey.siteID] as? Int64
+        let originSiteID: Int64?
         let originSite: Yosemite.Site?
         if stores.isAuthenticatedWithoutWPCom {
             // Application-password sessions are single-site and the payload site ID is unreliable, so use the selected site.
             properties[AnalyticKey.fromSelectedSite] = true
+            originSiteID = siteID
             originSite = stores.sessionManager.defaultSite
         } else {
+            originSiteID = notificationSiteID
             originSite = notificationSiteID.flatMap { loadTargetSite(siteID: $0) }
             if let siteID, let notificationSiteID {
                 properties[AnalyticKey.fromSelectedSite] = siteID == notificationSiteID
@@ -1250,12 +1253,12 @@ private extension PushNotificationsManager {
 
         switch applicationState {
         case .inactive:
-            analytics.track(event: .PushNotifications.pushNotificationAlertPressed(originSiteID: notificationSiteID,
+            analytics.track(event: .PushNotifications.pushNotificationAlertPressed(originSiteID: originSiteID,
                                                                                   originSite: originSite,
                                                                                   properties: properties))
         default:
             properties[AnalyticKey.appState] = applicationState.rawValue
-            analytics.track(event: .PushNotifications.pushNotificationReceived(originSiteID: notificationSiteID,
+            analytics.track(event: .PushNotifications.pushNotificationReceived(originSiteID: originSiteID,
                                                                               originSite: originSite,
                                                                               properties: properties))
         }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -1208,7 +1208,7 @@ private extension PushNotificationsManager {
     /// Tracks the specified Notification's Payload.
     ///
     func trackNotification(with userInfo: [AnyHashable: Any]) {
-        var properties = [String: Any]()
+        var properties = [String: WooAnalyticsEventPropertyType]()
 
         // Determine notification source - Woo driven PNs don't have `note_id` in the payload.
         // The value may be absent, Swift `nil`, or `NSNull`, so resolve it via `string(forKey:)`,
@@ -1234,19 +1234,30 @@ private extension PushNotificationsManager {
             properties[AnalyticKey.token] = theToken
         }
 
+        // Attribute the event to the notification's origin site, not the currently selected one.
         let notificationSiteID = userInfo[APNSKey.siteID] as? Int64
+        let originSite: Yosemite.Site?
         if stores.isAuthenticatedWithoutWPCom {
+            // Application-password sessions are single-site and the payload site ID is unreliable, so use the selected site.
             properties[AnalyticKey.fromSelectedSite] = true
-        } else if let siteID, let notificationSiteID {
-            properties[AnalyticKey.fromSelectedSite] = siteID == notificationSiteID
+            originSite = stores.sessionManager.defaultSite
+        } else {
+            originSite = notificationSiteID.flatMap { loadTargetSite(siteID: $0) }
+            if let siteID, let notificationSiteID {
+                properties[AnalyticKey.fromSelectedSite] = siteID == notificationSiteID
+            }
         }
 
         switch applicationState {
         case .inactive:
-            analytics.track(.pushNotificationAlertPressed, withProperties: properties)
+            analytics.track(event: .PushNotifications.pushNotificationAlertPressed(originSiteID: notificationSiteID,
+                                                                                  originSite: originSite,
+                                                                                  properties: properties))
         default:
             properties[AnalyticKey.appState] = applicationState.rawValue
-            analytics.track(.pushNotificationReceived, withProperties: properties)
+            analytics.track(event: .PushNotifications.pushNotificationReceived(originSiteID: notificationSiteID,
+                                                                              originSite: originSite,
+                                                                              properties: properties))
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -2003,6 +2003,54 @@ final class PushNotificationsManagerTests: XCTestCase {
         )
     }
 
+    func test_handleNotificationInTheForeground_when_authenticated_without_wpcom_and_no_default_site_then_tracks_selected_site_id() async throws {
+        // Given — application-password login before the site is synced: no `defaultSite`, only the selected store ID.
+        storesManager.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
+        storesManager.sessionManager.setStoreId(500)
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .active
+        let payload = notificationPayload(noteID: nil, type: .storeOrder, siteID: 999, title: Sample.defaultTitle)
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then — the unreliable payload site ID must not leak into `blog_id`.
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "push_notification_received"))
+        let properties = analyticsProvider.receivedProperties[index]
+        XCTAssertEqual(properties["blog_id"] as? Int64, 500)
+        XCTAssertEqual(properties["is_from_selected_site"] as? Bool, true)
+    }
+
+    func test_handleNotificationInTheForeground_when_payload_has_no_site_id_then_tracks_without_site_properties() async throws {
+        // Given — WPCom session; the payload carries no `blog` key.
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: 100, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true)
+        ])
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .active
+        var payload = notificationPayload(noteID: 1234, type: .storeOrder, title: Sample.defaultTitle)
+        payload.removeValue(forKey: "blog")
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then — no site attribution at all, rather than the selected site's.
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "push_notification_received"))
+        let properties = analyticsProvider.receivedProperties[index]
+        XCTAssertEqual(properties["push_notification_type"] as? String, "store_order")
+        XCTAssertNil(properties["blog_id"])
+        XCTAssertNil(properties["site_url"])
+        XCTAssertNil(properties["is_from_selected_site"])
+    }
+
     func test_handleUserResponseToNotification_when_app_is_inactive_then_alert_pressed_event_carries_origin_site_properties() async throws {
         // Given — selected site is 100; the tapped notification comes from stored site 200.
         let selectedSiteID: Int64 = 100

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1880,6 +1880,160 @@ final class PushNotificationsManagerTests: XCTestCase {
         )
     }
 
+    func test_handleNotificationInTheForeground_when_notification_from_different_site_then_tracks_origin_site_properties() async throws {
+        // Given — selected site is 100; the notification comes from stored site 200.
+        let selectedSiteID: Int64 = 100
+        let originSiteID: Int64 = 200
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(selectedSiteID)
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: selectedSiteID, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true),
+            (siteID: originSiteID, url: "https://beta.example", isWPCom: false, isJetpackInstalled: false, isJetpackConnected: false)
+        ])
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .active
+        let payload = notificationPayload(noteID: 1234, type: .storeOrder, siteID: originSiteID, title: Sample.defaultTitle)
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then — the event carries the origin site's identifiers, not the selected site's.
+        analyticsProvider.assertReceived(
+            event: "push_notification_received",
+            with: [
+                "blog_id": originSiteID,
+                "site_url": "https://beta.example",
+                "is_wpcom_store": false,
+                "is_from_selected_site": false
+            ]
+        )
+    }
+
+    func test_handleNotificationInTheForeground_when_origin_site_not_in_storage_then_tracks_origin_blog_id_from_payload() async throws {
+        // Given — selected site 100 is stored; the notification comes from site 300, which is not stored.
+        let selectedSiteID: Int64 = 100
+        let originSiteID: Int64 = 300
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(selectedSiteID)
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: selectedSiteID, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true)
+        ])
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .active
+        let payload = notificationPayload(noteID: 1234, type: .storeOrder, siteID: originSiteID, title: Sample.defaultTitle)
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then — `blog_id` still identifies the origin; no selected-site URL leaks in.
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "push_notification_received"))
+        let properties = analyticsProvider.receivedProperties[index]
+        XCTAssertEqual(properties["blog_id"] as? Int64, originSiteID)
+        XCTAssertNil(properties["site_url"])
+        XCTAssertEqual(properties["is_from_selected_site"] as? Bool, false)
+    }
+
+    func test_handleNotificationInTheForeground_when_woo_driven_store_stock_notification_then_tracks_origin_blog_id() async throws {
+        // Given — `store_stock` has no local identifier, so the origin must come from the site properties.
+        let selectedSiteID: Int64 = 100
+        let originSiteID: Int64 = 200
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(selectedSiteID)
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: selectedSiteID, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true),
+            (siteID: originSiteID, url: "https://beta.example", isWPCom: false, isJetpackInstalled: false, isJetpackConnected: false)
+        ])
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .active
+        let payload = notificationPayload(noteID: nil, type: .storeStock, siteID: originSiteID, title: Sample.defaultTitle)
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "push_notification_received"))
+        let properties = analyticsProvider.receivedProperties[index]
+        XCTAssertEqual(properties["blog_id"] as? Int64, originSiteID)
+        XCTAssertEqual(properties["site_url"] as? String, "https://beta.example")
+        XCTAssertEqual(properties["push_notification_type"] as? String, "store_stock")
+        XCTAssertEqual(properties["push_notification_source"] as? String, "woo_driven")
+        XCTAssertNil(properties["push_notification_note_id"])
+    }
+
+    func test_handleNotificationInTheForeground_when_authenticated_without_wpcom_then_tracks_session_default_site_properties() async throws {
+        // Given — application-password login: the payload site ID is unreliable, so the selected site is the origin.
+        storesManager.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
+        storesManager.sessionManager.setStoreId(500)
+        storesManager.updateDefaultStore(Yosemite.Site.fake().copy(
+            siteID: 500,
+            url: "https://gamma.example",
+            isJetpackThePluginInstalled: true,
+            isJetpackConnected: false,
+            isWordPressComStore: false
+        ))
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .active
+        let payload = notificationPayload(noteID: nil, type: .storeOrder, siteID: 999, title: Sample.defaultTitle)
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then
+        analyticsProvider.assertReceived(
+            event: "push_notification_received",
+            with: [
+                "blog_id": Int64(500),
+                "site_url": "https://gamma.example",
+                "is_jetpack_installed": true,
+                "is_jetpack_connected": false,
+                "is_from_selected_site": true
+            ]
+        )
+    }
+
+    func test_handleUserResponseToNotification_when_app_is_inactive_then_alert_pressed_event_carries_origin_site_properties() async throws {
+        // Given — selected site is 100; the tapped notification comes from stored site 200.
+        let selectedSiteID: Int64 = 100
+        let originSiteID: Int64 = 200
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(selectedSiteID)
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: selectedSiteID, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true),
+            (siteID: originSiteID, url: "https://beta.example", isWPCom: false, isJetpackInstalled: false, isJetpackConnected: false)
+        ])
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .inactive
+        let payload = notificationPayload(noteID: 1234, type: .storeOrder, siteID: originSiteID, title: Sample.defaultTitle)
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let response = try XCTUnwrap(MockNotificationResponse(notificationUserInfo: payload))
+        await manager.handleUserResponseToNotification(response)
+
+        // Then
+        analyticsProvider.assertReceived(
+            event: "push_notification_alert_pressed",
+            with: [
+                "blog_id": originSiteID,
+                "site_url": "https://beta.example",
+                "is_from_selected_site": false
+            ]
+        )
+    }
+
     func test_registerDeviceToken_when_eligibility_unknown_then_retries_eligibility_check() async {
         // Given — eligibility check does not complete during init
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)


### PR DESCRIPTION
WOOMOB-4006

## Description

`push_notification_received` and `push_notification_alert_pressed` carry `blog_id` and `site_url` from the selected-site enrichment, so for multi-store users they name whichever store was open at the time rather than the store that sent the notification. The origin site ID is already read from the APNS payload to compute `is_from_selected_site`, but was never written into the event, and `store_stock` notifications lost it entirely because they have no synthesized note ID. This PR applies the same pattern WOOMOB-2757 used for the token register/delete events: opt both events out of the default enrichment and attribute them to the origin site instead. When the origin store is no longer in the app's site list, the event still carries the payload's site ID so the origin is never lost.

- Opted `pushNotificationReceived` and `pushNotificationAlertPressed` out of `shouldSendSiteProperties` in `WooAnalyticsStat`.
- Added `WooAnalyticsEvent.PushNotifications.pushNotificationReceived(...)` and `pushNotificationAlertPressed(...)` factories that emit the origin site's `blog_id`, `site_url`, `is_wpcom_store` and Jetpack flags, falling back to the raw payload `blog_id` when the site can't be loaded locally.
- `PushNotificationsManager.trackNotification(with:)` now resolves the origin site via `loadTargetSite(siteID:)` and dispatches through the new factories.
- Application-password sessions attribute the event to the selected site (falling back to the selected store ID when `defaultSite` isn't loaded yet), matching the existing `is_from_selected_site = true` rule for those sessions and Android's `ResolveSiteBySiteId` behavior.
- Added tests for a stored origin site, an origin site missing from storage, a `store_stock` notification, application-password sessions with and without a loaded `defaultSite`, a payload without a site ID, and the alert-pressed path.
- Added an `[Internal]` release note.

## Notes for reviewers

- **Tracks semantics change.** `blog_id`, `site_url`, `is_wpcom_store` and the Jetpack flags on these two events now describe the origin store instead of the selected store. Existing per-store dashboards built on them will shift meaning. The Tracks spreadsheet entries for both events need updating.
- **`store_id` and `cached_woo_core_version` still describe the selected session store**, the same as the `woo_push_token_*` events. For a cross-store notification the event will carry `blog_id = B` and `store_id = A`. Kept deliberately to preserve the payload shape; the selected store remains recoverable via `store_id` and `is_from_selected_site`.
- **Parity divergence with Android.** Android's `NotificationAnalyticsTracker` drops the event entirely when `ResolveSiteBySiteId` can't resolve the origin site. iOS keeps the event with the raw payload `blog_id`, so notifications from a store no longer in the account (WOOMOB-4005) remain countable. Android currently has the same attribution bug and will need its own fix once this approach is accepted.

## Test Steps

1. Sign in with a WordPress.com account that has two Jetpack-connected stores with push notifications enabled, store A and store B.
2. Select store A in the app and leave it open.
3. Place an order on store B so a push notification arrives on the device.
4. Open Menu → Settings → Help & Support → Application Log and find the `🔵 Tracked push_notification_received` line that follows the `📱 Push Notification Received` line.
5. Verify `blog_id` and `site_url` name store B and `is_from_selected_site` is `false`.
6. Reduce a store B product below its low stock threshold so a `store_stock` notification arrives, and verify that event also carries store B's `blog_id` and `site_url`.
7. Kill the app, tap the notification, and verify the `push_notification_alert_pressed` event carries store B's `blog_id` and `site_url`.
8. Sign out and sign in to a single store with application-password credentials, trigger a notification, and verify `site_url` names that store, `blog_id` is `-1` (the placeholder used for every event in a store-credentials session), and `is_from_selected_site` is `true`.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

