### PR TITLE
Show actionable Offline Mode message in push notifications setup

### DIFF
--- a/Modules/Sources/Networking/Mapper/JetpackConnectionStatusMapper.swift
+++ b/Modules/Sources/Networking/Mapper/JetpackConnectionStatusMapper.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Mapper: Jetpack connection status
+///
+struct JetpackConnectionStatusMapper: Mapper {
+
+    func map(response: Data) throws -> JetpackConnectionStatus {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(JetpackConnectionStatusEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode(JetpackConnectionStatus.self, from: response)
+        }
+    }
+}
+
+/// JetpackConnectionStatus Disposable Entity:
+/// Models the response of the bare `jetpack/v4/connection` endpoint. Unlike `jetpack/v4/connection/data`,
+/// this endpoint is not gated by Jetpack capabilities, so it remains reachable even when the site is in
+/// Offline Mode (which otherwise makes the connection data endpoint return a 403).
+///
+public struct JetpackConnectionStatus: Decodable {
+    /// The site's Jetpack Offline Mode state, if reported.
+    public let offlineMode: OfflineMode?
+
+    /// Whether the site's Jetpack is currently in Offline Mode.
+    public var isInOfflineMode: Bool {
+        offlineMode?.isActive == true
+    }
+
+    public init(offlineMode: OfflineMode?) {
+        self.offlineMode = offlineMode
+    }
+
+    public struct OfflineMode: Decodable {
+        /// Whether Offline Mode is currently active for the site.
+        public let isActive: Bool?
+
+        public init(isActive: Bool?) {
+            self.isActive = isActive
+        }
+    }
+}
+
+/// JetpackConnectionStatusEnvelope Disposable Entity:
+/// The endpoint returns the document within a `data` key when tunneled through WPCom.
+/// This entity allows us to parse the returned model with JSONDecoder.
+///
+private struct JetpackConnectionStatusEnvelope: Decodable {
+    let data: JetpackConnectionStatus
+}

--- a/Modules/Sources/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Modules/Sources/Networking/Remote/JetpackConnectionRemote.swift
@@ -99,6 +99,16 @@ public final class JetpackConnectionRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Fetches the site's Jetpack connection status, including Offline Mode.
+    /// Unlike `fetchJetpackConnectionData`, this endpoint is not gated by Jetpack capabilities,
+    /// so it stays reachable when the site is in Offline Mode.
+    ///
+    public func fetchJetpackConnectionStatus(siteID: Int64, completion: @escaping (Result<JetpackConnectionStatus, Error>) -> Void) {
+        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: Path.jetpackConnection, availableAsRESTRequest: true)
+        let mapper = JetpackConnectionStatusMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Establishes a site-level connection between the site and WordPress.com using Jetpack.
     /// Returns WPCom `blogID` of the connected site.
     /// periphery: ignore - used in `JetpackConnectionStore` later
@@ -146,6 +156,7 @@ extension JetpackConnectionRemote: URLSessionDataDelegate {
 
 private extension JetpackConnectionRemote {
     enum Path {
+        static let jetpackConnection = "/jetpack/v4/connection"
         static let jetpackConnectionURL = "/jetpack/v4/connection/url"
         static let jetpackConnectionData = "/jetpack/v4/connection/data"
         static let jetpackConnectionRegister = "/jetpack/v4/connection/register"

--- a/Modules/Sources/Yosemite/Actions/JetpackConnectionAction.swift
+++ b/Modules/Sources/Yosemite/Actions/JetpackConnectionAction.swift
@@ -17,6 +17,8 @@ public enum JetpackConnectionAction: Action {
                                    completion: (Result<URL, Error>) -> Void)
     /// Fetches connection state with the given site's Jetpack.
     case fetchJetpackConnectionData(siteID: Int64, completion: (Result<JetpackConnectionData, Error>) -> Void)
+    /// Fetches the given site's Jetpack connection status, including Offline Mode.
+    case fetchJetpackConnectionStatus(siteID: Int64, completion: (Result<JetpackConnectionStatus, Error>) -> Void)
     /// Establishes site-level connection and returns WordPress.com blog ID.
     case registerSite(completion: (Result<Int64, Error>) -> Void)
     /// Provisions connection and returns provision response with scope and secret.

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -65,6 +65,7 @@ public typealias GoogleAdsCampaignStatsItem = Networking.GoogleAdsCampaignStatsI
 public typealias InboxNote = Networking.InboxNote
 public typealias InboxAction = Networking.InboxAction
 public typealias JetpackConnectionData = Networking.JetpackConnectionData
+public typealias JetpackConnectionStatus = Networking.JetpackConnectionStatus
 public typealias JetpackConnectionProvisionResponse = Networking.JetpackConnectionProvisionResponse
 public typealias JustInTimeMessageHook = Networking.JustInTimeMessagesRemote.MessagePath.Hook
 public typealias Media = Networking.Media

--- a/Modules/Sources/Yosemite/Stores/JetpackConnectionStore.swift
+++ b/Modules/Sources/Yosemite/Stores/JetpackConnectionStore.swift
@@ -46,6 +46,8 @@ public final class JetpackConnectionStore: DeauthenticatedStore {
                                       completion: completion)
         case .fetchJetpackConnectionData(let siteID, let completion):
             fetchJetpackConnectionData(siteID: siteID, completion: completion)
+        case .fetchJetpackConnectionStatus(let siteID, let completion):
+            fetchJetpackConnectionStatus(siteID: siteID, completion: completion)
         case .registerSite(let completion):
             registerSite(completion: completion)
         case .provisionConnection(let completion):
@@ -133,6 +135,14 @@ private extension JetpackConnectionStore {
             return
         }
         jetpackConnectionRemote.fetchJetpackConnectionData(siteID: siteID, completion: completion)
+    }
+
+    func fetchJetpackConnectionStatus(siteID: Int64, completion: @escaping (Result<JetpackConnectionStatus, Error>) -> Void) {
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
+            return
+        }
+        jetpackConnectionRemote.fetchJetpackConnectionStatus(siteID: siteID, completion: completion)
     }
 
     func registerSite(completion: @escaping (Result<Int64, Error>) -> Void) {

--- a/Modules/Tests/NetworkingTests/Mapper/JetpackConnectionStatusMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/JetpackConnectionStatusMapperTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import Networking
+
+@Suite("JetpackConnectionStatusMapper")
+struct JetpackConnectionStatusMapperTests {
+
+    @Test func test_offline_mode_is_parsed_as_active_when_offlineMode_isActive_is_true() throws {
+        // Given
+        let status = try mapStatus(from: "jetpack-connection-offline-mode")
+
+        // Then
+        #expect(status.offlineMode?.isActive == true)
+        #expect(status.isInOfflineMode)
+    }
+
+    @Test func test_offline_mode_is_parsed_from_data_envelope() throws {
+        // Given
+        let status = try mapStatus(from: "jetpack-connection-offline-mode-enveloped")
+
+        // Then
+        #expect(status.offlineMode?.isActive == true)
+        #expect(status.isInOfflineMode)
+    }
+
+    @Test func test_offline_mode_is_inactive_when_offlineMode_isActive_is_false() throws {
+        // Given
+        let status = try mapStatus(from: "jetpack-connection-online")
+
+        // Then
+        #expect(status.offlineMode?.isActive == false)
+        #expect(status.isInOfflineMode == false)
+    }
+
+    @Test func test_offline_mode_is_inactive_when_offlineMode_is_missing() throws {
+        // Given
+        let response = Data(#"{"isActive": true}"#.utf8)
+
+        // When
+        let status = try JetpackConnectionStatusMapper().map(response: response)
+
+        // Then
+        #expect(status.offlineMode == nil)
+        #expect(status.isInOfflineMode == false)
+    }
+}
+
+private extension JetpackConnectionStatusMapperTests {
+    func mapStatus(from filename: String) throws -> JetpackConnectionStatus {
+        guard let response = Loader.contentsOf(filename) else {
+            throw FileNotFoundError()
+        }
+        return try JetpackConnectionStatusMapper().map(response: response)
+    }
+
+    struct FileNotFoundError: Error {}
+}

--- a/Modules/Tests/NetworkingTests/Remote/JetpackConnectionRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/JetpackConnectionRemoteTests.swift
@@ -215,6 +215,44 @@ final class JetpackConnectionRemoteTests: XCTestCase {
         XCTAssertEqual(result.failure as? NetworkError, error)
     }
 
+    func test_fetchJetpackConnectionStatus_correctly_returns_offline_mode() throws {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/jetpack/v4/connection"
+        network.simulateResponse(requestUrlSuffix: urlSuffix, filename: "jetpack-connection-offline-mode")
+
+        // When
+        let result: Result<JetpackConnectionStatus, Error> = waitFor { promise in
+            remote.fetchJetpackConnectionStatus(siteID: 123) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let status = try XCTUnwrap(result.get())
+        XCTAssertTrue(status.isInOfflineMode)
+    }
+
+    func test_fetchJetpackConnectionStatus_properly_relays_errors() {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/jetpack/v4/connection"
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: urlSuffix, error: error)
+
+        // When
+        let result: Result<JetpackConnectionStatus, Error> = waitFor { promise in
+            remote.fetchJetpackConnectionStatus(siteID: 123) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, error)
+    }
+
     func test_registerSite_correctly_returns_blogID() async throws {
         // Given
         let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-connection-offline-mode-enveloped.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-connection-offline-mode-enveloped.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "isActive": false,
+        "isStaging": false,
+        "isRegistered": false,
+        "isUserConnected": false,
+        "hasConnectedOwner": false,
+        "offlineMode": {
+            "isActive": true,
+            "constant": true,
+            "url": true,
+            "filter": false,
+            "wpLocalConstant": false
+        },
+        "isPublic": true
+    }
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-connection-offline-mode.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-connection-offline-mode.json
@@ -1,0 +1,15 @@
+{
+    "isActive": false,
+    "isStaging": false,
+    "isRegistered": false,
+    "isUserConnected": false,
+    "hasConnectedOwner": false,
+    "offlineMode": {
+        "isActive": true,
+        "constant": true,
+        "url": true,
+        "filter": false,
+        "wpLocalConstant": false
+    },
+    "isPublic": true
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-connection-online.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/jetpack-connection-online.json
@@ -1,0 +1,15 @@
+{
+    "isActive": true,
+    "isStaging": false,
+    "isRegistered": true,
+    "isUserConnected": true,
+    "hasConnectedOwner": true,
+    "offlineMode": {
+        "isActive": false,
+        "constant": false,
+        "url": false,
+        "filter": false,
+        "wpLocalConstant": false
+    },
+    "isPublic": true
+}

--- a/Modules/Tests/YosemiteTests/Stores/JetpackConnectionStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/JetpackConnectionStoreTests.swift
@@ -251,6 +251,52 @@ final class JetpackConnectionStoreTests: XCTestCase {
         XCTAssertEqual(result.failure as? NetworkError, error)
     }
 
+    func test_fetchJetpackConnectionStatus_correctly_returns_offline_mode() throws {
+        // Given
+        let urlSuffix = "/jetpack/v4/connection"
+        network.simulateResponse(requestUrlSuffix: urlSuffix, filename: "jetpack-connection-offline-mode")
+        let store = JetpackConnectionStore(dispatcher: dispatcher)
+
+        let setupAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
+        store.onAction(setupAction)
+
+        // When
+        let result: Result<JetpackConnectionStatus, Error> = waitFor { promise in
+            let action = JetpackConnectionAction.fetchJetpackConnectionStatus(siteID: 0) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let status = try XCTUnwrap(result.get())
+        XCTAssertTrue(status.isInOfflineMode)
+    }
+
+    func test_fetchJetpackConnectionStatus_properly_relays_errors() {
+        // Given
+        let urlSuffix = "/jetpack/v4/connection"
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: urlSuffix, error: error)
+        let store = JetpackConnectionStore(dispatcher: dispatcher)
+
+        let setupAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
+        store.onAction(setupAction)
+
+        // When
+        let result: Result<JetpackConnectionStatus, Error> = waitFor { promise in
+            let action = JetpackConnectionAction.fetchJetpackConnectionStatus(siteID: 0) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, error)
+    }
+
     func test_loadWPComAccount_returns_parsed_account() {
         // Given
         let store = JetpackConnectionStore(dispatcher: dispatcher)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [Internal] POS: Removed the server-calculated refunds feature flag; the flow is on for every store running WooCommerce 11.1.0 or later. [https://github.com/woocommerce/woocommerce-ios/pull/17836]
 - [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax. [https://github.com/woocommerce/woocommerce-ios/pull/17827]
 - [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
+- [*] Push notifications: When a store's Jetpack is in Offline Mode, setup now shows a clear, actionable message explaining the cause instead of a generic permission error. [PR_URL]
 
 
 25.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,7 @@
 - [Internal] POS: Removed the server-calculated refunds feature flag; the flow is on for every store running WooCommerce 11.1.0 or later. [https://github.com/woocommerce/woocommerce-ios/pull/17836]
 - [*] POS: Fixed a refund failing with "Invalid refund amount" on stores that enter prices inclusive of tax. [https://github.com/woocommerce/woocommerce-ios/pull/17827]
 - [*] Login: Signing in with store credentials now asks for your WordPress sign-in or dashboard address when a security plugin has moved it, instead of failing. [https://github.com/woocommerce/woocommerce-ios/pull/17724]
-- [*] Push notifications: When a store's Jetpack is in Offline Mode, setup now shows a clear, actionable message explaining the cause instead of a generic permission error. [PR_URL]
+- [*] Push notifications: When a store's Jetpack is in Offline Mode, setup now shows a clear, actionable message explaining the cause instead of a generic permission error. [https://github.com/woocommerce/woocommerce-ios/pull/17857]
 
 
 25.6

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -45,6 +45,10 @@ protocol JetpackConnectionServiceProtocol {
 
     /// Fetches the current Jetpack connection data for the site.
     func fetchConnectionData() async throws -> JetpackConnectionData
+
+    /// Returns whether the site's Jetpack is currently in Offline Mode.
+    /// Best-effort: returns `false` if the status cannot be determined.
+    func isJetpackInOfflineMode() async -> Bool
 }
 
 final class JetpackConnectionService: JetpackConnectionServiceProtocol {
@@ -136,6 +140,18 @@ final class JetpackConnectionService: JetpackConnectionServiceProtocol {
     func fetchConnectionData() async throws -> JetpackConnectionData {
         try await dispatch { completion in
             JetpackConnectionAction.fetchJetpackConnectionData(siteID: self.siteID, completion: completion)
+        }
+    }
+
+    func isJetpackInOfflineMode() async -> Bool {
+        do {
+            let status: JetpackConnectionStatus = try await dispatch { completion in
+                JetpackConnectionAction.fetchJetpackConnectionStatus(siteID: self.siteID, completion: completion)
+            }
+            return status.isInOfflineMode
+        } catch {
+            DDLogError("⛔️ Error fetching Jetpack connection status: \(error)")
+            return false
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -115,8 +115,16 @@ final class WPComPushNotificationsBenefitsViewModel {
         } catch {
             DDLogError("⛔️ Failed to fetch Jetpack connection data: \(error)")
             if case NetworkError.unacceptableStatusCode(403, _) = error {
-                self.error = .noPermission
-                analytics.track(.pushNotificationsSetupIntroductionError, withProperties: ["error_type": "no_permission"])
+                // A 403 can mean the account lacks permission, or that Jetpack is in Offline Mode
+                // (which revokes the capability gating the connection data endpoint for everyone).
+                // Distinguish them so administrators get an actionable message in the Offline Mode case.
+                if await jetpackConnectionService.isJetpackInOfflineMode() {
+                    self.error = .offlineMode
+                    analytics.track(.pushNotificationsSetupIntroductionError, withProperties: ["error_type": "offline_mode"])
+                } else {
+                    self.error = .noPermission
+                    analytics.track(.pushNotificationsSetupIntroductionError, withProperties: ["error_type": "no_permission"])
+                }
             } else {
                 self.error = .generic(underlyingError: error)
                 analytics.track(.pushNotificationsSetupIntroductionError, properties: ["error_type": "generic"], error: error)
@@ -184,12 +192,15 @@ private extension WPComPushNotificationsBenefitsViewModel {
 extension WPComPushNotificationsBenefitsViewModel {
     enum VariantCheckError: Error {
         case noPermission
+        case offlineMode
         case generic(underlyingError: Error)
 
         var message: String {
             switch self {
             case .noPermission:
                 Localization.noPermission
+            case .offlineMode:
+                Localization.offlineMode
             case .generic:
                 Localization.generic
             }
@@ -201,6 +212,12 @@ extension WPComPushNotificationsBenefitsViewModel {
                 value: "Your account does not have permission to complete push notifications setup. " +
                 "Please ask your store administrator to handle this.",
                 comment: "Error message in the Push Notifications Benefits View for users without admin role"
+            )
+            static let offlineMode = NSLocalizedString(
+                "wpcomPushNotificationsBenefitsViewModel.variantCheckError.storeInOfflineMode",
+                value: "Push notifications can’t be set up because your store is in Offline Mode. " +
+                "If you still need help, please contact support.",
+                comment: "Error message in the Push Notifications Benefits View when the store's Jetpack is in Offline Mode"
             )
             static let generic = NSLocalizedString(
                 "wpcomPushNotificationsBenefitsViewModel.variantCheckError.generic",

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
@@ -185,6 +185,56 @@ final class JetpackConnectionServiceTests: XCTestCase {
         XCTAssertEqual(email, testEmail)
         XCTAssertEqual(fetchCount, 2)
     }
+
+    // MARK: - isJetpackInOfflineMode
+
+    func test_isJetpackInOfflineMode_returns_true_when_offline_mode_is_active() async {
+        // Given
+        let service = makeService()
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            if case .fetchJetpackConnectionStatus(_, let completion) = action {
+                completion(.success(JetpackConnectionStatus(offlineMode: .init(isActive: true))))
+            }
+        }
+
+        // When
+        let isOffline = await service.isJetpackInOfflineMode()
+
+        // Then
+        XCTAssertTrue(isOffline)
+    }
+
+    func test_isJetpackInOfflineMode_returns_false_when_offline_mode_is_inactive() async {
+        // Given
+        let service = makeService()
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            if case .fetchJetpackConnectionStatus(_, let completion) = action {
+                completion(.success(JetpackConnectionStatus(offlineMode: .init(isActive: false))))
+            }
+        }
+
+        // When
+        let isOffline = await service.isJetpackInOfflineMode()
+
+        // Then
+        XCTAssertFalse(isOffline)
+    }
+
+    func test_isJetpackInOfflineMode_returns_false_when_fetch_fails() async {
+        // Given
+        let service = makeService()
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            if case .fetchJetpackConnectionStatus(_, let completion) = action {
+                completion(.failure(NSError(domain: "Test", code: 403)))
+            }
+        }
+
+        // When
+        let isOffline = await service.isJetpackInOfflineMode()
+
+        // Then
+        XCTAssertFalse(isOffline)
+    }
 }
 
 // MARK: - Helpers

--- a/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
@@ -19,6 +19,9 @@ final class MockJetpackConnectionService: JetpackConnectionServiceProtocol {
     var fetchConnectionDataResult: Result<JetpackConnectionData, Error>?
     private(set) var fetchConnectionDataCallCount = 0
 
+    var isJetpackInOfflineModeResult: Bool = false
+    private(set) var isJetpackInOfflineModeCallCount = 0
+
     func establishSiteConnection(siteURL: String) async throws {
         establishSiteConnectionCallCount += 1
         try establishSiteConnectionResult.get()
@@ -46,5 +49,10 @@ final class MockJetpackConnectionService: JetpackConnectionServiceProtocol {
             throw NSError(domain: "MockJetpackConnectionService", code: 0, userInfo: [NSLocalizedDescriptionKey: "fetchConnectionDataResult not set"])
         }
         return try result.get()
+    }
+
+    func isJetpackInOfflineMode() async -> Bool {
+        isJetpackInOfflineModeCallCount += 1
+        return isJetpackInOfflineModeResult
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -326,6 +326,20 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
             provider.assertReceived(event: "push_notifications_setup_introduction_error", with: ["error_type": "no_permission"])
         }
 
+        // When 403 error and Jetpack is in Offline Mode, then tracks offline_mode
+        do {
+            let provider = MockAnalyticsProvider()
+            let analytics = WooAnalytics(analyticsProvider: provider)
+            let connectionService = MockJetpackConnectionService()
+            connectionService.fetchConnectionDataResult = .failure(NetworkError.unacceptableStatusCode(statusCode: 403, response: nil))
+            connectionService.isJetpackInOfflineModeResult = true
+            let viewModel = makeViewModel(jetpackConnectionService: connectionService, analytics: analytics)
+
+            await viewModel.determineSetupVariant()
+
+            provider.assertReceived(event: "push_notifications_setup_introduction_error", with: ["error_type": "offline_mode"])
+        }
+
         // When generic error, then tracks generic
         do {
             let provider = MockAnalyticsProvider()
@@ -375,6 +389,41 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
             return XCTFail("Expected noPermission error, got \(String(describing: viewModel.error))")
         }
         XCTAssertFalse(viewModel.isCheckingPlugin)
+    }
+
+    func test_error_is_offlineMode_when_fetching_connection_data_throws_403_and_jetpack_is_in_offline_mode() async {
+        // Given
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .failure(NetworkError.unacceptableStatusCode(statusCode: 403, response: nil))
+        connectionService.isJetpackInOfflineModeResult = true
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        guard case .offlineMode = viewModel.error else {
+            return XCTFail("Expected offlineMode error, got \(String(describing: viewModel.error))")
+        }
+        XCTAssertEqual(connectionService.isJetpackInOfflineModeCallCount, 1)
+        XCTAssertFalse(viewModel.isCheckingPlugin)
+    }
+
+    func test_error_is_noPermission_when_fetching_connection_data_throws_403_and_jetpack_is_not_in_offline_mode() async {
+        // Given
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .failure(NetworkError.unacceptableStatusCode(statusCode: 403, response: nil))
+        connectionService.isJetpackInOfflineModeResult = false
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        guard case .noPermission = viewModel.error else {
+            return XCTFail("Expected noPermission error, got \(String(describing: viewModel.error))")
+        }
+        XCTAssertEqual(connectionService.isJetpackInOfflineModeCallCount, 1)
     }
 
     func test_error_is_generic_when_fetching_connection_data_throws_non_403_error() async {


### PR DESCRIPTION
## Description
Fixes WOOMOB-4050.

When a merchant taps **Enable push notifications** on the My Store dashboard and their store's Jetpack is in **Offline Mode**, the setup flow dead-ends. The capabilities that gate `GET /jetpack/v4/connection/data` are revoked in Offline Mode, so the request returns **HTTP 403**, and the app maps that 403 to the generic "ask your store administrator" error — which is misleading and unactionable, since the administrator is the one seeing it and no user can fix it from the app.

This ports the Android fix (woocommerce-android #16551). On the 403 path, the app now checks the **bare, un-gated** `GET /jetpack/v4/connection` endpoint (which stays reachable in Offline Mode and reports `offlineMode.isActive`). If Offline Mode is active, it shows a clear, actionable message instead of the generic permission error; otherwise the existing behavior is unchanged.

## Test Steps
Reproducing the real condition requires a store with Jetpack in Offline Mode, so this is primarily covered by unit tests. To reproduce end-to-end:
1. Provision a WordPress site with WooCommerce + Jetpack installed and active but **not** connected to WordPress.com.
2. Add `define( 'WP_ENVIRONMENT_TYPE', 'local' );` to `wp-config.php`.
3. Log in to the store in the app with **site credentials** and grant the OS notification permission.
4. On **My store**, tap the **Enable push notifications** card.
5. **Expected**: the error now reads *"Push notifications can’t be set up because your store is in Offline Mode. If you still need help, please contact support."* instead of the generic "ask your store administrator" message.

## Screenshots

| Before | After |
|---|---|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-09-11 at 10 38 47" src="https://github.com/user-attachments/assets/2e94442a-2a6d-46e7-a6b3-11fd4b36d161" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-11 at 10 20 28" src="https://github.com/user-attachments/assets/bc33a873-559c-41a1-a7b6-e2abe2d20064" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.