### PR TITLE
[TEMP] Verify warning comment removal after cleanup

### DIFF
--- a/Modules/Sources/Yosemite/TemporaryWarningLifecycleFixture.swift
+++ b/Modules/Sources/Yosemite/TemporaryWarningLifecycleFixture.swift
@@ -1,0 +1,4 @@
+// Temporary CI validation fixture. Do not merge.
+#warning("[TEMP] Remove this warning after the lifecycle comment is verified")
+
+private enum TemporaryWarningLifecycleFixture {}

--- a/Modules/Sources/Yosemite/TemporaryWarningLifecycleFixture.swift
+++ b/Modules/Sources/Yosemite/TemporaryWarningLifecycleFixture.swift
@@ -1,4 +1,3 @@
 // Temporary CI validation fixture. Do not merge.
-#warning("[TEMP] Remove this warning after the lifecycle comment is verified")
 
 private enum TemporaryWarningLifecycleFixture {}


### PR DESCRIPTION
## Description

Disposable draft child of #17456. Do not merge.

Validates the real Swift compiler and warning-comment lifecycle in two runs. The first commit adds one explicit warning. A follow-up removes that warning but keeps a harmless Swift declaration so the normal build pipeline still runs.

The implementation branch is unchanged. This PR will be closed after verification.

## Test Steps

1. Confirm the first run reports the new fixture warning with the correct head and merge-base commits.
2. Record the warning comment ID and baseline source.
3. Remove only the warning directive and push the cleanup commit.
4. Confirm the next successful comparison deletes the existing warning comment and does not post a replacement. Confirm a real app build ran.
5. Record cache reuse if present, then close this PR without merging.

## Screenshots

N/A. Evidence is in CI artifacts and the warning comment history.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release notes are needed for disposable CI fixtures.
