### PR TITLE
[Swift 6] Move TestKit to Swift 6

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -215,7 +215,7 @@ let package = Package(
         .target(
             name: "TestKit",
             dependencies: ["Difference", "Nimble"],
-            swiftSettings: swift5
+            swiftSettings: swift6
         ),
         .target(
             name: "UITestsFoundation",

--- a/Modules/Sources/TestKit/Assertions.swift
+++ b/Modules/Sources/TestKit/Assertions.swift
@@ -3,19 +3,19 @@ import Difference
 
 /// Asserts that a collection is empty.
 ///
-public func assertEmpty<T: Collection>(_ collection: T, file: StaticString = #file, line: UInt = #line) {
+public func assertEmpty<T: Collection>(_ collection: T, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertTrue(collection.isEmpty, "Expected collection \(collection) to be empty.", file: file, line: line)
 }
 
 /// Asserts that a collection is not empty.
 ///
-public func assertNotEmpty<T: Collection>(_ collection: T, file: StaticString = #file, line: UInt = #line) {
+public func assertNotEmpty<T: Collection>(_ collection: T, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertFalse(collection.isEmpty, "Expected collection \(collection) to not be empty.", file: file, line: line)
 }
 
 /// Asserts that `lhs` has the same pointer address as `rhs`.
 ///
-public func assertThat(_ lhs: AnyObject?, isIdenticalTo rhs: AnyObject?, file: StaticString = #file, line: UInt = #line) {
+public func assertThat(_ lhs: AnyObject?, isIdenticalTo rhs: AnyObject?, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertTrue(lhs === rhs,
                   "Expected object \(String(describing: lhs)) to have the same pointer address as \(String(describing: rhs)).",
                   file: file,
@@ -24,7 +24,7 @@ public func assertThat(_ lhs: AnyObject?, isIdenticalTo rhs: AnyObject?, file: S
 
 /// Asserts that `subject` contains the given string.
 ///
-public func assertThat(_ subject: String, contains value: String, file: StaticString = #file, line: UInt = #line) {
+public func assertThat(_ subject: String, contains value: String, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertTrue(subject.contains(value),
                   "Expected “\(subject)” to contain “\(value)”.",
                   file: file,
@@ -35,7 +35,7 @@ public func assertThat(_ subject: String, contains value: String, file: StaticSt
 ///
 /// If `subject`'s type is just a subclass of `expectedType`, then this will fail.
 ///
-public func assertThat<T>(_ subject: Any?, isAnInstanceOf expectedType: T.Type, file: StaticString = #file, line: UInt = #line) {
+public func assertThat<T>(_ subject: Any?, isAnInstanceOf expectedType: T.Type, file: StaticString = #filePath, line: UInt = #line) {
     guard let subject else {
         XCTFail("Expected nil to be an instance of \(expectedType)",
                 file: file,
@@ -52,7 +52,7 @@ public func assertThat<T>(_ subject: Any?, isAnInstanceOf expectedType: T.Type, 
 /// Asserts that the async throws `expression` throws an error, and asserts the given Bool expression
 /// with the generated error.
 ///
-public func assertThrowsError(_ expression: () async throws -> (), errorAssert: (Error) -> Bool, file: StaticString = #file, line: UInt = #line) async {
+public func assertThrowsError(_ expression: () async throws -> (), errorAssert: (Error) -> Bool, file: StaticString = #filePath, line: UInt = #line) async {
     do {
         _ = try await expression()
         XCTFail("It should throw an error",

--- a/Modules/Sources/TestKit/XCTestCase+Wait.swift
+++ b/Modules/Sources/TestKit/XCTestCase+Wait.swift
@@ -114,7 +114,7 @@ extension XCTestCase {
     public func waitForAsync<ValueType>(file: StaticString = #file,
                                         line: UInt = #line,
                                         timeout: TimeInterval = 5.0,
-                                        awaiting: @escaping (_ promise: (@escaping (ValueType) -> Void)) async throws -> Void)
+                                        awaiting: @escaping @MainActor (_ promise: (@escaping (ValueType) -> Void)) async throws -> Void)
     async rethrows -> ValueType {
         let exp = expectation(description: "Expect promise to be called.")
 

--- a/Modules/Sources/TestKit/XCTestCase+Wait.swift
+++ b/Modules/Sources/TestKit/XCTestCase+Wait.swift
@@ -84,7 +84,7 @@ extension XCTestCase {
     /// XCTAssertEquals("expected_value", value)
     /// ```
     ///
-    public func waitFor<ValueType>(file: StaticString = #file,
+    public func waitFor<ValueType>(file: StaticString = #filePath,
                                    line: UInt = #line,
                                    timeout: TimeInterval = 5.0,
                                    awaiting: @escaping (_ promise: (@escaping (ValueType) -> Void)) throws -> Void) rethrows -> ValueType {
@@ -111,7 +111,7 @@ extension XCTestCase {
 
     /// Async/await version of `waitFor`, as `XCTWaiter.wait(for:timeout:)` does not support concurrency in `waitFor`.
     @MainActor
-    public func waitForAsync<ValueType>(file: StaticString = #file,
+    public func waitForAsync<ValueType>(file: StaticString = #filePath,
                                         line: UInt = #line,
                                         timeout: TimeInterval = 5.0,
                                         awaiting: @escaping @MainActor (_ promise: (@escaping (ValueType) -> Void)) async throws -> Void)

--- a/Modules/Sources/TestKit/XCTestCase+Wait.swift
+++ b/Modules/Sources/TestKit/XCTestCase+Wait.swift
@@ -110,6 +110,7 @@ extension XCTestCase {
     }
 
     /// Async/await version of `waitFor`, as `XCTWaiter.wait(for:timeout:)` does not support concurrency in `waitFor`.
+    @MainActor
     public func waitForAsync<ValueType>(file: StaticString = #file,
                                         line: UInt = #line,
                                         timeout: TimeInterval = 5.0,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -32,7 +32,6 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         storage = nil
     }
 
-    @MainActor
     func test_loading_is_enabled_while_marking_order_as_paid() async {
         // Given
         stores.whenReceivingAction(ofType: OrderAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -32,6 +32,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         storage = nil
     }
 
+    @MainActor
     func test_loading_is_enabled_while_marking_order_as_paid() async {
         // Given
         stores.whenReceivingAction(ofType: OrderAction.self) { action in


### PR DESCRIPTION
Closes WOOMOB-4059

## Description
Takes `TestKit` to zero warnings under complete concurrency checking and moves it to Swift 6 in `Modules/Package.swift`. It has no test target of its own, so the slice ends in the flip.

## Test Steps
- No runtime smoke needed: the module is XCTest helpers only, with no third-party callbacks.
- On a clean build, app should open normally.
- CI should pass.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
