### PR TITLE
POS refunds 3/4: Move the refund review preparation and submission into POSRefundController

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -15,6 +15,7 @@ import class Yosemite.AsyncPaginationTracker
 import protocol Experiments.FeatureFlagService
 import CocoaLumberjackSwift
 
+@MainActor
 protocol POSOrderListControllerProtocol {
     var ordersViewState: POSOrderListState { get }
     var selectedOrder: POSOrder? { get }
@@ -22,26 +23,16 @@ protocol POSOrderListControllerProtocol {
     var orderDetailsItemsState: POSOrderDetailsItemsState { get }
     var displayedLineItems: [POSOrderItem] { get }
     var displayedCustomAmounts: [POSOrderCustomAmount] { get }
-    var refundActionAvailability: RefundActionAvailability { get }
-    var refundSelectableItems: [POSRefundSelectableItem] { get }
-    var hasLoadedRefundableItems: Bool { get }
-    var currentRefundRequiresCardPresentRefund: Bool { get }
-    var hasModifiedRefundSelection: Bool { get }
     func loadOrders() async
     func refreshOrders() async
     func loadNextOrders() async
-    func selectOrder(_ order: POSOrder?)
     func updateOrder(orderID: Int64) async throws
-    func preloadRefundDetails() async
-    func startRefundFlow() async -> StartRefundFlowResult
-    func refreshRefundableItems() async -> StartRefundFlowResult
-    func toggleRefundItemSelection(at index: Int)
-    func clearRefundSelection()
-    func toggleAllRefundItemsSelection()
-    var refundReviewPreparationState: POSRefundReviewPreparationState { get }
-    func prepareRefundReview() async -> POSRefundReviewPreparationResult
-    func processRefund(reason: String?) async throws
     func loadOrderRefunds() async
+}
+
+@MainActor
+protocol POSOrderSelectionHandling {
+    func selectOrder(_ order: POSOrder?)
 }
 
 protocol POSSearchingOrderListControllerProtocol: POSOrderListControllerProtocol {
@@ -71,7 +62,7 @@ private enum POSOrderRefundDetailsState {
     }
 }
 
-@Observable final class POSOrderListController: POSSearchingOrderListControllerProtocol {
+@Observable final class POSOrderListController: POSSearchingOrderListControllerProtocol, POSOrderSelectionHandling {
     var ordersViewState: POSOrderListState
     private var strategyPaginationTracker: [String: AsyncPaginationTracker] = [:]
     private var fetchStrategy: POSOrderListFetchStrategy
@@ -82,8 +73,6 @@ private enum POSOrderRefundDetailsState {
     private var refundDetailsByOrderID: [Int64: POSOrderRefundDetailsState] = [:]
     private let orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol
     private let refundsService: POSRefundsServiceProtocol
-    private let refundSubmissionProcessor: POSRefundSubmissionProcessing
-    private let refundController: POSRefundController
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
              return existing
@@ -95,20 +84,11 @@ private enum POSOrderRefundDetailsState {
 
     init(orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol,
          refundsService: POSRefundsServiceProtocol,
-         refundSubmissionProcessor: POSRefundSubmissionProcessing,
-         refundController: POSRefundController,
          initialState: POSOrderListState = .loading([])) {
         self.ordersViewState = initialState
         self.orderListFetchStrategyFactory = orderListFetchStrategyFactory
         self.fetchStrategy = orderListFetchStrategyFactory.defaultStrategy()
         self.refundsService = refundsService
-        self.refundSubmissionProcessor = refundSubmissionProcessor
-        self.refundController = refundController
-    }
-
-    @MainActor
-    var refundReviewPreparationState: POSRefundReviewPreparationState {
-        refundController.reviewPreparationState
     }
 
     @MainActor
@@ -134,16 +114,6 @@ private enum POSOrderRefundDetailsState {
             customAmounts: displayedCustomAmounts,
             refundedItems: order.refunds.flatMap(\.items)
         )
-    }
-
-    @MainActor
-    var refundActionAvailability: RefundActionAvailability {
-        selectedOrder?.refundActionAvailability ?? .unavailable
-    }
-
-    @MainActor
-    var currentRefundRequiresCardPresentRefund: Bool {
-        refundController.requiresCardPresentRefund
     }
 
     @MainActor
@@ -302,7 +272,6 @@ private enum POSOrderRefundDetailsState {
             // which rebuild orders from summary data, don't re-show the skeleton and re-fetch.
             refundDetailsByOrderID[order.id] = .loaded(order.refunds)
         }
-        refundController.reset()
     }
 
     @MainActor
@@ -342,69 +311,6 @@ private enum POSOrderRefundDetailsState {
         if selectedOrder?.id == orderID {
             selectedOrder = updatedOrder
         }
-    }
-
-    // MARK: - Refund Item Selection
-
-    var refundSelectableItems: [POSRefundSelectableItem] {
-        refundController.selectableItems
-    }
-
-    var hasModifiedRefundSelection: Bool {
-        refundController.hasModifiedSelection
-    }
-
-    @MainActor
-    func preloadRefundDetails() async {
-        guard let order = selectedOrder else { return }
-        await refundController.preloadRefund(for: order)
-    }
-
-    @MainActor
-    func startRefundFlow() async -> StartRefundFlowResult {
-        guard let order = selectedOrder else { return .failed }
-        return await refundController.startRefundFlow(for: order)
-    }
-
-    @MainActor
-    var hasLoadedRefundableItems: Bool {
-        refundController.hasLoadedSelectableItems
-    }
-
-    @MainActor
-    func refreshRefundableItems() async -> StartRefundFlowResult {
-        return await refundController.refreshRefundableItems()
-    }
-
-    @MainActor
-    func toggleRefundItemSelection(at index: Int) {
-        refundController.toggleItemSelection(at: index)
-    }
-
-    @MainActor
-    func clearRefundSelection() {
-        refundController.clearSelection()
-    }
-
-    @MainActor
-    func toggleAllRefundItemsSelection() {
-        refundController.toggleAllItemsSelection()
-    }
-
-    // MARK: - Refund Review Data Preparation
-
-    @MainActor
-    func prepareRefundReview() async -> POSRefundReviewPreparationResult {
-        await refundController.prepareReview()
-    }
-
-    // MARK: - Refund Processing
-
-    @MainActor
-    func processRefund(reason: String?) async throws {
-        let result = try await refundController.processRefund(reason: reason)
-        try? await updateOrder(orderID: result.refundedOrderID)
-        await loadOrderRefunds()
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Observation
 import enum Yosemite.POSOrderListServiceError
-import enum Yosemite.RefundAPIError
 import protocol Yosemite.POSOrderListServiceProtocol
 import protocol Yosemite.POSOrderListFetchStrategyFactoryProtocol
 import protocol Yosemite.POSOrderListFetchStrategy
@@ -81,13 +80,10 @@ private enum POSOrderRefundDetailsState {
     /// Refund details fetch state per order. `.loaded` caches the fetched refunds so list refreshes,
     /// which rebuild orders from summary data, don't lose them or re-show the loading skeleton.
     private var refundDetailsByOrderID: [Int64: POSOrderRefundDetailsState] = [:]
-    private(set) var refundReviewPreparationState: POSRefundReviewPreparationState = .idle
-    private var refundReviewPreparationTask: Task<POSRefundReviewPreparationResult, Never>?
     private let orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol
     private let refundsService: POSRefundsServiceProtocol
     private let refundSubmissionProcessor: POSRefundSubmissionProcessing
     private let refundController: POSRefundController
-    private var isProcessingRefund = false
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
              return existing
@@ -108,6 +104,11 @@ private enum POSOrderRefundDetailsState {
         self.refundsService = refundsService
         self.refundSubmissionProcessor = refundSubmissionProcessor
         self.refundController = refundController
+    }
+
+    @MainActor
+    var refundReviewPreparationState: POSRefundReviewPreparationState {
+        refundController.reviewPreparationState
     }
 
     @MainActor
@@ -302,7 +303,6 @@ private enum POSOrderRefundDetailsState {
             refundDetailsByOrderID[order.id] = .loaded(order.refunds)
         }
         refundController.reset()
-        resetRefundReviewPreparation()
     }
 
     @MainActor
@@ -363,9 +363,7 @@ private enum POSOrderRefundDetailsState {
     @MainActor
     func startRefundFlow() async -> StartRefundFlowResult {
         guard let order = selectedOrder else { return .failed }
-        let result = await refundController.startRefundFlow(for: order)
-        resetRefundReviewPreparation()
-        return result
+        return await refundController.startRefundFlow(for: order)
     }
 
     @MainActor
@@ -375,129 +373,37 @@ private enum POSOrderRefundDetailsState {
 
     @MainActor
     func refreshRefundableItems() async -> StartRefundFlowResult {
-        let result = await refundController.refreshRefundableItems()
-        resetRefundReviewPreparation()
-        return result
+        return await refundController.refreshRefundableItems()
     }
 
     @MainActor
     func toggleRefundItemSelection(at index: Int) {
         refundController.toggleItemSelection(at: index)
-        resetRefundReviewPreparation()
     }
 
     @MainActor
     func clearRefundSelection() {
         refundController.clearSelection()
-        resetRefundReviewPreparation()
     }
 
     @MainActor
     func toggleAllRefundItemsSelection() {
         refundController.toggleAllItemsSelection()
-        resetRefundReviewPreparation()
     }
 
     // MARK: - Refund Review Data Preparation
 
     @MainActor
     func prepareRefundReview() async -> POSRefundReviewPreparationResult {
-        refundReviewPreparationTask?.cancel()
-
-        guard let order = refundController.order,
-              let preparation = refundController.preparation else {
-            refundReviewPreparationState = .idle
-            return .preparationError
-        }
-
-        let selectedItems = refundController.selectableItems.filter { $0.isSelected }
-        guard !selectedItems.isEmpty else {
-            refundReviewPreparationState = .idle
-            return .preparationError
-        }
-
-        let selectionSnapshot = refundController.selectableItems
-        refundReviewPreparationState = .loading
-        let preparationTask = Task { @MainActor [weak self] () -> POSRefundReviewPreparationResult in
-            guard let self else { return .superseded }
-            let state: POSRefundReviewPreparationState
-            let result: POSRefundReviewPreparationResult
-            do {
-                let reviewData = try await refundSubmissionProcessor.prepareReviewData(
-                    for: order,
-                    preparation: preparation,
-                    selectedItems: selectedItems,
-                    reason: nil
-                )
-                state = .idle
-                result = .ready(reviewData)
-            } catch is CancellationError {
-                return .superseded
-            } catch POSRefundSubmissionError.refundPreviewFailed {
-                state = .previewError()
-                result = .previewError
-            } catch RefundAPIError.orderNotRefundable {
-                state = .idle
-                result = .nothingToRefund
-            } catch let rejection as RefundAPIError {
-                state = .previewError(message: rejection.localizedDescription, recovery: rejection.recovery)
-                result = .previewError
-            } catch {
-                state = .idle
-                result = .preparationError
-            }
-            // Applied once for every outcome: a result computed against a selection the cashier has
-            // since changed must not be published, and a new catch must not be able to skip the check.
-            guard !Task.isCancelled, refundController.selectableItems == selectionSnapshot else { return .superseded }
-            refundReviewPreparationState = state
-            return result
-        }
-        refundReviewPreparationTask = preparationTask
-        return await preparationTask.value
-    }
-
-    @MainActor
-    func resetRefundReviewPreparation() {
-        refundReviewPreparationTask?.cancel()
-        refundReviewPreparationTask = nil
-        refundReviewPreparationState = .idle
+        await refundController.prepareReview()
     }
 
     // MARK: - Refund Processing
 
     @MainActor
     func processRefund(reason: String?) async throws {
-        guard !isProcessingRefund else {
-            throw POSRefundProcessingError.refundAlreadyInProgress
-        }
-
-        isProcessingRefund = true
-        defer {
-            isProcessingRefund = false
-        }
-
-        guard let order = refundController.order else {
-            throw POSRefundProcessingError.missingSelectedOrder
-        }
-
-        guard let preparation = refundController.preparation else {
-            throw POSRefundProcessingError.missingRefundPreparation
-        }
-
-        let selectedItems = refundSelectableItems.filter { $0.isSelected }
-        guard !selectedItems.isEmpty else {
-            throw POSRefundProcessingError.emptySelection
-        }
-
-        try await refundSubmissionProcessor.submitRefund(
-            for: order,
-            preparation: preparation,
-            selectedItems: selectedItems,
-            reason: reason
-        )
-
-        clearRefundSelection()
-        try? await updateOrder(orderID: order.id)
+        let result = try await refundController.processRefund(reason: reason)
+        try? await updateOrder(orderID: result.refundedOrderID)
         await loadOrderRefunds()
     }
 

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundController.swift
@@ -1,16 +1,20 @@
 import Foundation
 import Observation
 import enum Yosemite.OrderRefundEligibilityFailure
+import enum Yosemite.RefundAPIError
 import struct Yosemite.POSOrder
 
 @Observable final class POSRefundController {
     private(set) var selectableItems: [POSRefundSelectableItem] = []
     private(set) var hasModifiedSelection = false
+    private(set) var reviewPreparationState: POSRefundReviewPreparationState = .idle
 
     private(set) var order: POSOrder?
     private(set) var preparation: POSRefundPreparation?
 
     private let refundSubmissionProcessor: POSRefundSubmissionProcessing
+    private var reviewPreparationTask: Task<POSRefundReviewPreparationResult, Never>?
+    private var isProcessingRefund = false
 
     init(refundSubmissionProcessor: POSRefundSubmissionProcessing) {
         self.refundSubmissionProcessor = refundSubmissionProcessor
@@ -49,6 +53,7 @@ import struct Yosemite.POSOrder
 
         selectableItems = preparation.selectableItems
         hasModifiedSelection = false
+        resetReviewPreparation()
 
         return selectableItems.isEmpty ? .nothingToRefund : .hasItemsToRefund
     }
@@ -78,6 +83,7 @@ import struct Yosemite.POSOrder
         guard selectableItems.indices.contains(index) else { return }
         selectableItems[index].isSelected.toggle()
         hasModifiedSelection = true
+        resetReviewPreparation()
     }
 
     @MainActor
@@ -89,12 +95,14 @@ import struct Yosemite.POSOrder
             selectableItems[index].isSelected = newSelectionState
         }
         hasModifiedSelection = true
+        resetReviewPreparation()
     }
 
     @MainActor
     func clearSelection() {
         selectableItems = []
         hasModifiedSelection = false
+        resetReviewPreparation()
     }
 
     @MainActor
@@ -102,5 +110,106 @@ import struct Yosemite.POSOrder
         order = nil
         preparation = nil
         clearSelection()
+    }
+
+    // MARK: - Refund Review Data Preparation
+
+    @MainActor
+    func prepareReview() async -> POSRefundReviewPreparationResult {
+        reviewPreparationTask?.cancel()
+
+        guard let order, let preparation else {
+            reviewPreparationState = .idle
+            return .preparationError
+        }
+
+        let selectedItems = selectableItems.filter { $0.isSelected }
+        guard !selectedItems.isEmpty else {
+            reviewPreparationState = .idle
+            return .preparationError
+        }
+
+        let selectionSnapshot = selectableItems
+        reviewPreparationState = .loading
+        let preparationTask = Task { @MainActor [weak self] () -> POSRefundReviewPreparationResult in
+            guard let self else { return .superseded }
+            let state: POSRefundReviewPreparationState
+            let result: POSRefundReviewPreparationResult
+            do {
+                let reviewData = try await refundSubmissionProcessor.prepareReviewData(
+                    for: order,
+                    preparation: preparation,
+                    selectedItems: selectedItems,
+                    reason: nil
+                )
+                state = .idle
+                result = .ready(reviewData)
+            } catch is CancellationError {
+                return .superseded
+            } catch POSRefundSubmissionError.refundPreviewFailed {
+                state = .previewError()
+                result = .previewError
+            } catch RefundAPIError.orderNotRefundable {
+                state = .idle
+                result = .nothingToRefund
+            } catch let rejection as RefundAPIError {
+                state = .previewError(message: rejection.localizedDescription, recovery: rejection.recovery)
+                result = .previewError
+            } catch {
+                state = .idle
+                result = .preparationError
+            }
+            // Applied once for every outcome: a result computed against a selection the cashier has
+            // since changed must not be published, and a new catch must not be able to skip the check.
+            guard !Task.isCancelled, selectableItems == selectionSnapshot else { return .superseded }
+            reviewPreparationState = state
+            return result
+        }
+        reviewPreparationTask = preparationTask
+        return await preparationTask.value
+    }
+
+    @MainActor
+    private func resetReviewPreparation() {
+        reviewPreparationTask?.cancel()
+        reviewPreparationTask = nil
+        reviewPreparationState = .idle
+    }
+
+    // MARK: - Refund Processing
+
+    @MainActor
+    func processRefund(reason: String?) async throws -> POSRefundSubmissionResult {
+        guard !isProcessingRefund else {
+            throw POSRefundProcessingError.refundAlreadyInProgress
+        }
+
+        isProcessingRefund = true
+        defer {
+            isProcessingRefund = false
+        }
+
+        guard let order else {
+            throw POSRefundProcessingError.missingSelectedOrder
+        }
+
+        guard let preparation else {
+            throw POSRefundProcessingError.missingRefundPreparation
+        }
+
+        let selectedItems = selectableItems.filter { $0.isSelected }
+        guard !selectedItems.isEmpty else {
+            throw POSRefundProcessingError.emptySelection
+        }
+
+        try await refundSubmissionProcessor.submitRefund(
+            for: order,
+            preparation: preparation,
+            selectedItems: selectedItems,
+            reason: reason
+        )
+
+        clearSelection()
+        return POSRefundSubmissionResult(refundedOrderID: order.id)
     }
 }

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundController.swift
@@ -4,13 +4,31 @@ import enum Yosemite.OrderRefundEligibilityFailure
 import enum Yosemite.RefundAPIError
 import struct Yosemite.POSOrder
 
-@Observable final class POSRefundController {
+@MainActor
+protocol POSRefundControllerProtocol {
+    var selectableItems: [POSRefundSelectableItem] { get }
+    var hasLoadedSelectableItems: Bool { get }
+    var hasModifiedSelection: Bool { get }
+    var reviewPreparationState: POSRefundReviewPreparationState { get }
+    var requiresCardPresentRefund: Bool { get }
+    func preloadRefund(for order: POSOrder) async
+    func startRefundFlow(for order: POSOrder) async -> StartRefundFlowResult
+    func refreshRefundableItems() async -> StartRefundFlowResult
+    func toggleItemSelection(at index: Int)
+    func toggleAllItemsSelection()
+    func clearSelection()
+    func reset()
+    func prepareReview() async -> POSRefundReviewPreparationResult
+    func processRefund(reason: String?) async throws -> POSRefundSubmissionResult
+}
+
+@Observable final class POSRefundController: POSRefundControllerProtocol {
     private(set) var selectableItems: [POSRefundSelectableItem] = []
     private(set) var hasModifiedSelection = false
     private(set) var reviewPreparationState: POSRefundReviewPreparationState = .idle
 
-    private(set) var order: POSOrder?
-    private(set) var preparation: POSRefundPreparation?
+    private var order: POSOrder?
+    private var preparation: POSRefundPreparation?
 
     private let refundSubmissionProcessor: POSRefundSubmissionProcessing
     private var reviewPreparationTask: Task<POSRefundReviewPreparationResult, Never>?

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundFlowTypes.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundFlowTypes.swift
@@ -44,6 +44,10 @@ extension POSOrder {
     }
 }
 
+struct POSRefundSubmissionResult: Equatable {
+    let refundedOrderID: Int64
+}
+
 enum POSRefundProcessingError: LocalizedError, Equatable {
     case missingSelectedOrder
     case missingRefundPreparation

--- a/Modules/Sources/PointOfSale/Models/POSOrderListModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSOrderListModel.swift
@@ -1,16 +1,22 @@
 import Foundation
 import Observation
+import CocoaLumberjackSwift
 import struct Yosemite.POSOrder
 
 @Observable final class POSOrderListModel {
     let ordersController: POSSearchingOrderListControllerProtocol
     let receiptSender: POSReceiptSending
     let refundSubmissionModel: POSRefundSubmissionModel
+    private let orderSelectionHandler: POSOrderSelectionHandling
+    private let refundController: POSRefundControllerProtocol
 
-    init(ordersController: POSSearchingOrderListControllerProtocol,
+    init(ordersController: POSSearchingOrderListControllerProtocol & POSOrderSelectionHandling,
+         refundController: POSRefundControllerProtocol,
          receiptSender: POSReceiptSending,
          refundSubmissionModel: POSRefundSubmissionModel) {
         self.ordersController = ordersController
+        self.orderSelectionHandler = ordersController
+        self.refundController = refundController
         self.receiptSender = receiptSender
         self.refundSubmissionModel = refundSubmissionModel
     }
@@ -18,5 +24,95 @@ import struct Yosemite.POSOrder
     func sendReceipt(order: POSOrder, email: String) async throws {
         try await receiptSender.sendReceipt(orderID: order.id, recipientEmail: email)
         try await ordersController.updateOrder(orderID: order.id)
+    }
+
+    @MainActor
+    func selectOrder(_ order: POSOrder?) {
+        orderSelectionHandler.selectOrder(order)
+        refundController.reset()
+    }
+
+    // MARK: - Refund Flow
+
+    @MainActor
+    var refundActionAvailability: RefundActionAvailability {
+        ordersController.selectedOrder?.refundActionAvailability ?? .unavailable
+    }
+
+    @MainActor
+    var refundSelectableItems: [POSRefundSelectableItem] {
+        refundController.selectableItems
+    }
+
+    @MainActor
+    var hasLoadedRefundableItems: Bool {
+        refundController.hasLoadedSelectableItems
+    }
+
+    @MainActor
+    var hasModifiedRefundSelection: Bool {
+        refundController.hasModifiedSelection
+    }
+
+    @MainActor
+    var refundReviewPreparationState: POSRefundReviewPreparationState {
+        refundController.reviewPreparationState
+    }
+
+    @MainActor
+    var requiresCardPresentRefund: Bool {
+        refundController.requiresCardPresentRefund
+    }
+
+    @MainActor
+    func preloadRefund() async {
+        guard let order = ordersController.selectedOrder else {
+            return
+        }
+        await refundController.preloadRefund(for: order)
+    }
+
+    @MainActor
+    func startRefundFlow() async -> StartRefundFlowResult {
+        guard let order = ordersController.selectedOrder else {
+            return .failed
+        }
+        return await refundController.startRefundFlow(for: order)
+    }
+
+    @MainActor
+    func refreshRefundableItems() async -> StartRefundFlowResult {
+        await refundController.refreshRefundableItems()
+    }
+
+    @MainActor
+    func toggleRefundItemSelection(at index: Int) {
+        refundController.toggleItemSelection(at: index)
+    }
+
+    @MainActor
+    func toggleAllRefundItemsSelection() {
+        refundController.toggleAllItemsSelection()
+    }
+
+    @MainActor
+    func clearRefundSelection() {
+        refundController.clearSelection()
+    }
+
+    @MainActor
+    func prepareRefundReview() async -> POSRefundReviewPreparationResult {
+        await refundController.prepareReview()
+    }
+
+    @MainActor
+    func processRefund(reason: String?) async throws {
+        let result = try await refundController.processRefund(reason: reason)
+        do {
+            try await ordersController.updateOrder(orderID: result.refundedOrderID)
+        } catch {
+            DDLogError("⛔️ Failed to refresh order \(result.refundedOrderID) after refund: \(error)")
+        }
+        await ordersController.loadOrderRefunds()
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -137,7 +137,7 @@ struct POSOrderDetailsView: View {
                         errorStrings: refundErrorStrings,
                         onDismiss: { dismissRefundFlow() },
                         onRetryLoading: {
-                            if orderListModel.ordersController.hasLoadedRefundableItems {
+                            if orderListModel.hasLoadedRefundableItems {
                                 refreshRefundSelection()
                             } else {
                                 initiateRefundFlow()
@@ -185,7 +185,7 @@ struct POSOrderDetailsView: View {
             await orderListModel.ordersController.loadOrderRefunds()
         }
         .task {
-            await orderListModel.ordersController.preloadRefundDetails()
+            await orderListModel.preloadRefund()
         }
         .onAppear {
             if autoStartNextRefundFlow {
@@ -540,7 +540,7 @@ private extension POSOrderDetailsView {
         case .refunded:
             return .init(primary: email, secondary: [])
         case .completed:
-            switch orderListModel.ordersController.refundActionAvailability {
+            switch orderListModel.refundActionAvailability {
             case .available:
                 return .init(primary: .issueRefund, secondary: [email])
 
@@ -617,7 +617,7 @@ private extension POSOrderDetailsView {
         refundSelectionState = .loading
         presentRefundSelection()
         Task { @MainActor in
-            let result = await orderListModel.ordersController.startRefundFlow()
+            let result = await orderListModel.startRefundFlow()
             guard refundFlowPreparationID == preparationID else {
                 return
             }
@@ -637,7 +637,7 @@ private extension POSOrderDetailsView {
 
     func navigateToRefundReview() {
         Task { @MainActor in
-            switch await orderListModel.ordersController.prepareRefundReview() {
+            switch await orderListModel.prepareRefundReview() {
             case .ready(var reviewData):
                 reviewData.refundReason = currentRefundReason
                 refundModalState = .review(reviewData)
@@ -668,7 +668,7 @@ private extension POSOrderDetailsView {
         refundSelectionState = .loading
         presentRefundSelection()
         Task { @MainActor in
-            let result = await orderListModel.ordersController.refreshRefundableItems()
+            let result = await orderListModel.refreshRefundableItems()
             guard refundFlowPreparationID == preparationID else {
                 return
             }
@@ -701,7 +701,7 @@ private extension POSOrderDetailsView {
         refundSelectionState = nil
         refundModalState = nil
         currentRefundReason = nil
-        orderListModel.ordersController.clearRefundSelection()
+        orderListModel.clearRefundSelection()
         dismissRefundSelectionIfNeeded()
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -165,7 +165,7 @@ private extension POSOrdersView {
             return
         }
 
-        if orderListModel.ordersController.hasModifiedRefundSelection {
+        if orderListModel.hasModifiedRefundSelection {
             pendingOrderSelection = order
             isCancelRefundConfirmationPresented = true
         } else {
@@ -176,7 +176,7 @@ private extension POSOrdersView {
     func cancelActiveRefundSelectionAndSelect(_ order: POSOrder) {
         activeRefundSelectionOrderID = nil
         pendingOrderSelection = nil
-        orderListModel.ordersController.clearRefundSelection()
+        orderListModel.clearRefundSelection()
         selectOrder(order)
     }
 
@@ -185,7 +185,7 @@ private extension POSOrdersView {
             activeRefundSelectionOrderID = nil
             pendingOrderSelection = nil
         }
-        orderListModel.ordersController.selectOrder(order)
+        orderListModel.selectOrder(order)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -12,11 +12,11 @@ struct POSRefundItemsSelectionView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var refundSelectableItems: [POSRefundSelectableItem] {
-        orderListModel.ordersController.refundSelectableItems
+        orderListModel.refundSelectableItems
     }
 
     private var reviewPreparationState: POSRefundReviewPreparationState {
-        orderListModel.ordersController.refundReviewPreparationState
+        orderListModel.refundReviewPreparationState
     }
 
     /// The inline error shown above the continue button: the server's rejection copy when the
@@ -93,7 +93,7 @@ private extension POSRefundItemsSelectionView {
                 onToggle: {
                     let action = allItemsSelected ? "deselected" : "selected"
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.refundSelectAllTapped(action: action))
-                    orderListModel.ordersController.toggleAllRefundItemsSelection()
+                    orderListModel.toggleAllRefundItemsSelection()
                 }
             )
             .accessibilityLabel(Localization.selectAllAccessibilityLabel)
@@ -124,7 +124,7 @@ private extension POSRefundItemsSelectionView {
                     POSRefundItemRow(
                         item: item,
                         onToggle: {
-                            orderListModel.ordersController.toggleRefundItemSelection(at: index)
+                            orderListModel.toggleRefundItemSelection(at: index)
                         }
                     )
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -216,7 +216,7 @@ struct POSRefundModalContentView: View {
                 onClose: {},
                 onConfirm: {},
                 onBack: { returnToRefundConfirmation(reviewData: reviewData) },
-                shouldUseCardPresentCompletionStyle: orderListModel.ordersController.currentRefundRequiresCardPresentRefund,
+                shouldUseCardPresentCompletionStyle: orderListModel.requiresCardPresentRefund,
                 onPaymentCaptureErrorCancel: { cancelPayment in
                     handleAmbiguousCardPresentRefund(cancelPayment: cancelPayment)
                 }
@@ -251,7 +251,7 @@ struct POSRefundModalContentView: View {
 
     /// `true` when the card-present refund itself failed, rather than the store rejecting the request.
     private var isCardPresentRefundError: Bool {
-        orderListModel.ordersController.currentRefundRequiresCardPresentRefund
+        orderListModel.requiresCardPresentRefund
     }
 
     /// A recognised rejection is a deterministic validation error, so resubmitting the same request
@@ -407,7 +407,7 @@ struct POSRefundModalContentView: View {
     private func processRefund(reviewData: POSRefundReviewData) async {
         analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingStarted(flow: reviewData.calculationFlow))
         do {
-            try await orderListModel.ordersController.processRefund(reason: reviewData.refundReason)
+            try await orderListModel.processRefund(reason: reviewData.refundReason)
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingSuccess(flow: reviewData.calculationFlow))
             refundSubmissionModel.reset()
             modalState = .success(reviewData)
@@ -508,7 +508,7 @@ struct POSRefundModalContentView: View {
     }
 
     private func shouldRequireReaderConnection() -> Bool {
-        guard orderListModel.ordersController.currentRefundRequiresCardPresentRefund else {
+        guard orderListModel.requiresCardPresentRefund else {
             return false
         }
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -164,10 +164,9 @@ public struct PointOfSaleEntryPointView: View {
         self.receiptSender = receiptSender
         self.posEntryPointController = POSEntryPointController(eligibilityChecker: posEligibilityChecker)
         let ordersController = POSOrderListController(orderListFetchStrategyFactory: orderListFetchStrategyFactory,
-                                                      refundsService: refundsService,
-                                                      refundSubmissionProcessor: refundSubmissionProcessor,
-                                                      refundController: POSRefundController(refundSubmissionProcessor: refundSubmissionProcessor))
+                                                      refundsService: refundsService)
         self.orderListModel = POSOrderListModel(ordersController: ordersController,
+                                                refundController: POSRefundController(refundSubmissionProcessor: refundSubmissionProcessor),
                                                 receiptSender: receiptSender,
                                                 refundSubmissionModel: refundSubmissionProcessor.stateModel)
         if isLocalCatalogEligible, let grdbManager {

--- a/Modules/Sources/PointOfSale/README.md
+++ b/Modules/Sources/PointOfSale/README.md
@@ -51,6 +51,10 @@ Each `Controller` handles a piece of global shared state, and provides the inter
 
 Often, the best way to do that is to expose a single enum covering all valid possibilities for that state, rather than exposing model objects. We've not achieved that in all the controllers yet, and some global state hasn't been encapsulated in a controller successfully yet, for example card payments.
 
+#### Coordinating models
+
+When one screen spans several controllers, a coordinating model owns them and is the single surface its views talk to. `POSOrderListModel` is the example: it holds the order list controller and the refund controller, forwards their state and actions to the orders screens, and owns everything that spans both, such as resetting the refund flow when the selected order changes and refreshing an order after a refund. Neither controller knows about the other. `POSOrderListModel` deliberately holds the order list controller twice — once as the view-facing `POSSearchingOrderListControllerProtocol` and once privately as `POSOrderSelectionHandling` — so views can read list state but cannot change the selection behind the model's back.
+
 #### Services
 
 Ideally each `Service` should be stateless, and owned by a controller which handles the state in between service calls, where needed.

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -262,9 +262,11 @@ struct POSPreviewHelpers {
         )
     }
 
+    @MainActor
     static func makePreviewOrdersModel(state: POSOrderListState) -> POSOrderListModel {
         return POSOrderListModel(
             ordersController: POSConfigurablePreviewOrderListController(state: state),
+            refundController: POSPreviewRefundController(),
             receiptSender: POSReceiptSenderPreview(),
             refundSubmissionModel: POSRefundSubmissionModel())
     }
@@ -511,13 +513,11 @@ struct POSPreviewHelpers {
 
 
 // MARK: - Preview Orders Controller
-final class POSConfigurablePreviewOrderListController: POSSearchingOrderListControllerProtocol {
-    var refundSelectableItems: [POSRefundSelectableItem]
+final class POSConfigurablePreviewOrderListController: POSSearchingOrderListControllerProtocol, POSOrderSelectionHandling {
     let ordersViewState: POSOrderListState
 
     init(state: POSOrderListState) {
         self.ordersViewState = state
-        self.refundSelectableItems = []
     }
 
     var selectedOrder: POSOrder? {
@@ -534,28 +534,35 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     }
     var displayedLineItems: [POSOrderItem] { selectedOrder?.lineItems ?? [] }
     var displayedCustomAmounts: [POSOrderCustomAmount] { selectedOrder?.customAmounts ?? [] }
-    var refundActionAvailability: RefundActionAvailability { .available }
-    var hasLoadedRefundableItems: Bool { !refundSelectableItems.isEmpty }
-    var currentRefundRequiresCardPresentRefund: Bool { false }
-    var hasModifiedRefundSelection = false
 
     func loadOrders() async {}
     func loadNextOrders() async {}
     func refreshOrders() async {}
     func selectOrder(_ order: POSOrder?) {}
     func updateOrder(orderID: Int64) async throws {}
-    func preloadRefundDetails() async {}
     func searchOrders(searchTerm: String) async {}
     func clearSearchOrders() {}
-    func startRefundFlow() async -> StartRefundFlowResult { .hasItemsToRefund }
-    func refreshRefundableItems() async -> StartRefundFlowResult { .hasItemsToRefund }
-    func toggleRefundItemSelection(at index: Int) {}
-    func clearRefundSelection() {}
-    func toggleAllRefundItemsSelection() {}
-    var refundReviewPreparationState: POSRefundReviewPreparationState { .idle }
-    func prepareRefundReview() async -> POSRefundReviewPreparationResult { .preparationError }
-    func processRefund(reason: String?) async throws {}
     func loadOrderRefunds() async {}
+}
+
+final class POSPreviewRefundController: POSRefundControllerProtocol {
+    var selectableItems: [POSRefundSelectableItem] = []
+    var hasLoadedSelectableItems: Bool { !selectableItems.isEmpty }
+    var hasModifiedSelection = false
+    var reviewPreparationState: POSRefundReviewPreparationState = .idle
+    var requiresCardPresentRefund = false
+
+    func preloadRefund(for order: POSOrder) async {}
+    func startRefundFlow(for order: POSOrder) async -> StartRefundFlowResult { .hasItemsToRefund }
+    func refreshRefundableItems() async -> StartRefundFlowResult { .hasItemsToRefund }
+    func toggleItemSelection(at index: Int) {}
+    func toggleAllItemsSelection() {}
+    func clearSelection() {}
+    func reset() {}
+    func prepareReview() async -> POSRefundReviewPreparationResult { .preparationError }
+    func processRefund(reason: String?) async throws -> POSRefundSubmissionResult {
+        POSRefundSubmissionResult(refundedOrderID: 0)
+    }
 }
 
 // MARK: - Barcode Scan Service

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1385,7 +1385,7 @@ final class POSOrderListControllerTests {
         _ = await awaitReviewPreparation(sut)
 
         // When
-        sut.resetRefundReviewPreparation()
+        sut.clearRefundSelection()
 
         // Then
         #expect(sut.refundReviewPreparationState == .idle)

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -3,36 +3,21 @@ import TestKit
 import Foundation
 @testable import PointOfSale
 import enum Yosemite.POSOrderListServiceError
-import enum Yosemite.RefundAPIError
-import struct NetworkingCore.Order
-import Observation
 import struct Yosemite.POSOrder
 import struct Yosemite.POSOrderItem
 import struct Yosemite.POSOrderCustomAmount
 import enum Yosemite.OrderStatusEnum
-import enum Yosemite.OrderRefundEligibilityFailure
-import typealias Yosemite.OrderItemAttribute
-@testable import struct Yosemite.POSRefund
 @testable import struct Yosemite.POSRefundItem
 import struct Yosemite.POSOrderRefund
-@testable import struct Yosemite.POSRefundsResult
-import class WooFoundation.CurrencySettings
-import class WooFoundation.CurrencyFormatter
 
 @Suite(.timeLimit(.minutes(5)))
+@MainActor
 final class POSOrderListControllerTests {
     private let orderListService = MockPOSOrderListService()
     private let refundsService = MockPOSRefundsService()
     private lazy var fetchStrategyFactory = MockPOSOrderListFetchStrategyFactory(orderService: orderListService)
-    private lazy var currencySettingsProvider = MockCurrencySettingsProvider()
-    private lazy var currencyFormatter = CurrencyFormatter(currencySettings: currencySettingsProvider.currencySettings)
-    private lazy var refundSubmissionProcessor = MockPOSRefundSubmissionProcessor(refundsService: refundsService,
-                                                                                  currencyFormatter: currencyFormatter)
-    private lazy var refundController = POSRefundController(refundSubmissionProcessor: refundSubmissionProcessor)
     private lazy var sut = POSOrderListController(orderListFetchStrategyFactory: fetchStrategyFactory,
-                                                   refundsService: refundsService,
-                                                   refundSubmissionProcessor: refundSubmissionProcessor,
-                                                   refundController: refundController)
+                                                   refundsService: refundsService)
 
     @Test func loadOrders_requests_first_page_after_loading_two_pages() async throws {
         try #require(sut.ordersViewState.isLoading)
@@ -388,1350 +373,10 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder?.customerEmail == "selected-updated@example.com")
     }
 
-    @MainActor
-    @Test func refundActionAvailability_when_completed_order_selected_then_available() async throws {
-        // Given
-        let order = makeOrder(id: 1)
 
-        // When
-        sut.selectOrder(order)
-
-        // Then
-        #expect(sut.refundActionAvailability == .available)
-    }
-
-    @MainActor
-    @Test func refundActionAvailability_when_no_selected_order_then_unavailable() async throws {
-        // When / Then
-        #expect(sut.refundActionAvailability == .unavailable)
-    }
-
-    @MainActor
-    @Test func refundActionAvailability_when_order_completed_then_available() async throws {
-        // Given
-        let order = makeOrder(id: 1, status: .completed)
-
-        // When
-        sut.selectOrder(order)
-
-        // Then
-        #expect(sut.refundActionAvailability == .available)
-    }
-
-    @MainActor
-    @Test func refundActionAvailability_when_order_not_completed_then_unavailable() async throws {
-        // Given
-        let order = makeOrder(id: 1, status: .processing)
-
-        // When
-        sut.selectOrder(order)
-
-        // Then
-        #expect(sut.refundActionAvailability == .unavailable)
-    }
-
-    // MARK: - Refund Item Selection Tests
-
-    @MainActor
-    @Test func preloadRefundDetails_when_refund_is_available_then_preloads_without_opening_refund_flow() async throws {
-        // Given
-        let order = makeOrder(id: 1, status: .completed)
-        sut.selectOrder(order)
-
-        // When
-        await sut.preloadRefundDetails()
-
-        // Then
-        #expect(refundSubmissionProcessor.preloadedOrderIDs == [order.id])
-        #expect(sut.refundSelectableItems.isEmpty)
-        #expect(refundController.preparation == nil, "Preloading should not move the visible refund flow state.")
-    }
-
-    @MainActor
-    @Test func preloadRefundDetails_when_refund_is_unavailable_then_does_not_preload() async throws {
-        // Given
-        let order = makeOrder(id: 1, status: .processing)
-        sut.selectOrder(order)
-
-        // When
-        await sut.preloadRefundDetails()
-
-        // Then
-        #expect(refundSubmissionProcessor.preloadedOrderIDs.isEmpty)
-    }
-
-    @MainActor
-    @Test func startRefundFlow_when_product_has_multiple_quantities_then_creates_one_row_per_unit() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, name: "Item A", quantity: 3, formattedPrice: "$10.00", formattedTotal: "$30.00"),
-            makePOSOrderItem(itemID: 2, name: "Item B", quantity: 1, formattedPrice: "$5.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        #expect(sut.refundSelectableItems.count == 4)
-    }
-
-    @MainActor
-    @Test func startRefundFlow_then_all_items_are_selected_by_default() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        #expect(sut.refundSelectableItems.count == 2)
-        for item in sut.refundSelectableItems {
-            #expect(item.isSelected)
-        }
-    }
-
-    @MainActor
-    @Test func startRefundFlow_when_no_selected_order_then_items_remain_empty() async throws {
-        // When
-        _ = await sut.startRefundFlow()
-
-        // Then
-        #expect(sut.refundSelectableItems.isEmpty)
-    }
-
-    @MainActor
-    @Test func startRefundFlow_when_order_is_ineligible_then_returns_specific_failure() async throws {
-        // Given
-        let order = makeOrder()
-        refundSubmissionProcessor.prepareRefundErrorToThrow = OrderRefundEligibilityFailure.giftCardUnsupported
-        sut.selectOrder(order)
-
-        // When
-        let result = await sut.startRefundFlow()
-
-        // Then
-        guard case .ineligible(.giftCardUnsupported) = result else {
-            Issue.record("Expected the gift-card eligibility failure.")
-            return
-        }
-    }
-
-    @MainActor
-    @Test func startRefundFlow_when_item_partially_refunded_then_excludes_refunded_quantity() async throws {
-        // Given: Order has 3 units of item, 1 was previously refunded
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -1, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 3, formattedPrice: "$10.00", formattedTotal: "$30.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then: Should only show 2 available (3 - 1 refunded)
-        #expect(sut.refundSelectableItems.count == 2)
-    }
-
-    @MainActor
-    @Test func startRefundFlow_when_item_fully_refunded_then_excludes_item_entirely() async throws {
-        // Given: Order has 2 units of item, both were previously refunded
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00"),
-            makePOSOrderItem(itemID: 2, quantity: 1, formattedPrice: "$5.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then: Should only show item 2 (item 1 is fully refunded)
-        #expect(sut.refundSelectableItems.count == 1)
-        #expect(sut.refundSelectableItems[0].itemID == 2)
-    }
-
-    @MainActor
-    @Test func test_startRefundFlow_when_order_has_custom_amount_then_appends_lump_sum_selectable() async throws {
-        // Given
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
-        let order = makeOrder(
-            lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00")],
-            customAmounts: [customAmount]
-        )
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        #expect(sut.refundSelectableItems.count == 2)
-        let feeRow = try #require(sut.refundSelectableItems.first(where: { $0.isLumpSum }))
-        #expect(feeRow.itemID == 777)
-        #expect(feeRow.name == "Discount Fee")
-        #expect(feeRow.lineItemTotal == 10)
-        #expect(feeRow.originalQuantity == 1)
-        #expect(feeRow.isSelected == true)
-    }
-
-    @MainActor
-    @Test func test_startRefundFlow_when_custom_amount_already_refunded_then_excludes_fee() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 777, quantity: 0, name: "Discount Fee",
-                                                     formattedPrice: "", formattedTotal: "", imageSrc: nil, isLumpSum: true)])],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
-        let order = makeOrder(
-            lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00")],
-            customAmounts: [customAmount]
-        )
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        #expect(sut.refundSelectableItems.count == 1)
-        #expect(sut.refundSelectableItems.contains(where: { $0.isLumpSum }) == false)
-    }
-
-    @MainActor
-    @Test func test_startRefundFlow_with_only_unrefunded_custom_amount_then_returns_hasItemsToRefund() async throws {
-        // Given
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
-        let order = makeOrder(lineItems: [], customAmounts: [customAmount])
-
-        // When
-        sut.selectOrder(order)
-        let availability = await sut.startRefundFlow()
-
-        // Then
-        #expect(availability == .hasItemsToRefund)
-        #expect(sut.refundSelectableItems.count == 1)
-        #expect(sut.refundSelectableItems.first?.isLumpSum == true)
-    }
-
-    @MainActor
-    @Test func test_prepareRefundReview_with_custom_amount_only_then_returns_lump_sum_total() async throws {
-        // Given - one fee of $10, no products
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
-        let order = makeOrder(lineItems: [], customAmounts: [customAmount])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        let reviewData = await prepareReviewData(sut)
-
-        // Then
-        #expect(reviewData?.itemsCount == 1)
-        #expect(reviewData?.formattedItemsSubtotal == "$10.00")
-        #expect(reviewData?.formattedRefundTotal == "$10.00")
-    }
-
-    @MainActor
-    @Test func test_prepareRefundReview_with_mixed_products_and_custom_amount_then_sums_both() async throws {
-        // Given - one product ($10) and one fee ($5)
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 5, totalTax: 0)
-        let order = makeOrder(
-            lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")],
-            customAmounts: [customAmount]
-        )
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        let reviewData = await prepareReviewData(sut)
-
-        // Then
-        #expect(reviewData?.itemsCount == 2)
-        #expect(reviewData?.formattedItemsSubtotal == "$15.00")
-        #expect(reviewData?.formattedRefundTotal == "$15.00")
-    }
-
-    @MainActor
-    @Test func startRefundFlow_when_multiple_refunds_exist_then_aggregates_refunded_quantities() async throws {
-        // Given: Order has 5 units of item, refunded across two separate refunds (2 + 2 = 4)
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [
-                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)]),
-                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])
-            ],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 5, formattedPrice: "$10.00", formattedTotal: "$50.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then: Should only show 1 available (5 - 4 refunded)
-        #expect(sut.refundSelectableItems.count == 1)
-    }
-
-    @MainActor
-    @Test func toggleRefundItemSelection_then_toggles_item_at_index() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        sut.toggleRefundItemSelection(at: 0)
-        let isSelectedAfterToggle = sut.refundSelectableItems[0].isSelected
-
-        // Then
-        #expect(isSelectedAfterToggle == false)
-    }
-
-    @MainActor
-    @Test func toggleRefundItemSelection_then_marks_refund_selection_as_modified() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        #expect(sut.hasModifiedRefundSelection == false)
-
-        // When
-        sut.toggleRefundItemSelection(at: 0)
-
-        // Then
-        #expect(sut.hasModifiedRefundSelection == true)
-    }
-
-    @Test func toggleRefundItemSelection_when_index_out_of_bounds_then_does_not_crash() async throws {
-        // When
-        let items = await MainActor.run {
-            sut.toggleRefundItemSelection(at: 999)
-            return sut.refundSelectableItems
-        }
-
-        // Then
-        #expect(items.isEmpty)
-    }
-
-    @MainActor
-    @Test func clearRefundSelection_then_removes_all_items() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        try #require(sut.refundSelectableItems.count == 2)
-
-        // When
-        sut.clearRefundSelection()
-
-        // Then
-        #expect(sut.refundSelectableItems.isEmpty)
-    }
-
-    @MainActor
-    @Test func clearRefundSelection_then_resets_modified_refund_selection() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 0)
-        try #require(sut.hasModifiedRefundSelection == true)
-
-        // When
-        sut.clearRefundSelection()
-
-        // Then
-        #expect(sut.hasModifiedRefundSelection == false)
-    }
-
-    @MainActor
-    @Test func toggleAllRefundItemsSelection_when_all_selected_then_deselects_all() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        sut.toggleAllRefundItemsSelection()
-
-        // Then
-        for item in sut.refundSelectableItems {
-            #expect(item.isSelected == false)
-        }
-    }
-
-    @MainActor
-    @Test func toggleAllRefundItemsSelection_then_marks_refund_selection_as_modified() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        #expect(sut.hasModifiedRefundSelection == false)
-
-        // When
-        sut.toggleAllRefundItemsSelection()
-
-        // Then
-        #expect(sut.hasModifiedRefundSelection == true)
-    }
-
-    @MainActor
-    @Test func toggleAllRefundItemsSelection_when_some_deselected_then_selects_all() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 0) // Deselect first item
-
-        // When
-        sut.toggleAllRefundItemsSelection()
-
-        // Then
-        for item in sut.refundSelectableItems {
-            #expect(item.isSelected == true)
-        }
-    }
-
-    @MainActor
-    @Test func toggleAllRefundItemsSelection_when_none_selected_then_selects_all() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleAllRefundItemsSelection() // Deselect all
-
-        // When
-        sut.toggleAllRefundItemsSelection() // Should select all
-
-        // Then
-        for item in sut.refundSelectableItems {
-            #expect(item.isSelected == true)
-        }
-    }
-
-    @MainActor
-    @Test func selectOrder_then_clears_refund_selection_state() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 0)
-        try #require(sut.hasModifiedRefundSelection == true)
-        try #require(sut.refundSelectableItems.isNotEmpty)
-
-        // When
-        sut.selectOrder(makeOrder(id: order.id + 1))
-
-        // Then
-        #expect(sut.refundSelectableItems.isEmpty)
-        #expect(sut.hasModifiedRefundSelection == false)
-    }
-
-    // MARK: - Prepare Refund Review Data Tests
-
-    @MainActor
-    @Test func prepareRefundReview_when_no_selected_order_then_returns_nil() async throws {
-        // When
-        _ = await sut.startRefundFlow()
-
-        // Then
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData == nil)
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_no_items_selected_then_returns_nil() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleAllRefundItemsSelection() // Deselect all
-
-        // Then
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData == nil)
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_then_returns_correct_items_count() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 3, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData?.itemsCount == 3)
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_then_returns_correct_subtotal() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00"),
-            makePOSOrderItem(itemID: 2, quantity: 1, price: 5.50, formattedPrice: "$5.50")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        // 2 × $10.00 + 1 × $5.50 = $25.50
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData?.formattedItemsSubtotal == "$25.50")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_full_refund_then_uses_original_tax() async throws {
-        // Given - item with quantity 2 and totalTax of $1.50 (for both units)
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, totalTax: 1.50, formattedPrice: "$10.00")
-        ])
-
-        // When - all items selected (full refund)
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then - should use original totalTax directly ($1.50)
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData?.formattedTax == "$1.50")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_partial_refund_then_calculates_proportional_tax() async throws {
-        // Given - item with quantity 2 and totalTax of $1.50 (for both units)
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, totalTax: 1.50, formattedPrice: "$10.00")
-        ])
-
-        // When - only 1 of 2 items selected (partial refund)
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 0) // Deselect first item, leaving 1 selected
-
-        // Then - should calculate proportionally: $1.50 / 2 × 1 = $0.75
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData?.formattedTax == "$0.75")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_then_returns_correct_total() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, totalTax: 1.00, formattedPrice: "$10.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then - $10.00 + $1.00 = $11.00
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData?.formattedRefundTotal == "$11.00")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_then_returns_via_payment_method_title() async throws {
-        // Given
-        let order = makeOrder(paymentMethodTitle: "WooCommerce In-Person Payments", lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData?.paymentMethodDescription == "via WooCommerce In-Person Payments")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_then_refund_reason_is_nil_by_default() async throws {
-        // Given
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        let reviewData = await prepareReviewData(sut)
-        #expect(reviewData?.refundReason == nil)
-    }
-
-    @MainActor
-    @Test func currentRefundRequiresCardPresentRefund_when_preparation_requires_card_present_refund_then_returns_true() async throws {
-        // Given
-        refundSubmissionProcessor.requiresCardPresentRefund = true
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        #expect(sut.currentRefundRequiresCardPresentRefund == true)
-    }
-
-    // MARK: - Currency Formatting Tests
-
-    @MainActor
-    @Test func prepareRefundReview_with_EUR_currency_then_formats_with_comma_decimal_separator() async throws {
-        // Given - EUR with comma decimal separator and dot thousand separator
-        let eurSettings = CurrencySettings(
-            currencyCode: .EUR,
-            currencyPosition: .rightSpace,
-            thousandSeparator: ".",
-            decimalSeparator: ",",
-            numberOfDecimals: 2
-        )
-        let controller = makeController(currencySettings: eurSettings)
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, price: 1172.02, totalTax: 234.40, formattedPrice: "1.172,02 €")
-        ])
-
-        // When
-        controller.selectOrder(order)
-        _ = await controller.startRefundFlow()
-        let reviewData = await prepareReviewData(controller)
-
-        // Then - 2 × €1,172.02 = €2,344.04, tax = €234.40, total = €2,578.44
-        // Note: CurrencyFormatter uses non-breaking space (\u{00A0}) before currency symbol
-        #expect(reviewData?.formattedItemsSubtotal == "2.344,04\u{00A0}€")
-        #expect(reviewData?.formattedTax == "234,40\u{00A0}€")
-        #expect(reviewData?.formattedRefundTotal == "2.578,44\u{00A0}€")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_with_JPY_currency_then_formats_without_decimals() async throws {
-        // Given - JPY with no decimals
-        let jpySettings = CurrencySettings(
-            currencyCode: .JPY,
-            currencyPosition: .left,
-            thousandSeparator: ",",
-            decimalSeparator: ".",
-            numberOfDecimals: 0
-        )
-        let controller = makeController(currencySettings: jpySettings)
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 2344, totalTax: 234, formattedPrice: "¥2,344")
-        ])
-
-        // When
-        controller.selectOrder(order)
-        _ = await controller.startRefundFlow()
-        let reviewData = await prepareReviewData(controller)
-
-        // Then
-        #expect(reviewData?.formattedItemsSubtotal == "¥2,344")
-        #expect(reviewData?.formattedTax == "¥234")
-        #expect(reviewData?.formattedRefundTotal == "¥2,578")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_with_GBP_and_large_values_then_formats_correctly() async throws {
-        // Given - GBP with large values
-        let gbpSettings = CurrencySettings(
-            currencyCode: .GBP,
-            currencyPosition: .left,
-            thousandSeparator: ",",
-            decimalSeparator: ".",
-            numberOfDecimals: 2
-        )
-        let controller = makeController(currencySettings: gbpSettings)
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 12345.67, totalTax: 2469.13, formattedPrice: "£12,345.67")
-        ])
-
-        // When
-        controller.selectOrder(order)
-        _ = await controller.startRefundFlow()
-        let reviewData = await prepareReviewData(controller)
-
-        // Then
-        #expect(reviewData?.formattedItemsSubtotal == "£12,345.67")
-        #expect(reviewData?.formattedTax == "£2,469.13")
-        #expect(reviewData?.formattedRefundTotal == "£14,814.80")
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_with_USD_and_large_value_from_screenshot_then_formats_correctly() async throws {
-        // Given - USD with value from screenshot: $2,344.04
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 2344.04, totalTax: 234.40, formattedPrice: "$2,344.04")
-        ])
-
-        // When
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        let reviewData = await prepareReviewData(sut)
-
-        // Then
-        #expect(reviewData?.formattedItemsSubtotal == "$2,344.04")
-        #expect(reviewData?.formattedTax == "$234.40")
-        #expect(reviewData?.formattedRefundTotal == "$2,578.44")
-    }
-
-    // MARK: - Refund Review Preparation State
-
-    @MainActor
-    @Test func prepareRefundReview_when_processor_throws_then_state_is_previewError_and_retry_recovers() async throws {
-        // Given
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        refundSubmissionProcessor.prepareReviewDataErrorToThrow = POSRefundSubmissionError.refundPreviewFailed
-
-        // When
-        let failedResult = await awaitReviewPreparation(sut)
-
-        // Then the failure is returned and the inline-error state is published for the sheet
-        #expect(failedResult == .previewError)
-        #expect(sut.refundReviewPreparationState == .previewError())
-
-        // When the failure is resolved and the user retries
-        refundSubmissionProcessor.prepareReviewDataErrorToThrow = nil
-        let recoveredResult = await awaitReviewPreparation(sut)
-
-        // Then
-        guard case .ready = recoveredResult else {
-            Issue.record("Expected .ready after retry, got \(recoveredResult)")
-            return
-        }
-        #expect(sut.refundReviewPreparationState == .idle)
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_processor_throws_typed_rejection_then_state_carries_its_message() async throws {
-        // Given the preview was rejected with an actionable code (e.g. the order changed since loading)
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.quantityExceedsRefundable
-
-        // When
-        let result = await awaitReviewPreparation(sut)
-
-        // Then the inline-error state carries the rejection's cashier-facing copy, and offers the
-        // item reload rather than a retry that would be rejected the same way
-        #expect(result == .previewError)
-        #expect(sut.refundReviewPreparationState == .previewError(
-            message: RefundAPIError.quantityExceedsRefundable.localizedDescription,
-            recovery: .refreshItems
-        ))
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_order_is_not_refundable_then_flow_ends_on_the_terminal_state() async throws {
-        // Given the store reports the order as having nothing refundable left
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.orderNotRefundable
-
-        // When
-        let result = await awaitReviewPreparation(sut)
-
-        // Then there is no selection to recover to, so the caller is told to end the flow
-        #expect(result == .nothingToRefund)
-        #expect(sut.refundReviewPreparationState == .idle)
-    }
-
-    @MainActor
-    @Test func refreshRefundableItems_when_the_reloaded_list_is_unchanged_then_clears_the_selection() async throws {
-        // Given two refundable units, with only the first one selected
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 1)
-
-        // When the reload returns the same list, as an order-level rejection does
-        let result = await sut.refreshRefundableItems()
-
-        // Then nothing is selected
-        #expect(result == .hasItemsToRefund)
-        #expect(sut.refundSelectableItems.count == 2)
-        #expect(sut.refundSelectableItems.allSatisfy { !$0.isSelected })
-    }
-
-    @MainActor
-    @Test func refreshRefundableItems_when_a_unit_was_refunded_elsewhere_then_clears_the_selection() async throws {
-        // Given three refundable units, all selected
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 3, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When another register refunds one unit and the cashier reloads
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1,
-                                                     quantity: -1,
-                                                     name: "",
-                                                     formattedPrice: "",
-                                                     formattedTotal: "",
-                                                     imageSrc: nil)])],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-        let result = await sut.refreshRefundableItems()
-
-        // Then the two remaining units are listed and none of them is selected
-        #expect(result == .hasItemsToRefund)
-        #expect(sut.refundSelectableItems.count == 2)
-        #expect(sut.refundSelectableItems.allSatisfy { !$0.isSelected })
-    }
-
-    @MainActor
-    @Test func refreshRefundableItems_when_the_reload_fails_then_keeps_the_previously_loaded_items() async throws {
-        // Given two refundable units, with only the first one selected
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 1)
-
-        // When the reload fails, for example because the register lost connectivity
-        refundSubmissionProcessor.prepareRefundErrorToThrow = NSError(domain: "test", code: 1)
-        let result = await sut.refreshRefundableItems()
-
-        // Then the previous list is still there, so a retry reloads instead of starting a new flow
-        #expect(result == .failed)
-        #expect(sut.refundSelectableItems.count == 2)
-        #expect(sut.hasLoadedRefundableItems == true)
-    }
-
-    @MainActor
-    @Test func hasLoadedRefundableItems_when_no_load_has_succeeded_then_is_false() async throws {
-        // Given a selected order
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-
-        // Then
-        #expect(sut.hasLoadedRefundableItems == false)
-
-        // When the first load fails
-        refundSubmissionProcessor.prepareRefundErrorToThrow = NSError(domain: "test", code: 1)
-        _ = await sut.startRefundFlow()
-
-        // Then
-        #expect(sut.hasLoadedRefundableItems == false)
-    }
-
-    @MainActor
-    @Test func hasLoadedRefundableItems_when_the_flow_ends_then_is_false_again() async throws {
-        // Given a loaded list of refundable items
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        #expect(sut.hasLoadedRefundableItems == true)
-
-        // When the cashier dismisses the flow
-        sut.clearRefundSelection()
-
-        // Then
-        #expect(sut.hasLoadedRefundableItems == false)
-    }
-
-    @MainActor
-    @Test func refreshRefundableItems_then_hasModifiedRefundSelection_is_false_until_the_next_toggle() async throws {
-        // Given a reloaded list with nothing selected
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 1)
-        _ = await sut.refreshRefundableItems()
-
-        // Then nothing of the cashier's is held, so switching orders needs no prompt
-        #expect(sut.hasModifiedRefundSelection == false)
-
-        // When the cashier picks again
-        sut.toggleRefundItemSelection(at: 0)
-
-        // Then the prompt applies again
-        #expect(sut.hasModifiedRefundSelection == true)
-    }
-
-    @MainActor
-    @Test func refreshRefundableItems_when_a_preview_error_is_shown_then_it_is_cleared() async throws {
-        // Given a rejected preview
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.lineItemAlreadyRefunded
-        _ = await awaitReviewPreparation(sut)
-
-        // When the cashier reloads the refundable items
-        refundSubmissionProcessor.prepareReviewDataErrorToThrow = nil
-        _ = await sut.refreshRefundableItems()
-
-        // Then the selection step is back to a clean state
-        #expect(sut.refundReviewPreparationState == .idle)
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_selection_changes_mid_flight_then_result_is_dropped() async throws {
-        // Given an order with two refundable units so a toggle is possible mid-flight
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        refundSubmissionProcessor.onPrepareReviewDataCalled = { [weak sut] in
-            sut?.toggleRefundItemSelection(at: 0)
-        }
-
-        // When
-        let result = await awaitReviewPreparation(sut)
-
-        // Then the toggle superseded the preparation, and the stale result never advanced the state
-        #expect(result == .superseded)
-        await Task.yield()
-        await Task.yield()
-        #expect(sut.refundReviewPreparationState == .idle)
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_order_changes_mid_flight_then_preparation_is_cancelled_and_reset() async throws {
-        // Given
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        refundSubmissionProcessor.onPrepareReviewDataCalled = { [weak sut] in
-            sut?.selectOrder(nil)
-        }
-
-        // When
-        let result = await awaitReviewPreparation(sut)
-
-        // Then the order switch cancelled the in-flight preparation and reset the state
-        #expect(result == .superseded)
-        #expect(sut.refundReviewPreparationState == .idle)
-    }
-
-    @MainActor
-    @Test func prepareRefundReview_when_no_preparation_loaded_then_returns_preparationError() async throws {
-        // Given no selected order / no started refund flow
-
-        // When
-        let result = await sut.prepareRefundReview()
-
-        // Then
-        #expect(result == .preparationError)
-        #expect(sut.refundReviewPreparationState == .idle)
-    }
-
-    @MainActor
-    @Test func resetRefundReviewPreparation_returns_state_to_idle() async throws {
-        // Given a completed preparation
-        let order = makeOrder(lineItems: [makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        _ = await awaitReviewPreparation(sut)
-
-        // When
-        sut.clearRefundSelection()
-
-        // Then
-        #expect(sut.refundReviewPreparationState == .idle)
-    }
-
-    // MARK: - Process Refund Tests
-
-    @MainActor
-    @Test func processRefund_then_submits_refund_with_correct_order_id() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(id: 123, lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        try await sut.processRefund(reason: .none)
-
-        // Then
-        #expect(refundSubmissionProcessor.submitRefundCalled == true)
-        #expect(refundSubmissionProcessor.spySubmitRefundOrderID == 123)
-    }
-
-    @MainActor
-    @Test func processRefund_then_submits_refund_with_selected_items() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00"),
-            makePOSOrderItem(itemID: 2, quantity: 1, price: 5.00, formattedPrice: "$5.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleRefundItemSelection(at: 0) // Deselect first item of itemID 1
-
-        // When
-        try await sut.processRefund(reason: .none)
-
-        // Then
-        let items = try #require(refundSubmissionProcessor.spySubmitRefundItems)
-        #expect(items.count == 2)
-        #expect(items.contains(where: { $0.itemID == 1 }))
-        #expect(items.contains(where: { $0.itemID == 2 }))
-    }
-
-    @MainActor
-    @Test func processRefund_then_submits_refund_with_reason() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        try await sut.processRefund(reason: "Customer changed their mind")
-
-        // Then
-        #expect(refundSubmissionProcessor.spySubmitRefundReason == "Customer changed their mind")
-    }
-
-    @MainActor
-    @Test func processRefund_when_successful_then_clears_selection() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        try #require(sut.refundSelectableItems.count == 2)
-
-        // When
-        try await sut.processRefund(reason: .none)
-
-        // Then
-        #expect(sut.refundSelectableItems.isEmpty)
-    }
-
-    @MainActor
-    @Test func processRefund_when_submission_throws_then_propagates_error() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        struct TestError: Error {}
-        refundSubmissionProcessor.submitRefundErrorToThrow = TestError()
-
-        // When / Then
-        var thrownError: Error?
-        do {
-            try await sut.processRefund(reason: .none)
-        } catch {
-            thrownError = error
-        }
-
-        #expect(thrownError is TestError)
-    }
-
-    @MainActor
-    @Test func processRefund_when_no_selected_order_then_throws_missingSelectedOrder() async throws {
-        await #expect(performing: {
-            try await sut.processRefund(reason: .none)
-        }, throws: { error in
-            (error as? POSRefundProcessingError) == .missingSelectedOrder
-        })
-    }
-
-    @MainActor
-    @Test func processRefund_when_no_refund_flow_was_started_then_throws_missingSelectedOrder() async throws {
-        // Given an order is selected but the refund flow was never started
-        sut.selectOrder(makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ]))
-
-        // When / Then
-        await #expect(performing: {
-            try await sut.processRefund(reason: .none)
-        }, throws: { error in
-            (error as? POSRefundProcessingError) == .missingSelectedOrder
-        })
-    }
-
-    @MainActor
-    @Test func processRefund_when_refund_is_not_prepared_then_throws_missingRefundPreparation() async throws {
-        // Given
-        refundSubmissionProcessor.prepareRefundErrorToThrow = NSError(domain: "test", code: 1)
-        sut.selectOrder(makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ]))
-        _ = await sut.startRefundFlow()
-
-        // When / Then
-        await #expect(performing: {
-            try await sut.processRefund(reason: .none)
-        }, throws: { error in
-            (error as? POSRefundProcessingError) == .missingRefundPreparation
-        })
-    }
-
-    @MainActor
-    @Test func processRefund_when_no_items_are_selected_then_throws_emptySelection() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        sut.toggleAllRefundItemsSelection()
-
-        // When / Then
-        await #expect(performing: {
-            try await sut.processRefund(reason: .none)
-        }, throws: { error in
-            (error as? POSRefundProcessingError) == .emptySelection
-        })
-    }
-
-    @MainActor
-    @Test func processRefund_when_refund_is_already_in_progress_then_throws_refundAlreadyInProgress() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-        refundSubmissionProcessor.shouldSuspendSubmitRefund = true
-
-        var firstRefundTask: Task<Void, Error>?
-        await fireOnce { fire in
-            refundSubmissionProcessor.onSubmitRefundStarted = {
-                fire()
-            }
-            firstRefundTask = Task { @MainActor in
-                try await sut.processRefund(reason: .none)
-            }
-        }
-
-        // When / Then
-        await #expect(performing: {
-            try await sut.processRefund(reason: .none)
-        }, throws: { error in
-            (error as? POSRefundProcessingError) == .refundAlreadyInProgress
-        })
-
-        refundSubmissionProcessor.resumeSubmitRefund()
-        try await firstRefundTask?.value
-    }
-
-    @MainActor
-    @Test func processRefund_then_converts_items_with_correct_properties() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 42, quantity: 3, price: 15.50, totalTax: 1.55, formattedPrice: "$15.50")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        try await sut.processRefund(reason: .none)
-
-        // Then
-        let items = try #require(refundSubmissionProcessor.spySubmitRefundItems)
-        #expect(items.count == 3)
-
-        let firstItem = items[0]
-        #expect(firstItem.itemID == 42)
-        #expect(firstItem.lineItemTotal == 46.50)
-        #expect(firstItem.totalTax == 1.55)
-        #expect(firstItem.originalQuantity == 3)
-    }
-
-    @MainActor
-    @Test func processRefund_when_supportsAutomaticRefund_is_true_then_submits_refund_with_automatic_refund_true() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        try await sut.processRefund(reason: .none)
-
-        // Then
-        #expect(refundSubmissionProcessor.spySubmitRefundIsAutomaticRefund == true)
-    }
-
-    @MainActor
-    @Test func processRefund_when_supportsAutomaticRefund_is_false_then_submits_refund_with_automatic_refund_false() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: false
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        try await sut.processRefund(reason: .none)
-
-        // Then
-        #expect(refundSubmissionProcessor.spySubmitRefundIsAutomaticRefund == false)
-    }
-
-    @MainActor
-    @Test func processRefund_when_successful_then_updates_order() async throws {
-        // Given
-        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [],
-            isFullyRefunded: false,
-            supportsAutomaticRefund: true
-        )
-
-        let order = makeOrder(lineItems: [
-            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
-        ])
-        orderListService.orderPages = [[order]]
-        orderListService.loadOrderResult = order
-
-        await sut.loadOrders()
-
-        sut.selectOrder(order)
-        _ = await sut.startRefundFlow()
-
-        // When
-        try await sut.processRefund(reason: .none)
-
-        // Then
-        #expect(orderListService.loadOrderWasCalled == true)
-        #expect(orderListService.lastLoadOrderID == order.id)
-    }
-
-    @MainActor
     @Test func test_loadOrderRefunds_when_order_has_refunds_then_enriches_refunds_with_items() async throws {
         // Given
-        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let order = POSOrderTestFactory.makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$15.00", items: [
@@ -1758,11 +403,10 @@ final class POSOrderListControllerTests {
         #expect(refundedItems?.count == 2)
     }
 
-    @MainActor
     @Test func test_orderDetailsItemsState_when_refunded_order_selected_then_starts_loading_before_request() async throws {
         // Given
-        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
-        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let items = [POSOrderTestFactory.makePOSOrderItem(itemID: 1), POSOrderTestFactory.makePOSOrderItem(itemID: 2)]
+        let order = POSOrderTestFactory.makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
 
         // When
         sut.selectOrder(order)
@@ -1776,11 +420,10 @@ final class POSOrderListControllerTests {
         #expect(sut.isLoadingOrderRefunds)
     }
 
-    @MainActor
     @Test func test_orderDetailsItemsState_when_refund_response_has_no_items_then_finishes_loading() async throws {
         // Given
-        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
-        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let items = [POSOrderTestFactory.makePOSOrderItem(itemID: 1), POSOrderTestFactory.makePOSOrderItem(itemID: 2)]
+        let order = POSOrderTestFactory.makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [])
@@ -1800,11 +443,10 @@ final class POSOrderListControllerTests {
         #expect(!sut.isLoadingOrderRefunds)
     }
 
-    @MainActor
     @Test func test_orderDetailsItemsState_when_reselecting_loaded_refunded_order_then_uses_cached_refunds() async throws {
         // Given
-        let order = makeOrder(
-            lineItems: [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)],
+        let order = POSOrderTestFactory.makeOrder(
+            lineItems: [POSOrderTestFactory.makePOSOrderItem(itemID: 1), POSOrderTestFactory.makePOSOrderItem(itemID: 2)],
             refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")]
         )
         sut.selectOrder(order)
@@ -1832,11 +474,10 @@ final class POSOrderListControllerTests {
         #expect(!sut.isLoadingOrderRefunds)
     }
 
-    @MainActor
     @Test func test_orderDetailsItemsState_when_refund_details_loaded_then_filters_refunded_line_items() async throws {
         // Given
-        let order = makeOrder(
-            lineItems: [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)],
+        let order = POSOrderTestFactory.makeOrder(
+            lineItems: [POSOrderTestFactory.makePOSOrderItem(itemID: 1), POSOrderTestFactory.makePOSOrderItem(itemID: 2)],
             refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")]
         )
         sut.selectOrder(order)
@@ -1863,7 +504,6 @@ final class POSOrderListControllerTests {
         #expect(refundedItems.compactMap(\.refundedItemID) == [1])
     }
 
-    @MainActor
     @Test func test_loadOrderRefunds_when_no_selected_order_then_selectedOrder_is_nil() async throws {
         // Given — no order selected
 
@@ -1874,10 +514,9 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder == nil)
     }
 
-    @MainActor
     @Test func test_loadOrderRefunds_when_order_has_no_refunds_then_refunds_unchanged() async throws {
         // Given
-        let order = makeOrder(refunds: [])
+        let order = POSOrderTestFactory.makeOrder(refunds: [])
         sut.selectOrder(order)
 
         // When
@@ -1887,10 +526,9 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
 
-    @MainActor
     @Test func test_loadOrderRefunds_when_service_throws_then_refunds_unchanged() async throws {
         // Given
-        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let order = POSOrderTestFactory.makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsErrorToThrow = NSError(domain: "test", code: 1)
 
@@ -1901,10 +539,9 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder?.refunds.first?.items.isEmpty == true)
     }
 
-    @MainActor
     @Test func test_selectOrder_when_reselecting_after_failed_refund_load_then_retries_loading() async throws {
         // Given — a refund details fetch that failed
-        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let order = POSOrderTestFactory.makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsErrorToThrow = NSError(domain: "test", code: 1)
         await sut.loadOrderRefunds()
@@ -1931,10 +568,9 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder?.refunds.flatMap(\.items).count == 1)
     }
 
-    @MainActor
     @Test func test_updateOrder_when_refund_details_cached_then_drops_cache_and_shows_loading() async throws {
         // Given — a selected refunded order with loaded refund details
-        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let order = POSOrderTestFactory.makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
@@ -1965,10 +601,9 @@ final class POSOrderListControllerTests {
         }
     }
 
-    @MainActor
     @Test func test_selectOrder_when_payload_refunds_carry_items_then_caches_them_for_summary_reselection() async throws {
         // Given — an order whose payload refunds already include item details
-        let orderWithItems = makeOrder(refunds: [
+        let orderWithItems = POSOrderTestFactory.makeOrder(refunds: [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
                 POSRefundItem(refundedItemID: 1,
                               quantity: -1,
@@ -1992,10 +627,9 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder?.refunds.flatMap(\.items).count == 1)
     }
 
-    @MainActor
     @Test func test_selectOrder_then_new_order_has_no_refunded_items() async throws {
         // Given: Load some refunded products first
-        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let order = POSOrderTestFactory.makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
@@ -2011,17 +645,16 @@ final class POSOrderListControllerTests {
         try #require(sut.selectedOrder?.refunds.flatMap { $0.items }.count == 1)
 
         // When
-        sut.selectOrder(makeOrder(id: 2))
+        sut.selectOrder(POSOrderTestFactory.makeOrder(id: 2))
 
         // Then
         #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
 
-    @MainActor
     @Test func test_loadOrderRefunds_when_selected_order_changes_during_fetch_then_discards_stale_result() async throws {
         // Given
-        let orderA = makeOrder(id: 1, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
-        let orderB = makeOrder(id: 2, refunds: [POSOrderRefund(refundID: 2, formattedTotal: "-$5.00")])
+        let orderA = POSOrderTestFactory.makeOrder(id: 1, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let orderB = POSOrderTestFactory.makeOrder(id: 2, refunds: [POSOrderRefund(refundID: 2, formattedTotal: "-$5.00")])
         sut.selectOrder(orderA)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
@@ -2045,11 +678,10 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
 
-    @MainActor
     @Test func test_displayedLineItems_when_loading_refunds_then_returns_all_items() async throws {
         // Given
-        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
-        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let items = [POSOrderTestFactory.makePOSOrderItem(itemID: 1), POSOrderTestFactory.makePOSOrderItem(itemID: 2)]
+        let order = POSOrderTestFactory.makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
 
         var displayedLineItemsCountWhileLoading: Int?
@@ -2064,11 +696,10 @@ final class POSOrderListControllerTests {
         #expect(displayedLineItemsCountWhileLoading == 2)
     }
 
-    @MainActor
     @Test func test_displayedLineItems_when_refunds_loaded_then_filters_fully_refunded_items() async throws {
         // Given
-        let items = [makePOSOrderItem(itemID: 1, quantity: 2), makePOSOrderItem(itemID: 2, quantity: 1)]
-        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let items = [POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2), POSOrderTestFactory.makePOSOrderItem(itemID: 2, quantity: 1)]
+        let order = POSOrderTestFactory.makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
@@ -2089,11 +720,10 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedLineItems.first?.itemID == 1)
     }
 
-    @MainActor
     @Test func test_displayedLineItems_when_partially_refunded_then_includes_item() async throws {
         // Given
-        let items = [makePOSOrderItem(itemID: 1, quantity: 3)]
-        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let items = [POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 3)]
+        let order = POSOrderTestFactory.makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
@@ -2114,11 +744,10 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedLineItems.first?.itemID == 1)
     }
 
-    @MainActor
     @Test func test_displayedCustomAmounts_when_fee_fully_refunded_then_filters_it_out() async throws {
         // Given
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
-        let order = makeOrder(
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
+        let order = POSOrderTestFactory.makeOrder(
             lineItems: [],
             customAmounts: [customAmount],
             refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$5.00")]
@@ -2143,14 +772,13 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedCustomAmounts.isEmpty)
     }
 
-    @MainActor
     @Test func test_displayedCustomAmounts_when_other_fee_unrefunded_then_keeps_it() async throws {
         // Given - one fee refunded, another not
-        let order = makeOrder(
+        let order = POSOrderTestFactory.makeOrder(
             lineItems: [],
             customAmounts: [
-                makePOSOrderCustomAmount(id: 777, name: "Discount Fee"),
-                makePOSOrderCustomAmount(id: 888, name: "Tip")
+                POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee"),
+                POSOrderTestFactory.makePOSOrderCustomAmount(id: 888, name: "Tip")
             ],
             refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$5.00")]
         )
@@ -2175,13 +803,12 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedCustomAmounts.first?.id == 888)
     }
 
-    @MainActor
     @Test func test_displayedCustomAmounts_when_fee_lines_absent_from_refund_response_then_fee_remains_visible() async throws {
         // Given - simulates an older WooCommerce store whose refund response omits `fee_lines`,
         // so the loaded refund has no entry pointing back to the original fee id. The fee
         // can't be filtered out and stays visible (documented limitation).
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
-        let order = makeOrder(
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
+        let order = POSOrderTestFactory.makeOrder(
             lineItems: [],
             customAmounts: [customAmount],
             refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$5.00")]
@@ -2201,11 +828,10 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedCustomAmounts.first?.id == 777)
     }
 
-    @MainActor
     @Test func test_displayedCustomAmounts_when_order_has_no_refunds_then_returns_all_custom_amounts() async throws {
         // Given
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
-        let order = makeOrder(lineItems: [], customAmounts: [customAmount])
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
+        let order = POSOrderTestFactory.makeOrder(lineItems: [], customAmounts: [customAmount])
 
         // When
         sut.selectOrder(order)
@@ -2214,255 +840,13 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedCustomAmounts.count == 1)
     }
 
-    @MainActor
     @Test func test_displayedLineItems_when_no_items_refunded_then_returns_all_items() async throws {
         // Given
-        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
-        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let items = [POSOrderTestFactory.makePOSOrderItem(itemID: 1), POSOrderTestFactory.makePOSOrderItem(itemID: 2)]
+        let order = POSOrderTestFactory.makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
 
         // When/Then — all items returned regardless of refunds
         #expect(sut.displayedLineItems.count == 2)
-    }
-}
-
-private extension POSOrderListControllerTests {
-    /// Runs review preparation and returns its outcome.
-    @MainActor
-    func awaitReviewPreparation(_ controller: POSOrderListController) async -> POSRefundReviewPreparationResult {
-        await controller.prepareRefundReview()
-    }
-
-    /// Runs async review preparation and returns the review data, or `nil` when preparation failed.
-    @MainActor
-    func prepareReviewData(_ controller: POSOrderListController) async -> POSRefundReviewData? {
-        guard case .ready(let reviewData) = await awaitReviewPreparation(controller) else {
-            return nil
-        }
-        return reviewData
-    }
-
-    func makeController(currencySettings: CurrencySettings) -> POSOrderListController {
-        let formatter = CurrencyFormatter(currencySettings: currencySettings)
-        let processor = MockPOSRefundSubmissionProcessor(refundsService: refundsService,
-                                                         currencyFormatter: formatter)
-        return POSOrderListController(
-            orderListFetchStrategyFactory: fetchStrategyFactory,
-            refundsService: refundsService,
-            refundSubmissionProcessor: processor,
-            refundController: POSRefundController(refundSubmissionProcessor: processor)
-        )
-    }
-
-    func makeOrder(id: Int64 = 1,
-                   status: OrderStatusEnum = .completed,
-                   paymentMethodID: String = "woocommerce_payments",
-                   paymentMethodTitle: String = "cod",
-                   lineItems: [POSOrderItem] = [],
-                   customAmounts: [POSOrderCustomAmount] = [],
-                   refunds: [POSOrderRefund] = []) -> POSOrder {
-        POSOrder(
-            id: id,
-            number: "\(id)",
-            dateCreated: Date(),
-            status: status,
-            formattedTotal: "$25.99",
-            formattedSubtotal: "$25.99",
-            customerEmail: "customer1@example.com",
-            paymentMethodID: paymentMethodID,
-            paymentMethodTitle: paymentMethodTitle,
-            lineItems: lineItems,
-            customAmounts: customAmounts,
-            refunds: refunds,
-            formattedDiscountTotal: nil,
-            formattedTotalTax: "$0.00",
-            formattedPaymentTotal: "$25.99",
-            formattedNetAmount: nil,
-            datePaid: status == .completed || status == .processing ? Date() : nil
-        )
-    }
-
-    func makePOSOrderCustomAmount(
-        id: Int64 = 1,
-        name: String = "Discount Fee",
-        formattedTotal: String = "$5.00",
-        total: Decimal = 5,
-        totalTax: Decimal = 0
-    ) -> POSOrderCustomAmount {
-        POSOrderCustomAmount(
-            id: id,
-            name: name,
-            formattedTotal: formattedTotal,
-            total: total,
-            totalTax: totalTax
-        )
-    }
-
-    func makePOSOrderItem(
-        itemID: Int64 = 1,
-        name: String = "Test Item",
-        quantity: Decimal = 1,
-        price: Decimal = 10.00,
-        total: Decimal? = nil,
-        totalTax: Decimal = 0,
-        formattedPrice: String = "$10.00",
-        formattedTotal: String? = nil,
-        imageSrc: String? = nil,
-        attributes: [OrderItemAttribute] = []
-    ) -> POSOrderItem {
-        POSOrderItem(
-            itemID: itemID,
-            name: name,
-            quantity: quantity,
-            price: price,
-            total: total ?? (price * quantity),
-            totalTax: totalTax,
-            formattedPrice: formattedPrice,
-            formattedTotal: formattedTotal ?? formattedPrice,
-            imageSrc: imageSrc,
-            attributes: attributes
-        )
-    }
-}
-
-private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcessing {
-    let stateModel = POSRefundSubmissionModel()
-
-    nonisolated(unsafe) private let refundsService: MockPOSRefundsService
-    nonisolated(unsafe) private let currencyFormatter: CurrencyFormatter
-    private var refundResultsByOrderID: [Int64: POSRefundsResult] = [:]
-    var requiresCardPresentRefund = false
-    var shouldSuspendSubmitRefund = false
-    var onSubmitRefundStarted: (() -> Void)?
-    private var submitRefundContinuation: CheckedContinuation<Void, Never>?
-
-    private(set) var submitRefundCalled = false
-    private(set) var spySubmitRefundOrderID: Int64?
-    private(set) var spySubmitRefundItems: [POSRefundSelectableItem]?
-    private(set) var spySubmitRefundReason: String?
-    private(set) var spySubmitRefundIsAutomaticRefund: Bool?
-    var submitRefundErrorToThrow: Error?
-
-    nonisolated init(refundsService: MockPOSRefundsService,
-                     currencyFormatter: CurrencyFormatter) {
-        self.refundsService = refundsService
-        self.currencyFormatter = currencyFormatter
-    }
-
-    private(set) var preloadedOrderIDs: [Int64] = []
-    var prepareRefundErrorToThrow: Error?
-
-    func preloadRefund(for order: POSOrder) async {
-        preloadedOrderIDs.append(order.id)
-    }
-
-    func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
-        if let prepareRefundErrorToThrow {
-            throw prepareRefundErrorToThrow
-        }
-        let refundsResult = try await refundsService.providePointOfSaleRefunds(for: order)
-        refundResultsByOrderID[order.id] = refundsResult
-
-        let refundedQuantitiesByItemID = refundsResult.refunds.flatMap(\.items).refundedQuantitiesByItemID()
-        let productSelectables = order.lineItems.flatMap { item -> [POSRefundSelectableItem] in
-            let originalQuantity = NSDecimalNumber(decimal: item.quantity).intValue
-            let refundedQuantity = refundedQuantitiesByItemID[item.itemID] ?? 0
-            let availableQuantity = originalQuantity - refundedQuantity
-            guard availableQuantity > 0 else { return [] }
-
-            return (0..<availableQuantity).map { index in
-                POSRefundSelectableItem(from: item, isSelected: true, index: index)
-            }
-        }
-
-        let alreadyRefundedItemIDs = Set(refundsResult.refunds.flatMap(\.items).compactMap(\.refundedItemID))
-        let feeSelectables = order.customAmounts
-            .filter { !alreadyRefundedItemIDs.contains($0.id) }
-            .map { POSRefundSelectableItem(from: $0, isSelected: true) }
-
-        return POSRefundPreparation(
-            orderID: order.id,
-            selectableItems: productSelectables + feeSelectables,
-            paymentMethodDescription: String(format: "via %1$@", order.paymentMethodTitle),
-            customerEmail: order.customerEmail,
-            requiresCardPresentRefund: requiresCardPresentRefund
-        )
-    }
-
-    var prepareReviewDataErrorToThrow: Error?
-    var onPrepareReviewDataCalled: (@MainActor () async -> Void)?
-
-    func prepareReviewData(for order: POSOrder,
-                           preparation: POSRefundPreparation,
-                           selectedItems: [POSRefundSelectableItem],
-                           reason: String?) async throws -> POSRefundReviewData {
-        await onPrepareReviewDataCalled?()
-        if let error = prepareReviewDataErrorToThrow {
-            throw error
-        }
-
-        let amounts = reviewAmounts(for: selectedItems)
-        return POSRefundReviewData(
-            itemsCount: selectedItems.count,
-            formattedItemsSubtotal: currencyFormatter.formatAmount(amounts.subtotal) ?? "",
-            formattedTax: currencyFormatter.formatAmount(amounts.tax) ?? "",
-            formattedRefundTotal: currencyFormatter.formatAmount(amounts.subtotal + amounts.tax) ?? "",
-            paymentMethodDescription: preparation.paymentMethodDescription,
-            customerEmail: preparation.customerEmail,
-            refundReason: reason,
-            isFullRefund: selectedItems.count == preparation.selectableItems.count,
-            calculationFlow: .local
-        )
-    }
-
-    func submitRefund(for order: POSOrder,
-                      preparation: POSRefundPreparation,
-                      selectedItems: [POSRefundSelectableItem],
-                      reason: String?) async throws {
-        onSubmitRefundStarted?()
-        if shouldSuspendSubmitRefund {
-            await withCheckedContinuation { continuation in
-                submitRefundContinuation = continuation
-            }
-        }
-
-        submitRefundCalled = true
-        spySubmitRefundOrderID = order.id
-        spySubmitRefundItems = selectedItems
-        spySubmitRefundReason = reason
-        spySubmitRefundIsAutomaticRefund = refundResultsByOrderID[preparation.orderID]?.supportsAutomaticRefund ?? true
-
-        if let error = submitRefundErrorToThrow {
-            throw error
-        }
-
-        stateModel.state = .completed
-    }
-
-    private func reviewAmounts(for items: [POSRefundSelectableItem]) -> (subtotal: Decimal, tax: Decimal) {
-        let groupedItems = Dictionary(grouping: items, by: \.itemID)
-        return groupedItems.values.reduce((subtotal: Decimal.zero, tax: Decimal.zero)) { result, items in
-            let subtotal = calculateAmount(for: items, keyPath: \.lineItemTotal)
-            let tax = calculateAmount(for: items, keyPath: \.totalTax)
-            return (result.subtotal + subtotal, result.tax + tax)
-        }
-    }
-
-    private func calculateAmount(for items: [POSRefundSelectableItem], keyPath: KeyPath<POSRefundSelectableItem, Decimal>) -> Decimal {
-        guard let firstItem = items.first, firstItem.originalQuantity > 0 else {
-            return .zero
-        }
-
-        if firstItem.isLumpSum || Decimal(items.count) == firstItem.originalQuantity {
-            return firstItem[keyPath: keyPath]
-        }
-
-        return (firstItem[keyPath: keyPath] / firstItem.originalQuantity) * Decimal(items.count)
-    }
-
-    func resumeSubmitRefund() {
-        shouldSuspendSubmitRefund = false
-        submitRefundContinuation?.resume()
-        submitRefundContinuation = nil
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSRefundControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSRefundControllerTests.swift
@@ -1,0 +1,1259 @@
+import Testing
+import TestKit
+import Foundation
+@testable import PointOfSale
+import enum Yosemite.RefundAPIError
+import struct Yosemite.POSOrder
+import struct Yosemite.POSOrderItem
+import enum Yosemite.OrderRefundEligibilityFailure
+@testable import struct Yosemite.POSRefund
+@testable import struct Yosemite.POSRefundItem
+import struct Yosemite.POSOrderRefund
+@testable import struct Yosemite.POSRefundsResult
+import class WooFoundation.CurrencySettings
+import class WooFoundation.CurrencyFormatter
+
+@Suite(.timeLimit(.minutes(5)))
+@MainActor
+final class POSRefundControllerTests {
+    private let refundsService = MockPOSRefundsService()
+    private lazy var currencySettingsProvider = MockCurrencySettingsProvider()
+    private lazy var currencyFormatter = CurrencyFormatter(currencySettings: currencySettingsProvider.currencySettings)
+    private lazy var refundSubmissionProcessor = MockPOSRefundSubmissionProcessor(refundsService: refundsService,
+                                                                                  currencyFormatter: currencyFormatter)
+    private lazy var sut = POSRefundController(refundSubmissionProcessor: refundSubmissionProcessor)
+
+    enum TestError: Error {
+        case prepareRefundFailed
+    }
+
+    @Test func refundActionAvailability_when_order_is_completed_then_available() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(id: 1, status: .completed)
+
+        // When / Then
+        #expect(order.refundActionAvailability == .available)
+    }
+
+    @Test func refundActionAvailability_when_order_is_not_completed_then_unavailable() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(id: 1, status: .processing)
+
+        // When / Then
+        #expect(order.refundActionAvailability == .unavailable)
+    }
+
+    // MARK: - Refund Item Selection Tests
+
+    @Test func preloadRefund_when_refund_is_available_then_preloads_without_opening_refund_flow() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(id: 1, status: .completed)
+
+        // When
+        await sut.preloadRefund(for: order)
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs == [order.id])
+        #expect(sut.selectableItems.isEmpty)
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    @Test func preloadRefund_when_refund_is_unavailable_then_does_not_preload() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(id: 1, status: .processing)
+
+        // When
+        await sut.preloadRefund(for: order)
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs.isEmpty)
+    }
+
+    @Test func startRefundFlow_when_product_has_multiple_quantities_then_creates_one_row_per_unit() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, name: "Item A", quantity: 3, formattedPrice: "$10.00", formattedTotal: "$30.00"),
+            POSOrderTestFactory.makePOSOrderItem(itemID: 2, name: "Item B", quantity: 1, formattedPrice: "$5.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        #expect(sut.selectableItems.count == 4)
+    }
+
+    @Test func startRefundFlow_then_all_items_are_selected_by_default() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        #expect(sut.selectableItems.count == 2)
+        for item in sut.selectableItems {
+            #expect(item.isSelected)
+        }
+    }
+
+    @Test func startRefundFlow_when_order_is_ineligible_then_returns_specific_failure() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder()
+        refundSubmissionProcessor.prepareRefundErrorToThrow = OrderRefundEligibilityFailure.giftCardUnsupported
+
+        // When
+        let result = await sut.startRefundFlow(for: order)
+
+        // Then
+        guard case .ineligible(.giftCardUnsupported) = result else {
+            Issue.record("Expected the gift-card eligibility failure.")
+            return
+        }
+    }
+
+    @Test func startRefundFlow_when_item_partially_refunded_then_excludes_refunded_quantity() async throws {
+        // Given: Order has 3 units of item, 1 was previously refunded
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -1, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 3, formattedPrice: "$10.00", formattedTotal: "$30.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then: Should only show 2 available (3 - 1 refunded)
+        #expect(sut.selectableItems.count == 2)
+    }
+
+    @Test func startRefundFlow_when_item_fully_refunded_then_excludes_item_entirely() async throws {
+        // Given: Order has 2 units of item, both were previously refunded
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00"),
+            POSOrderTestFactory.makePOSOrderItem(itemID: 2, quantity: 1, formattedPrice: "$5.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then: Should only show item 2 (item 1 is fully refunded)
+        #expect(sut.selectableItems.count == 1)
+        #expect(sut.selectableItems[0].itemID == 2)
+    }
+
+    @Test func test_startRefundFlow_when_order_has_custom_amount_then_appends_lump_sum_selectable() async throws {
+        // Given
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
+        let order = POSOrderTestFactory.makeOrder(
+            lineItems: [POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00")],
+            customAmounts: [customAmount]
+        )
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        #expect(sut.selectableItems.count == 2)
+        let feeRow = try #require(sut.selectableItems.first(where: { $0.isLumpSum }))
+        #expect(feeRow.itemID == 777)
+        #expect(feeRow.name == "Discount Fee")
+        #expect(feeRow.lineItemTotal == 10)
+        #expect(feeRow.originalQuantity == 1)
+        #expect(feeRow.isSelected == true)
+    }
+
+    @Test func test_startRefundFlow_when_custom_amount_already_refunded_then_excludes_fee() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 777, quantity: 0, name: "Discount Fee",
+                                                     formattedPrice: "", formattedTotal: "", imageSrc: nil, isLumpSum: true)])],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
+        let order = POSOrderTestFactory.makeOrder(
+            lineItems: [POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00")],
+            customAmounts: [customAmount]
+        )
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        #expect(sut.selectableItems.count == 1)
+        #expect(sut.selectableItems.contains(where: { $0.isLumpSum }) == false)
+    }
+
+    @Test func test_startRefundFlow_with_only_unrefunded_custom_amount_then_returns_hasItemsToRefund() async throws {
+        // Given
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
+        let order = POSOrderTestFactory.makeOrder(lineItems: [], customAmounts: [customAmount])
+
+        // When
+        let availability = await sut.startRefundFlow(for: order)
+
+        // Then
+        #expect(availability == .hasItemsToRefund)
+        #expect(sut.selectableItems.count == 1)
+        #expect(sut.selectableItems.first?.isLumpSum == true)
+    }
+
+    @Test func test_prepareRefundReview_with_custom_amount_only_then_returns_lump_sum_total() async throws {
+        // Given - one fee of $10, no products
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 10, totalTax: 0)
+        let order = POSOrderTestFactory.makeOrder(lineItems: [], customAmounts: [customAmount])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+        let reviewData = await prepareReviewData(sut)
+
+        // Then
+        #expect(reviewData?.itemsCount == 1)
+        #expect(reviewData?.formattedItemsSubtotal == "$10.00")
+        #expect(reviewData?.formattedRefundTotal == "$10.00")
+    }
+
+    @Test func test_prepareRefundReview_with_mixed_products_and_custom_amount_then_sums_both() async throws {
+        // Given - one product ($10) and one fee ($5)
+        let customAmount = POSOrderTestFactory.makePOSOrderCustomAmount(id: 777, name: "Discount Fee", total: 5, totalTax: 0)
+        let order = POSOrderTestFactory.makeOrder(
+            lineItems: [POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")],
+            customAmounts: [customAmount]
+        )
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+        let reviewData = await prepareReviewData(sut)
+
+        // Then
+        #expect(reviewData?.itemsCount == 2)
+        #expect(reviewData?.formattedItemsSubtotal == "$15.00")
+        #expect(reviewData?.formattedRefundTotal == "$15.00")
+    }
+
+    @Test func startRefundFlow_when_multiple_refunds_exist_then_aggregates_refunded_quantities() async throws {
+        // Given: Order has 5 units of item, refunded across two separate refunds (2 + 2 = 4)
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [
+                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)]),
+                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])
+            ],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 5, formattedPrice: "$10.00", formattedTotal: "$50.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then: Should only show 1 available (5 - 4 refunded)
+        #expect(sut.selectableItems.count == 1)
+    }
+
+    @Test func toggleItemSelection_then_toggles_item_at_index() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        sut.toggleItemSelection(at: 0)
+        let isSelectedAfterToggle = sut.selectableItems[0].isSelected
+
+        // Then
+        #expect(isSelectedAfterToggle == false)
+    }
+
+    @Test func toggleItemSelection_then_marks_refund_selection_as_modified() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        #expect(sut.hasModifiedSelection == false)
+
+        // When
+        sut.toggleItemSelection(at: 0)
+
+        // Then
+        #expect(sut.hasModifiedSelection == true)
+    }
+
+    @Test func toggleItemSelection_when_index_out_of_bounds_then_does_not_crash() async throws {
+        // When
+        let items = await MainActor.run {
+            sut.toggleItemSelection(at: 999)
+            return sut.selectableItems
+        }
+
+        // Then
+        #expect(items.isEmpty)
+    }
+
+    @Test func clearSelection_then_removes_all_items() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        try #require(sut.selectableItems.count == 2)
+
+        // When
+        sut.clearSelection()
+
+        // Then
+        #expect(sut.selectableItems.isEmpty)
+    }
+
+    @Test func clearSelection_then_resets_modified_refund_selection() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 0)
+        try #require(sut.hasModifiedSelection == true)
+
+        // When
+        sut.clearSelection()
+
+        // Then
+        #expect(sut.hasModifiedSelection == false)
+    }
+
+    @Test func toggleAllItemsSelection_when_all_selected_then_deselects_all() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        sut.toggleAllItemsSelection()
+
+        // Then
+        for item in sut.selectableItems {
+            #expect(item.isSelected == false)
+        }
+    }
+
+    @Test func toggleAllItemsSelection_then_marks_refund_selection_as_modified() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        #expect(sut.hasModifiedSelection == false)
+
+        // When
+        sut.toggleAllItemsSelection()
+
+        // Then
+        #expect(sut.hasModifiedSelection == true)
+    }
+
+    @Test func toggleAllItemsSelection_when_some_deselected_then_selects_all() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 0) // Deselect first item
+
+        // When
+        sut.toggleAllItemsSelection()
+
+        // Then
+        for item in sut.selectableItems {
+            #expect(item.isSelected == true)
+        }
+    }
+
+    @Test func toggleAllItemsSelection_when_none_selected_then_selects_all() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleAllItemsSelection() // Deselect all
+
+        // When
+        sut.toggleAllItemsSelection() // Should select all
+
+        // Then
+        for item in sut.selectableItems {
+            #expect(item.isSelected == true)
+        }
+    }
+
+    @Test func reset_then_clears_the_selection() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 0)
+        try #require(sut.hasModifiedSelection == true)
+        try #require(sut.selectableItems.isNotEmpty)
+
+        // When
+        sut.reset()
+
+        // Then
+        #expect(sut.selectableItems.isEmpty)
+        #expect(sut.hasModifiedSelection == false)
+
+        // The pinned order is dropped: submitting after a reset fails instead of
+        // refunding the previously selected order.
+        await #expect(performing: {
+            _ = try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .missingSelectedOrder
+        })
+    }
+
+    // MARK: - Prepare Refund Review Data Tests
+
+    @Test func prepareReview_when_no_items_selected_then_returns_nil() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleAllItemsSelection() // Deselect all
+
+        // Then
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData == nil)
+    }
+
+    @Test func prepareReview_then_returns_correct_items_count() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 3, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData?.itemsCount == 3)
+    }
+
+    @Test func prepareReview_then_returns_correct_subtotal() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00"),
+            POSOrderTestFactory.makePOSOrderItem(itemID: 2, quantity: 1, price: 5.50, formattedPrice: "$5.50")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        // 2 × $10.00 + 1 × $5.50 = $25.50
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData?.formattedItemsSubtotal == "$25.50")
+    }
+
+    @Test func prepareReview_when_full_refund_then_uses_original_tax() async throws {
+        // Given - item with quantity 2 and totalTax of $1.50 (for both units)
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, totalTax: 1.50, formattedPrice: "$10.00")
+        ])
+
+        // When - all items selected (full refund)
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then - should use original totalTax directly ($1.50)
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData?.formattedTax == "$1.50")
+    }
+
+    @Test func prepareReview_when_partial_refund_then_calculates_proportional_tax() async throws {
+        // Given - item with quantity 2 and totalTax of $1.50 (for both units)
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, totalTax: 1.50, formattedPrice: "$10.00")
+        ])
+
+        // When - only 1 of 2 items selected (partial refund)
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 0) // Deselect first item, leaving 1 selected
+
+        // Then - should calculate proportionally: $1.50 / 2 × 1 = $0.75
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData?.formattedTax == "$0.75")
+    }
+
+    @Test func prepareReview_then_returns_correct_total() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, totalTax: 1.00, formattedPrice: "$10.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then - $10.00 + $1.00 = $11.00
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData?.formattedRefundTotal == "$11.00")
+    }
+
+    @Test func prepareReview_then_returns_via_payment_method_title() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(paymentMethodTitle: "WooCommerce In-Person Payments", lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData?.paymentMethodDescription == "via WooCommerce In-Person Payments")
+    }
+
+    @Test func prepareReview_then_refund_reason_is_nil_by_default() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        let reviewData = await prepareReviewData(sut)
+        #expect(reviewData?.refundReason == nil)
+    }
+
+    @Test func requiresCardPresentRefund_when_preparation_requires_card_present_refund_then_returns_true() async throws {
+        // Given
+        refundSubmissionProcessor.requiresCardPresentRefund = true
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        #expect(sut.requiresCardPresentRefund == true)
+    }
+
+    // MARK: - Currency Formatting Tests
+
+    @Test func prepareReview_with_EUR_currency_then_formats_with_comma_decimal_separator() async throws {
+        // Given - EUR with comma decimal separator and dot thousand separator
+        let eurSettings = CurrencySettings(
+            currencyCode: .EUR,
+            currencyPosition: .rightSpace,
+            thousandSeparator: ".",
+            decimalSeparator: ",",
+            numberOfDecimals: 2
+        )
+        let controller = makeController(currencySettings: eurSettings)
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 1172.02, totalTax: 234.40, formattedPrice: "1.172,02 €")
+        ])
+
+        // When
+        _ = await controller.startRefundFlow(for: order)
+        let reviewData = await prepareReviewData(controller)
+
+        // Then - 2 × €1,172.02 = €2,344.04, tax = €234.40, total = €2,578.44
+        // Note: CurrencyFormatter uses non-breaking space (\u{00A0}) before currency symbol
+        #expect(reviewData?.formattedItemsSubtotal == "2.344,04\u{00A0}€")
+        #expect(reviewData?.formattedTax == "234,40\u{00A0}€")
+        #expect(reviewData?.formattedRefundTotal == "2.578,44\u{00A0}€")
+    }
+
+    @Test func prepareReview_with_JPY_currency_then_formats_without_decimals() async throws {
+        // Given - JPY with no decimals
+        let jpySettings = CurrencySettings(
+            currencyCode: .JPY,
+            currencyPosition: .left,
+            thousandSeparator: ",",
+            decimalSeparator: ".",
+            numberOfDecimals: 0
+        )
+        let controller = makeController(currencySettings: jpySettings)
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 2344, totalTax: 234, formattedPrice: "¥2,344")
+        ])
+
+        // When
+        _ = await controller.startRefundFlow(for: order)
+        let reviewData = await prepareReviewData(controller)
+
+        // Then
+        #expect(reviewData?.formattedItemsSubtotal == "¥2,344")
+        #expect(reviewData?.formattedTax == "¥234")
+        #expect(reviewData?.formattedRefundTotal == "¥2,578")
+    }
+
+    @Test func prepareReview_with_GBP_and_large_values_then_formats_correctly() async throws {
+        // Given - GBP with large values
+        let gbpSettings = CurrencySettings(
+            currencyCode: .GBP,
+            currencyPosition: .left,
+            thousandSeparator: ",",
+            decimalSeparator: ".",
+            numberOfDecimals: 2
+        )
+        let controller = makeController(currencySettings: gbpSettings)
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 12345.67, totalTax: 2469.13, formattedPrice: "£12,345.67")
+        ])
+
+        // When
+        _ = await controller.startRefundFlow(for: order)
+        let reviewData = await prepareReviewData(controller)
+
+        // Then
+        #expect(reviewData?.formattedItemsSubtotal == "£12,345.67")
+        #expect(reviewData?.formattedTax == "£2,469.13")
+        #expect(reviewData?.formattedRefundTotal == "£14,814.80")
+    }
+
+    @Test func prepareReview_with_USD_and_large_value_from_screenshot_then_formats_correctly() async throws {
+        // Given - USD with value from screenshot: $2,344.04
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 2344.04, totalTax: 234.40, formattedPrice: "$2,344.04")
+        ])
+
+        // When
+        _ = await sut.startRefundFlow(for: order)
+        let reviewData = await prepareReviewData(sut)
+
+        // Then
+        #expect(reviewData?.formattedItemsSubtotal == "$2,344.04")
+        #expect(reviewData?.formattedTax == "$234.40")
+        #expect(reviewData?.formattedRefundTotal == "$2,578.44")
+    }
+
+    // MARK: - Refund Review Preparation State
+
+    @Test func prepareReview_when_processor_throws_then_state_is_previewError_and_retry_recovers() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = POSRefundSubmissionError.refundPreviewFailed
+
+        // When
+        let failedResult = await awaitReviewPreparation(sut)
+
+        // Then the failure is returned and the inline-error state is published for the sheet
+        #expect(failedResult == .previewError)
+        #expect(sut.reviewPreparationState == .previewError())
+
+        // When the failure is resolved and the user retries
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = nil
+        let recoveredResult = await awaitReviewPreparation(sut)
+
+        // Then
+        guard case .ready = recoveredResult else {
+            Issue.record("Expected .ready after retry, got \(recoveredResult)")
+            return
+        }
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    @Test func prepareReview_when_processor_throws_typed_rejection_then_state_carries_its_message() async throws {
+        // Given the preview was rejected with an actionable code (e.g. the order changed since loading)
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.quantityExceedsRefundable
+
+        // When
+        let result = await awaitReviewPreparation(sut)
+
+        // Then the inline-error state carries the rejection's cashier-facing copy, and offers the
+        // item reload rather than a retry that would be rejected the same way
+        #expect(result == .previewError)
+        #expect(sut.reviewPreparationState == .previewError(
+            message: RefundAPIError.quantityExceedsRefundable.localizedDescription,
+            recovery: .refreshItems
+        ))
+    }
+
+    @Test func prepareReview_when_order_is_not_refundable_then_flow_ends_on_the_terminal_state() async throws {
+        // Given the store reports the order as having nothing refundable left
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.orderNotRefundable
+
+        // When
+        let result = await awaitReviewPreparation(sut)
+
+        // Then there is no selection to recover to, so the caller is told to end the flow
+        #expect(result == .nothingToRefund)
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    @Test func refreshRefundableItems_when_the_reloaded_list_is_unchanged_then_clears_the_selection() async throws {
+        // Given two refundable units, with only the first one selected
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 1)
+
+        // When the reload returns the same list, as an order-level rejection does
+        let result = await sut.refreshRefundableItems()
+
+        // Then nothing is selected
+        #expect(result == .hasItemsToRefund)
+        #expect(sut.selectableItems.count == 2)
+        #expect(sut.selectableItems.allSatisfy { !$0.isSelected })
+    }
+
+    @Test func refreshRefundableItems_when_a_unit_was_refunded_elsewhere_then_clears_the_selection() async throws {
+        // Given three refundable units, all selected
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 3, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+
+        // When another register refunds one unit and the cashier reloads
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1,
+                                                     quantity: -1,
+                                                     name: "",
+                                                     formattedPrice: "",
+                                                     formattedTotal: "",
+                                                     imageSrc: nil)])],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+        let result = await sut.refreshRefundableItems()
+
+        // Then the two remaining units are listed and none of them is selected
+        #expect(result == .hasItemsToRefund)
+        #expect(sut.selectableItems.count == 2)
+        #expect(sut.selectableItems.allSatisfy { !$0.isSelected })
+    }
+
+    @Test func refreshRefundableItems_when_the_reload_fails_then_keeps_the_previously_loaded_items() async throws {
+        // Given two refundable units, with only the first one selected
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 1)
+
+        // When the reload fails, for example because the register lost connectivity
+        refundSubmissionProcessor.prepareRefundErrorToThrow = NSError(domain: "test", code: 1)
+        let result = await sut.refreshRefundableItems()
+
+        // Then the previous list is still there, so a retry reloads instead of starting a new flow
+        #expect(result == .failed)
+        #expect(sut.selectableItems.count == 2)
+        #expect(sut.hasLoadedSelectableItems == true)
+    }
+
+    @Test func hasLoadedSelectableItems_when_no_load_has_succeeded_then_is_false() async throws {
+        // Given a controller with no refund flow started
+        #expect(sut.hasLoadedSelectableItems == false)
+
+        // When the first load fails
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        refundSubmissionProcessor.prepareRefundErrorToThrow = NSError(domain: "test", code: 1)
+        _ = await sut.startRefundFlow(for: order)
+
+        // Then
+        #expect(sut.hasLoadedSelectableItems == false)
+    }
+
+    @Test func hasLoadedSelectableItems_when_the_flow_ends_then_is_false_again() async throws {
+        // Given a loaded list of refundable items
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        #expect(sut.hasLoadedSelectableItems == true)
+
+        // When the cashier dismisses the flow
+        sut.clearSelection()
+
+        // Then
+        #expect(sut.hasLoadedSelectableItems == false)
+    }
+
+    @Test func refreshRefundableItems_then_hasModifiedRefundSelection_is_false_until_the_next_toggle() async throws {
+        // Given a reloaded list with nothing selected
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 1)
+        _ = await sut.refreshRefundableItems()
+
+        // Then nothing of the cashier's is held, so switching orders needs no prompt
+        #expect(sut.hasModifiedSelection == false)
+
+        // When the cashier picks again
+        sut.toggleItemSelection(at: 0)
+
+        // Then the prompt applies again
+        #expect(sut.hasModifiedSelection == true)
+    }
+
+    @Test func refreshRefundableItems_when_a_preview_error_is_shown_then_it_is_cleared() async throws {
+        // Given a rejected preview
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = RefundAPIError.lineItemAlreadyRefunded
+        _ = await awaitReviewPreparation(sut)
+
+        // When the cashier reloads the refundable items
+        refundSubmissionProcessor.prepareReviewDataErrorToThrow = nil
+        _ = await sut.refreshRefundableItems()
+
+        // Then the selection step is back to a clean state
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    @Test func prepareReview_when_selection_changes_mid_flight_then_result_is_dropped() async throws {
+        // Given an order with two refundable units so a toggle is possible mid-flight
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        refundSubmissionProcessor.onPrepareReviewDataCalled = { [weak sut] in
+            sut?.toggleItemSelection(at: 0)
+        }
+
+        // When
+        let result = await awaitReviewPreparation(sut)
+
+        // Then the toggle superseded the preparation, and the stale result never advanced the state
+        #expect(result == .superseded)
+        await Task.yield()
+        await Task.yield()
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    @Test func prepareReview_when_the_flow_is_reset_mid_flight_then_preparation_is_cancelled() async throws {
+        // Given
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        refundSubmissionProcessor.onPrepareReviewDataCalled = { [weak sut] in
+            sut?.reset()
+        }
+
+        // When
+        let result = await awaitReviewPreparation(sut)
+
+        // Then the reset cancelled the in-flight preparation and returned the state to idle
+        #expect(result == .superseded)
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    @Test func prepareReview_when_no_preparation_loaded_then_returns_preparationError() async throws {
+        // Given no selected order / no started refund flow
+
+        // When
+        let result = await sut.prepareReview()
+
+        // Then
+        #expect(result == .preparationError)
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    @Test func clearSelection_after_a_completed_preparation_returns_state_to_idle() async throws {
+        // Given a completed preparation
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        _ = await awaitReviewPreparation(sut)
+
+        // When
+        sut.clearSelection()
+
+        // Then
+        #expect(sut.reviewPreparationState == .idle)
+    }
+
+    // MARK: - Process Refund Tests
+
+    @Test func processRefund_then_submits_refund_with_correct_order_id() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(id: 123, lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        _ = try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(refundSubmissionProcessor.submitRefundCalled == true)
+        #expect(refundSubmissionProcessor.spySubmitRefundOrderID == 123)
+    }
+
+    @Test func processRefund_then_submits_refund_with_selected_items() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00"),
+            POSOrderTestFactory.makePOSOrderItem(itemID: 2, quantity: 1, price: 5.00, formattedPrice: "$5.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleItemSelection(at: 0) // Deselect first item of itemID 1
+
+        // When
+        _ = try await sut.processRefund(reason: .none)
+
+        // Then
+        let items = try #require(refundSubmissionProcessor.spySubmitRefundItems)
+        #expect(items.count == 2)
+        #expect(items.contains(where: { $0.itemID == 1 }))
+        #expect(items.contains(where: { $0.itemID == 2 }))
+    }
+
+    @Test func processRefund_then_submits_refund_with_reason() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        _ = try await sut.processRefund(reason: "Customer changed their mind")
+
+        // Then
+        #expect(refundSubmissionProcessor.spySubmitRefundReason == "Customer changed their mind")
+    }
+
+    @Test func processRefund_when_successful_then_clears_selection() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+        try #require(sut.selectableItems.count == 2)
+
+        // When
+        _ = try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(sut.selectableItems.isEmpty)
+    }
+
+    @Test func processRefund_when_successful_then_returns_the_refunded_order_id() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+        let order = POSOrderTestFactory.makeOrder(id: 321, lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        let result = try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(result.refundedOrderID == 321)
+    }
+
+    @Test func processRefund_when_successful_then_keeps_requiresCardPresentRefund_for_the_completion_screens() async throws {
+        // Given a prepared flow that requires a card present refund
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+        refundSubmissionProcessor.requiresCardPresentRefund = true
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        try #require(sut.requiresCardPresentRefund)
+
+        // When
+        _ = try await sut.processRefund(reason: .none)
+
+        // Then the completion screens can still read the preparation
+        #expect(sut.requiresCardPresentRefund)
+    }
+
+    @Test func processRefund_when_submission_throws_then_propagates_error() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        struct TestError: Error {}
+        refundSubmissionProcessor.submitRefundErrorToThrow = TestError()
+
+        // When / Then
+        var thrownError: Error?
+        do {
+            _ = try await sut.processRefund(reason: .none)
+        } catch {
+            thrownError = error
+        }
+
+        #expect(thrownError is TestError)
+    }
+
+    @Test func processRefund_when_no_refund_flow_was_started_then_throws_missingSelectedOrder() async throws {
+        await #expect(performing: {
+            _ = try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .missingSelectedOrder
+        })
+    }
+
+    @Test func processRefund_when_refund_is_not_prepared_then_throws_missingRefundPreparation() async throws {
+        // Given the flow was started for an order the store failed to prepare
+        refundSubmissionProcessor.prepareRefundErrorToThrow = TestError.prepareRefundFailed
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+
+        // When / Then
+        await #expect(performing: {
+            _ = try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .missingRefundPreparation
+        })
+    }
+
+    @Test func processRefund_when_no_items_are_selected_then_throws_emptySelection() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        sut.toggleAllItemsSelection()
+
+        // When / Then
+        await #expect(performing: {
+            _ = try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .emptySelection
+        })
+    }
+
+    @Test func processRefund_when_refund_is_already_in_progress_then_throws_refundAlreadyInProgress() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        _ = await sut.startRefundFlow(for: order)
+        refundSubmissionProcessor.shouldSuspendSubmitRefund = true
+
+        var firstRefundTask: Task<Void, Error>?
+        await fireOnce { fire in
+            refundSubmissionProcessor.onSubmitRefundStarted = {
+                fire()
+            }
+            firstRefundTask = Task { @MainActor in
+                _ = try await sut.processRefund(reason: .none)
+            }
+        }
+
+        // When / Then
+        await #expect(performing: {
+            _ = try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .refundAlreadyInProgress
+        })
+
+        refundSubmissionProcessor.resumeSubmitRefund()
+        try await firstRefundTask?.value
+    }
+
+    @Test func processRefund_then_converts_items_with_correct_properties() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 42, quantity: 3, price: 15.50, totalTax: 1.55, formattedPrice: "$15.50")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        _ = try await sut.processRefund(reason: .none)
+
+        // Then
+        let items = try #require(refundSubmissionProcessor.spySubmitRefundItems)
+        #expect(items.count == 3)
+
+        let firstItem = items[0]
+        #expect(firstItem.itemID == 42)
+        #expect(firstItem.lineItemTotal == 46.50)
+        #expect(firstItem.totalTax == 1.55)
+        #expect(firstItem.originalQuantity == 3)
+    }
+
+    @Test func processRefund_when_supportsAutomaticRefund_is_true_then_submits_refund_with_automatic_refund_true() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        _ = try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(refundSubmissionProcessor.spySubmitRefundIsAutomaticRefund == true)
+    }
+
+    @Test func processRefund_when_supportsAutomaticRefund_is_false_then_submits_refund_with_automatic_refund_false() async throws {
+        // Given
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: false
+        )
+
+        let order = POSOrderTestFactory.makeOrder(lineItems: [
+            POSOrderTestFactory.makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        _ = await sut.startRefundFlow(for: order)
+
+        // When
+        _ = try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(refundSubmissionProcessor.spySubmitRefundIsAutomaticRefund == false)
+    }
+}
+
+private extension POSRefundControllerTests {
+    /// Runs review preparation and returns its outcome.
+    @MainActor
+    func awaitReviewPreparation(_ controller: POSRefundController) async -> POSRefundReviewPreparationResult {
+        await controller.prepareReview()
+    }
+
+    /// Runs async review preparation and returns the review data, or `nil` when preparation failed.
+    @MainActor
+    func prepareReviewData(_ controller: POSRefundController) async -> POSRefundReviewData? {
+        guard case .ready(let reviewData) = await awaitReviewPreparation(controller) else {
+            return nil
+        }
+        return reviewData
+    }
+
+    func makeController(currencySettings: CurrencySettings) -> POSRefundController {
+        let formatter = CurrencyFormatter(currencySettings: currencySettings)
+        return POSRefundController(
+            refundSubmissionProcessor: MockPOSRefundSubmissionProcessor(refundsService: refundsService,
+                                                                        currencyFormatter: formatter)
+        )
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -4,7 +4,7 @@ import struct Yosemite.POSOrder
 import struct Yosemite.POSOrderItem
 import struct Yosemite.POSOrderCustomAmount
 
-final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol {
+final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol, POSOrderSelectionHandling {
     var ordersViewState: POSOrderListState = .empty
     var selectedOrder: POSOrder?
     var isLoadingOrderRefunds = false
@@ -20,14 +20,10 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
     }
     var displayedLineItems: [POSOrderItem] = []
     var displayedCustomAmounts: [POSOrderCustomAmount] = []
-    var refundActionAvailability: RefundActionAvailability = .available
-    var refundSelectableItems: [POSRefundSelectableItem] = []
-    var hasLoadedRefundableItems: Bool { !refundSelectableItems.isEmpty }
-    var currentRefundRequiresCardPresentRefund = false
-    var hasModifiedRefundSelection = false
     var updateOrderCalled = false
     var spyUpdateOrderID: Int64?
     var shouldThrowError = false
+    private(set) var loadOrderRefundsCalled = false
 
     enum TestError: Error {
         case updateOrderFailed
@@ -41,8 +37,6 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
 
     func selectOrder(_ order: POSOrder?) {
         selectedOrder = order
-        refundSelectableItems = []
-        hasModifiedRefundSelection = false
     }
 
     func updateOrder(orderID: Int64) async throws {
@@ -54,117 +48,11 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
         }
     }
 
-    func preloadRefundDetails() async {}
-
     func searchOrders(searchTerm: String) async {}
 
     func clearSearchOrders() {}
 
-    var stubStartRefundFlowResult: StartRefundFlowResult = .hasItemsToRefund
-
-    func startRefundFlow() async -> StartRefundFlowResult {
-        guard let order = selectedOrder else { return .failed }
-        switch stubStartRefundFlowResult {
-        case .hasItemsToRefund:
-            refundSelectableItems = order.lineItems.map {
-                POSRefundSelectableItem(from: $0, isSelected: true, index: 0)
-            }
-            hasModifiedRefundSelection = false
-        case .nothingToRefund:
-            refundSelectableItems = []
-            hasModifiedRefundSelection = false
-        case .ineligible, .failed:
-            break
-        }
-        return stubStartRefundFlowResult
-    }
-
-    private(set) var refreshRefundableItemsCallCount = 0
-    var stubRefreshedRefundSelectableItems: [POSRefundSelectableItem]?
-
-    func refreshRefundableItems() async -> StartRefundFlowResult {
-        refreshRefundableItemsCallCount += 1
-        switch stubStartRefundFlowResult {
-        case .hasItemsToRefund:
-            if let stubRefreshedRefundSelectableItems {
-                refundSelectableItems = stubRefreshedRefundSelectableItems
-            }
-            for index in refundSelectableItems.indices {
-                refundSelectableItems[index].isSelected = false
-            }
-            hasModifiedRefundSelection = false
-        case .nothingToRefund:
-            refundSelectableItems = []
-            hasModifiedRefundSelection = false
-        case .ineligible, .failed:
-            break
-        }
-        return stubStartRefundFlowResult
-    }
-
-    func toggleRefundItemSelection(at index: Int) {
-        guard refundSelectableItems.indices.contains(index) else { return }
-        refundSelectableItems[index].isSelected.toggle()
-        hasModifiedRefundSelection = true
-    }
-
-    func clearRefundSelection() {
-        refundSelectableItems = []
-        hasModifiedRefundSelection = false
-    }
-
-    func toggleAllRefundItemsSelection() {
-        guard !refundSelectableItems.isEmpty else { return }
-        let allSelected = refundSelectableItems.allSatisfy { $0.isSelected }
-        let newSelectionState = !allSelected
-        for index in refundSelectableItems.indices {
-            refundSelectableItems[index].isSelected = newSelectionState
-        }
-        hasModifiedRefundSelection = true
-    }
-
-    // MARK: - Refund Review Data
-
-    var stubPOSRefundReviewData: POSRefundReviewData?
-    private(set) var refundReviewPreparationState: POSRefundReviewPreparationState = .idle
-
-    func prepareRefundReview() async -> POSRefundReviewPreparationResult {
-        if let stubData = stubPOSRefundReviewData {
-            return .ready(stubData)
-        }
-
-        let selectedItems = refundSelectableItems.filter { $0.isSelected }
-        guard !selectedItems.isEmpty else {
-            return .preparationError
-        }
-
-        return .ready(POSRefundReviewData(
-            itemsCount: selectedItems.count,
-            formattedItemsSubtotal: "$0.00",
-            formattedTax: "$0.00",
-            formattedRefundTotal: "$0.00",
-            paymentMethodDescription: "Via payment card",
-            customerEmail: nil,
-            refundReason: nil,
-            isFullRefund: selectedItems.count == refundSelectableItems.count,
-            calculationFlow: .local
-        ))
-    }
-
-    func loadOrderRefunds() async {}
-
-    // MARK: - Refund Processing
-
-    var processRefundCalled = false
-    var spyProcessRefundReason: String?
-    var shouldThrowProcessRefundError = false
-
-    func processRefund(reason: String?) async throws {
-        processRefundCalled = true
-        spyProcessRefundReason = reason
-
-        if shouldThrowProcessRefundError {
-            throw TestError.updateOrderFailed
-        }
+    func loadOrderRefunds() async {
+        loadOrderRefundsCalled = true
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundController.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.POSOrder
+
+@MainActor
+final class MockPOSRefundController: POSRefundControllerProtocol {
+    var selectableItems: [POSRefundSelectableItem] = []
+    var hasLoadedSelectableItems: Bool { !selectableItems.isEmpty }
+    var hasModifiedSelection = false
+    var reviewPreparationState: POSRefundReviewPreparationState = .idle
+    var requiresCardPresentRefund = false
+
+    private(set) var preloadedOrderID: Int64?
+    private(set) var startRefundFlowOrderID: Int64?
+    private(set) var resetCalled = false
+    private(set) var processRefundCalled = false
+    private(set) var spyProcessRefundReason: String?
+
+    var stubStartRefundFlowResult: StartRefundFlowResult = .hasItemsToRefund
+    var stubRefundedOrderID: Int64 = 123
+    var processRefundErrorToThrow: Error?
+
+    enum TestError: Error {
+        case processRefundFailed
+    }
+
+    func preloadRefund(for order: POSOrder) async {
+        preloadedOrderID = order.id
+    }
+
+    func startRefundFlow(for order: POSOrder) async -> StartRefundFlowResult {
+        startRefundFlowOrderID = order.id
+        return stubStartRefundFlowResult
+    }
+
+    func refreshRefundableItems() async -> StartRefundFlowResult {
+        stubStartRefundFlowResult
+    }
+
+    func toggleItemSelection(at index: Int) {}
+
+    func toggleAllItemsSelection() {}
+
+    func clearSelection() {
+        selectableItems = []
+        hasModifiedSelection = false
+    }
+
+    func reset() {
+        resetCalled = true
+        clearSelection()
+    }
+
+    func prepareReview() async -> POSRefundReviewPreparationResult {
+        .preparationError
+    }
+
+    func processRefund(reason: String?) async throws -> POSRefundSubmissionResult {
+        processRefundCalled = true
+        spyProcessRefundReason = reason
+
+        if let processRefundErrorToThrow {
+            throw processRefundErrorToThrow
+        }
+
+        return POSRefundSubmissionResult(refundedOrderID: stubRefundedOrderID)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundSubmissionProcessor.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundSubmissionProcessor.swift
@@ -1,0 +1,147 @@
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.POSOrder
+@testable import struct Yosemite.POSRefundsResult
+import class WooFoundation.CurrencyFormatter
+
+final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcessing {
+    let stateModel = POSRefundSubmissionModel()
+
+    nonisolated(unsafe) private let refundsService: MockPOSRefundsService
+    nonisolated(unsafe) private let currencyFormatter: CurrencyFormatter
+    private var refundResultsByOrderID: [Int64: POSRefundsResult] = [:]
+    var requiresCardPresentRefund = false
+    var shouldSuspendSubmitRefund = false
+    var onSubmitRefundStarted: (() -> Void)?
+    private var submitRefundContinuation: CheckedContinuation<Void, Never>?
+
+    private(set) var submitRefundCalled = false
+    private(set) var spySubmitRefundOrderID: Int64?
+    private(set) var spySubmitRefundItems: [POSRefundSelectableItem]?
+    private(set) var spySubmitRefundReason: String?
+    private(set) var spySubmitRefundIsAutomaticRefund: Bool?
+    var submitRefundErrorToThrow: Error?
+
+    nonisolated init(refundsService: MockPOSRefundsService,
+                     currencyFormatter: CurrencyFormatter) {
+        self.refundsService = refundsService
+        self.currencyFormatter = currencyFormatter
+    }
+
+    private(set) var preloadedOrderIDs: [Int64] = []
+    var prepareRefundErrorToThrow: Error?
+
+    func preloadRefund(for order: POSOrder) async {
+        preloadedOrderIDs.append(order.id)
+    }
+
+    func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
+        if let prepareRefundErrorToThrow {
+            throw prepareRefundErrorToThrow
+        }
+        let refundsResult = try await refundsService.providePointOfSaleRefunds(for: order)
+        refundResultsByOrderID[order.id] = refundsResult
+
+        let refundedQuantitiesByItemID = refundsResult.refunds.flatMap(\.items).refundedQuantitiesByItemID()
+        let productSelectables = order.lineItems.flatMap { item -> [POSRefundSelectableItem] in
+            let originalQuantity = NSDecimalNumber(decimal: item.quantity).intValue
+            let refundedQuantity = refundedQuantitiesByItemID[item.itemID] ?? 0
+            let availableQuantity = originalQuantity - refundedQuantity
+            guard availableQuantity > 0 else { return [] }
+
+            return (0..<availableQuantity).map { index in
+                POSRefundSelectableItem(from: item, isSelected: true, index: index)
+            }
+        }
+
+        let alreadyRefundedItemIDs = Set(refundsResult.refunds.flatMap(\.items).compactMap(\.refundedItemID))
+        let feeSelectables = order.customAmounts
+            .filter { !alreadyRefundedItemIDs.contains($0.id) }
+            .map { POSRefundSelectableItem(from: $0, isSelected: true) }
+
+        return POSRefundPreparation(
+            orderID: order.id,
+            selectableItems: productSelectables + feeSelectables,
+            paymentMethodDescription: String(format: "via %1$@", order.paymentMethodTitle),
+            customerEmail: order.customerEmail,
+            requiresCardPresentRefund: requiresCardPresentRefund
+        )
+    }
+
+    var prepareReviewDataErrorToThrow: Error?
+    var onPrepareReviewDataCalled: (@MainActor () async -> Void)?
+
+    func prepareReviewData(for order: POSOrder,
+                           preparation: POSRefundPreparation,
+                           selectedItems: [POSRefundSelectableItem],
+                           reason: String?) async throws -> POSRefundReviewData {
+        await onPrepareReviewDataCalled?()
+        if let error = prepareReviewDataErrorToThrow {
+            throw error
+        }
+
+        let amounts = reviewAmounts(for: selectedItems)
+        return POSRefundReviewData(
+            itemsCount: selectedItems.count,
+            formattedItemsSubtotal: currencyFormatter.formatAmount(amounts.subtotal) ?? "",
+            formattedTax: currencyFormatter.formatAmount(amounts.tax) ?? "",
+            formattedRefundTotal: currencyFormatter.formatAmount(amounts.subtotal + amounts.tax) ?? "",
+            paymentMethodDescription: preparation.paymentMethodDescription,
+            customerEmail: preparation.customerEmail,
+            refundReason: reason,
+            isFullRefund: selectedItems.count == preparation.selectableItems.count,
+            calculationFlow: .local
+        )
+    }
+
+    func submitRefund(for order: POSOrder,
+                      preparation: POSRefundPreparation,
+                      selectedItems: [POSRefundSelectableItem],
+                      reason: String?) async throws {
+        onSubmitRefundStarted?()
+        if shouldSuspendSubmitRefund {
+            await withCheckedContinuation { continuation in
+                submitRefundContinuation = continuation
+            }
+        }
+
+        submitRefundCalled = true
+        spySubmitRefundOrderID = order.id
+        spySubmitRefundItems = selectedItems
+        spySubmitRefundReason = reason
+        spySubmitRefundIsAutomaticRefund = refundResultsByOrderID[preparation.orderID]?.supportsAutomaticRefund ?? true
+
+        if let error = submitRefundErrorToThrow {
+            throw error
+        }
+
+        stateModel.state = .completed
+    }
+
+    private func reviewAmounts(for items: [POSRefundSelectableItem]) -> (subtotal: Decimal, tax: Decimal) {
+        let groupedItems = Dictionary(grouping: items, by: \.itemID)
+        return groupedItems.values.reduce((subtotal: Decimal.zero, tax: Decimal.zero)) { result, items in
+            let subtotal = calculateAmount(for: items, keyPath: \.lineItemTotal)
+            let tax = calculateAmount(for: items, keyPath: \.totalTax)
+            return (result.subtotal + subtotal, result.tax + tax)
+        }
+    }
+
+    private func calculateAmount(for items: [POSRefundSelectableItem], keyPath: KeyPath<POSRefundSelectableItem, Decimal>) -> Decimal {
+        guard let firstItem = items.first, firstItem.originalQuantity > 0 else {
+            return .zero
+        }
+
+        if firstItem.isLumpSum || Decimal(items.count) == firstItem.originalQuantity {
+            return firstItem[keyPath: keyPath]
+        }
+
+        return (firstItem[keyPath: keyPath] / firstItem.originalQuantity) * Decimal(items.count)
+    }
+
+    func resumeSubmitRefund() {
+        shouldSuspendSubmitRefund = false
+        submitRefundContinuation?.resume()
+        submitRefundContinuation = nil
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/POSOrderTestFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/POSOrderTestFactory.swift
@@ -1,0 +1,80 @@
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.POSOrder
+import struct Yosemite.POSOrderItem
+import struct Yosemite.POSOrderCustomAmount
+import struct Yosemite.POSOrderRefund
+import enum Yosemite.OrderStatusEnum
+import typealias Yosemite.OrderItemAttribute
+
+enum POSOrderTestFactory {
+    static func makeOrder(id: Int64 = 1,
+                   status: OrderStatusEnum = .completed,
+                   paymentMethodID: String = "woocommerce_payments",
+                   paymentMethodTitle: String = "cod",
+                   lineItems: [POSOrderItem] = [],
+                   customAmounts: [POSOrderCustomAmount] = [],
+                   refunds: [POSOrderRefund] = []) -> POSOrder {
+        POSOrder(
+            id: id,
+            number: "\(id)",
+            dateCreated: Date(),
+            status: status,
+            formattedTotal: "$25.99",
+            formattedSubtotal: "$25.99",
+            customerEmail: "customer1@example.com",
+            paymentMethodID: paymentMethodID,
+            paymentMethodTitle: paymentMethodTitle,
+            lineItems: lineItems,
+            customAmounts: customAmounts,
+            refunds: refunds,
+            formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
+            formattedPaymentTotal: "$25.99",
+            formattedNetAmount: nil,
+            datePaid: status == .completed || status == .processing ? Date() : nil
+        )
+    }
+
+    static func makePOSOrderCustomAmount(
+        id: Int64 = 1,
+        name: String = "Discount Fee",
+        formattedTotal: String = "$5.00",
+        total: Decimal = 5,
+        totalTax: Decimal = 0
+    ) -> POSOrderCustomAmount {
+        POSOrderCustomAmount(
+            id: id,
+            name: name,
+            formattedTotal: formattedTotal,
+            total: total,
+            totalTax: totalTax
+        )
+    }
+
+    static func makePOSOrderItem(
+        itemID: Int64 = 1,
+        name: String = "Test Item",
+        quantity: Decimal = 1,
+        price: Decimal = 10.00,
+        total: Decimal? = nil,
+        totalTax: Decimal = 0,
+        formattedPrice: String = "$10.00",
+        formattedTotal: String? = nil,
+        imageSrc: String? = nil,
+        attributes: [OrderItemAttribute] = []
+    ) -> POSOrderItem {
+        POSOrderItem(
+            itemID: itemID,
+            name: name,
+            quantity: quantity,
+            price: price,
+            total: total ?? (price * quantity),
+            totalTax: totalTax,
+            formattedPrice: formattedPrice,
+            formattedTotal: formattedTotal ?? formattedPrice,
+            imageSrc: imageSrc,
+            attributes: attributes
+        )
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Models/POSOrderListModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSOrderListModelTests.swift
@@ -4,11 +4,14 @@ import Foundation
 import struct Yosemite.POSOrder
 import enum NetworkingCore.OrderStatusEnum
 
+@MainActor
 final class POSOrderListModelTests {
     private let mockOrdersController = MockPOSOrderListController()
+    private let mockRefundController = MockPOSRefundController()
     private let mockReceiptSender = MockPOSReceiptSender()
     private lazy var sut = POSOrderListModel(
         ordersController: mockOrdersController,
+        refundController: mockRefundController,
         receiptSender: mockReceiptSender,
         refundSubmissionModel: POSRefundSubmissionModel()
     )
@@ -64,6 +67,113 @@ final class POSOrderListModelTests {
         #expect(mockReceiptSender.sendReceiptCalledWithEmail == testEmail)
         #expect(mockOrdersController.updateOrderCalled == true)
         #expect(mockOrdersController.spyUpdateOrderID == 999)
+    }
+
+    @Test func selectOrder_then_selects_the_order_and_resets_the_refund_flow() async throws {
+        // Given
+        let testOrder = makeTestOrder(id: 321, email: "customer@example.com")
+
+        // When
+        sut.selectOrder(testOrder)
+
+        // Then
+        #expect(mockOrdersController.selectedOrder?.id == 321)
+        #expect(mockRefundController.resetCalled == true)
+    }
+
+    @Test func startRefundFlow_then_starts_it_for_the_selected_order() async throws {
+        // Given
+        mockOrdersController.selectedOrder = makeTestOrder(id: 555, email: "customer@example.com")
+
+        // When
+        let result = await sut.startRefundFlow()
+
+        // Then
+        #expect(mockRefundController.startRefundFlowOrderID == 555)
+        #expect(result == .hasItemsToRefund)
+    }
+
+    @Test func startRefundFlow_when_no_order_is_selected_then_fails_without_starting_it() async throws {
+        // When
+        let result = await sut.startRefundFlow()
+
+        // Then
+        #expect(mockRefundController.startRefundFlowOrderID == nil)
+        #expect(result == .failed)
+    }
+
+    @Test func preloadRefund_then_preloads_for_the_selected_order() async throws {
+        // Given
+        mockOrdersController.selectedOrder = makeTestOrder(id: 777, email: "customer@example.com")
+
+        // When
+        await sut.preloadRefund()
+
+        // Then
+        #expect(mockRefundController.preloadedOrderID == 777)
+    }
+
+    @Test func preloadRefund_when_no_order_is_selected_then_does_not_preload() async throws {
+        // When
+        await sut.preloadRefund()
+
+        // Then
+        #expect(mockRefundController.preloadedOrderID == nil)
+    }
+
+    @Test func processRefund_when_successful_then_refreshes_the_refunded_order() async throws {
+        // Given
+        mockRefundController.stubRefundedOrderID = 456
+
+        // When
+        try await sut.processRefund(reason: "Damaged")
+
+        // Then
+        #expect(mockRefundController.processRefundCalled == true)
+        #expect(mockRefundController.spyProcessRefundReason == "Damaged")
+        #expect(mockOrdersController.spyUpdateOrderID == 456)
+        #expect(mockOrdersController.loadOrderRefundsCalled == true)
+    }
+
+    @Test func processRefund_when_order_refresh_fails_then_still_loads_the_refunds() async throws {
+        // Given a successful refund whose post-refund order refresh fails
+        mockRefundController.stubRefundedOrderID = 456
+        mockOrdersController.shouldThrowError = true
+
+        // When
+        try await sut.processRefund(reason: nil)
+
+        // Then
+        #expect(mockOrdersController.updateOrderCalled == true)
+        #expect(mockOrdersController.loadOrderRefundsCalled == true)
+    }
+
+    @Test func refundActionAvailability_when_no_order_is_selected_then_unavailable() async throws {
+        // Given
+        mockOrdersController.selectedOrder = nil
+
+        // When / Then
+        #expect(sut.refundActionAvailability == .unavailable)
+    }
+
+    @Test func refundActionAvailability_when_a_completed_order_is_selected_then_available() async throws {
+        // Given
+        mockOrdersController.selectedOrder = makeTestOrder(id: 1, email: "customer@example.com")
+
+        // When / Then
+        #expect(sut.refundActionAvailability == .available)
+    }
+
+    @Test func processRefund_when_submission_fails_then_throws_without_refreshing_the_order() async throws {
+        // Given
+        mockRefundController.processRefundErrorToThrow = MockPOSRefundController.TestError.processRefundFailed
+
+        // When & Then
+        await #expect(throws: MockPOSRefundController.TestError.processRefundFailed) {
+            try await sut.processRefund(reason: nil)
+        }
+        #expect(mockOrdersController.updateOrderCalled == false)
+        #expect(mockOrdersController.loadOrderRefundsCalled == false)
     }
 
     private func makeTestOrder(id: Int64, email: String) -> POSOrder {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.7
 -----
+- [Internal] POS: Moved the refund flow state out of POSOrderListController into a new POSRefundController. No user-visible change. [https://github.com/woocommerce/woocommerce-ios/pull/17864]
 - [*] Order Creation: Kept Popular and Last Sold suggestions stable while loading more products. [https://github.com/woocommerce/woocommerce-ios/pull/17838]
 - [**] POS: Fixed the refund item selection after the store rejects a refund and the items reload. The selection is now cleared so the cashier picks again, instead of coming back covering items they had deselected. [https://github.com/woocommerce/woocommerce-ios/pull/17810]
 - [***] Age verification: pending or denied parental consent for significant app changes now shows a recoverable blocking screen instead of logging the user out, and consent requests are only sent on explicit user action. Affects the post-login age gate all users pass through — smoke test critical flows, including the sandbox age-assurance scenarios. [https://github.com/woocommerce/woocommerce-ios/pull/17822]


### PR DESCRIPTION
## Description

Part 3 of the WOOMOB-3649 stack. The parts merge as a unit.

1. #17861 — Move the refund flow types into their own file
2. #17862 — Move the refund item selection into POSRefundController
3. **#17863 — Move the refund review preparation and submission into POSRefundController**
4. #17864 — Make POSOrderListModel the single surface for the refund flow

This part moves the review preparation and the submission next to the selection they operate on. `POSRefundController` now resets its own preparation on selection changes, and `processRefund` returns the refunded order id so the caller can refresh that order. `POSOrderListController` still forwards; part 4 removes that. The pinned order deliberately serves both starting the flow and `refreshRefundableItems`: the reject-recovery reload must target the order the flow was started for, not the live selection.

## Test Steps

No user-visible change. Start a refund, pick items, and check the review totals. Change the selection and confirm the review updates. Submit and confirm the order details refresh.

## Screenshots

None. No UI change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
