### PR TITLE
[WOOMOB-3340] Add Cell component to the design system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,15 @@ Modules/Tests/PointOfSaleTests/  # POS unit tests
 WooCommerce/Classes/POS/         # App-target POS integration (POSTabCoordinator, adaptors)
 ```
 
+## Design System (StoreDesignSystem)
+
+`Modules/Sources/StoreDesignSystem/` is the Woo Mobile Design System module: tokens (`Tokens/` — color, typography, icons, spacing, padding, radius, size, stroke, motion) and `Store*` components (`Components/<Name>/`). Figma source: the "Mobile Design System" file. The in-app gallery lives in Debug Panel → Design System (`WooCommerce/Classes/ViewRelated/DesignSystemDemo/`).
+
+- **New SwiftUI views use `StoreDesignSystem`**: `Store*` components, `.storeTextStyle(_:)`, `Color.store*`, `StoreSpacing`/`StorePadding`/`StoreRadius`/`StoreIcon`. No hardcoded sizes, colors, or system fonts alongside them.
+- **Do not mix legacy styling with DS tokens** in one view: a view is either legacy (`Color(.text)`, `.headline`, `.withColorStudio`) or design-system, never both.
+- **Adding a component**: `Components/<Name>/Store<Name>.swift` plus closed variant/tone types, tokens only, a demo view in `DesignSystemDemo/` registered in `DesignSystemDemoView`, `#Preview` blocks, and Swift Testing coverage in `Modules/Tests/StoreDesignSystemTests/`. Pull the spec from the Figma node before implementing.
+- **Screen migrations** are flag-gated and swap the view layer only; view models and business logic stay shared.
+
 ## WooAIAssistant Module
 
 The WooAIAssistant module (`Modules/Sources/WooAIAssistant/`) is a self-contained feature module that ships an in-app conversational agent for merchants. The architecture is designed to be flexible: it can integrate REST tools, MCP tools, or both, and the chat endpoint is swappable without touching the agentic loop. The module renders rich entity cards that integrate with existing app views and screens. See `Modules/Sources/WooAIAssistant/AGENTS.md` for architecture, decisions, and anti-patterns. Live evaluation runs through the `/woo-ai-smoke` skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,6 @@ WooCommerce/Classes/POS/         # App-target POS integration (POSTabCoordinator
 - **New SwiftUI views use `StoreDesignSystem`**: `Store*` components, `.storeTextStyle(_:)`, `Color.store*`, `StoreSpacing`/`StorePadding`/`StoreRadius`/`StoreIcon`. No hardcoded sizes, colors, or system fonts alongside them.
 - **Do not mix legacy styling with DS tokens** in one view: a view is either legacy (`Color(.text)`, `.headline`, `.withColorStudio`) or design-system, never both.
 - **Adding a component**: `Components/<Name>/Store<Name>.swift` plus closed variant/tone types, tokens only, a demo view in `DesignSystemDemo/` registered in `DesignSystemDemoView`, `#Preview` blocks, and Swift Testing coverage in `Modules/Tests/StoreDesignSystemTests/`. Pull the spec from the Figma node before implementing.
-- **Screen migrations** are flag-gated and swap the view layer only; view models and business logic stay shared.
 
 ## WooAIAssistant Module
 

--- a/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCell.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCell.swift
@@ -45,7 +45,7 @@ public struct StoreCell<Leading: View, Trailing: View>: View {
             .buttonStyle(StoreCellButtonStyle())
         } else {
             content
-                .accessibilityElement(children: StoreCellAccessibility.childBehavior(hasTrailingContent: hasTrailingContent))
+                .accessibilityElement(children: .contain)
         }
     }
 
@@ -53,10 +53,8 @@ public struct StoreCell<Leading: View, Trailing: View>: View {
         StoreCellAppearance(isEnabled: isEnabled)
     }
 
-    private var hasTrailingContent: Bool {
-        Trailing.self != EmptyView.self
-    }
-
+    /// The leading visual sits `s5` from the text (the "cell content" spec); the trailing slot and the
+    /// disclosure indicator sit `s6` from the content (the row spec).
     private var content: some View {
         HStack(alignment: .center, spacing: StoreSpacing.s6) {
             HStack(alignment: .center, spacing: StoreSpacing.s5) {
@@ -67,20 +65,18 @@ public struct StoreCell<Leading: View, Trailing: View>: View {
             trailing
                 .foregroundStyle(appearance.slot)
             if showsDisclosureIndicator {
-                StoreIcon.AngleRight.regular.image(size: Constants.disclosureIconSize)
+                StoreIcon.AngleRight.regular.image(size: StoreCellConstants.disclosureIconSize)
                     .foregroundStyle(appearance.slot)
                     .flipsForRightToLeftLayoutDirection(true)
                     .accessibilityHidden(true)
             }
         }
         .padding(StorePadding.p7)
-        .frame(minHeight: StoreSize.minimumTapTarget)
         .background(appearance.background)
         .contentShape(Rectangle())
     }
 
-    /// The leading visual sits `s5` from the text (the "cell content" spec); the trailing slot and the
-    /// disclosure indicator sit `s6` from the content (the row spec).
+    /// Title and description read as one VoiceOver element, whatever the slots hold.
     private var text: some View {
         VStack(alignment: .leading, spacing: StoreSpacing.s1) {
             Text(title)
@@ -93,6 +89,7 @@ public struct StoreCell<Leading: View, Trailing: View>: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
     }
 }
 
@@ -143,7 +140,7 @@ public extension StoreCell where Leading == EmptyView {
 }
 
 /// File-scoped rather than nested in ``StoreCell`` because a generic type can't hold static stored properties.
-private enum Constants {
+private enum StoreCellConstants {
     /// The chevron size from the design (18 pt).
     static let disclosureIconSize: StoreIconSize = .medium
 }

--- a/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCell.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCell.swift
@@ -59,19 +59,11 @@ public struct StoreCell<Leading: View, Trailing: View>: View {
 
     private var content: some View {
         HStack(alignment: .center, spacing: StoreSpacing.s6) {
-            leading
-                .foregroundStyle(appearance.slot)
-            VStack(alignment: .leading, spacing: StoreSpacing.s1) {
-                Text(title)
-                    .storeTextStyle(.bodyLarge.emphasized)
-                    .foregroundStyle(appearance.title)
-                if let description {
-                    Text(description)
-                        .storeTextStyle(.bodyMedium)
-                        .foregroundStyle(appearance.description)
-                }
+            HStack(alignment: .center, spacing: StoreSpacing.s5) {
+                leading
+                    .foregroundStyle(appearance.slot)
+                text
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             trailing
                 .foregroundStyle(appearance.slot)
             if showsDisclosureIndicator {
@@ -85,6 +77,22 @@ public struct StoreCell<Leading: View, Trailing: View>: View {
         .frame(minHeight: StoreSize.minimumTapTarget)
         .background(appearance.background)
         .contentShape(Rectangle())
+    }
+
+    /// The leading visual sits `s5` from the text (the "cell content" spec); the trailing slot and the
+    /// disclosure indicator sit `s6` from the content (the row spec).
+    private var text: some View {
+        VStack(alignment: .leading, spacing: StoreSpacing.s1) {
+            Text(title)
+                .storeTextStyle(.bodyLarge.emphasized)
+                .foregroundStyle(appearance.title)
+            if let description {
+                Text(description)
+                    .storeTextStyle(.bodyMedium)
+                    .foregroundStyle(appearance.description)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCell.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCell.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+/// A single list row: a title with an optional description between optional leading and trailing
+/// slots, on a surface-bright container. Combine cells (separated by ``StoreDivider``) to build lists.
+///
+/// - Note: Pass `action` to make the whole row one tappable button. A `trailing` slot that carries its
+///   own control (e.g. a toggle) belongs on a row without `action`, so the row doesn't expose two
+///   competing actions. `.disabled(_:)` dims the row and blocks its action.
+public struct StoreCell<Leading: View, Trailing: View>: View {
+    @Environment(\.isEnabled) private var isEnabled
+
+    private let title: String
+    private let description: String?
+    private let showsDisclosureIndicator: Bool
+    private let action: (() -> Void)?
+    private let leading: Leading
+    private let trailing: Trailing
+
+    /// - Parameters:
+    ///   - title: The row's primary text.
+    ///   - description: Secondary text shown under the title.
+    ///   - showsDisclosureIndicator: Shows the trailing chevron that signals the row opens a detail.
+    ///   - action: Makes the whole row a button. `nil` renders a static row.
+    ///   - leading: Content before the text, e.g. a ``StoreIconContainer`` or an image.
+    ///   - trailing: Content after the text, e.g. a value label, a ``StoreBadge`` or a toggle.
+    public init(_ title: String,
+                description: String? = nil,
+                showsDisclosureIndicator: Bool = false,
+                action: (() -> Void)? = nil,
+                @ViewBuilder leading: () -> Leading,
+                @ViewBuilder trailing: () -> Trailing) {
+        self.title = title
+        self.description = description
+        self.showsDisclosureIndicator = showsDisclosureIndicator
+        self.action = action
+        self.leading = leading()
+        self.trailing = trailing()
+    }
+
+    public var body: some View {
+        if let action {
+            Button(action: action) {
+                content
+            }
+            .buttonStyle(StoreCellButtonStyle())
+        } else {
+            content
+                .accessibilityElement(children: StoreCellAccessibility.childBehavior(hasTrailingContent: hasTrailingContent))
+        }
+    }
+
+    private var appearance: StoreCellAppearance {
+        StoreCellAppearance(isEnabled: isEnabled)
+    }
+
+    private var hasTrailingContent: Bool {
+        Trailing.self != EmptyView.self
+    }
+
+    private var content: some View {
+        HStack(alignment: .center, spacing: StoreSpacing.s6) {
+            leading
+                .foregroundStyle(appearance.slot)
+            VStack(alignment: .leading, spacing: StoreSpacing.s1) {
+                Text(title)
+                    .storeTextStyle(.bodyLarge.emphasized)
+                    .foregroundStyle(appearance.title)
+                if let description {
+                    Text(description)
+                        .storeTextStyle(.bodyMedium)
+                        .foregroundStyle(appearance.description)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            trailing
+                .foregroundStyle(appearance.slot)
+            if showsDisclosureIndicator {
+                StoreIcon.AngleRight.regular.image(size: Constants.disclosureIconSize)
+                    .foregroundStyle(appearance.slot)
+                    .flipsForRightToLeftLayoutDirection(true)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(StorePadding.p7)
+        .frame(minHeight: StoreSize.minimumTapTarget)
+        .background(appearance.background)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Slot-less conveniences
+
+public extension StoreCell where Leading == EmptyView, Trailing == EmptyView {
+    init(_ title: String,
+         description: String? = nil,
+         showsDisclosureIndicator: Bool = false,
+         action: (() -> Void)? = nil) {
+        self.init(title,
+                  description: description,
+                  showsDisclosureIndicator: showsDisclosureIndicator,
+                  action: action,
+                  leading: { EmptyView() },
+                  trailing: { EmptyView() })
+    }
+}
+
+public extension StoreCell where Trailing == EmptyView {
+    init(_ title: String,
+         description: String? = nil,
+         showsDisclosureIndicator: Bool = false,
+         action: (() -> Void)? = nil,
+         @ViewBuilder leading: () -> Leading) {
+        self.init(title,
+                  description: description,
+                  showsDisclosureIndicator: showsDisclosureIndicator,
+                  action: action,
+                  leading: leading,
+                  trailing: { EmptyView() })
+    }
+}
+
+public extension StoreCell where Leading == EmptyView {
+    init(_ title: String,
+         description: String? = nil,
+         showsDisclosureIndicator: Bool = false,
+         action: (() -> Void)? = nil,
+         @ViewBuilder trailing: () -> Trailing) {
+        self.init(title,
+                  description: description,
+                  showsDisclosureIndicator: showsDisclosureIndicator,
+                  action: action,
+                  leading: { EmptyView() },
+                  trailing: trailing)
+    }
+}
+
+/// File-scoped rather than nested in ``StoreCell`` because a generic type can't hold static stored properties.
+private enum Constants {
+    /// The chevron size from the design (18 pt).
+    static let disclosureIconSize: StoreIconSize = .medium
+}
+
+/// Renders a tappable row as its plain content plus the module's press feedback — no button tint.
+private struct StoreCellButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? Constants.pressedOpacity : 1)
+            .animation(.easeOut(duration: StoreMotion.pressDuration), value: configuration.isPressed)
+    }
+
+    private enum Constants {
+        static let pressedOpacity: Double = 0.7
+    }
+}

--- a/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCellAppearance.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCellAppearance.swift
@@ -25,12 +25,3 @@ struct StoreCellAppearance: Equatable {
         }
     }
 }
-
-/// How a non-interactive ``StoreCell`` groups its children for VoiceOver.
-enum StoreCellAccessibility {
-    /// A cell whose trailing slot is empty reads as one element (title, description). A populated
-    /// trailing slot may hold its own control (e.g. a toggle), so the children stay reachable.
-    static func childBehavior(hasTrailingContent: Bool) -> AccessibilityChildBehavior {
-        hasTrailingContent ? .contain : .combine
-    }
-}

--- a/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCellAppearance.swift
+++ b/Modules/Sources/StoreDesignSystem/Components/Cell/StoreCellAppearance.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// The colors of a ``StoreCell``, resolved for its enabled state.
+///
+/// - Note: The design defines one container (surface bright) and no disabled variant, so the
+///   disabled presentation follows the module's uniform state-layer rule (as ``StoreButton`` does)
+///   rather than a cell-specific token.
+struct StoreCellAppearance: Equatable {
+    let background: Color
+    let title: Color
+    let description: Color
+    /// The tint applied to the leading / trailing slots and the disclosure indicator.
+    let slot: Color
+
+    init(isEnabled: Bool) {
+        background = .storeSurfaceBright
+        if isEnabled {
+            title = .storeOnSurface
+            description = .storeOnSurfaceVariant
+            slot = .storeOnSurfaceVariant
+        } else {
+            title = .storeStateLayerOnSurfaceOpacity24
+            description = .storeStateLayerOnSurfaceOpacity24
+            slot = .storeStateLayerOnSurfaceOpacity24
+        }
+    }
+}
+
+/// How a non-interactive ``StoreCell`` groups its children for VoiceOver.
+enum StoreCellAccessibility {
+    /// A cell whose trailing slot is empty reads as one element (title, description). A populated
+    /// trailing slot may hold its own control (e.g. a toggle), so the children stay reachable.
+    static func childBehavior(hasTrailingContent: Bool) -> AccessibilityChildBehavior {
+        hasTrailingContent ? .contain : .combine
+    }
+}

--- a/Modules/Tests/StoreDesignSystemTests/StoreCellAppearanceTests.swift
+++ b/Modules/Tests/StoreDesignSystemTests/StoreCellAppearanceTests.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import Testing
+@testable import StoreDesignSystem
+
+@Suite struct StoreCellAppearanceTests {
+
+    @Test func test_init_when_enabled_then_uses_surface_roles() {
+        // Given / When an enabled cell resolves its appearance
+        let sut = StoreCellAppearance(isEnabled: true)
+
+        // Then the container is surface bright with on-surface text and on-surface-variant slots
+        #expect(sut.background == .storeSurfaceBright)
+        #expect(sut.title == .storeOnSurface)
+        #expect(sut.description == .storeOnSurfaceVariant)
+        #expect(sut.slot == .storeOnSurfaceVariant)
+    }
+
+    @Test func test_init_when_disabled_then_keeps_container_and_dims_foreground() {
+        // Given / When a disabled cell resolves its appearance
+        let sut = StoreCellAppearance(isEnabled: false)
+
+        // Then the container is unchanged and every foreground follows the state-layer rule
+        #expect(sut.background == .storeSurfaceBright)
+        #expect(sut.title == .storeStateLayerOnSurfaceOpacity24)
+        #expect(sut.description == .storeStateLayerOnSurfaceOpacity24)
+        #expect(sut.slot == .storeStateLayerOnSurfaceOpacity24)
+    }
+
+    @Test func test_childBehavior_when_trailing_slot_is_empty_then_combines_children() {
+        // Given a static cell without trailing content / When resolving its VoiceOver grouping
+        // Then the row reads as one element
+        #expect(StoreCellAccessibility.childBehavior(hasTrailingContent: false) == .combine)
+    }
+
+    @Test func test_childBehavior_when_trailing_slot_has_content_then_keeps_children_reachable() {
+        // Given a static cell with trailing content (which may hold a control) / When resolving its grouping
+        // Then the children stay individually reachable
+        #expect(StoreCellAccessibility.childBehavior(hasTrailingContent: true) == .contain)
+    }
+}

--- a/Modules/Tests/StoreDesignSystemTests/StoreCellAppearanceTests.swift
+++ b/Modules/Tests/StoreDesignSystemTests/StoreCellAppearanceTests.swift
@@ -25,16 +25,4 @@ import Testing
         #expect(sut.description == .storeStateLayerOnSurfaceOpacity24)
         #expect(sut.slot == .storeStateLayerOnSurfaceOpacity24)
     }
-
-    @Test func test_childBehavior_when_trailing_slot_is_empty_then_combines_children() {
-        // Given a static cell without trailing content / When resolving its VoiceOver grouping
-        // Then the row reads as one element
-        #expect(StoreCellAccessibility.childBehavior(hasTrailingContent: false) == .combine)
-    }
-
-    @Test func test_childBehavior_when_trailing_slot_has_content_then_keeps_children_reachable() {
-        // Given a static cell with trailing content (which may hold a control) / When resolving its grouping
-        // Then the children stay individually reachable
-        #expect(StoreCellAccessibility.childBehavior(hasTrailingContent: true) == .contain)
-    }
 }

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/CellComponentView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/CellComponentView.swift
@@ -1,0 +1,107 @@
+#if DEBUG || ALPHA
+import SwiftUI
+import StoreDesignSystem
+
+struct CellComponentView: View {
+    private enum Leading: String, CaseIterable, Identifiable {
+        case none = "None"
+        case icon = "Icon"
+        case iconContainer = "Icon Container"
+
+        var id: Self { self }
+    }
+
+    private enum Trailing: String, CaseIterable, Identifiable {
+        case none = "None"
+        case value = "Value"
+        case badge = "Badge"
+        case toggle = "Toggle"
+
+        var id: Self { self }
+    }
+
+    @State private var leading: Leading = .iconContainer
+    @State private var trailing: Trailing = .none
+    @State private var showsDescription = true
+    @State private var showsDisclosureIndicator = true
+    @State private var isTappable = true
+    @State private var isEnabled = true
+    @State private var isToggleOn = true
+
+    var body: some View {
+        ComponentDemoScaffold(title: "Cell", previewHeight: 300) {
+            Picker("Leading", selection: $leading) {
+                ForEach(Leading.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            Picker("Trailing", selection: $trailing) {
+                ForEach(Trailing.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            Toggle("Description", isOn: $showsDescription)
+            Toggle("Disclosure indicator", isOn: $showsDisclosureIndicator)
+            Toggle("Tappable", isOn: $isTappable)
+            Toggle("Enabled", isOn: $isEnabled)
+        } preview: {
+            VStack(spacing: 0) {
+                cell("Store details", description: "Manage address, currency, and contact information.")
+                StoreDivider(variant: .inset)
+                cell("Payments", description: "Card readers, cash, and checkout options.")
+            }
+            .disabled(!isEnabled)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.storeSectionBackground)
+        }
+    }
+
+    private func cell(_ title: String, description: String) -> some View {
+        StoreCell(title,
+                  description: showsDescription ? description : nil,
+                  showsDisclosureIndicator: showsDisclosureIndicator,
+                  action: isTappable ? {} : nil) {
+            leadingContent
+        } trailing: {
+            trailingContent
+        }
+    }
+
+    @ViewBuilder private var leadingContent: some View {
+        switch leading {
+        case .none:
+            EmptyView()
+        case .icon:
+            StoreIcon.Gear.regular.image(size: .largeIncreased)
+        case .iconContainer:
+            StoreIconContainer(StoreIcon.Gear.regular)
+        }
+    }
+
+    @ViewBuilder private var trailingContent: some View {
+        switch trailing {
+        case .none:
+            EmptyView()
+        case .value:
+            Text("USD").storeTextStyle(.bodyMedium)
+        case .badge:
+            StoreBadge("New", tone: .info)
+        case .toggle:
+            Toggle("Enabled", isOn: $isToggleOn).labelsHidden()
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CellComponentView()
+    }
+}
+
+#Preview("RTL") {
+    NavigationStack {
+        CellComponentView()
+    }
+    .environment(\.layoutDirection, .rightToLeft)
+}
+#endif

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/CellComponentView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/CellComponentView.swift
@@ -87,7 +87,7 @@ struct CellComponentView: View {
         case .badge:
             StoreBadge("New", tone: .info)
         case .toggle:
-            Toggle("Enabled", isOn: $isToggleOn).labelsHidden()
+            Toggle("Notifications", isOn: $isToggleOn).labelsHidden()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
+++ b/WooCommerce/Classes/ViewRelated/DesignSystemDemo/DesignSystemDemoView.swift
@@ -32,6 +32,7 @@ private struct ComponentsView: View {
         List {
             NavigationLink("Badge") { BadgeComponentView() }
             NavigationLink("Button") { ButtonComponentView() }
+            NavigationLink("Cell") { CellComponentView() }
             NavigationLink("Checkbox") { CheckboxComponentView() }
             NavigationLink("Icon Container") { IconContainerComponentView() }
             NavigationLink("Divider") { DividerComponentView() }


### PR DESCRIPTION
WOOMOB-3340

## Description

The Cell is the first of the remaining foundation components in the design-system migration, and the one the More menu pilot and the Table component both depend on. Figma defines it as a row shell (surface-bright container, 24pt padding, a content slot, an optional trailing disclosure indicator) with the actual content living on the separate "Cell Content" page. This PR implements the shell with the standard title/description content, generic leading and trailing slots for everything else, and follows the module's existing component conventions (tokens only, closed appearance type, demo view, Swift Testing coverage). Disabled styling follows the module's state-layer rule since Figma defines no disabled cell state.

- Added `StoreCell` with title, optional description, `leading`/`trailing` slots, `showsDisclosureIndicator`, an optional row-level `action`, slot-less convenience initializers, RTL chevron flipping, and VoiceOver grouping that reads the title and description as one element while keeping a trailing control reachable.
- Added `StoreCellAppearance`, the color resolver for the enabled and disabled states.
- Added `StoreCellAppearanceTests` covering the appearance resolver.
- Added `CellComponentView` to the Debug Panel design-system gallery, with light/dark and RTL previews.
- Added a "Design System" section to `AGENTS.md` (use `StoreDesignSystem` for new views, don't mix legacy styling with DS tokens, component checklist).
- Spacing follows Figma: 16pt between the leading visual and the text (Cell Content spec), 20pt before the trailing slot and chevron (Cell spec). Android uses 24h/12v padding with a 48dp minimum height instead; iOS follows the Figma node.
- Disabled foreground uses the state-layer token, matching `StoreButton`, `StoreCheckbox`, and the radio button. Android uses `onVariantLowest` for the same state.

## Test Steps

- Run the `StoreDesignSystemTests` target through the `WooCommerce` scheme and confirm all tests pass.
- Build and run a Debug build on a simulator, log in to any store.
- Open the More tab → Settings → Debug Panel → Design System → Components → Cell.
- Change the Leading, Trailing, Description, and Disclosure indicator controls and confirm the two preview rows update accordingly.
- Turn on Tappable and tap a row: it should dim briefly while pressed.
- Turn off Enabled: text, slots, and chevron should turn light gray and rows should no longer react to taps.
- Switch the simulator to dark mode and confirm the rows stay readable on the dark section background.
- Switch the simulator to a right-to-left language (Settings → General → Language & Region, e.g. Arabic) and confirm the chevron points left.

## Screenshots

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9d1e6387-ae85-4e0c-8ed7-a37e189cf017" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

