### PR TITLE
Stabilize Product Search navigation transition

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -475,8 +475,14 @@ private extension ProductsSplitViewCoordinator {
         }
         let isShowingProductSearch = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
 
-        // Releasing an interactive swipe starts a final noninteractive transition segment. Wait for that segment to finish
-        // before hiding the bar so Product Search first-responder layout cannot race the split navigation bars (Sentry 1523523535).
+        // UIKit does not scrub a navigation-bar visibility animation with an interactive pop. Starting that animation in
+        // `willShow` can therefore leave the product detail bar visible briefly after the swipe finishes. Wait until UIKit
+        // finishes the complete transition, then hide the bar immediately only for a completed pop.
+        //
+        // IMPORTANT: This intentionally leaves navigation-bar-sized space above Product Search briefly after a back swipe.
+        // Do not remove that gap by hiding the bar or forcing Search to lay out earlier in the transition. In a collapsed
+        // split view, the product detail navigation item can still belong to the secondary navigation bar at that point.
+        // Forcing the primary bar to lay it out risks the NSInternalInconsistencyException in Sentry issue 1523523535.
         if isShowingProductSearch,
            let transitionCoordinator = navigationController.transitionCoordinator,
            transitionCoordinator.isInteractive {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -482,7 +482,7 @@ private extension ProductsSplitViewCoordinator {
         // IMPORTANT: This intentionally leaves navigation-bar-sized space above Product Search briefly after a back swipe.
         // Do not remove that gap by hiding the bar or forcing Search to lay out earlier in the transition. In a collapsed
         // split view, the product detail navigation item can still belong to the secondary navigation bar at that point.
-        // Forcing the primary bar to lay it out risks the NSInternalInconsistencyException in Sentry issue 1523523535.
+        // Doing either too early risks the NSInternalInconsistencyException in Sentry issues 7669931391 and 1523523535.
         if isShowingProductSearch,
            let transitionCoordinator = navigationController.transitionCoordinator,
            transitionCoordinator.isInteractive {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -116,15 +116,21 @@ final class ProductsSplitViewCoordinator: NSObject {
         reconcilePrimaryNavigationBarVisibility(afterShowing: productsViewController, in: primaryNavigationController)
     }
 
-    /// Hides the primary navigation bar once an interactive pop back to Product Search commits.
+    /// Hides the primary navigation bar once an interactive pop back to Product Search finishes.
     ///
     /// A cancelled gesture leaves the bar alone, because Product Detail stays on screen and keeps needing it.
     /// Extracted from the transition coordinator callback so the completed and cancelled cases can be tested.
-    func hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: Bool) {
+    func hidePrimaryNavigationBarWhenTransitionCompletes(isCancelled: Bool) {
         guard !isCancelled else {
             return
         }
         primaryNavigationController.setNavigationBarHiddenIfNeeded(true, animated: false)
+    }
+
+    func schedulePrimaryNavigationBarHide(after transitionCoordinator: UIViewControllerTransitionCoordinator) {
+        transitionCoordinator.animate(alongsideTransition: nil) { [weak self] context in
+            self?.hidePrimaryNavigationBarWhenTransitionCompletes(isCancelled: context.isCancelled)
+        }
     }
 
     /// Returns the product form of the given product ID being displayed on the secondary column if available.
@@ -469,20 +475,12 @@ private extension ProductsSplitViewCoordinator {
         }
         let isShowingProductSearch = viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
 
-        // UIKit does not scrub a navigation-bar visibility animation with an interactive pop. Starting that animation in
-        // `willShow` can therefore leave the product detail bar visible briefly after the swipe finishes. Wait until UIKit
-        // knows whether the gesture will finish or cancel, then hide the bar immediately only for a completed pop.
-        //
-        // IMPORTANT: This intentionally leaves navigation-bar-sized space above Product Search briefly after a back swipe.
-        // Do not remove that gap by hiding the bar or forcing Search to lay out earlier in the transition. In a collapsed
-        // split view, the product detail navigation item can still belong to the secondary navigation bar at that point.
-        // Forcing the primary bar to lay it out caused NSInternalInconsistencyException crashes (Sentry issue 7669931391).
+        // Releasing an interactive swipe starts a final noninteractive transition segment. Wait for that segment to finish
+        // before hiding the bar so Product Search first-responder layout cannot race the split navigation bars (Sentry 1523523535).
         if isShowingProductSearch,
            let transitionCoordinator = navigationController.transitionCoordinator,
            transitionCoordinator.isInteractive {
-            transitionCoordinator.notifyWhenInteractionChanges { [weak self] context in
-                self?.hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: context.isCancelled)
-            }
+            schedulePrimaryNavigationBarHide(after: transitionCoordinator)
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -175,10 +175,6 @@ where Cell.SearchModel == Command.CellViewModel {
         if searchUICommand.hideNavigationBar {
             navigationController?.setNavigationBarHiddenIfNeeded(true, animated: searchUICommand.animateNavigationBarVisibilityChanges)
         }
-
-        if searchUICommand.makeSearchBarFirstResponderOnStart {
-            searchBar.becomeFirstResponder()
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -186,6 +182,10 @@ where Cell.SearchModel == Command.CellViewModel {
 
         // Note: configuring the search bar text color does not work in `viewDidLoad` and `viewWillAppear`.
         configureSearchBar()
+
+        if searchUICommand.makeSearchBarFirstResponderOnStart {
+            searchBar.becomeFirstResponder()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -101,29 +101,52 @@ struct ProductsSplitViewCoordinatorTests {
     }
 
     @Test
-    func test_hidePrimaryNavigationBarWhenInteractionCompletes_when_swipe_completes_then_hides_the_bar() throws {
+    func test_hidePrimaryNavigationBarWhenTransitionCompletes_when_swipe_completes_then_hides_the_bar() throws {
         // Given
         let (sut, primaryNavigationController, _) = try makeSUT()
         primaryNavigationController.setNavigationBarHidden(false, animated: false)
 
         // When
-        sut.hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: false)
+        sut.hidePrimaryNavigationBarWhenTransitionCompletes(isCancelled: false)
 
         // Then
         #expect(primaryNavigationController.isNavigationBarHidden)
     }
 
     @Test
-    func test_hidePrimaryNavigationBarWhenInteractionCompletes_when_swipe_is_cancelled_then_leaves_the_bar_visible() throws {
+    func test_hidePrimaryNavigationBarWhenTransitionCompletes_when_swipe_is_cancelled_then_leaves_the_bar_visible() throws {
         // Given
         let (sut, primaryNavigationController, _) = try makeSUT()
         primaryNavigationController.setNavigationBarHidden(false, animated: false)
 
         // When
-        sut.hidePrimaryNavigationBarWhenInteractionCompletes(isCancelled: true)
+        sut.hidePrimaryNavigationBarWhenTransitionCompletes(isCancelled: true)
 
         // Then
         #expect(primaryNavigationController.isNavigationBarHidden == false)
+    }
+
+    @Test
+    func test_schedulePrimaryNavigationBarHide_then_waits_until_the_interactive_transition_completes() throws {
+        // Given
+        let (sut, primaryNavigationController, _) = try makeSUT()
+        let transitionCoordinator = MockInteractiveTransitionCoordinator()
+        primaryNavigationController.setNavigationBarHidden(false, animated: false)
+
+        // When
+        sut.schedulePrimaryNavigationBarHide(after: transitionCoordinator)
+        transitionCoordinator.changeInteraction(isCancelled: false)
+
+        // Then
+        #expect(primaryNavigationController.isNavigationBarHidden == false)
+        #expect(primaryNavigationController.navigationBar.isHidden == false)
+
+        // When
+        transitionCoordinator.completeTransition(isCancelled: false)
+
+        // Then
+        #expect(primaryNavigationController.isNavigationBarHidden)
+        #expect(primaryNavigationController.navigationBar.isHidden)
     }
 
     @Test
@@ -206,4 +229,63 @@ private extension ProductsSplitViewCoordinatorTests {
 
 private final class CollapsedSplitViewController: UISplitViewController {
     override var isCollapsed: Bool { true }
+}
+
+@objc private final class MockInteractiveTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
+    private var interactionChangeHandler: ((UIViewControllerTransitionCoordinatorContext) -> Void)?
+    private var completionHandler: ((UIViewControllerTransitionCoordinatorContext) -> Void)?
+
+    private(set) var isCancelled = false
+
+    func changeInteraction(isCancelled: Bool) {
+        self.isCancelled = isCancelled
+        interactionChangeHandler?(self)
+    }
+
+    func completeTransition(isCancelled: Bool) {
+        self.isCancelled = isCancelled
+        completionHandler?(self)
+    }
+
+    func animate(alongsideTransition animation: ((UIViewControllerTransitionCoordinatorContext) -> Void)?,
+                 completion: ((UIViewControllerTransitionCoordinatorContext) -> Void)? = nil) -> Bool {
+        completionHandler = completion
+        return true
+    }
+
+    func animateAlongsideTransition(in view: UIView?,
+                                    animation: ((UIViewControllerTransitionCoordinatorContext) -> Void)?,
+                                    completion: ((UIViewControllerTransitionCoordinatorContext) -> Void)? = nil) -> Bool {
+        completionHandler = completion
+        return true
+    }
+
+    func notifyWhenInteractionEnds(_ handler: @escaping (UIViewControllerTransitionCoordinatorContext) -> Void) {
+        interactionChangeHandler = handler
+    }
+
+    func notifyWhenInteractionChanges(_ handler: @escaping (UIViewControllerTransitionCoordinatorContext) -> Void) {
+        interactionChangeHandler = handler
+    }
+
+    let isAnimated = true
+    let presentationStyle: UIModalPresentationStyle = .none
+    let initiallyInteractive = true
+    let isInterruptible = true
+    let isInteractive = true
+    let transitionDuration: TimeInterval = 0.35
+    let percentComplete: CGFloat = 0
+    let completionVelocity: CGFloat = 1
+    let completionCurve: UIView.AnimationCurve = .easeInOut
+
+    func viewController(forKey key: UITransitionContextViewControllerKey) -> UIViewController? {
+        nil
+    }
+
+    func view(forKey key: UITransitionContextViewKey) -> UIView? {
+        nil
+    }
+
+    let containerView = UIView()
+    let targetTransform: CGAffineTransform = .identity
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsSplitViewCoordinatorTests.swift
@@ -231,7 +231,7 @@ private final class CollapsedSplitViewController: UISplitViewController {
     override var isCollapsed: Bool { true }
 }
 
-@objc private final class MockInteractiveTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
+private final class MockInteractiveTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
     private var interactionChangeHandler: ((UIViewControllerTransitionCoordinatorContext) -> Void)?
     private var completionHandler: ((UIViewControllerTransitionCoordinatorContext) -> Void)?
 


### PR DESCRIPTION
WOOMOB-3737

## Description


Sentry issue 1523523535 reports a navigation-bar ownership crash around Product Search and Product Detail navigation.

This is yet another fix in this area. Slowly chipping away in the declining crash rate.

⚠️  The original production crash could not be reproduced locally.

The overarching issue is likely due to two navigation controllers briefly owning the same navigation item which causes the crash. It only happens when something forces a view layout during the transition which then ends up in a corrupted UIKit state. WOOMOB-3932 may be able to address this.

### Solution

Solution focuses to reduce the chance of a view requiring to layout while transition happens.

This change:
-  waits for the complete interactive transition before hiding the primary navigation bar. A cancelled swipe leaves Product Detail and its navigation bar unchanged.
-  The shared Search screen now focuses its search field in `viewDidAppear`, after its presentation transition finishes.

I verified the affected flows on iOS 18 and iPadOS 26 and found no regressions. 

The existing temporary space above Product Search during an interactive Back transition remains because the navigation bar must stay available until UIKit completes the navigation-item handoff.

## Test Steps

1. On an iPhone, open **Products**, enter Product Search, and confirm that the search field receives focus and the keyboard appears.
2. Select a simple product, tap Back, and confirm that Product Search returns without a crash or incorrect navigation bar.
3. Select a product again, start an edge-swipe Back gesture, and cancel it. Confirm that Product Detail remains visible with its navigation bar and Back button.
4. Complete the edge-swipe Back gesture. Confirm that Product Search returns and remains usable. Repeat the completed and cancelled gestures several times.
5. Repeat with a variable product and after editing and saving a product.
6. On an iPad, repeat the Product Search path in collapsed and expanded layouts, including after changing orientation or window width.
7. Open Order Search and confirm that its search field still receives focus when the screen appears.

## Screenshots

### Back button — Before


https://github.com/user-attachments/assets/95e989b5-5c7b-4006-95d2-164453654a46



### Back button — After

https://github.com/user-attachments/assets/48778145-7c8e-431c-94b3-aa3a880e667b



### Edge-swipe Back — Before

https://github.com/user-attachments/assets/aa1ff393-4874-4a58-85cd-1db5ad4e68ef



### Edge-swipe Back — After

https://github.com/user-attachments/assets/6e704101-5f83-45a9-9601-04bb634d6dae



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. No release note is needed for this internal crash fix.
