### PR TITLE
Resume lifecycle tracking when analytics is enabled

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -14,6 +14,7 @@ import WooFoundationCore
 final class WooAnalytics: Analytics {
 
     typealias ABTestStarter = @MainActor (ExperimentContext) async -> Void
+    typealias WidgetConfigurationProvider = (@escaping (Result<[WidgetInfo], Error>) -> Void) -> Void
 
     // MARK: - Properties
 
@@ -32,6 +33,9 @@ final class WooAnalytics: Analytics {
     private let userDefaults: UserDefaults
 
     private let startABTest: ABTestStarter
+    private let notificationCenter: NotificationCenter
+    private let getWidgetConfigurations: WidgetConfigurationProvider
+    private var isObservingNotifications = false
 
     /// Check user opt-in for analytics
     ///
@@ -53,10 +57,16 @@ final class WooAnalytics: Analytics {
     ///
     init(analyticsProvider: AnalyticsProvider & WPAnalyticsTracker,
          userDefaults: UserDefaults = .standard,
+         notificationCenter: NotificationCenter = .default,
+         getWidgetConfigurations: @escaping WidgetConfigurationProvider = { completion in
+             WidgetCenter.shared.getCurrentConfigurations(completion)
+         },
          startABTest: @escaping ABTestStarter = { await ABTest.start(for: $0) }) {
         self.analyticsProvider = analyticsProvider
         self.userDefaults = userDefaults
         self.startABTest = startABTest
+        self.notificationCenter = notificationCenter
+        self.getWidgetConfigurations = getWidgetConfigurations
         WPAnalytics.register(analyticsProvider)
     }
 }
@@ -136,6 +146,7 @@ extension WooAnalytics {
             DDLogInfo("🔴 Tracking opt-out complete.")
         } else {
             refreshUserData()
+            startObservingNotifications()
             DDLogInfo("🔵 Tracking started.")
         }
     }
@@ -292,23 +303,24 @@ private extension Analytics {
 private extension WooAnalytics {
 
     func startObservingNotifications() {
-        guard userHasOptedIn == true else {
+        guard userHasOptedIn, !isObservingNotifications else {
             return
         }
+        isObservingNotifications = true
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(trackApplicationOpened),
-                                               name: UIApplication.didBecomeActiveNotification,
-                                               object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(trackApplicationOpened),
+                                       name: UIApplication.didBecomeActiveNotification,
+                                       object: nil)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(trackApplicationClosed),
-                                               name: UIApplication.didEnterBackgroundNotification,
-                                               object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(trackApplicationClosed),
+                                       name: UIApplication.didEnterBackgroundNotification,
+                                       object: nil)
     }
 
     @objc func trackApplicationOpened() {
-        WidgetCenter.shared.getCurrentConfigurations { [weak self] configurationResult in
+        getWidgetConfigurations { [weak self] configurationResult in
             guard let self else { return }
 
             let applicationProperties = self.applicationOpenedProperties(configurationResult)

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -36,6 +36,10 @@ final class MockStoresManager: DefaultStoresManager {
         super.init(sessionManager: sessionManager)
     }
 
+    init(sessionManager: SessionManagerProtocol) {
+        super.init(sessionManager: sessionManager)
+    }
+
     // MARK: - Overridden Properties
 
     override var posCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? {

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -29,6 +29,8 @@ class WooAnalyticsTests: XCTestCase {
     ///
     private var userDefaultsSuiteName: String!
 
+    private var notificationCenter: NotificationCenter!
+
     private let sampleSiteID: Int64 = 12345
 
     private let sampleSiteURL: String = "https://example.com"
@@ -39,20 +41,21 @@ class WooAnalyticsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false,
-                                                                   defaultSite: Site.fake().copy(
-                                                                    siteID: sampleSiteID,
-                                                                    url: sampleSiteURL)))
+        let sessionManager = MockSessionManager()
+        sessionManager.defaultSite = Site.fake().copy(siteID: sampleSiteID, url: sampleSiteURL)
+        stores = MockStoresManager(sessionManager: sessionManager)
         ServiceLocator.setStores(stores)
         userDefaultsSuiteName = UUID().uuidString
         userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)!
-        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider(), userDefaults: userDefaults)
+        notificationCenter = NotificationCenter()
+        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider(), userDefaults: userDefaults, notificationCenter: notificationCenter)
     }
 
     override func tearDown() {
         userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
         userDefaults = nil
         userDefaultsSuiteName = nil
+        notificationCenter = nil
         super.tearDown()
         ServiceLocator.setStores(originalStores)
     }
@@ -185,6 +188,7 @@ class WooAnalyticsTests: XCTestCase {
         var startedContexts: [ExperimentContext] = []
         analytics = WooAnalytics(analyticsProvider: testingProvider,
                                  userDefaults: userDefaults,
+                                 notificationCenter: notificationCenter,
                                  startABTest: { context in
             startedContexts.append(context)
             abTestStarted.fulfill()
@@ -214,6 +218,7 @@ class WooAnalyticsTests: XCTestCase {
         var startedContexts: [ExperimentContext] = []
         analytics = WooAnalytics(analyticsProvider: provider,
                                  userDefaults: userDefaults,
+                                 notificationCenter: notificationCenter,
                                  startABTest: { context in
             startedContexts.append(context)
             abTestStarted.fulfill()
@@ -226,6 +231,74 @@ class WooAnalyticsTests: XCTestCase {
         await fulfillment(of: [abTestStarted], timeout: 1.0)
         XCTAssertEqual(startedContexts, [.loggedIn])
         XCTAssertEqual(provider.refreshUserDataCallCount, 0)
+    }
+
+    @MainActor
+    func test_lifecycle_notifications_when_enabling_after_opted_out_launch_then_tracks_open_and_close_events() {
+        // Given
+        analytics = makeAnalyticsForLifecycleTests()
+        analytics.userHasOptedIn = false
+        analytics.initialize()
+
+        // When
+        analytics.setUserHasOptedOut(false)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(testingProvider?.receivedEvents, [WooAnalyticsStat.applicationOpened.rawValue, WooAnalyticsStat.applicationClosed.rawValue])
+    }
+
+    @MainActor
+    func test_lifecycle_notifications_when_initializing_and_enabling_repeatedly_then_tracks_each_event_once() {
+        // Given
+        analytics = makeAnalyticsForLifecycleTests()
+        analytics.initialize()
+
+        // When
+        analytics.initialize()
+        analytics.setUserHasOptedOut(false)
+        analytics.setUserHasOptedOut(false)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(testingProvider?.receivedEvents, [WooAnalyticsStat.applicationOpened.rawValue, WooAnalyticsStat.applicationClosed.rawValue])
+    }
+
+    @MainActor
+    func test_lifecycle_notifications_when_disabling_and_reenabling_then_tracks_only_while_enabled_without_duplicates() {
+        // Given
+        analytics = makeAnalyticsForLifecycleTests()
+        analytics.initialize()
+
+        // When
+        analytics.setUserHasOptedOut(true)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(testingProvider?.receivedEvents, [])
+
+        // When
+        analytics.setUserHasOptedOut(false)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(testingProvider?.receivedEvents, [WooAnalyticsStat.applicationOpened.rawValue, WooAnalyticsStat.applicationClosed.rawValue])
+    }
+
+    @MainActor
+    private func makeAnalyticsForLifecycleTests() -> WooAnalytics {
+        let provider = MockAnalyticsProvider()
+        provider.defersRefreshUserDataCompletion = true
+        return WooAnalytics(analyticsProvider: provider,
+                     userDefaults: userDefaults,
+                     notificationCenter: notificationCenter,
+                     getWidgetConfigurations: { completion in
+            completion(.failure(NSError(domain: "WidgetConfigurationError", code: 0)))
+        }, startABTest: { _ in })
     }
 
     func test_events_when_logged_in_include_site_properties() {
@@ -242,7 +315,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: "sample_store_uuid",
                                                                    cachedWooCommerceVersion: "10.0"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)
@@ -280,7 +353,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)
@@ -318,7 +391,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(Event.bookingDetailAttendanceStatusUpdate(bookingStatus: .attended))
@@ -339,7 +412,7 @@ class WooAnalyticsTests: XCTestCase {
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(Event.bookingDetailAttendanceStatusUpdate(bookingStatus: .attended))
@@ -367,7 +440,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: "sample_store_uuid",
                                                                    cachedWooCommerceVersion: "10.0"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(WooAnalyticsStat.cardReaderLocationSuccess.rawValue, properties: Constants.testProperty1, error: nil)
@@ -393,7 +466,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     url: sampleSiteURL),
                                                                    defaultStoreUUID: "sample_store_uuid"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track(WooAnalyticsStat.wooPushTokenRegisterSuccess.rawValue, properties: Constants.testProperty1, error: nil)
@@ -417,7 +490,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     url: sampleSiteURL),
                                                                    defaultStoreUUID: "sample_store_uuid"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
 
         // When
         analytics.track("an_event_name_that_is_not_a_stat", properties: Constants.testProperty1, error: nil)
@@ -442,7 +515,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: nil,
                                                                    cachedWooCommerceVersion: nil))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
         let callerProperties: [AnyHashable: Any] = [
             "cached_woo_core_version": "9.8.0",
             "store_id": "caller_store_uuid"
@@ -472,7 +545,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: "session_store_uuid",
                                                                    cachedWooCommerceVersion: "10.0"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults, notificationCenter: notificationCenter)
         let callerProperties: [AnyHashable: Any] = [
             "cached_woo_core_version": "9.8.0",
             "store_id": "caller_store_uuid"


### PR DESCRIPTION
Part of: WOOMOB-4012

## Description

Tracking on iOS doesn't automatically restart lifecycle events (`applicationOpened` and `applicationClosed`) after enabling analytics.

I found this while working on [the Tracks identity fix](https://github.com/woocommerce/woocommerce-ios/pull/17858), under the same [WOOMOB-4012 issue](https://linear.app/a8c/issue/WOOMOB-4012/ios-merchants-signed-in-with-site-credentials-get-a-new-tracks).

If the app launches with analytics disabled, initialization skips lifecycle observers. Enabling analytics later never registers them, so foreground and background events remain absent until another launch.

I now register observers when analytics is enabled:

```swift
refreshUserData()
startObservingNotifications()
```

Registration runs once per analytics instance, so repeated setting updates and off/on toggles do not duplicate events. The existing consent check still blocks tracking while analytics is disabled.

I verified on trunk that lifecycle events do not resume after enabling analytics following an opted-out launch. On the fixed branch, I confirmed that `applicationOpened` and `applicationClosed` resume without restarting.

## Test Steps

1. Disable analytics. Fully stop and relaunch the app.
2. Enable analytics without restarting. Background and foreground the app twice. Confirm one `application_closed` and one `application_opened` event per cycle.
3. Disable analytics and repeat: no events should be recorded. Enable analytics again and repeat: events should resume without duplicates.

## Screenshots

No visible UI change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
