### PR TITLE
[Swift 6] Update `WooAIAssistant`

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -320,7 +320,7 @@ let package = Package(
                 "NetworkingCore",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
             ],
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .target(
             name: "StoreDesignSystem",
@@ -424,7 +424,7 @@ let package = Package(
             dependencies: [
                 .target(name: "WooAIAssistant"),
             ],
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .testTarget(
             name: "ParcelFittingCheckTests",

--- a/Modules/Sources/NetworkingCore/Settings/Settings.swift
+++ b/Modules/Sources/NetworkingCore/Settings/Settings.swift
@@ -7,7 +7,7 @@ public struct Settings {
 
     /// WordPress.com API Base URL
     ///
-    public static var wordpressApiBaseURL: String = {
+    public static let wordpressApiBaseURL: String = {
         if ProcessInfo.processInfo.arguments.contains("mocked-wpcom-api") {
             return "http://localhost:8282/"
         } else if let wpComApiBaseURL = ProcessInfo.processInfo.environment["wpcom-api-base-url"] {

--- a/Modules/Sources/NetworkingCore/Settings/UserAgent.swift
+++ b/Modules/Sources/NetworkingCore/Settings/UserAgent.swift
@@ -13,13 +13,13 @@ public class UserAgent {
 
     /// Returns the default WooCommerce iOS User Agent
     ///
-    public static var defaultUserAgent: String = {
+    public static let defaultUserAgent: String = {
         return webkitUserAgent + " " + Constants.woocommerceIdentifier + "/" + bundleShortVersion
     }()
 
     /// Returns a user agent string similar to (but may not exactly match) the one used in `WKWebView`.
     ///
-    static var webkitUserAgent: String = {
+    static let webkitUserAgent: String = {
         // Examples user agent strings from `WKWebView` in iOS simulators:
         //
         // ## iPhone 15 Pro (iOS 17.2)

--- a/Modules/Sources/WooAIAssistant/Presentation/AssistantConfirmationHandler.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/AssistantConfirmationHandler.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Environment-injected so confirmation cards stay retain-cycle free and previewable.
-struct AssistantConfirmationHandler {
-    var onConfirm: (UUID) -> Void = { _ in }
-    var onCancel: (UUID) -> Void = { _ in }
+struct AssistantConfirmationHandler: Sendable {
+    var onConfirm: @MainActor (UUID) -> Void = { _ in }
+    var onCancel: @MainActor (UUID) -> Void = { _ in }
 }
 
 private struct AssistantConfirmationHandlerKey: EnvironmentKey {

--- a/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
+++ b/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
@@ -35,24 +35,30 @@ final class MockAssistantBackend: AssistantBackendConfirming {
         continuation.finish()
     }
 
-    func send(turn: AssistantTurn,
-              context: AssistantContext,
-              session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
-        let index = recordTurn(turn)
-        return AsyncThrowingStream { continuation in
-            self.start(index: index, continuation: continuation)
+    nonisolated func send(turn: AssistantTurn,
+                          context: AssistantContext,
+                          session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
+        MainActor.assumeIsolated {
+            let index = recordTurn(turn)
+            return AsyncThrowingStream { continuation in
+                self.start(index: index, continuation: continuation)
+            }
         }
     }
 
-    func confirmProposal(_ id: UUID) async {
-        recordConfirmedProposal(id)
+    nonisolated func confirmProposal(_ id: UUID) async {
+        await recordConfirmedProposal(id)
     }
 
-    func cancelProposal(_ id: UUID) async {
-        recordCancelledProposal(id)
+    nonisolated func cancelProposal(_ id: UUID) async {
+        await recordCancelledProposal(id)
     }
 
-    func reset() async {
+    nonisolated func reset() async {
+        await performReset()
+    }
+
+    private func performReset() async {
         resetCallCount += 1
         if resetIsHeld {
             await withCheckedContinuation { continuation in

--- a/Modules/Tests/WooAIAssistantTests/Presentation/EntityCardTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Presentation/EntityCardTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import WooAIAssistant
 
 @Suite(.timeLimit(.minutes(1)))
+@MainActor
 struct EntityCardTests {
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Presentation/MessageBubbleOrderingTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Presentation/MessageBubbleOrderingTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import WooAIAssistant
 
 @Suite(.timeLimit(.minutes(1)))
+@MainActor
 struct MessageBubbleOrderingTests {
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Presentation/MessageBubbleRenderingTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Presentation/MessageBubbleRenderingTests.swift
@@ -4,6 +4,7 @@ import Testing
 @testable import WooAIAssistant
 
 @Suite(.timeLimit(.minutes(1)))
+@MainActor
 struct MessageBubbleRenderingTests {
 
     private let docsURL = URL(string: "https://woocommerce.com/document/woocommerce-ios/")!

--- a/Modules/Tests/WooAIAssistantTests/Presentation/ToolActivityCarouselTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Presentation/ToolActivityCarouselTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import WooAIAssistant
 
+@MainActor
 struct ToolActivityCarouselTests {
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Telemetry/AssistantShowCardsTelemetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Telemetry/AssistantShowCardsTelemetryTests.swift
@@ -35,10 +35,10 @@ struct AssistantShowCardsTelemetryTests {
         await registry.setResult(for: ShowCardsTool.name,
                                  result: .success(.init(toolName: ShowCardsTool.name,
                                                         structured: structured)))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "show me",
@@ -84,10 +84,10 @@ struct AssistantShowCardsTelemetryTests {
                                  result: .failed(.init(toolName: ShowCardsTool.name,
                                                        kind: .invalidToolCall,
                                                        reason: "bad args")))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "show me",
@@ -130,10 +130,10 @@ struct AssistantShowCardsTelemetryTests {
         await registry.setResult(for: ShowCardsTool.name,
                                  result: .success(.init(toolName: ShowCardsTool.name,
                                                         structured: .array([.int(1)]))))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "show me",

--- a/Modules/Tests/WooAIAssistantTests/Telemetry/AssistantToolCallTelemetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Telemetry/AssistantToolCallTelemetryTests.swift
@@ -28,10 +28,10 @@ struct AssistantToolCallTelemetryTests {
         await registry.setResult(for: "orders_list",
                                  result: .success(.init(toolName: "orders_list",
                                                         structured: .object(["count": .int(1)]))))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "list",
@@ -71,10 +71,10 @@ struct AssistantToolCallTelemetryTests {
                                  result: .failed(.init(toolName: "orders_update",
                                                        kind: .network,
                                                        reason: "boom")))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",
@@ -101,10 +101,10 @@ struct AssistantToolCallTelemetryTests {
             [.completed(.stop)]
         ])
         let registry = MockToolRegistry()
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",
@@ -135,10 +135,10 @@ struct AssistantToolCallTelemetryTests {
             [.completed(.stop)]
         ])
         let registry = MockToolRegistry()
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",
@@ -175,10 +175,10 @@ struct AssistantToolCallTelemetryTests {
         let proposal = ToolResult.ConfirmationProposal(toolName: "orders_list",
                                                        proposal: .object([:]))
         await registry.setResult(for: "orders_list", result: .awaitingConfirmation(proposal))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",
@@ -213,11 +213,11 @@ struct AssistantToolCallTelemetryTests {
         await registry.setResult(for: "orders_list",
                                  result: .success(.init(toolName: "orders_list",
                                                         structured: .object(["count": .int(0)]))))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         perToolPerTurnCap: 2,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   perToolPerTurnCap: 2,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",
@@ -247,10 +247,10 @@ struct AssistantToolCallTelemetryTests {
              .completed(.toolCalls)],
             [.completed(.stop)]
         ])
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: nil,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: nil,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",
@@ -290,10 +290,10 @@ struct AssistantToolCallTelemetryTests {
         await registry.setResult(for: "orders_list",
                                  result: .success(.init(toolName: "orders_list",
                                                         structured: .object(["count": .int(0)]))))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",
@@ -329,10 +329,10 @@ struct AssistantToolCallTelemetryTests {
         await registry.setResult(for: "orders_list",
                                  result: .success(.init(toolName: "orders_list",
                                                         structured: .object(["count": .int(0)]))))
-        let tracker = await RecordingAssistantTelemetryTracker()
-        let orchestrator = await AgenticLoopOrchestrator(chatService: chat,
-                                                         toolRegistry: registry,
-                                                         telemetryTracker: tracker)
+        let tracker = RecordingAssistantTelemetryTracker()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   telemetryTracker: tracker)
 
         // When
         for try await _ in orchestrator.run(prompt: "go",

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsGetToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsGetToolTests.swift
@@ -97,8 +97,9 @@ struct ProductsGetToolTests {
         let result = await tool.executor(#"{"id": 9999}"#, client)
 
         // Then
-        guard case .failed(let failed) = result else {
+        guard case .failed = result else {
             Issue.record("expected failed")
             return
-        }    }
+        }
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/REST/ToolArgumentValidationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/REST/ToolArgumentValidationTests.swift
@@ -31,9 +31,8 @@ struct ToolArgumentValidationTests {
                                                      toolName: "orders_update")
 
         // Then
-        let unwrapped = try? #require(failed)
-        #expect(unwrapped?.kind == .invalidToolCall)
-        #expect(unwrapped?.reason == "Unsupported orders_update argument(s): discount_total")
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason == "Unsupported orders_update argument(s): discount_total")
     }
 
     @Test
@@ -48,8 +47,7 @@ struct ToolArgumentValidationTests {
                                                      toolName: "orders_update")
 
         // Then
-        let unwrapped = try? #require(failed)
-        #expect(unwrapped?.reason.contains("_method, discount_total") == true)
+        #expect(failed.reason.contains("_method, discount_total") == true)
     }
 
     @Test
@@ -96,8 +94,7 @@ struct ToolArgumentValidationTests {
                                                      toolName: "orders_bulk_update")
 
         // Then
-        let unwrapped = try? #require(failed)
-        #expect(unwrapped?.kind == .invalidToolCall)
-        #expect(unwrapped?.reason.contains("discount_total") == true)
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("discount_total") == true)
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/REST/ToolArgumentValidationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/REST/ToolArgumentValidationTests.swift
@@ -20,7 +20,7 @@ struct ToolArgumentValidationTests {
     }
 
     @Test
-    func test_validate_when_args_contain_unknown_key_then_failed_with_invalidToolCall_kind_is_returned() {
+    func test_validate_when_args_contain_unknown_key_then_failed_with_invalidToolCall_kind_is_returned() throws {
         // Given
         let arguments = #"{"id": 1, "discount_total": "9.00"}"#
         let allowed: Set<String> = ["id", "status"]
@@ -31,12 +31,13 @@ struct ToolArgumentValidationTests {
                                                      toolName: "orders_update")
 
         // Then
-        #expect(failed.kind == .invalidToolCall)
-        #expect(failed.reason == "Unsupported orders_update argument(s): discount_total")
+        let unwrapped = try #require(failed)
+        #expect(unwrapped.kind == .invalidToolCall)
+        #expect(unwrapped.reason == "Unsupported orders_update argument(s): discount_total")
     }
 
     @Test
-    func test_validate_when_args_contain_multiple_unknown_keys_then_message_lists_them_comma_separated() {
+    func test_validate_when_args_contain_multiple_unknown_keys_then_message_lists_them_comma_separated() throws {
         // Given
         let arguments = #"{"id": 1, "_method": "delete", "discount_total": "9.00"}"#
         let allowed: Set<String> = ["id"]
@@ -47,7 +48,8 @@ struct ToolArgumentValidationTests {
                                                      toolName: "orders_update")
 
         // Then
-        #expect(failed.reason.contains("_method, discount_total") == true)
+        let unwrapped = try #require(failed)
+        #expect(unwrapped.reason.contains("_method, discount_total") == true)
     }
 
     @Test
@@ -81,7 +83,7 @@ struct ToolArgumentValidationTests {
     }
 
     @Test
-    func test_validate_patch_when_object_has_unknown_key_then_failed_is_returned() {
+    func test_validate_patch_when_object_has_unknown_key_then_failed_is_returned() throws {
         // Given
         let patch: AnyCodableJSON = .object([
             "status": .string("completed"),
@@ -94,7 +96,8 @@ struct ToolArgumentValidationTests {
                                                      toolName: "orders_bulk_update")
 
         // Then
-        #expect(failed.kind == .invalidToolCall)
-        #expect(failed.reason.contains("discount_total") == true)
+        let unwrapped = try #require(failed)
+        #expect(unwrapped.kind == .invalidToolCall)
+        #expect(unwrapped.reason.contains("discount_total") == true)
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -15,7 +15,7 @@ struct WCRESTClientRetryTests {
         let recorder = SleepRecorder()
         let client = RetryingWCRESTClient(inner: stub,
                                           policy: .default,
-                                          sleep: recorder.record)
+                                          sleep: { try await recorder.record($0) })
 
         // When
         let response = await client.request(method: "GET",
@@ -37,7 +37,7 @@ struct WCRESTClientRetryTests {
         let recorder = SleepRecorder()
         let client = RetryingWCRESTClient(inner: stub,
                                           policy: .default,
-                                          sleep: recorder.record)
+                                          sleep: { try await recorder.record($0) })
 
         // When
         let response = await client.request(method: "GET",
@@ -82,7 +82,7 @@ struct WCRESTClientRetryTests {
         let recorder = SleepRecorder()
         let client = RetryingWCRESTClient(inner: stub,
                                           policy: .default,
-                                          sleep: recorder.record)
+                                          sleep: { try await recorder.record($0) })
 
         // When
         let response = await client.request(method: "GET",
@@ -104,7 +104,7 @@ struct WCRESTClientRetryTests {
         let recorder = SleepRecorder()
         let client = RetryingWCRESTClient(inner: stub,
                                           policy: .default,
-                                          sleep: recorder.record)
+                                          sleep: { try await recorder.record($0) })
 
         // When
         let response = await client.request(method: "POST",
@@ -128,7 +128,7 @@ struct WCRESTClientRetryTests {
         let recorder = SleepRecorder()
         let client = RetryingWCRESTClient(inner: stub,
                                           policy: .default,
-                                          sleep: recorder.record)
+                                          sleep: { try await recorder.record($0) })
 
         // When
         let response = await client.request(method: "GET",


### PR DESCRIPTION
Closes WOOMOB-4029

## Description
Takes `WooAIAssistant` and `WooAIAssistantTests` to zero warnings under complete concurrency checking and moves both to Swift 6 in `Modules/Package.swift`. 

## Test Steps
- On a clean build, the app compiles fine
- CI passes

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
