### PR TITLE
Track specific POS ineligibility reasons

### DIFF
--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSaleIneligibleUI.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSaleIneligibleUI.swift
@@ -34,9 +34,12 @@ private extension POSIneligibleReason {
             return "feature_switch_disabled"
         case .wooCommercePluginNotFound:
             return "unknown_wc_plugin"
-        case .siteSettingsNotAvailable,
-             .selfDeallocated:
-            return "other"
+        case .unsupportedCountry:
+            return "store_country"
+        case .siteSettingsNotAvailable:
+            return "site_settings_unavailable"
+        case .selfDeallocated:
+            return "self_deallocated"
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Models/POSIneligibleReason.swift
+++ b/Modules/Sources/PointOfSale/Models/POSIneligibleReason.swift
@@ -6,6 +6,7 @@ import enum WooFoundation.CurrencyCode
 public enum POSIneligibleReason: Equatable {
     case noInternetConnection
     case unsupportedWooCommerceVersion(minimumVersion: String)
+    case unsupportedCountry
     case siteSettingsNotAvailable
     case wooCommercePluginNotFound
     case featureSwitchDisabled

--- a/Modules/Sources/PointOfSale/Presentation/POSIneligibleView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSIneligibleView.swift
@@ -152,7 +152,7 @@ struct POSIneligibleView: View {
                 "and %2$@ is a placeholder for the localized list of supported currency codes."
             )
             return String.localizedStringWithFormat(format, countryCode.readableCountry, formattedCurrencyList)
-        case .siteSettingsNotAvailable:
+        case .siteSettingsNotAvailable, .unsupportedCountry:
             return NSLocalizedString("pos.ineligible.suggestion.siteSettingsNotAvailable.1",
                                      value: "We were unable to load the site settings info. Please check your internet connection and try again. " +
                                      "If the issue persists, contact support for assistance.",
@@ -202,6 +202,7 @@ private extension POSIneligibleReason {
         case .noInternetConnection,
                 .unsupportedWooCommerceVersion,
                 .siteSettingsNotAvailable,
+                .unsupportedCountry,
                 .wooCommercePluginNotFound,
                 .unsupportedCurrency,
                 .selfDeallocated:

--- a/Modules/Tests/PointOfSaleTests/Analytics/POSIneligibleAnalyticsEventTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Analytics/POSIneligibleAnalyticsEventTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import struct WooFoundation.WooAnalyticsEvent
+@testable import PointOfSale
+
+struct POSIneligibleAnalyticsEventTests {
+    @Test(arguments: [
+        (POSIneligibleReason.siteSettingsNotAvailable, "site_settings_unavailable"),
+        (.selfDeallocated, "self_deallocated"),
+        (.unsupportedCountry, "store_country"),
+        (.noInternetConnection, "no_internet_connection"),
+        (.unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD]), "store_currency"),
+        (.unsupportedWooCommerceVersion(minimumVersion: "9.6.0"), "wc_plugin_version"),
+        (.featureSwitchDisabled, "feature_switch_disabled"),
+        (.wooCommercePluginNotFound, "unknown_wc_plugin")
+    ])
+    func test_ineligible_events_when_reason_is_known_then_report_specific_reason(reason: POSIneligibleReason, expected: String) {
+        // Given / When
+        let events = [
+            WooAnalyticsEvent.PointOfSaleIneligibleUI.ineligibleUIShown(reason: reason),
+            WooAnalyticsEvent.PointOfSaleIneligibleUI.ineligibleUIRetryTapped(reason: reason),
+            WooAnalyticsEvent.PointOfSaleIneligibleUI.ineligibleUILearnMoreTapped(reason: reason)
+        ]
+
+        // Then
+        for event in events {
+            #expect(event.properties["reason"] as? String == expected)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -120,7 +120,7 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
 
     func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState {
         switch ineligibleReason {
-        case .siteSettingsNotAvailable, .unsupportedCurrency:
+        case .siteSettingsNotAvailable, .unsupportedCountry, .unsupportedCurrency:
             do {
                 try await syncSiteSettingsRemotely()
                 return await checkEligibility(forceRemoteCheck: false)
@@ -216,7 +216,7 @@ private extension POSIneligibleReason {
         switch self {
         case .unsupportedWooCommerceVersion, .wooCommercePluginNotFound, .featureSwitchDisabled, .unsupportedCurrency:
             return true
-        case .noInternetConnection, .siteSettingsNotAvailable, .selfDeallocated:
+        case .noInternetConnection, .siteSettingsNotAvailable, .unsupportedCountry, .selfDeallocated:
             return false
         }
     }
@@ -300,11 +300,10 @@ private extension POSTabEligibilityChecker {
             return .eligible
         case .ineligible(reason: let reason):
             switch reason {
-            case .siteSettingsNotAvailable, .unsupportedCountry:
-                // This is an edge case where the store country is expected to be eligible from the visilibity check, but site settings might have
-                // changed to an unsupported country during the session. In this case, we return an ineligible reason that prompts the merchant to
-                // relaunch the app.
+            case .siteSettingsNotAvailable:
                 return .ineligible(reason: .siteSettingsNotAvailable)
+            case .unsupportedCountry:
+                return .ineligible(reason: .unsupportedCountry)
             case let .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrencies):
                 return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrencies))
             }
@@ -320,6 +319,9 @@ private extension POSTabEligibilityChecker {
 
         // Conditions that can change if site settings are synced during the lifetime.
         let countryCode = SiteAddress(siteSettings: siteSettings).countryCode
+        guard countryCode != .unknown else {
+            return .ineligible(reason: .siteSettingsNotAvailable)
+        }
         let currencyCode = CurrencySettings(siteSettings: siteSettings).currencyCode
 
         return isEligibleFromCountryAndCurrencyCode(countryCode: countryCode, currencyCode: currencyCode)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -129,7 +129,52 @@ struct POSTabEligibilityCheckerTests {
         let result = await checker.checkEligibility(forceRemoteCheck: false)
 
         // Then
+        #expect(result == .ineligible(reason: .unsupportedCountry))
+    }
+
+    @Test(arguments: [nil, "", "INVALID"] as [String?])
+    func test_checkEligibility_when_country_is_missing_or_invalid_then_reports_unavailable_settings(country: String?) async throws {
+        // Given
+        var settings = [mockCurrencySetting(currency: .USD)]
+        if let country {
+            settings.append(mockCountrySetting(country: .us).copy(value: country))
+        }
+        siteSettings.mockSettingsStream = [
+            (siteID: siteID, settings: settings, source: SettingsUpdateSource.refresh)
+        ].publisher.eraseToAnyPublisher()
+        let checker = makeEligibilityChecker()
+
+        // When
+        let result = await checker.checkEligibility(forceRemoteCheck: false)
+
+        // Then
         #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
+    }
+
+    @Test func test_checkEligibility_when_settings_stream_finishes_empty_then_reports_unavailable_settings() async throws {
+        // Given
+        siteSettings.mockSettingsStream = Empty(completeImmediately: true).eraseToAnyPublisher()
+        let checker = makeEligibilityChecker()
+
+        // When
+        let result = await checker.checkEligibility(forceRemoteCheck: false)
+
+        // Then
+        #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
+    }
+
+    @Test func test_checkEligibility_when_country_is_unsupported_then_keeps_cached_eligibility() async throws {
+        // Given
+        eligibilityService.cacheLastKnownPOSEligibility(siteID: siteID, isEligible: true)
+        setupCountry(country: .es, currency: .EUR)
+        let checker = makeEligibilityChecker()
+
+        // When
+        let result = await checker.checkEligibility(forceRemoteCheck: true)
+
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedCountry))
+        #expect(eligibilityService.loadLastKnownPOSEligibility(siteID: siteID) == true)
     }
 
     @Test(arguments: [
@@ -429,6 +474,7 @@ struct POSTabEligibilityCheckerTests {
 
     @Test(arguments: [
         POSIneligibleReason.siteSettingsNotAvailable,
+        POSIneligibleReason.unsupportedCountry,
         POSIneligibleReason.unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD])
     ])
     fileprivate func refreshEligibility_syncs_site_settings_and_checks_eligibility_for_site_settings_issues(ineligibleReason: POSIneligibleReason) async throws {
@@ -461,6 +507,7 @@ struct POSTabEligibilityCheckerTests {
 
     @Test(arguments: [
         POSIneligibleReason.siteSettingsNotAvailable,
+        POSIneligibleReason.unsupportedCountry,
         POSIneligibleReason.unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD])
     ])
     fileprivate func refreshEligibility_returns_siteSettingsNotAvailable_when_site_settings_sync_fails(ineligibleReason: POSIneligibleReason) async throws {
@@ -719,8 +766,8 @@ struct POSTabEligibilityCheckerTests {
         // When
         let result = await checker.checkEligibility(forceRemoteCheck: false)
 
-        // Then - falls through with `siteSettingsNotAvailable` (the unsupportedCountry path is mapped here)
-        #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedCountry))
     }
 
     @Test func expansion_country_with_mismatched_currency_is_ineligible() async throws {


### PR DESCRIPTION
Fixes WOOMOB-4065

## Description

Comes for the data that shows that a lot of events here have "other" reason and this PR makes it more granular

## Test Steps

1. Turn POS Local Catalog off in Experimental Features.
2. Set the store to US / GB, relaunch the app, and open POS to get the currency error.
3. Keep the app in the foreground, change the country to Spain in desktop wp-admin, then tap Retry. The screen event reports `store_country`.
4. Tap Retry again to check the retry event also reports `store_country`.
5. Restore US / USD and tap Retry to open POS, then restore the local catalog toggle.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

