### PR TITLE
Preserve Tracks identity for site address logins

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -13,7 +13,7 @@ import WooFoundationCore
 
 final class WooAnalytics: Analytics {
 
-    typealias ABTestStarter = @MainActor (ExperimentContext) async -> Void
+    typealias ABTestStarter = (ExperimentContext) -> Void
 
     // MARK: - Properties
 
@@ -32,6 +32,7 @@ final class WooAnalytics: Analytics {
     private let userDefaults: UserDefaults
 
     private let startABTest: ABTestStarter
+    private let notificationCenter: NotificationCenter
 
     /// Check user opt-in for analytics
     ///
@@ -53,10 +54,16 @@ final class WooAnalytics: Analytics {
     ///
     init(analyticsProvider: AnalyticsProvider & WPAnalyticsTracker,
          userDefaults: UserDefaults = .standard,
-         startABTest: @escaping ABTestStarter = { await ABTest.start(for: $0) }) {
+         notificationCenter: NotificationCenter = .default,
+         startABTest: @escaping ABTestStarter = { context in
+             Task { @MainActor in
+                 await ABTest.start(for: context)
+             }
+         }) {
         self.analyticsProvider = analyticsProvider
         self.userDefaults = userDefaults
         self.startABTest = startABTest
+        self.notificationCenter = notificationCenter
         WPAnalytics.register(analyticsProvider)
     }
 }
@@ -69,7 +76,8 @@ extension WooAnalytics {
     /// Initialize the analytics engine
     ///
     func initialize() {
-        refreshUserData()
+        // Restore the saved Tracks identity on launch, including site-credential sessions.
+        refreshUserData(includingSiteCredentialSessions: true)
         startObservingNotifications()
     }
 
@@ -77,26 +85,25 @@ extension WooAnalytics {
     /// It's good to call this function after a user logs in or out of the app.
     ///
     func refreshUserData() {
+        refreshUserData(includingSiteCredentialSessions: false)
+    }
+
+    private func refreshUserData(includingSiteCredentialSessions: Bool) {
         guard userHasOptedIn == true else {
             return
         }
 
-        // Skips refreshing user data when user is authenticated without WPCom
-        // since they are still identified with anonymous ID.
         let context: ExperimentContext = ServiceLocator.stores.isAuthenticated ?
             .loggedIn: .loggedOut
 
-        let refreshABTests: () -> Void = { [startABTest] in
-            Task { @MainActor in
-                await startABTest(context)
+        if includingSiteCredentialSessions || ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
+            // Refreshes A/B experiments after Tracks finishes switching users because that switch resets `ExPlat.shared`.
+            analyticsProvider.refreshUserData { [startABTest] in
+                startABTest(context)
             }
-        }
-
-        // Refreshes A/B experiments after Tracks finishes switching users because that switch resets `ExPlat.shared`.
-        if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
-            analyticsProvider.refreshUserData(completion: refreshABTests)
         } else {
-            refreshABTests()
+            // Keep the login-time skip from #9485, which addressed missing application-password approval events.
+            startABTest(context)
         }
     }
 
@@ -128,6 +135,7 @@ extension WooAnalytics {
 extension WooAnalytics {
 
     func setUserHasOptedOut(_ optedOut: Bool) {
+        let wasOptedIn = userHasOptedIn
         userHasOptedIn = !optedOut
 
         if optedOut {
@@ -135,7 +143,9 @@ extension WooAnalytics {
             analyticsProvider.clearUsers()
             DDLogInfo("🔴 Tracking opt-out complete.")
         } else {
-            refreshUserData()
+            // An opted-out launch skips identity restoration. Restore it when tracking becomes enabled.
+            // Repeated enabled settings must keep the regular site-credential login skip.
+            refreshUserData(includingSiteCredentialSessions: !wasOptedIn)
             DDLogInfo("🔵 Tracking started.")
         }
     }
@@ -296,15 +306,15 @@ private extension WooAnalytics {
             return
         }
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(trackApplicationOpened),
-                                               name: UIApplication.didBecomeActiveNotification,
-                                               object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(trackApplicationOpened),
+                                       name: UIApplication.didBecomeActiveNotification,
+                                       object: nil)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(trackApplicationClosed),
-                                               name: UIApplication.didEnterBackgroundNotification,
-                                               object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(trackApplicationClosed),
+                                       name: UIApplication.didEnterBackgroundNotification,
+                                       object: nil)
     }
 
     @objc func trackApplicationOpened() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -36,6 +36,10 @@ final class MockStoresManager: DefaultStoresManager {
         super.init(sessionManager: sessionManager)
     }
 
+    init(sessionManager: SessionManagerProtocol) {
+        super.init(sessionManager: sessionManager)
+    }
+
     // MARK: - Overridden Properties
 
     override var posCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? {

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -29,6 +29,8 @@ class WooAnalyticsTests: XCTestCase {
     ///
     private var userDefaultsSuiteName: String!
 
+    private var notificationCenter: NotificationCenter!
+
     private let sampleSiteID: Int64 = 12345
 
     private let sampleSiteURL: String = "https://example.com"
@@ -39,20 +41,21 @@ class WooAnalyticsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false,
-                                                                   defaultSite: Site.fake().copy(
-                                                                    siteID: sampleSiteID,
-                                                                    url: sampleSiteURL)))
+        let sessionManager = MockSessionManager()
+        sessionManager.defaultSite = Site.fake().copy(siteID: sampleSiteID, url: sampleSiteURL)
+        stores = MockStoresManager(sessionManager: sessionManager)
         ServiceLocator.setStores(stores)
         userDefaultsSuiteName = UUID().uuidString
         userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)!
-        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider(), userDefaults: userDefaults)
+        notificationCenter = NotificationCenter()
+        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider(), userDefaults: userDefaults, notificationCenter: notificationCenter)
     }
 
     override func tearDown() {
         userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
         userDefaults = nil
         userDefaultsSuiteName = nil
+        notificationCenter = nil
         super.tearDown()
         ServiceLocator.setStores(originalStores)
     }
@@ -175,57 +178,193 @@ class WooAnalyticsTests: XCTestCase {
     }
 
     @MainActor
-    func test_refreshUserData_starts_AB_tests_after_provider_refresh_completes() async {
-        // Given
-        guard let testingProvider else {
-            return XCTFail("Testing provider not available")
-        }
-        testingProvider.defersRefreshUserDataCompletion = true
-        let abTestStarted = expectation(description: "A/B test started")
-        var startedContexts: [ExperimentContext] = []
-        analytics = WooAnalytics(analyticsProvider: testingProvider,
-                                 userDefaults: userDefaults,
-                                 startABTest: { context in
-            startedContexts.append(context)
-            abTestStarted.fulfill()
-        })
-
-        // When
-        analytics.refreshUserData()
-        await Task.yield()
-
-        // Then
-        XCTAssertTrue(startedContexts.isEmpty)
-
-        testingProvider.completeRefreshUserData()
-        await fulfillment(of: [abTestStarted], timeout: 1.0)
-        XCTAssertEqual(startedContexts, [.loggedOut])
+    func test_refreshUserData_when_logged_out_then_starts_AB_tests_after_provider_refresh() {
+        assertABTestsStartAfterProviderRefresh(credentials: nil, expectedContext: .loggedOut)
     }
 
     @MainActor
-    func test_refreshUserData_when_authenticated_without_WPCom_then_starts_AB_tests_without_refreshing_provider() async {
-        // Given
-        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
-        ServiceLocator.setStores(stores)
+    func test_refreshUserData_when_authenticated_with_WPCom_then_starts_AB_tests_after_provider_refresh() {
+        assertABTestsStartAfterProviderRefresh(credentials: SessionSettings.wpcomCredentials, expectedContext: .loggedIn)
+    }
 
+    @MainActor
+    func test_initialize_when_authenticated_with_site_credentials_then_starts_AB_tests_after_provider_refresh() {
+        assertABTestsStartAfterProviderRefresh(credentials: SessionSettings.wporgCredentials,
+                                              expectedContext: .loggedIn,
+                                              operation: { $0.initialize() })
+    }
+
+    @MainActor
+    func test_initialize_when_authenticated_with_application_password_then_starts_AB_tests_after_provider_refresh() {
+        assertABTestsStartAfterProviderRefresh(credentials: SessionSettings.applicationPasswordCredentials,
+                                              expectedContext: .loggedIn,
+                                              operation: { $0.initialize() })
+    }
+
+    @MainActor
+    func test_initialize_when_logged_out_then_starts_AB_tests_after_provider_refresh() {
+        assertABTestsStartAfterProviderRefresh(credentials: nil, expectedContext: .loggedOut, operation: { $0.initialize() })
+    }
+
+    @MainActor
+    func test_initialize_when_authenticated_with_WPCom_then_starts_AB_tests_after_provider_refresh() {
+        assertABTestsStartAfterProviderRefresh(credentials: SessionSettings.wpcomCredentials,
+                                              expectedContext: .loggedIn,
+                                              operation: { $0.initialize() })
+    }
+
+    @MainActor
+    func test_setUserHasOptedOut_when_enabling_after_site_credential_launch_then_refreshes_provider_before_AB_tests() {
+        assertABTestsStartAfterProviderRefresh(credentials: SessionSettings.wporgCredentials,
+                                              expectedContext: .loggedIn,
+                                              operation: {
+            $0.userHasOptedIn = false
+            $0.initialize()
+            $0.setUserHasOptedOut(false)
+        })
+    }
+
+    @MainActor
+    func test_setUserHasOptedOut_when_enabling_after_application_password_launch_then_refreshes_provider_before_AB_tests() {
+        assertABTestsStartAfterProviderRefresh(credentials: SessionSettings.applicationPasswordCredentials,
+                                              expectedContext: .loggedIn,
+                                              operation: {
+            $0.userHasOptedIn = false
+            $0.initialize()
+            $0.setUserHasOptedOut(false)
+        })
+    }
+
+    @MainActor
+    func test_setUserHasOptedOut_when_already_enabled_after_site_credential_login_then_does_not_refresh_provider_again() {
+        assertLoginDoesNotRefreshProvider(credentials: SessionSettings.wporgCredentials, operation: { $0.setUserHasOptedOut(false) })
+    }
+
+    @MainActor
+    func test_setUserHasOptedOut_when_already_enabled_after_application_password_login_then_does_not_refresh_provider_again() {
+        assertLoginDoesNotRefreshProvider(credentials: SessionSettings.applicationPasswordCredentials, operation: { $0.setUserHasOptedOut(false) })
+    }
+
+    @MainActor
+    func test_refreshUserData_when_signing_in_with_site_credentials_then_does_not_refresh_provider_again() {
+        assertLoginDoesNotRefreshProvider(credentials: SessionSettings.wporgCredentials)
+    }
+
+    @MainActor
+    func test_refreshUserData_when_signing_in_with_application_password_then_does_not_refresh_provider_again() {
+        assertLoginDoesNotRefreshProvider(credentials: SessionSettings.applicationPasswordCredentials)
+    }
+
+    @MainActor
+    private func assertLoginDoesNotRefreshProvider(credentials: Credentials,
+                                                  operation: (WooAnalytics) -> Void = { $0.refreshUserData() },
+                                                  file: StaticString = #filePath,
+                                                  line: UInt = #line) {
+        // Given: startup has restored the anonymous identity before the merchant signs in.
+        let sessionManager = MockSessionManager()
+        stores = MockStoresManager(sessionManager: sessionManager)
+        ServiceLocator.setStores(stores)
         let provider = MockAnalyticsProvider()
         provider.defersRefreshUserDataCompletion = true
-        let abTestStarted = expectation(description: "A/B test started")
         var startedContexts: [ExperimentContext] = []
         analytics = WooAnalytics(analyticsProvider: provider,
                                  userDefaults: userDefaults,
+                                 notificationCenter: notificationCenter,
                                  startABTest: { context in
             startedContexts.append(context)
-            abTestStarted.fulfill()
         })
+        analytics.initialize()
+        provider.completeRefreshUserData()
+        XCTAssertEqual(provider.refreshUserDataCallCount, 1, file: file, line: line)
+        XCTAssertEqual(startedContexts, [.loggedOut], file: file, line: line)
+
+        // When: the login event is recorded immediately before the authentication state changes.
+        analytics.track(.applicationPasswordAuthorizationApproved)
+        sessionManager.defaultCredentials = credentials
+        stores = MockStoresManager(sessionManager: sessionManager)
+        ServiceLocator.setStores(stores)
+        operation(analytics)
+
+        // Then: preserve the login-time skip from #9485 while starting logged-in experiments.
+        XCTAssertEqual(provider.refreshUserDataCallCount, 1, file: file, line: line)
+        XCTAssertEqual(startedContexts, [.loggedOut, .loggedIn], file: file, line: line)
+    }
+
+    @MainActor
+    func test_refreshUserData_when_opted_out_then_does_not_refresh_provider_or_start_AB_tests() {
+        // Given
+        let provider = MockAnalyticsProvider()
+        var startedContexts: [ExperimentContext] = []
+        analytics = WooAnalytics(analyticsProvider: provider,
+                                 userDefaults: userDefaults,
+                                 notificationCenter: notificationCenter,
+                                 startABTest: { context in
+            startedContexts.append(context)
+        })
+        analytics.userHasOptedIn = false
 
         // When
         analytics.refreshUserData()
 
         // Then
-        await fulfillment(of: [abTestStarted], timeout: 1.0)
-        XCTAssertEqual(startedContexts, [.loggedIn])
         XCTAssertEqual(provider.refreshUserDataCallCount, 0)
+        XCTAssertTrue(startedContexts.isEmpty)
+    }
+
+    @MainActor
+    func test_initialize_when_opted_out_then_does_not_refresh_provider_or_start_AB_tests() {
+        // Given
+        let provider = MockAnalyticsProvider()
+        var startedContexts: [ExperimentContext] = []
+        analytics = WooAnalytics(analyticsProvider: provider,
+                                 userDefaults: userDefaults,
+                                 notificationCenter: notificationCenter,
+                                 startABTest: { context in
+            startedContexts.append(context)
+        })
+        analytics.userHasOptedIn = false
+
+        // When
+        analytics.initialize()
+
+        // Then
+        XCTAssertEqual(provider.refreshUserDataCallCount, 0)
+        XCTAssertTrue(startedContexts.isEmpty)
+    }
+
+    @MainActor
+    private func assertABTestsStartAfterProviderRefresh(credentials: Credentials?,
+                                                      expectedContext: ExperimentContext,
+                                                      operation: (WooAnalytics) -> Void = { $0.refreshUserData() },
+                                                      file: StaticString = #filePath,
+                                                      line: UInt = #line) {
+        // Given
+        let sessionManager = MockSessionManager()
+        sessionManager.defaultCredentials = credentials
+        stores = MockStoresManager(sessionManager: sessionManager)
+        ServiceLocator.setStores(stores)
+        let provider = MockAnalyticsProvider()
+        provider.defersRefreshUserDataCompletion = true
+        var startedContexts: [ExperimentContext] = []
+        analytics = WooAnalytics(analyticsProvider: provider,
+                                 userDefaults: userDefaults,
+                                 notificationCenter: notificationCenter,
+                                 startABTest: { context in
+            startedContexts.append(context)
+        })
+
+        // When
+        operation(analytics)
+
+        // Then: experiments must wait until the test explicitly completes the refresh.
+        XCTAssertEqual(provider.refreshUserDataCallCount, 1, file: file, line: line)
+        XCTAssertTrue(startedContexts.isEmpty, file: file, line: line)
+
+        // When
+        provider.completeRefreshUserData()
+
+        // Then
+        XCTAssertEqual(startedContexts, [expectedContext], file: file, line: line)
     }
 
     func test_events_when_logged_in_include_site_properties() {
@@ -242,7 +381,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: "sample_store_uuid",
                                                                    cachedWooCommerceVersion: "10.0"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)
@@ -280,7 +419,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)
@@ -318,7 +457,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(Event.bookingDetailAttendanceStatusUpdate(bookingStatus: .attended))
@@ -339,7 +478,7 @@ class WooAnalyticsTests: XCTestCase {
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(Event.bookingDetailAttendanceStatusUpdate(bookingStatus: .attended))
@@ -367,7 +506,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: "sample_store_uuid",
                                                                    cachedWooCommerceVersion: "10.0"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(WooAnalyticsStat.cardReaderLocationSuccess.rawValue, properties: Constants.testProperty1, error: nil)
@@ -393,7 +532,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     url: sampleSiteURL),
                                                                    defaultStoreUUID: "sample_store_uuid"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(WooAnalyticsStat.wooPushTokenRegisterSuccess.rawValue, properties: Constants.testProperty1, error: nil)
@@ -417,7 +556,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     url: sampleSiteURL),
                                                                    defaultStoreUUID: "sample_store_uuid"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track("an_event_name_that_is_not_a_stat", properties: Constants.testProperty1, error: nil)
@@ -442,7 +581,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: nil,
                                                                    cachedWooCommerceVersion: nil))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
         let callerProperties: [AnyHashable: Any] = [
             "cached_woo_core_version": "9.8.0",
             "store_id": "caller_store_uuid"
@@ -472,7 +611,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: "session_store_uuid",
                                                                    cachedWooCommerceVersion: "10.0"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
         let callerProperties: [AnyHashable: Any] = [
             "cached_woo_core_version": "9.8.0",
             "store_id": "caller_store_uuid"


### PR DESCRIPTION
Part of: WOOMOB-4012

## Description

Tracking on iOS for site address login sites is broken because:

- A different user ID is used after each cold launch.
- After disabling analytics, relaunching, and enabling analytics again, events use a different user ID.

Tracks starts with a random ID. The provider refresh that restores the saved anonymous ID is skipped for site-credential sessions:

```swift
if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
    analyticsProvider.refreshUserData(completion: refreshABTests)
}
```

### Solution

I now **restore site credentials login the identity at launch**:

```swift
refreshUserData(includingSiteCredentialSessions: true)
```

For opt-in, I capture the previous consent value before changing it. The enabled branch then restores the identity only when consent changed from off to on:

```swift
let wasOptedIn = userHasOptedIn
userHasOptedIn = !optedOut

// In the enabled branch:
refreshUserData(includingSiteCredentialSessions: !wasOptedIn)
```

For example, repeated launches previously tracked IDs `A → B → C`; they now use `A → A → A`. An opted-out launch followed by opt-in also restores `A` before the next event.

Repeated enabled settings and ordinary login refreshes keep the workaround from #9485 for missing application-password approval events. A/B tests still start after the provider finishes switching identity. The tests use a synchronous A/B starter and explicit provider completion.

I reproduced tests 1 and 2 on trunk and verified both fixes on the branch by inspecting `_userID` at `TracksService.m:148`, where the event receives `self.userID`.

## Test Steps

Use a site-address login session and keep the app installed. Inspect `_userID` at `TracksService.m:148`

1. Enable analytics. Fully stop and relaunch three times. Confirm events use the same anonymous ID `_userID` on every launch.
2. Disable analytics and record the saved anonymous ID. Fully stop and relaunch while analytics is disabled. Enable analytics without restarting, then open an order or product. Confirm the next event uses the saved ID.
3. Complete application-password authorization on a physical device with the debugger detached. Confirm login succeeds and `application_password_authorization_approved` reaches Tracks after normal batching.

I tested all these cases, compared behavior with trunk. Confirmed the fix.

## Screenshots

No visible UI change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
