### PR TITLE
Keep the site credential form disabled until sign-in finishes

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -610,7 +610,10 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             endpointUnderVerification == .admin
         )
         useCase.setupHandlers(onLoginSuccess: {
-            onLoading(false)
+            // Deliberately no `onLoading(false)` here, unlike the failure branch below. The credential
+            // transaction succeeding only starts the sign-in: `onSuccess` goes on to run the application
+            // password, role eligibility and WooCommerce installation checks, and the form has to stay
+            // disabled until one of those navigates away.
             onSuccess(credentials.replacingAuthenticationEndpoints(with: endpoints))
         }, onLoginFailure: { [weak self] error, loginEntryVerified, offersBrowserAlternative in
             onLoading(false)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -1214,7 +1214,14 @@ extension AuthenticationManager {
             useCase = try makeApplicationPasswordUseCase(for: siteCredentials)
         } catch {
             // Authenticated credentials without a constructible canonical site cannot safely enter the eligibility flow.
-            assertionFailure("⛔️ Error creating application password use case")
+            // Nothing further along clears the sign-in loading state, so plainly returning would strand the merchant on a
+            // credential form whose fields, submit button and back button all stay disabled. Report the broken invariant
+            // and restart login, which is the same escape the post-login eligibility alerts already offer.
+            ServiceLocator.crashLogging.logError(error,
+                                                 userInfo: ["site_url": siteURL],
+                                                 level: .error)
+            stores.deauthenticate()
+            navigationController.popToRootViewController(animated: true)
             return
         }
         let credentials = Credentials.wporg(

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -1070,6 +1070,35 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual(events, ["loading:true", "handle", "success"])
     }
 
+    /// Nothing further along clears the sign-in loading state when the application password use case cannot be built,
+    /// so plainly returning would leave the merchant on a credential form whose fields, submit button and back button
+    /// are all still disabled. Login has to restart instead.
+    ///
+    func test_didAuthenticateUser_when_the_application_password_use_case_cannot_be_created_then_login_restarts() throws {
+        // Given
+        let sessionManager = SessionManager(
+            defaults: try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString)),
+            keychainServiceName: UUID().uuidString
+        )
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        stores.authenticate(credentials: .wporg(username: "merchant", password: "password", siteAddress: "https://example.com"))
+        let root = UIViewController()
+        navigationController.setViewControllers([root, UIViewController()], animated: false)
+        let manager = AuthenticationManager(
+            stores: stores,
+            applicationPasswordUseCaseFactory: .init(makeWordPressOrgUseCase: { _, _, _, _ in
+                throw ApplicationPasswordUseCaseError.failedToConstructLoginOrAdminURLUsingSiteAddress
+            })
+        )
+
+        // When
+        manager.didAuthenticateUser(to: "https://example.com", with: siteCredentials(), in: navigationController)
+
+        // Then
+        waitUntil { self.navigationController.viewControllers == [root] }
+        XCTAssertFalse(stores.isAuthenticated)
+    }
+
     func test_authenticate_site_credentials_when_login_retry_has_invalid_unverified_response_then_recovers_not_found() {
         // Given
         let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -1041,6 +1041,35 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual(events, ["loading:true", "handle", "loading:false", "recovery"])
     }
 
+    /// The credential transaction succeeding is not the end of the sign-in: `onSuccess` kicks off the
+    /// application password, role eligibility and WooCommerce installation checks, which take several
+    /// seconds more. Ending the loading state here would re-enable the submit button and restore the back
+    /// button while the merchant is still being signed in.
+    ///
+    func test_authenticate_site_credentials_when_login_succeeds_then_the_loading_state_is_not_ended() {
+        // Given
+        let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
+        var events = [String]()
+        useCase.onHandleLogin = { events.append("handle") }
+        let manager = AuthenticationManager(siteCredentialLoginUseCaseFactory: { _, _, _ in useCase })
+
+        // When
+        manager.authenticateSiteCredentials(
+            credentials: siteCredentials(),
+            loginURL: nil,
+            adminURL: nil,
+            endpointUnderVerification: nil,
+            onLoading: { events.append("loading:\($0)") },
+            onSuccess: { _ in events.append("success") },
+            onRecovery: { _ in XCTFail("Expected the login to succeed") },
+            onFailure: { _, _, _, _ in XCTFail("Expected the login to succeed") }
+        )
+        useCase.succeed()
+
+        // Then
+        XCTAssertEqual(events, ["loading:true", "handle", "success"])
+    }
+
     func test_authenticate_site_credentials_when_login_retry_has_invalid_unverified_response_then_recovers_not_found() {
         // Given
         let useCase = MockAuthenticationManagerSiteCredentialLoginUseCase()
@@ -1385,7 +1414,9 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertEqual((options["login_url"] as? [String: String])?["value"], "https://example.com/custom-login")
         XCTAssertNil(options["admin_url"])
         XCTAssertEqual((options["unrelated"] as? [String: String])?["value"], "preserved")
-        XCTAssertEqual(loading, [true, false])
+        // The loading state is not ended on success: the post-login checks still have to run.
+        // See `test_authenticate_site_credentials_when_login_succeeds_then_the_loading_state_is_not_ended`.
+        XCTAssertEqual(loading, [true])
 
         let defaultEndpoints = try CookieNonceAuthenticationEndpoints(
             siteURL: XCTUnwrap(URL(string: "https://example.com"))

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -875,6 +875,10 @@ extension SiteCredentialsViewController {
         }
     }
 
+    /// - Note: the screen is still in its loading state when this runs, and stays there until something navigates away
+    ///   from it. A `completionHandler` caller is therefore responsible for dismissing or popping this view controller
+    ///   itself; leaving it on screen leaves the merchant on a permanently disabled form.
+    ///
     func finishedLogin(withUsername username: String, password: String, xmlrpc: String, options: [AnyHashable: Any]) {
         let wporg = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
         /// If `completionHandler` is available, return early with the credentials.


### PR DESCRIPTION
## Description

In site credentials login, the Continue button became tappable again — along with the username/password fields and the back button — while the merchant was still being signed in.

`AuthenticationManager.authenticateSiteCredentials(credentials:loginURL:adminURL:endpointUnderVerification:...)`, the endpoint-recovery aware overload added in #17738, ended the loading state inside its `onLoginSuccess` handler:

```swift
useCase.setupHandlers(onLoginSuccess: {
    onLoading(false)   // <-- too early
    onSuccess(credentials.replacingAuthenticationEndpoints(with: endpoints))
}, ...
```

`onLoginSuccess` only means the cookie/nonce credential transaction finished. `onSuccess` then kicks off the rest of the sign-in, ending in `PostSiteCredentialLoginChecker.checkEligibility`, which runs three more sequential network round trips — application password generation, role eligibility, WooCommerce installation — before anything navigates away. Against a real store that left the form interactive for roughly ten seconds.

The legacy overload directly above it has deliberately never ended the loading state on success since `247fa27b91` (2023) — only on failure, precisely so the spinner survives the post-login checks. This restores that contract for the newer overload. The failure and recovery branches are unchanged and still end the loading state correctly.

**No release note:** the regression only ever existed on trunk. It is not in 25.6.0.0 or any earlier release, so no user has seen it.

The existing test `test_authenticate_site_credentials_when_custom_or_standard_login_succeeds_then_persists_only_nondefault_endpoints` asserted `loading == [true, false]`, which had codified the buggy sequence. That test's subject is endpoint persistence, so the incidental assertion is corrected to `[true]`.

## Second commit: report and recover instead of dead-ending

Raised in review of the first commit, and included here because it is a direct consequence of it.

`didAuthenticateUser` bails out when the application password use case cannot be built, and that bail-out did nothing at all — `assertionFailure` is compiled out in Release, so the `return` left no alert, no navigation and no error callback behind. That was survivable while the loading state was (wrongly) ended on success, because the form had already been re-enabled: the merchant got a silent dead end but could still retry or go back. With the first commit in place, the same bail-out would leave them with locked fields, a frozen spinner and a hidden back button.

**This is defensive, not a fix for an observed failure.** The branch looks unreachable from site credentials login: the mismatch guard compares `resolvedEndpoints.siteURL` against `defaultEndpoints.siteURL`, and both are normalized from the same site address string, so it cannot trip; the other two guards would already have failed the login before it could succeed. The practical win is observability — `assertionFailure` has never given us any production signal that this invariant broke, whereas `crashLogging.logError` will. The recovery (`deauthenticate` + pop to root) is the same escape the post-login eligibility alerts already offer.

Also documents on `finishedLogin` that a `completionHandler` caller of `SiteCredentialsViewController` now owns dismissing the screen, since the loading state is no longer cleared for it on success. That path has no production caller today, so it is a note for whoever wires it up.

## Test Steps

1. Log out, then sign in to a self-hosted store with **store credentials** (site address -> username + password).
2. Tap **Continue** and watch the button until the dashboard appears.
3. Expected: the button keeps its spinner and stays disabled, the username/password fields stay disabled, and the back button stays hidden for the **whole** duration — not just the first few seconds. Before this change it went solid purple and tappable about ten seconds early.
4. Failure paths should be unaffected: sign in with a **wrong password**, and separately with a store whose `wp-login.php` has been moved by a security plugin. In both cases the form must become interactive again so the merchant can retry or supply a recovery URL.

The second commit's branch is not reachable by manual testing (see above), so it is covered by a unit test that injects a throwing application-password factory and asserts login restarts rather than stranding the form.

## Screenshots

N/A — the change is a button enablement state.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
